### PR TITLE
xAuth Ldap patch

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -1140,7 +1140,7 @@ function upgrade_046_to_047() {
 		if (isset($config['ipsec']['mobileclients']['enable'])) {
 			$config['ipsec']['client']['enable'] = true;
 			$config['ipsec']['client']['enable'] = $config['ipsec']['mobileclients']['user_source'];
-			//$config['ipsec']['client']['user_source'] = 'system';
+			\\$config['ipsec']['client']['user_source'] = 'system';
 			$config['ipsec']['client']['group_source'] = 'system';
 		}
 

--- a/etc/inc/vpn.inc
+++ b/etc/inc/vpn.inc
@@ -402,7 +402,7 @@ function vpn_ipsec_configure($ipchg = false)
 				$racoonconf .= "}\n\n";
 			}
 			/* end mode_cfg section */
-		
+
 			$authcfg =  $config['system']['authserver'][0];
 	
 			/* begin ldap_cfg */
@@ -418,7 +418,7 @@ function vpn_ipsec_configure($ipchg = false)
 			$racoonconf .= "\tbind_pw \"".$authcfg['ldap_bindpw']."\";\n";
 			$racoonconf .= "\tattr_user \"".$authcfg['ldap_attr_user']."\";\n";
 			$racoonconf .= "}\n\n";
-			
+
 			/* begin remote sections */
 			if (is_array($a_phase1) && count($a_phase1)) {
 				/* begin remote */

--- a/usr/local/www/vpn_ipsec_mobile.php
+++ b/usr/local/www/vpn_ipsec_mobile.php
@@ -55,6 +55,7 @@ if (count($a_client)) {
 
 	$pconfig['user_source'] = $a_client['user_source'];
 	$pconfig['group_source'] = $a_client['group_source'];
+
 	$pconfig['pool_address'] = $a_client['pool_address'];
 	$pconfig['pool_netbits'] = $a_client['pool_netbits'];
 	$pconfig['net_list'] = $a_client['net_list'];
@@ -354,8 +355,8 @@ function login_banner_change() {
 						<td width="78%" class="vtable">
 							<?=gettext("Source"); ?>:&nbsp;&nbsp;
 							<select name="user_source" class="formselect" id="user_source">
-								<option value="<?=htmlspecialchars($pconfig['user_source']);?>"><?=gettext($pconfig['user_source']); ?></option>
-								<option value="system">System</option>
+							<option value="<?=htmlspecialchars($pconfig['user_source']);?>"><?=gettext($pconfig['user_source']); ?></option>
+								<option value="system"><?=gettext("system"); ?></option>
 							</select>
 						</td>
 					</tr>


### PR DESCRIPTION
/etc/inc/vpn.inc has been modified to create the required ldapcfg block in racoon.conf to allow xauth to use the ldap server and settings that are setup for the existing ldap server under system-> authentication servers.

/etc/inc/upgrade.inc has been changed to remove the accept the value of the field on the web page instead of just using the hard-coded 'system'
$config['ipsec']['client']['enable'] = $config['ipsec']['mobileclients']['user_source'];
//$config['ipsec']['client']['user_source'] = 'system';

/usr/local/www/vpn_ipsec_mobile.php has been modified to include ldap as an option for auth_source instead of just System to the select dialog.

Thanks,
