### PR TITLE
DHCP IPv4 / IPv6 next-server, filename, and root-path improvements.

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -516,8 +516,10 @@ EOD;
 
 		// net boot information
 		if(isset($dhcpifconf['netboot'])) {
-			if (($dhcpifconf['next-server'] <> "") && ($dhcpifconf['filename'] <> "")) {
-				$dhcpdconf .= "	next-server {$dhcpifconf['next-server']};\n";
+			if ($dhcpifconf['nextserver'] <> "") {
+				$dhcpdconf .= "	next-server {$dhcpifconf['nextserver']};\n";
+			}
+			if ($dhcpifconf['filename'] <> "") {
 				$dhcpdconf .= "	filename \"{$dhcpifconf['filename']}\";\n";
 			}
 			if ($dhcpifconf['rootpath'] <> "") {
@@ -548,8 +550,11 @@ EOD;
 					$dhhostname = str_replace(".", "_", $dhhostname);
 					$dhcpdconf .= "	option host-name \"{$dhhostname}\";\n";
 				}
-				if ($sm['netbootfile'])
-					$dhcpdconf .= "	filename \"{$sm['netbootfile']}\";\n";
+				if ($sm['filename'])
+					$dhcpdconf .= "	filename \"{$sm['filename']}\";\n";
+
+				if ($sm['rootpath'])
+					$dhcpdconf .= "	option root-path \"{$sm['rootpath']}\";\n";
 
 				$dhcpdconf .= "}\n";
 				$i++;
@@ -851,8 +856,10 @@ EOD;
 
 		// net boot information
 		if(isset($dhcpv6ifconf['netboot'])) {
-			if (($dhcpv6ifconf['next-server'] <> "") && ($dhcpv6ifconf['filename'] <> "")) {
-				$dhcpdv6conf .= "	next-server {$dhcpv6ifconf['next-server']};\n";
+			if ($dhcpv6ifconf['nextserver'] <> "") {
+				$dhcpdv6conf .= "	next-server {$dhcpv6ifconf['nextserver']};\n";
+			}
+			if ($dhcpv6ifconf['filename'] <> "") {
 				$dhcpdv6conf .= "	filename \"{$dhcpv6ifconf['filename']}\";\n";
 			}
 			if ($dhcpv6ifconf['rootpath'] <> "") {
@@ -862,6 +869,7 @@ EOD;
 		
 		$dhcpdv6conf .= <<<EOD
 }
+
 EOD;
 
 		/* add static mappings */
@@ -883,8 +891,11 @@ EOD;
 					$dhhostname = str_replace(".", "_", $dhhostname);
 					$dhcpdv6conf .= "	option host-name {$dhhostname};\n";
 				}
-				if ($sm['netbootfile'])
-					$dhcpdv6conf .= "	filename \"{$sm['netbootfile']}\";\n";
+				if ($sm['filename'])
+					$dhcpdv6conf .= "	filename \"{$sm['filename']}\";\n";
+
+				if ($sm['rootpath'])
+					$dhcpdv6conf .= "	option root-path \"{$sm['rootpath']}\";\n";
 
 				$dhcpdv6conf .= "}\n";
 				$i++;

--- a/usr/local/www/services_dhcp.php
+++ b/usr/local/www/services_dhcp.php
@@ -145,7 +145,7 @@ if (is_array($config['dhcpd'][$if])){
 	$pconfig['tftp'] = $config['dhcpd'][$if]['tftp'];
 	$pconfig['ldap'] = $config['dhcpd'][$if]['ldap'];
 	$pconfig['netboot'] = isset($config['dhcpd'][$if]['netboot']);
-	$pconfig['nextserver'] = $config['dhcpd'][$if]['next-server'];
+	$pconfig['nextserver'] = $config['dhcpd'][$if]['nextserver'];
 	$pconfig['filename'] = $config['dhcpd'][$if]['filename'];
 	$pconfig['rootpath'] = $config['dhcpd'][$if]['rootpath'];
 	$pconfig['failover_peerip'] = $config['dhcpd'][$if]['failover_peerip'];
@@ -367,7 +367,7 @@ if ($_POST) {
 		$config['dhcpd'][$if]['tftp'] = $_POST['tftp'];
 		$config['dhcpd'][$if]['ldap'] = $_POST['ldap'];
 		$config['dhcpd'][$if]['netboot'] = ($_POST['netboot']) ? true : false;
-		$config['dhcpd'][$if]['next-server'] = $_POST['nextserver'];
+		$config['dhcpd'][$if]['nextserver'] = $_POST['nextserver'];
 		$config['dhcpd'][$if]['filename'] = $_POST['filename'];
 		$config['dhcpd'][$if]['rootpath'] = $_POST['rootpath'];
 

--- a/usr/local/www/services_dhcp_edit.php
+++ b/usr/local/www/services_dhcp_edit.php
@@ -87,12 +87,14 @@ if (isset($id) && $a_maps[$id]) {
         $pconfig['mac'] = $a_maps[$id]['mac'];
 		$pconfig['hostname'] = $a_maps[$id]['hostname'];
         $pconfig['ipaddr'] = $a_maps[$id]['ipaddr'];
-	$pconfig['netbootfile'] = $a_maps[$id]['netbootfile'];
+	    $pconfig['filename'] = $a_maps[$id]['filename'];
+		$pconfig['rootpath'] = $a_maps[$id]['rootpath'];
         $pconfig['descr'] = $a_maps[$id]['descr'];
 } else {
         $pconfig['mac'] = $_GET['mac'];
 		$pconfig['hostname'] = $_GET['hostname'];
-	$pconfig['netbootfile'] = $_GET['netbootfile'];
+	    $pconfig['filename'] = $_GET['filename'];
+		$pconfig['rootpath'] = $_GET['rootpath'];
         $pconfig['descr'] = $_GET['descr'];
 }
 
@@ -166,7 +168,8 @@ if ($_POST) {
 		$mapent['ipaddr'] = $_POST['ipaddr'];
 		$mapent['hostname'] = $_POST['hostname'];
 		$mapent['descr'] = $_POST['descr'];
-		$mapent['netbootfile'] = $_POST['netbootfile'];
+		$mapent['filename'] = $_POST['filename'];
+		$mapent['rootpath'] = $_POST['rootpath'];
 
 		if (isset($id) && $a_maps[$id])
 			$a_maps[$id] = $mapent;
@@ -232,10 +235,16 @@ include("head.inc");
                 </tr>				
                 <?php if($netboot_enabled) { ?>
 		<tr>
-		  <td width="22%" valign="top" class="vncell">Netboot filename</td>
+		  <td width="22%" valign="top" class="vncell">Netboot Filename</td>
 		  <td width="78%" class="vtable">
-		    <input name="netbootfile" type="text" class="formfld unknown" id="netbootfile" size="20" value="<?=htmlspecialchars($pconfig['netbootfile']);?>">
+		    <input name="filename" type="text" class="formfld unknown" id="filename" size="20" value="<?=htmlspecialchars($pconfig['filename']);?>">
 		    <br> <span class="vexpl">Name of the file that should be loaded when this host boots off of the network, overrides setting on main page.</span></td>
+		</tr>
+		<tr>
+		  <td width="22%" valign="top" class="vncell">Root Path</td>
+		  <td width="78%" class="vtable">
+			<input name="rootpath" type="text" class="formfld unknown" id="rootpath" size="90" value="<?=htmlspecialchars($pconfig['rootpath']);?>">
+		    <br> <span class="vexpl"><?=gettext("Enter the"); ?> <b><?=gettext("root-path"); ?></b>-<?=gettext("string");?>, overrides setting on main page.</span></td>
 		</tr>
 		<?php } ?>
                 <tr> 

--- a/usr/local/www/services_dhcpv6.php
+++ b/usr/local/www/services_dhcpv6.php
@@ -113,7 +113,7 @@ if (is_array($config['dhcpdv6'][$if])){
 	$pconfig['tftp'] = $config['dhcpdv6'][$if]['tftp'];
 	$pconfig['ldap'] = $config['dhcpdv6'][$if]['ldap'];
 	$pconfig['netboot'] = isset($config['dhcpdv6'][$if]['netboot']);
-	$pconfig['nextserver'] = $config['dhcpdv6'][$if]['next-server'];
+	$pconfig['nextserver'] = $config['dhcpdv6'][$if]['nextserver'];
 	$pconfig['filename'] = $config['dhcpdv6'][$if]['filename'];
 	$pconfig['rootpath'] = $config['dhcpdv6'][$if]['rootpath'];
 	$pconfig['failover_peerip'] = $config['dhcpdv6'][$if]['failover_peerip'];
@@ -305,7 +305,7 @@ if ($_POST) {
 		$config['dhcpdv6'][$if]['tftp'] = $_POST['tftp'];
 		$config['dhcpdv6'][$if]['ldap'] = $_POST['ldap'];
 		$config['dhcpdv6'][$if]['netboot'] = ($_POST['netboot']) ? true : false;
-		$config['dhcpdv6'][$if]['next-server'] = $_POST['nextserver'];
+		$config['dhcpdv6'][$if]['nextserver'] = $_POST['nextserver'];
 		$config['dhcpdv6'][$if]['filename'] = $_POST['filename'];
 		$config['dhcpdv6'][$if]['rootpath'] = $_POST['rootpath'];
 

--- a/usr/local/www/services_dhcpv6_edit.php
+++ b/usr/local/www/services_dhcpv6_edit.php
@@ -87,12 +87,14 @@ if (isset($id) && $a_maps[$id]) {
         $pconfig['duid'] = $a_maps[$id]['duid'];
 	$pconfig['hostname'] = $a_maps[$id]['hostname'];
         $pconfig['ipaddrv6'] = $a_maps[$id]['ipaddrv6'];
-	$pconfig['netbootfile'] = $a_maps[$id]['netbootfile'];
+	$pconfig['filename'] = $a_maps[$id]['filename'];
+		$pconfig['rootpath'] = $a_maps[$id]['rootpath'];
         $pconfig['descr'] = $a_maps[$id]['descr'];
 } else {
         $pconfig['duid'] = $_GET['duid'];
 	$pconfig['hostname'] = $_GET['hostname'];
-	$pconfig['netbootfile'] = $_GET['netbootfile'];
+	$pconfig['filename'] = $_GET['filename'];
+		$pconfig['rootpath'] = $a_maps[$id]['rootpath'];
         $pconfig['descr'] = $_GET['descr'];
 }
 
@@ -148,7 +150,8 @@ if ($_POST) {
 		$mapent['ipaddrv6'] = $_POST['ipaddrv6'];
 		$mapent['hostname'] = $_POST['hostname'];
 		$mapent['descr'] = $_POST['descr'];
-		$mapent['netbootfile'] = $_POST['netbootfile'];
+		$mapent['filename'] = $_POST['filename'];
+		$mapent['rootpath'] = $_POST['rootpath'];
 
 		if (isset($id) && $a_maps[$id])
 			$a_maps[$id] = $mapent;
@@ -211,8 +214,14 @@ include("head.inc");
 		<tr>
 		  <td width="22%" valign="top" class="vncell">Netboot filename</td>
 		  <td width="78%" class="vtable">
-		    <input name="netbootfile" type="text" class="formfld unknown" id="netbootfile" size="28" value="<?=htmlspecialchars($pconfig['netbootfile']);?>">
+		    <input name="filename" type="text" class="formfld unknown" id="filename" size="28" value="<?=htmlspecialchars($pconfig['filename']);?>">
 		    <br> <span class="vexpl">Name of the file that should be loaded when this host boots off of the network, overrides setting on main page.</span></td>
+		</tr>
+		<tr>
+		  <td width="22%" valign="top" class="vncell">Root Path</td>
+		  <td width="78%" class="vtable">
+			<input name="rootpath" type="text" class="formfld unknown" id="rootpath" size="90" value="<?=htmlspecialchars($pconfig['rootpath']);?>">
+		    <br> <span class="vexpl"><?=gettext("Enter the"); ?> <b><?=gettext("root-path"); ?></b>-<?=gettext("string");?>, overrides setting on main page.</span></td>
 		</tr>
 		<?php } ?>
                 <tr> 


### PR DESCRIPTION
Hello.

In this patch we have :-

1) Rationalised the variables used for the next-server, filename, and root-path setup for the IPv4 and IPv6 DHCP server settings.
2) Allows you to set next-server only (filename and root-path are optional) in the global DHCP configuration.
3) Allows you to have a per host override for filename and root-path.

I hope this is all ok ?

TTFN Tony
