### PR TITLE
xAuth Ldap patch

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -110,8 +110,8 @@ function upgrade_010_to_011() {
 			$fr['interface'] = $ifmap[$fr['interface']];
 		else {
 			/* remove the rule */
-			printf(gettext("%sWarning: filter rule removed " .
-				"(interface '%s' does not exist anymore)."), "\n", $fr['interface']);
+			echo "\nWarning: filter rule removed " .
+				"(interface '{$fr['interface']}' does not exist anymore).";
 			unset($config['filter']['rule'][$i]);
 			continue;
 		}
@@ -122,8 +122,8 @@ function upgrade_010_to_011() {
 				$fr['source']['network'] = $ifmap[$fr['source']['network']];
 			else {
 				/* remove the rule */
-				printf(gettext("%sWarning: filter rule removed " .
-					"(source network '%s' does not exist anymore)."), "\n", $fr['source']['network']);
+				echo "\nWarning: filter rule removed " .
+					"(source network '{$fr['source']['network']}' does not exist anymore).";
 				unset($config['filter']['rule'][$i]);
 				continue;
 			}
@@ -135,8 +135,8 @@ function upgrade_010_to_011() {
 				$fr['destination']['network'] = $ifmap[$fr['destination']['network']];
 			else {
 				/* remove the rule */
-				printf(gettext("%sWarning: filter rule removed " .
-					"(destination network '%s' does not exist anymore)."), "\n", $fr['destination']['network']);
+				echo "\nWarning: filter rule removed " .
+					"(destination network '{$fr['destination']['network']}' does not exist anymore).";
 				unset($config['filter']['rule'][$i]);
 				continue;
 			}
@@ -155,8 +155,8 @@ function upgrade_010_to_011() {
 			$fr['interface'] = $ifmap[$fr['interface']];
 		else {
 			/* remove the rule */
-			printf(gettext("%sWarning: traffic shaper rule removed " .
-				"(interface '%s' does not exist anymore)."), "\n", $fr['interface']);
+			echo "\nWarning: traffic shaper rule removed " .
+				"(interface '{$fr['interface']}' does not exist anymore).";
 			unset($config['pfqueueing']['rule'][$i]);
 			continue;
 		}
@@ -167,8 +167,8 @@ function upgrade_010_to_011() {
 				$fr['source']['network'] = $ifmap[$fr['source']['network']];
 			else {
 				/* remove the rule */
-				printf(gettext("%sWarning: traffic shaper rule removed " .
-					"(source network '%s' does not exist anymore)."), "\n", $fr['source']['network']);
+				echo "\nWarning: traffic shaper rule removed " .
+					"(source network '{$fr['source']['network']}' does not exist anymore).";
 				unset($config['pfqueueing']['rule'][$i]);
 				continue;
 			}
@@ -180,8 +180,8 @@ function upgrade_010_to_011() {
 				$fr['destination']['network'] = $ifmap[$fr['destination']['network']];
 			else {
 				/* remove the rule */
-				printf(gettext("%sWarning: traffic shaper rule removed " .
-					"(destination network '%s' does not exist anymore)."), "\n", $fr['destination']['network']);
+				echo "\nWarning: traffic shaper rule removed " .
+					"(destination network '{$fr['destination']['network']}' does not exist anymore).";
 				unset($config['pfqueueing']['rule'][$i]);
 				continue;
 			}
@@ -330,7 +330,7 @@ function upgrade_017_to_018() {
 			$vip = array();
 			$vip['mode'] = "carp";
 			$vip['interface'] = "AUTO";
-			$vip['descr'] = sprintf(gettext("CARP vhid %s"), $carpent['vhid']);
+			$vip['descr'] = "CARP vhid {$carpent['vhid']}";
 			$vip['type'] = "single";
 			$vip['vhid'] = $carpent['vhid'];
 			$vip['advskew'] = $carpent['advskew'];
@@ -507,7 +507,7 @@ function upgrade_028_to_029() {
 	$rule_item['type'] = "pass";
 	$rule_item['source']['any'] = true;
 	$rule_item['destination']['any'] = true;
-	$rule_item['descr'] = gettext("Permit IPsec traffic.");
+	$rule_item['descr'] = "Permit IPsec traffic.";
 	$rule_item['statetype'] = "keep state";
 	$a_filter[] = $rule_item;
 }
@@ -582,7 +582,7 @@ function upgrade_039_to_040() {
 	if (isset ($config['system']['username'])) {
 		$config['system']['group'] = array();
 		$config['system']['group'][0]['name'] = "admins";
-		$config['system']['group'][0]['description'] = gettext("System Administrators");
+		$config['system']['group'][0]['description'] = "System Administrators";
 		$config['system']['group'][0]['scope'] = "system";
 		$config['system']['group'][0]['priv'] = "page-all";
 		$config['system']['group'][0]['home'] = "index.php";
@@ -601,19 +601,19 @@ function upgrade_039_to_040() {
 		$config['system']['user'][0]['priv'] = array();
 		$config['system']['user'][0]['priv'][0]['id'] = "lockwc";
 		$config['system']['user'][0]['priv'][0]['name'] = "Lock webConfigurator";
-		$config['system']['user'][0]['priv'][0]['descr'] = gettext("Indicates whether this user will lock access to the webConfigurator for other users.");
+		$config['system']['user'][0]['priv'][0]['descr'] = "Indicates whether this user will lock access to the webConfigurator for other users.";
 		$config['system']['user'][0]['priv'][1]['id'] = "lock-ipages";
 		$config['system']['user'][0]['priv'][1]['name'] = "Lock individual pages";
-		$config['system']['user'][0]['priv'][1]['descr'] = gettext("Indicates whether this user will lock individual HTML pages after having accessed a particular page (the lock will be freed if the user leaves or saves the page form).");
+		$config['system']['user'][0]['priv'][1]['descr'] = "Indicates whether this user will lock individual HTML pages after having accessed a particular page (the lock will be freed if the user leaves or saves the page form).";
 		$config['system']['user'][0]['priv'][2]['id'] = "hasshell";
 		$config['system']['user'][0]['priv'][2]['name'] = "Has shell access";
-		$config['system']['user'][0]['priv'][2]['descr'] = gettext("Indicates whether this user is able to login for example via SSH.");
+		$config['system']['user'][0]['priv'][2]['descr'] = "Indicates whether this user is able to login for example via SSH.";
 		$config['system']['user'][0]['priv'][3]['id'] = "copyfiles";
 		$config['system']['user'][0]['priv'][3]['name'] = "Is allowed to copy files";
-		$config['system']['user'][0]['priv'][3]['descr'] = sprintf(gettext("Indicates whether this user is allowed to copy files onto the %s appliance via SCP/SFTP. If you are going to use this privilege, you must install scponly on the appliance (Hint: pkg_add -r scponly)."), $g['product_name']);
+		$config['system']['user'][0]['priv'][3]['descr'] = "Indicates whether this user is allowed to copy files onto the {$g['product_name']} appliance via SCP/SFTP. If you are going to use this privilege, you must install scponly on the appliance (Hint: pkg_add -r scponly).";
 		$config['system']['user'][0]['priv'][4]['id'] = "isroot";
 		$config['system']['user'][0]['priv'][4]['name'] = "Is root user";
-		$config['system']['user'][0]['priv'][4]['descr'] = gettext("This user is associated with the UNIX root user (you should associate this privilege only with one single user).");
+		$config['system']['user'][0]['priv'][4]['descr'] = "This user is associated with the UNIX root user (you should associate this privilege only with one single user).";
 
 		$config['system']['nextuid'] = "111";
 		$config['system']['nextgid'] = "111";
@@ -630,75 +630,75 @@ function upgrade_040_to_041() {
 		$config['sysctl']['item'] = array();
 
 		$config['sysctl']['item'][0]['tunable'] = "net.inet.tcp.blackhole";
-		$config['sysctl']['item'][0]['descr'] =    gettext("Drop packets to closed TCP ports without returning a RST");
+		$config['sysctl']['item'][0]['descr'] =    "Drop packets to closed TCP ports without returning a RST";
 		$config['sysctl']['item'][0]['value'] =   "default";
 
 		$config['sysctl']['item'][1]['tunable'] = "net.inet.udp.blackhole";
-		$config['sysctl']['item'][1]['descr'] =    gettext("Do not send ICMP port unreachable messages for closed UDP ports");
+		$config['sysctl']['item'][1]['descr'] =    "Do not send ICMP port unreachable messages for closed UDP ports";
 		$config['sysctl']['item'][1]['value'] =   "default";
 
 		$config['sysctl']['item'][2]['tunable'] = "net.inet.ip.random_id";
-		$config['sysctl']['item'][2]['descr'] =    gettext("Randomize the ID field in IP packets (default is 0: sequential IP IDs)");
+		$config['sysctl']['item'][2]['descr'] =    "Randomize the ID field in IP packets (default is 0: sequential IP IDs)";
 		$config['sysctl']['item'][2]['value'] =   "default";
 
 		$config['sysctl']['item'][3]['tunable'] = "net.inet.tcp.drop_synfin";
-		$config['sysctl']['item'][3]['descr'] =    gettext("Drop SYN-FIN packets (breaks RFC1379, but nobody uses it anyway)");
+		$config['sysctl']['item'][3]['descr'] =    "Drop SYN-FIN packets (breaks RFC1379, but nobody uses it anyway)";
 		$config['sysctl']['item'][3]['value'] =   "default";
 
 		$config['sysctl']['item'][4]['tunable'] = "net.inet.ip.redirect";
-		$config['sysctl']['item'][4]['descr'] =    gettext("Sending of IPv4 ICMP redirects");
+		$config['sysctl']['item'][4]['descr'] =    "Sending of IPv4 ICMP redirects";
 		$config['sysctl']['item'][4]['value'] =   "default";
 
 		$config['sysctl']['item'][5]['tunable'] = "net.inet6.ip6.redirect";
-		$config['sysctl']['item'][5]['descr'] =    gettext("Sending of IPv6 ICMP redirects");
+		$config['sysctl']['item'][5]['descr'] =    "Sending of IPv6 ICMP redirects";
 		$config['sysctl']['item'][5]['value'] =   "default";
 
 		$config['sysctl']['item'][6]['tunable'] = "net.inet.tcp.syncookies";
-		$config['sysctl']['item'][6]['descr'] =    gettext("Generate SYN cookies for outbound SYN-ACK packets");
+		$config['sysctl']['item'][6]['descr'] =    "Generate SYN cookies for outbound SYN-ACK packets";
 		$config['sysctl']['item'][6]['value'] =   "default";
 
 		$config['sysctl']['item'][7]['tunable'] = "net.inet.tcp.recvspace";
-		$config['sysctl']['item'][7]['descr'] =    gettext("Maximum incoming TCP datagram size");
+		$config['sysctl']['item'][7]['descr'] =    "Maximum incoming TCP datagram size";
 		$config['sysctl']['item'][7]['value'] =   "default";
 
 		$config['sysctl']['item'][8]['tunable'] = "net.inet.tcp.sendspace";
-		$config['sysctl']['item'][8]['descr'] =    gettext("Maximum outgoing TCP datagram size");
+		$config['sysctl']['item'][8]['descr'] =    "Maximum outgoing TCP datagram size";
 		$config['sysctl']['item'][8]['value'] =   "default";
 
 		$config['sysctl']['item'][9]['tunable'] = "net.inet.ip.fastforwarding";
-		$config['sysctl']['item'][9]['descr'] =    gettext("Fastforwarding (see http://lists.freebsd.org/pipermail/freebsd-net/2004-January/002534.html)");
+		$config['sysctl']['item'][9]['descr'] =    "Fastforwarding (see http://lists.freebsd.org/pipermail/freebsd-net/2004-January/002534.html)";
 		$config['sysctl']['item'][9]['value'] =   "default";
 
 		$config['sysctl']['item'][10]['tunable'] = "net.inet.tcp.delayed_ack";
-		$config['sysctl']['item'][10]['descr'] =    gettext("Do not delay ACK to try and piggyback it onto a data packet");
+		$config['sysctl']['item'][10]['descr'] =    "Do not delay ACK to try and piggyback it onto a data packet";
 		$config['sysctl']['item'][10]['value'] =   "default";
 
 		$config['sysctl']['item'][11]['tunable'] = "net.inet.udp.maxdgram";
-		$config['sysctl']['item'][11]['descr'] =    gettext("Maximum outgoing UDP datagram size");
+		$config['sysctl']['item'][11]['descr'] =    "Maximum outgoing UDP datagram size";
 		$config['sysctl']['item'][11]['value'] =   "default";
 
 		$config['sysctl']['item'][12]['tunable'] = "net.link.bridge.pfil_onlyip";
-		$config['sysctl']['item'][12]['descr'] =    gettext("Handling of non-IP packets which are not passed to pfil (see if_bridge(4))");
+		$config['sysctl']['item'][12]['descr'] =    "Handling of non-IP packets which are not passed to pfil (see if_bridge(4))";
 		$config['sysctl']['item'][12]['value'] =   "default";
 
 		$config['sysctl']['item'][13]['tunable'] = "net.link.tap.user_open";
-		$config['sysctl']['item'][13]['descr'] =    gettext("Allow unprivileged access to tap(4) device nodes");
+		$config['sysctl']['item'][13]['descr'] =    "Allow unprivileged access to tap(4) device nodes";
 		$config['sysctl']['item'][13]['value'] =   "default";
 
 		$config['sysctl']['item'][15]['tunable'] = "kern.randompid";
-		$config['sysctl']['item'][15]['descr'] =    gettext("Randomize PID's (see src/sys/kern/kern_fork.c: sysctl_kern_randompid())");
+		$config['sysctl']['item'][15]['descr'] =    "Randomize PID's (see src/sys/kern/kern_fork.c: sysctl_kern_randompid())";
 		$config['sysctl']['item'][15]['value'] =   "default";
 
 		$config['sysctl']['item'][16]['tunable'] = "net.inet.tcp.inflight.enable";
-		$config['sysctl']['item'][16]['descr'] =    gettext("The system will attempt to calculate the bandwidth delay product for each connection and limit the amount of data queued to the network to just the amount required to maintain optimum throughput. ");
+		$config['sysctl']['item'][16]['descr'] =    "The system will attempt to calculate the bandwidth delay product for each connection and limit the amount of data queued to the network to just the amount required to maintain optimum throughput. ";
 		$config['sysctl']['item'][16]['value'] =   "default";
 
 		$config['sysctl']['item'][17]['tunable'] = "net.inet.icmp.icmplim";
-		$config['sysctl']['item'][17]['descr'] =    gettext("Set ICMP Limits");
+		$config['sysctl']['item'][17]['descr'] =    "Set ICMP Limits";
 		$config['sysctl']['item'][17]['value'] =   "default";
 
 		$config['sysctl']['item'][18]['tunable'] = "net.inet.tcp.tso";
-		$config['sysctl']['item'][18]['descr'] =    gettext("TCP Offload engine");
+		$config['sysctl']['item'][18]['descr'] =    "TCP Offload engine";
 		$config['sysctl']['item'][18]['value'] =   "default";
 		
 		$config['sysctl']['item'][19]['tunable'] = "net.inet.ip.portrange.first";
@@ -739,10 +739,10 @@ function upgrade_042_to_043() {
 		$config['gateways']['gateway_item'][$i] = array();
 		if(is_ipaddr($config['interfaces'][$ifname]['gateway'])) {
 			$config['gateways']['gateway_item'][$i]['gateway'] = $config['interfaces'][$ifname]['gateway'];
-			$config['gateways']['gateway_item'][$i]['descr'] = sprintf(gettext("Interface %s Static Gateway"), $ifname);
+			$config['gateways']['gateway_item'][$i]['descr'] = "Interface $ifname Static Gateway";			
 		} else {
 			$config['gateways']['gateway_item'][$i]['gateway'] = "dynamic";
-			$config['gateways']['gateway_item'][$i]['descr'] = sprintf(gettext("Interface %s Dynamic Gateway"), $ifname);
+			$config['gateways']['gateway_item'][$i]['descr'] = "Interface $ifname Dynamic Gateway";			
 		}
 		$config['gateways']['gateway_item'][$i]['interface'] = $ifname;
 		$config['gateways']['gateway_item'][$i]['name'] = "GW_" . strtoupper($ifname);
@@ -807,7 +807,7 @@ function upgrade_043_to_044() {
 				$gwmap[$sroute['gateway']] = $gateway['name'];
 				$gateway['gateway'] = $sroute['gateway'];
 				$gateway['interface'] = $sroute['interface'];
-				$gateway['descr'] = sprintf(gettext("Upgraded static route for %s"), $sroute['network']);
+				$gateway['descr'] = "Upgraded static route for {$sroute['network']}";
 				if (!is_array($config['gateways']['gateway_item']))
 					$config['gateways']['gateway_item'] = array();
 				$config['gateways']['gateway_item'][] = $gateway;
@@ -904,7 +904,7 @@ function upgrade_045_to_046() {
 				$pool['type'] = 'server';
 				$pool['behaviour'] = 'balance';
 				$pool['name'] = "{$vs_a[$i]['name']}-sitedown";
-				$pool['descr'] = sprintf(gettext("Sitedown pool for VS: %s"), $vs_a[$i]['name']);
+				$pool['descr'] = "Sitedown pool for VS: {$vs_a[$i]['name']}";
 				$pool['port'] = $pools[$vs_a[$i]['pool']]['port'];
 				$pool['servers'] = array();
 				$pool['servers'][] = $vs_a[$i]['sitedown'];
@@ -1057,7 +1057,7 @@ function upgrade_046_to_047() {
 			if (isset($tunnel['disabled']))
 				$ph1ent['disabled'] = $tunnel['disabled'];
 
-			$ph2ent['descr'] = sprintf(gettext("phase2 for %s"), $tunnel['descr']);
+			$ph2ent['descr'] = "phase2 for ".$tunnel['descr'];
 
 			$type = "lan";
 			if ($tunnel['local-subnet']['network'])
@@ -1139,7 +1139,8 @@ function upgrade_046_to_047() {
 
 		if (isset($config['ipsec']['mobileclients']['enable'])) {
 			$config['ipsec']['client']['enable'] = true;
-			$config['ipsec']['client']['user_source'] = 'system';
+			$config['ipsec']['client']['enable'] = $config['ipsec']['mobileclients']['user_source'];
+			//$config['ipsec']['client']['user_source'] = 'system';
 			$config['ipsec']['client']['group_source'] = 'system';
 		}
 
@@ -1284,7 +1285,7 @@ function upgrade_047_to_048() {
 			$tempdyn['host'] = $config['dyndns'][0]['host'];
 			$tempdyn['mx'] = $config['dyndns'][0]['mx'];		
 			$tempdyn['interface'] = "wan";
-			$tempdyn['descr'] = sprintf(gettext("Upgraded Dyndns %s"), $tempdyn['type']);
+			$tempdyn['descr'] = "Upgraded Dyndns {$tempdyn['type']}";
 			$config['dyndnses']['dyndns'][] = $tempdyn;
 		}
 		unset($config['dyndns']);
@@ -1336,7 +1337,7 @@ function upgrade_048_to_049() {
 	/* setup new all users group */
 	$all = array();
 	$all['name'] = "all";
-	$all['description'] = gettext("All Users");
+	$all['description'] = "All Users";
 	$all['scope'] = "system";
 	$all['gid'] = 1998;
 	$all['member'] = array();
@@ -1468,7 +1469,7 @@ function upgrade_050_to_051() {
 			if (isset($intf['bridge']) && $intf['bridge'] <> "") {
 				$nbridge = array();
 				$nbridge['members'] = "{$ifr},{$intf['bridge']}";
-				$nbridge['descr'] = sprintf(gettext("Converted bridged %s"), $ifr);
+				$nbridge['descr'] = "Converted bridged {$ifr}";
 				$nbridge['bridgeif'] = "bridge{$i}";
 				$config['bridges']['bridged'][] = $nbridge;
 				unset($intf['bridge']);
@@ -1794,7 +1795,7 @@ function upgrade_051_to_052() {
                 $ovpnrule['destination'] = array();
                 $ovpnrule['source']['any'] = true;
                 $ovpnrule['destination']['any'] = true;
-                $ovpnrule['descr'] = gettext("Auto added OpenVPN rule from config upgrade.");
+                $ovpnrule['descr'] = "Auto added OpenVPN rule from config upgrade.";
 		$config['filter']['rule'][] = $ovpnrule;
 	}
 
@@ -1964,7 +1965,7 @@ function upgrade_054_to_055() {
 		$xmldumpnew = "{$database}.new.xml";
 
 		if ($g['booting'])
-			echo "Migrate RRD database {$database} to new format for IPv6 \n";
+			echo "Migrate RRD database {$database} to new format \n";
 		mwexec("$rrdtool tune {$rrddbpath}{$database} -r roundtrip:delay 2>&1");
 
 		dump_rrd_to_xml("{$rrddbpath}/{$database}", "{$g['tmp_path']}/{$xmldump}");
@@ -2516,8 +2517,8 @@ function upgrade_075_to_076() {
 function upgrade_076_to_077() {
 	global $config;
 	foreach($config['filter']['rule'] as & $rule) {
-	if (isset($rule['protocol']) && !empty($rule['protocol']))
-		$rule['protocol'] = strtolower($rule['protocol']);
+		if (isset($rule['protocol']) && !empty($rule['protocol']))
+			$rule['protocol'] = strtolower($rule['protocol']);
 	}
 }
 
@@ -2538,6 +2539,7 @@ function upgrade_077_to_078() {
 		$config['pptpd']['radius'] = $radarr;
 	}
 }
+
 function upgrade_078_to_079() {
 	global $g;
 	/* Delete old and unused RRD file */
@@ -2555,95 +2557,4 @@ function upgrade_079_to_080() {
 	}
 }
 
-function upgrade_080_to_081() {
-	global $config;
-	global $g;
-
-	/* RRD files changed for quality, traffic and packets graphs */
-	/* convert traffic RRD file */
-	global $parsedcfg, $listtags;
-	$listtags = array("ds", "v", "rra", "row");
-
-	$rrddbpath = "/var/db/rrd/";
-	$rrdtool = "/usr/bin/nice -n20 /usr/local/bin/rrdtool";
-
-	$rrdinterval = 60;
-	$valid = $rrdinterval * 2;
-
-	/* Asume GigE for now */
-	$downstream = 125000000;
-	$upstream = 125000000;
-
-	/* build a list of traffic and packets databases */
-	$databases = array();
-	exec("cd $rrddbpath;/usr/bin/find *-traffic.rrd *-packets.rrd", $databases);
-	rsort($databases);
-	foreach($databases as $database) {
-		$databasetmp = "{$database}.tmp";
-		$xmldump = "{$database}.old.xml";
-		$xmldumptmp = "{$database}.tmp.xml";
-		$xmldumpnew = "{$database}.new.xml";
-
-		if ($g['booting'])
-			echo "Migrate RRD database {$database} to new format for IPv6.\n";
-
-		/* dump contents to xml and move database out of the way */
-		dump_rrd_to_xml("{$rrddbpath}/{$database}", "{$g['tmp_path']}/{$xmldump}");
-
-		/* create new rrd database file */
-		$rrdcreate = "$rrdtool create {$g['tmp_path']}/{$databasetmp} --step $rrdinterval ";
-		$rrdcreate .= "DS:inpass:COUNTER:$valid:0:$downstream ";
-		$rrdcreate .= "DS:outpass:COUNTER:$valid:0:$upstream ";
-		$rrdcreate .= "DS:inblock:COUNTER:$valid:0:$downstream ";
-		$rrdcreate .= "DS:outblock:COUNTER:$valid:0:$upstream ";
-		$rrdcreate .= "DS:inpass6:COUNTER:$valid:0:$downstream ";
-		$rrdcreate .= "DS:outpass6:COUNTER:$valid:0:$upstream ";
-		$rrdcreate .= "DS:inblock6:COUNTER:$valid:0:$downstream ";
-		$rrdcreate .= "DS:outblock6:COUNTER:$valid:0:$upstream ";
-		$rrdcreate .= "RRA:AVERAGE:0.5:1:1000 ";
-		$rrdcreate .= "RRA:AVERAGE:0.5:5:1000 ";
-		$rrdcreate .= "RRA:AVERAGE:0.5:60:1000 ";
-		$rrdcreate .= "RRA:AVERAGE:0.5:720:3000 ";
-
-		create_new_rrd("$rrdcreate");
-		/* create temporary xml from new RRD */
-		dump_rrd_to_xml("{$g['tmp_path']}/{$databasetmp}", "{$g['tmp_path']}/{$xmldumptmp}");
-
-		$rrdoldxml = file_get_contents("{$g['tmp_path']}/{$xmldump}");
-		$rrdold = xml2array($rrdoldxml, 1, "tag");
-		$rrdold = $rrdold['rrd'];
-
-		$rrdnewxml = file_get_contents("{$g['tmp_path']}/{$xmldumptmp}");
-		$rrdnew = xml2array($rrdnewxml, 1, "tag");
-		$rrdnew = $rrdnew['rrd'];
-
-		/* remove any MAX RRA's. Not needed for traffic. */
-		$i = 0;
-		foreach ($rrdold['rra'] as $rra) {
-			if(trim($rra['cf']) == "MAX") {
-				unset($rrdold['rra'][$i]);
-			}
-			$i++;
-		}
-
-		$rrdxmlarray = migrate_rrd_format($rrdold, $rrdnew);
-		$rrdxml = dump_xml_config_raw($rrdxmlarray, "rrd");
-		file_put_contents("{$g['tmp_path']}/{$xmldumpnew}", $rrdxml);
-		mwexec("$rrdtool restore -f {$g['tmp_path']}/{$xmldumpnew} {$rrddbpath}/{$database} 2>&1");
-
-	}
-	enable_rrd_graphing();
-	if ($g['booting'])
-		echo "Updating configuration...";
-	foreach($config['filter']['rule'] as & $rule) {
-		if (isset($rule['protocol']) && !empty($rule['protocol']))
-			$rule['protocol'] = strtolower($rule['protocol']);
-	}
-}
-
-function upgrade_081_to_082() {
-	global $config;
-	/* enable the allow IPv6 toggle */
-	$config['system']['ipv6allow'] = true;
-}
 ?>

--- a/etc/inc/vpn.inc
+++ b/etc/inc/vpn.inc
@@ -121,7 +121,7 @@ function vpn_ipsec_configure($ipchg = false)
 		mwexec("/sbin/sysctl net.inet.ip.ipsec_in_use=1");
 
 		if ($g['booting'])
-			echo gettext("Configuring IPsec VPN... ");
+			echo "Configuring IPsec VPN... ";
 
 		/* fastforwarding is not compatible with ipsec tunnels */
 		mwexec("/sbin/sysctl net.inet.ip.fastforwarding=0");
@@ -138,13 +138,12 @@ function vpn_ipsec_configure($ipchg = false)
 
 			$ipsecpinghosts = "";
 			/* step through each phase1 entry */
-			$ipsecpinghosts = "";
 			foreach ($a_phase1 as $ph1ent) {
 				if (isset($ph1ent['disabled']))
 					continue;
 
 				$ep = ipsec_get_phase1_src($ph1ent);
-				if (!is_ipaddr($ep))
+				if (!$ep)
 					continue;
 
 				if(!in_array($ep,$ipmap))
@@ -183,43 +182,27 @@ function vpn_ipsec_configure($ipchg = false)
 					if ($ikeid != $ph1ent['ikeid'])
 						continue;
 
-					$ph2ent['localid']['mode'] = $ph2ent['mode'];
 					/* add an ipsec pinghosts entry */
 					if ($ph2ent['pinghost']) {
 						$iflist = get_configured_interface_list();
 						foreach ($iflist as $ifent => $ifname) {
-							if(is_ipaddrv6($ph2ent['pinghost'])) {
-								$interface_ip = get_interface_ipv6($ifent);
-								if(!is_ipaddrv6($interface_ip))
-									continue;
-								$local_subnet = ipsec_idinfo_to_cidr($ph2ent['localid'], true);
-								if (ip_in_subnet($interface_ip, $local_subnet)) {
-									$srcip = $interface_ip;
-									break;
-								}
-							} else {
-								$interface_ip = get_interface_ip($ifent);
-								if(!is_ipaddrv4($interface_ip))
-									continue;
-								$local_subnet = ipsec_idinfo_to_cidr($ph2ent['localid'], true);
-								if (ip_in_subnet($interface_ip, $local_subnet)) {
-									$srcip = $interface_ip;
-									break;
-								}
+							$interface_ip = get_interface_ip($ifent);
+							$local_subnet = ipsec_idinfo_to_cidr($ph2ent['localid'], true);
+							if (ip_in_subnet($interface_ip, $local_subnet)) {
+								$srcip = $interface_ip;
+								break;
 							}
 						}
 						$dstip = $ph2ent['pinghost'];
-						if(is_ipaddrv6($dstip)) {
-							$family = "inet6";
-						} else {
-							$family = "inet";
-						}
 						if (is_ipaddr($srcip))
-							$ipsecpinghosts[] = "{$srcip}|{$dstip}|3|||||{$family}|\n";
-
+							$ipsecpinghosts .= "{$srcip}|{$dstip}|3\n";
 					}
 				}
-				file_put_contents("{$g['vardb_path']}/ipsecpinghosts", $ipsecpinghosts);
+				$pfd = fopen("{$g['vardb_path']}/ipsecpinghosts", "w");
+				if ($pfd) {
+					fwrite($pfd, $ipsecpinghosts);
+					fclose($pfd);
+				}
 				
 			}
 		}
@@ -228,18 +211,18 @@ function vpn_ipsec_configure($ipchg = false)
 		if (is_array($config['ca']) && count($config['ca'])) {
 			foreach ($config['ca'] as $ca) {
 				if (!isset($ca['crt'])) {
-					log_error(sprintf(gettext("Error: Invalid certificate info for %s"), $ca['descr']));
+					log_error("Error: Invalid certificate info for {$ca['descr']}");
 					continue;
 				}
 				$cert = base64_decode($ca['crt']);
 				$x509cert = openssl_x509_parse(openssl_x509_read($cert));
 				if (!is_array($x509cert) || !isset($x509cert['hash'])) {
-					log_error(sprintf(gettext("Error: Invalid certificate hash info for %s"), $ca['descr']));
+					log_error("Error: Invalid certificate hash info for {$ca['descr']}");
 					continue;
 				}
 				$fname = $g['varetc_path']."/".$x509cert['hash'].".0";
 				if (!file_put_contents($fname, $cert)) {
-					log_error(sprintf(gettext("Error: Cannot write IPsec CA file for %s"), $ca['descr']));
+					log_error("Error: Cannot write IPsec CA file for {$ca['descr']}");
 					continue;
 				}
 			}
@@ -248,7 +231,7 @@ function vpn_ipsec_configure($ipchg = false)
 		/* generate psk.txt */
 		$fd = fopen("{$g['varetc_path']}/psk.txt", "w");
 		if (!$fd) {
-			printf(gettext("Error: cannot open psk.txt in vpn_ipsec_configure().") . "\n");
+			printf("Error: cannot open psk.txt in vpn_ipsec_configure().\n");
 			return 1;
 		}
 
@@ -311,7 +294,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 			$fd = fopen("{$g['varetc_path']}/racoon.conf", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open racoon.conf in vpn_ipsec_configure().") . "\n");
+				printf("Error: cannot open racoon.conf in vpn_ipsec_configure().\n");
 				return 1;
 			}
 
@@ -403,7 +386,7 @@ function vpn_ipsec_configure($ipchg = false)
 					$fn = "{$g['varetc_path']}/racoon.motd";
 					$fd1 = fopen($fn, "w");
 					if (!$fd1) {
-						printf(gettext("Error: cannot open server %s in vpn.\n"), $fn);
+						printf("Error: cannot open server{$fn} in vpn.\n");
 						return 1;
 					}
 
@@ -419,7 +402,23 @@ function vpn_ipsec_configure($ipchg = false)
 				$racoonconf .= "}\n\n";
 			}
 			/* end mode_cfg section */
-
+		
+			$authcfg =  $config['system']['authserver'][0];
+	
+			/* begin ldap_cfg */
+			$racoonconf .= "ldapcfg {\n";
+			$racoonconf .= "\tversion 3;\n";
+			$racoonconf .= "\thost \"".$authcfg['host']."\";\n";
+		 	$lport = "389";
+			if ($authcfg['port'] != "") {$lport = $authcfg['port'];};	
+			$racoonconf .= "\tport ".$lport.";\n"; 
+			$racoonconf .= "\tbase \"".$authcfg['ldap_basedn']."\";\n";
+			$racoonconf .= "\tsubtree on;\n";
+			$racoonconf .= "\tbind_dn \"".$authcfg['ldap_binddn']."\";\n";
+			$racoonconf .= "\tbind_pw \"".$authcfg['ldap_bindpw']."\";\n";
+			$racoonconf .= "\tattr_user \"".$authcfg['ldap_attr_user']."\";\n";
+			$racoonconf .= "}\n\n";
+			
 			/* begin remote sections */
 			if (is_array($a_phase1) && count($a_phase1)) {
 				/* begin remote */
@@ -454,7 +453,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 						case "dyn_dns":
 							$myid_type = "address";
-							$myid_data = resolve_retry($ph1ent['myid_data']);
+							$myid_data = gethostbyname($ph1ent['myid_data']);
 							break;
 
 						case "address";
@@ -534,7 +533,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 						if (!$cert)
 						{
-							log_error(sprintf(gettext("Error: Invalid phase1 certificate reference for %s"), $ph1ent['name']));
+							log_error("Error: Invalid phase1 certificate reference for {$ph1ent['name']}");
 							continue;
 						}
 
@@ -543,7 +542,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 						if (!file_put_contents($certpath, base64_decode($cert['crt'])))
 						{
-							log_error(sprintf(gettext("Error: Cannot write phase1 certificate file for %s"), $ph1ent['name']));
+							log_error("Error: Cannot write phase1 certificate file for {$ph1ent['name']}");
 							continue;
 						}
 
@@ -554,7 +553,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 						if (!file_put_contents($keypath, base64_decode($cert['prv'])))
 						{
-							log_error(sprintf(gettext("Error: Cannot write phase1 key file for %s"), $ph1ent['name']));
+							log_error("Error: Cannot write phase1 key file for {$ph1ent['name']}");
 							continue;
 						}
 
@@ -567,7 +566,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 							if (!file_put_contents($capath, base64_decode($ca['crt'])))
 							{
-								log_error(sprintf(gettext("Error: Cannot write phase1 CA certificate file for %s"), $ph1ent['name']));
+								log_error("Error: Cannot write phase1 CA certificate file for {$ph1ent['name']}");
 								continue;
 							}
 
@@ -654,10 +653,9 @@ EOD;
 					if (isset($ph2ent['mobile']) && !isset($a_client['enable']))
 						continue;
 
-					if (($ph2ent['mode'] == 'tunnel') or ($ph2ent['mode'] == 'tunnel6')) {
+					if ($ph2ent['mode'] == 'tunnel') {
 
 						$localid_type = $ph2ent['localid']['type'];
-						$ph2ent['localid']['mode'] = $ph2ent['mode'];
 						$localid_data = ipsec_idinfo_to_cidr($ph2ent['localid']);
 						/* Do not print localid in some cases, such as a pure-psk or psk/xauth single phase2 mobile tunnel */
 						if (($localid_type == "none") ||
@@ -800,7 +798,7 @@ EOD;
 			/* generate spd.conf */
 			$fd = fopen("{$g['varetc_path']}/spd.conf", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open spd.conf in vpn_ipsec_configure().") . "\n");
+				printf("Error: cannot open spd.conf in vpn_ipsec_configure().\n");
 				return 1;
 			}
 
@@ -809,18 +807,11 @@ EOD;
 			/* Try to prevent people from locking themselves out of webgui. Just in case. */
 			if ($config['interfaces']['lan']) {
 				$lanip = get_interface_ip("lan");
-				if (!empty($lanip) && is_ipaddrv4($lanip)) {
+				if (!empty($lanip) && is_ipaddr($lanip)) {
 					$lansn = get_interface_subnet("lan");
 					$lansa = gen_subnet($lanip, $lansn);
-					$spdconf .= "spdadd -4 {$lanip}/32 {$lansa}/{$lansn} any -P out none;\n";
-					$spdconf .= "spdadd -4 {$lansa}/{$lansn} {$lanip}/32 any -P in none;\n";
-				}
-				$lanipv6 = get_interface_ipv6("lan");
-				if (!empty($lanipv6) && is_ipaddrv6($lanipv6)) {
-					$lansnv6 = get_interface_subnetv6("lan");
-					$lansav6 = gen_subnetv6($lanipv6, $lansnv6);
-					$spdconf .= "spdadd -6 {$lanipv6}/128 {$lansav6}/{$lansnv6} any -P out none;\n";
-					$spdconf .= "spdadd -6 {$lansav6}/{$lansnv6} {$lanipv6}/128 any -P in none;\n";
+					$spdconf .= "spdadd {$lanip}/32 {$lansa}/{$lansn} any -P out none;\n";
+					$spdconf .= "spdadd {$lansa}/{$lansn} {$lanip}/32 any -P in none;\n";
 				}
 			}
 
@@ -846,20 +837,15 @@ EOD;
 				if(!is_ipaddr($rgip))
 					continue;
 
-				$ph2ent['localid']['mode'] = $ph2ent['mode'];
 				$localid = ipsec_idinfo_to_cidr($ph2ent['localid'],true);
 				$remoteid = ipsec_idinfo_to_cidr($ph2ent['remoteid'],true);
 
-				if(($ph2ent['mode'] == "tunnel") or ($ph2ent['mode'] == 'tunnel6')) {
-					if($ph2ent['mode'] == "tunnel6")
-						$family = "-6";
-					else
-						$family = "-4";
+				if($ph2ent['mode'] == "tunnel") {
 
-					$spdconf .= "spdadd {$family} {$localid} {$remoteid} any -P out ipsec " .
+					$spdconf .= "spdadd {$localid} {$remoteid} any -P out ipsec " .
 						"{$ph2ent['protocol']}/tunnel/{$ep}-{$rgip}/unique;\n";
 
-					$spdconf .= "spdadd {$family} {$remoteid} {$localid} any -P in ipsec " .
+					$spdconf .= "spdadd {$remoteid} {$localid} any -P in ipsec " .
 						"{$ph2ent['protocol']}/tunnel/{$rgip}-{$ep}/unique;\n";
 
 				} else {
@@ -985,7 +971,7 @@ function vpn_ipsec_force_reload() {
 
 	/* if ipsec is enabled, start up again */
 	if (isset($ipseccfg['enable'])) {
-		log_error(gettext("Forcefully reloading IPsec racoon daemon"));
+		log_error("Forcefully reloading IPsec racoon daemon");
 		vpn_ipsec_configure();
 	}
 
@@ -1024,7 +1010,7 @@ function vpn_pptpd_configure() {
 		if (!$pptpdcfg['mode'] || ($pptpdcfg['mode'] == "off"))
 			return 0;
 
-		echo gettext("Configuring PPTP VPN service... ");
+		echo "Configuring PPTP VPN service... ";
 	} else {
 		/* kill mpd */
 		killbypid("{$g['varrun_path']}/pptp-vpn.pid");
@@ -1034,7 +1020,7 @@ function vpn_pptpd_configure() {
 
 		if (is_process_running("mpd -b")) {
 			killbypid("{$g['varrun_path']}/pptp-vpn.pid");
-			log_error(gettext("Could not kill mpd within 3 seconds.   Trying again."));
+			log_error("Could not kill mpd within 3 seconds.   Trying again.");
 		}
 
 		/* remove mpd.conf, if it exists */
@@ -1052,7 +1038,7 @@ function vpn_pptpd_configure() {
 			/* write mpd.conf */
 			$fd = fopen("{$g['varetc_path']}/pptp-vpn/mpd.conf", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.conf in vpn_pptpd_configure().") . "\n");
+				printf("Error: cannot open mpd.conf in vpn_pptpd_configure().\n");
 				return 1;
 			}
 
@@ -1165,7 +1151,7 @@ EOD;
 			/* write mpd.links */
 			$fd = fopen("{$g['varetc_path']}/pptp-vpn/mpd.links", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.links in vpn_pptpd_configure().") . "\n");
+				printf("Error: cannot open mpd.links in vpn_pptpd_configure().\n");
 				return 1;
 			}
 
@@ -1189,7 +1175,7 @@ EOD;
 			/* write mpd.secret */
 			$fd = fopen("{$g['varetc_path']}/pptp-vpn/mpd.secret", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.secret in vpn_pptpd_configure().") . "\n");
+				printf("Error: cannot open mpd.secret in vpn_pptpd_configure().\n");
 				return 1;
 			}
 
@@ -1243,7 +1229,7 @@ function vpn_pppoe_configure(&$pppoecfg) {
 		if (!$pppoecfg['mode'] || ($pppoecfg['mode'] == "off"))
 			return 0;
 
-		echo gettext("Configuring PPPoE VPN service... ");
+		echo "Configuring PPPoE VPN service... ";
 	} else {
 		/* kill mpd */
 		killbypid("{$g['varrun_path']}/pppoe{$pppoecfg['pppoeid']}-vpn.pid");
@@ -1267,7 +1253,7 @@ function vpn_pppoe_configure(&$pppoecfg) {
 			/* write mpd.conf */
 			$fd = fopen("{$g['varetc_path']}/pppoe{$pppoecfg['pppoeid']}-vpn/mpd.conf", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.conf in vpn_pppoe_configure().") . "\n");
+				printf("Error: cannot open mpd.conf in vpn_pppoe_configure().\n");
 				return 1;
 			}
 			$mpdconf = "\n\n";
@@ -1370,7 +1356,7 @@ EOD;
 			/* write mpd.links */
 			$fd = fopen("{$g['varetc_path']}/pppoe{$pppoecfg['pppoeid']}-vpn/mpd.links", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.links in vpn_pppoe_configure().") . "\n");
+				printf("Error: cannot open mpd.links in vpn_pppoe_configure().\n");
 				return 1;
 			}
 
@@ -1396,7 +1382,7 @@ EOD;
 				/* write mpd.secret */
 				$fd = fopen("{$g['varetc_path']}/pppoe{$pppoecfg['pppoeid']}-vpn/mpd.secret", "w");
 				if (!$fd) {
-					printf(gettext("Error: cannot open mpd.secret in vpn_pppoe_configure().") . "\n");
+					printf("Error: cannot open mpd.secret in vpn_pppoe_configure().\n");
 					return 1;
 				}
 
@@ -1424,7 +1410,7 @@ EOD;
 	}
 
 	if ($g['booting'])
-		echo gettext("done") . "\n";
+		echo "done\n";
 
 	return 0;
 }
@@ -1443,7 +1429,7 @@ function vpn_l2tp_configure() {
 		if (!$l2tpcfg['mode'] || ($l2tpcfg['mode'] == "off"))
 			return 0;
 
-		echo gettext("Configuring l2tp VPN service... ");
+		echo "Configuring l2tp VPN service... ";
 	} else {
 		/* kill mpd */
 		killbypid("{$g['varrun_path']}/l2tp-vpn.pid");
@@ -1468,7 +1454,7 @@ function vpn_l2tp_configure() {
 			/* write mpd.conf */
 			$fd = fopen("{$g['varetc_path']}/l2tp-vpn/mpd.conf", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.conf in vpn_l2tp_configure().") . "\n");
+				printf("Error: cannot open mpd.conf in vpn_l2tp_configure().\n");
 				return 1;
 			}
 			$mpdconf = "\n\n";
@@ -1561,7 +1547,7 @@ EOD;
 			/* write mpd.links */
 			$fd = fopen("{$g['varetc_path']}/l2tp-vpn/mpd.links", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.links in vpn_l2tp_configure().") . "\n");
+				printf("Error: cannot open mpd.links in vpn_l2tp_configure().\n");
 				return 1;
 			}
 
@@ -1586,7 +1572,7 @@ EOD;
 			/* write mpd.secret */
 			$fd = fopen("{$g['varetc_path']}/l2tp-vpn/mpd.secret", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.secret in vpn_l2tp_configure().") . "\n");
+				printf("Error: cannot open mpd.secret in vpn_l2tp_configure().\n");
 				return 1;
 			}
 
@@ -1703,7 +1689,6 @@ function reload_tunnel_spd_policy($phase1, $phase2, $old_phase1, $old_phase2) {
 	$sad_arr = ipsec_dump_sad();
 
 	$ep = ipsec_get_phase1_src($phase1);
-	$phase2['localid']['mode'] = $phase2['mode'];
 	$local_subnet = ipsec_idinfo_to_cidr($phase2['localid']);
 	$remote_subnet = ipsec_idinfo_to_cidr($phase2['remoteid']);
 
@@ -1711,7 +1696,6 @@ function reload_tunnel_spd_policy($phase1, $phase2, $old_phase1, $old_phase2) {
 	$old_gw = trim($old_phase1['remote-gateway']);
 
 	$old_ep = ipsec_get_phase1_src($old_phase1);
-	$old_phase2['localid']['mode'] = $old_phase2['mode'];
 	$old_local_subnet = ipsec_idinfo_to_cidr($old_phase2['localid']);
 	$old_remote_subnet = ipsec_idinfo_to_cidr($old_phase2['remoteid']);
 
@@ -1733,30 +1717,25 @@ function reload_tunnel_spd_policy($phase1, $phase2, $old_phase1, $old_phase2) {
 		$rgip = $phase1['remote-gateway'];
 	}
 	if (!$ep) {
-		log_error(sprintf(gettext("Could not determine VPN endpoint for '%s'"), $phase1['descr']));
+		log_error("Could not determine VPN endpoint for '{$phase1['descr']}'");
 		return false;
 	}
 
 	if((!is_ipaddr($old_ep)) || (! is_ipaddr($ep))) {
-		log_error(sprintf(gettext("IPSEC: ERROR: One of the endpoints is not a IP address. Old EP '%1\$s' new EP '%2\$s'"), $old_ep, $ep));
+		log_error("IPSEC: ERROR: One of the endpoints is not a IP address. Old EP '{$old_ep}' new EP '{$ep}'");
 	}
 	if((! is_ipaddr($rgip)) || (! is_ipaddr($old_gw))) {
-		log_error(sprintf(gettext("IPSEC: ERROR: One of the remote endpoints is not a IP address. Old RG '%1\$s' new RG '%2\$s'"), $old_gw, $rgip));
+		log_error("IPSEC: ERROR: One of the remote endpoints is not a IP address. Old RG '{$old_gw}' new RG '{$rgip}'");
 	}
 
 	$spdconf = "";
 	/* Delete old SPD policies if there are changes between the old and new */
 	if(($phase1 != $old_phase1) || ($phase2 != $old_phase2)) {
-		if($old_phase2['mode'] == "tunnel6")
-			$family = "-6";
-		else
-			$family = "-4";
-
-		$spdconf .= "spddelete {$family} {$old_local_subnet} " .
+		$spdconf .= "spddelete {$old_local_subnet} " .
 			"{$old_remote_subnet} any -P out ipsec " .
 			"{$old_phase2['protocol']}/tunnel/{$old_ep}-" .
 			"{$old_gw}/unique;\n";
-		$spdconf .= "spddelete {$family} {$old_remote_subnet} " .
+		$spdconf .= "spddelete {$old_remote_subnet} " .
 			"{$old_local_subnet} any -P in ipsec " .
 			"{$old_phase2['protocol']}/tunnel/{$old_gw}-" .
 			"{$old_ep}/unique;\n";
@@ -1764,40 +1743,35 @@ function reload_tunnel_spd_policy($phase1, $phase2, $old_phase1, $old_phase2) {
 		/* zap any existing SA entries */
 		foreach($sad_arr as $sad) {
 			if(($sad['dst'] == $old_ep) && ($sad['src'] == $old_gw)) {
-				$spdconf .= "delete {$family} {$old_ep} {$old_gw} {$old_phase2['protocol']} 0x{$sad['spi']};\n";
+				$spdconf .= "delete {$old_ep} {$old_gw} {$old_phase2['protocol']} 0x{$sad['spi']};\n";
 			}
 			if(($sad['src'] == $oldep) && ($sad['dst'] == $old_gw)) {
-				$spdconf .= "delete {$family} {$old_gw} {$old_ep} {$old_phase2['protocol']} 0x{$sad['spi']};\n";
+				$spdconf .= "delete {$old_gw} {$old_ep} {$old_phase2['protocol']} 0x{$sad['spi']};\n";
 			}
 		}
 	}
-
-	if($phase2['mode'] == "tunnel6")
-		$family = "-6";
-	else
-		$family = "-4";
 
 	/* Create new SPD entries for the new configuration */
 	/* zap any existing SA entries beforehand */
 	foreach($sad_arr as $sad) {
 		if(($sad['dst'] == $ep) && ($sad['src'] == $rgip)) {
-			$spdconf .= "delete {$family} {$rgip} {$ep} {$phase2['protocol']} 0x{$sad['spi']};\n";
+			$spdconf .= "delete {$rgip} {$ep} {$phase2['protocol']} 0x{$sad['spi']};\n";
 		}
 		if(($sad['src'] == $ep) && ($sad['dst'] == $rgip)) {
-			$spdconf .= "delete {$family} {$ep} {$rgip} {$phase2['protocol']} 0x{$sad['spi']};\n";
+			$spdconf .= "delete {$ep} {$rgip} {$phase2['protocol']} 0x{$sad['spi']};\n";
 		}
 	}
 	/* add new SPD policies to replace them */
-	$spdconf .= "spdadd {$family} {$local_subnet} " .
+	$spdconf .= "spdadd {$local_subnet} " .
 		"{$remote_subnet} any -P out ipsec " .
 		"{$phase2['protocol']}/tunnel/{$ep}-" .
 		"{$rgip}/unique;\n";
-	$spdconf .= "spdadd {$family} {$remote_subnet} " .
+	$spdconf .= "spdadd {$remote_subnet} " .
 		"{$local_subnet} any -P in ipsec " .
 		"{$phase2['protocol']}/tunnel/{$rgip}-" .
 		"{$ep}/unique;\n";
 
-	log_error(sprintf(gettext("Reloading IPsec tunnel '%1\$s'. Previous IP '%2\$s', current IP '%3\$s'. Reloading policy"), $phase1['descr'], $old_gw, $rgip));
+	log_error("Reloading IPsec tunnel '{$phase1['descr']}'. Previous IP '{$old_gw}', current IP '{$rgip}'. Reloading policy");
 
 	$now = time();
 	$spdfile = tempnam("{$g['tmp_path']}", "spd.conf.reload.{$now}.");

--- a/usr/local/www/vpn_ipsec_mobile.php
+++ b/usr/local/www/vpn_ipsec_mobile.php
@@ -55,7 +55,6 @@ if (count($a_client)) {
 
 	$pconfig['user_source'] = $a_client['user_source'];
 	$pconfig['group_source'] = $a_client['group_source'];
-
 	$pconfig['pool_address'] = $a_client['pool_address'];
 	$pconfig['pool_netbits'] = $a_client['pool_netbits'];
 	$pconfig['net_list'] = $a_client['net_list'];
@@ -355,7 +354,8 @@ function login_banner_change() {
 						<td width="78%" class="vtable">
 							<?=gettext("Source"); ?>:&nbsp;&nbsp;
 							<select name="user_source" class="formselect" id="user_source">
-								<option value="system"><?=gettext("system"); ?></option>
+								<option value="<?=htmlspecialchars($pconfig['user_source']);?>"><?=gettext($pconfig['user_source']); ?></option>
+								<option value="system">System</option>
 							</select>
 						</td>
 					</tr>


### PR DESCRIPTION
/etc/inc/vpn.inc has been modified to create the required ldapcfg block in racoon.conf to allow xauth to use the ldap server and settings that are setup for the existing ldap server under system-> authentication servers.

/etc/inc/upgrade.inc has been changed to remove the accept the value of the field on the web page instead of just using the hard-coded 'system'
$config['ipsec']['client']['enable'] = $config['ipsec']['mobileclients']['user_source'];
//$config['ipsec']['client']['user_source'] = 'system';

/usr/local/www/vpn_ipsec_mobile.php has been modified to include ldap as an option for auth_source instead of just System to the select dialog.

Thanks,
