### PR TITLE
Declare $rtadvdifs as an array before it is used to prevent error on dhcpdv6 start up.

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -90,6 +90,7 @@ EOD;
 
 	/* Process all links which need the router advertise daemon */
 	$rtadvdnum = 0;
+	$rtadvdifs=array();
 	foreach ($dhcpdv6cfg as $dhcpv6if => $dhcpv6ifconf) {
 		if($dhcpv6ifconf['mode'] != "enable")
 			continue;


### PR DESCRIPTION
Let me know if this is not the way to do this.
