### PR TITLE
load balance monitor type send/expect must have a '' when using more then

### DIFF
--- a/conf.default/config.xml
+++ b/conf.default/config.xml
@@ -733,7 +733,7 @@
 			<type>send</type>
 			<descr><![CDATA[Generic SMTP]]></descr>
 			<options>
-				<send>EHLO nosuchhost</send>
+				<send>'EHLO nosuchhost'</send>
 				<expect>250-</expect>
 			</options>
 		</monitor_type>


### PR DESCRIPTION
load balance monitor type send/expect must have a '' when using more then one argument.
