### PR TITLE
Fix for some "duplicate menues" with some themes. 

### DIFF
--- a/usr/local/www/themes/code-red/all.css
+++ b/usr/local/www/themes/code-red/all.css
@@ -434,8 +434,8 @@ table#marquee div#container div#scroller {
 
 #navigation li li a {
 	display: block;
-	padding-left: 10px;
-	padding-right: 10px;
+	padding-left: 5px;
+	margin-right: 10px;
 }
 
 #navigation ul li ul li a.navlnk:hover {

--- a/usr/local/www/themes/metallic/all.css
+++ b/usr/local/www/themes/metallic/all.css
@@ -413,8 +413,8 @@ table#marquee div#container div#scroller {
 
 #navigation li li a {
 	display: block;
-	padding-left: 10px;
-	padding-right: 10px;
+	padding-left: 5px;
+	margin-right: 10px;
 }
 
 #navigation ul li ul li a.navlnk:hover {

--- a/usr/local/www/themes/nervecenter/all.css
+++ b/usr/local/www/themes/nervecenter/all.css
@@ -436,8 +436,8 @@ table#marquee div#container div#scroller {
 
 #navigation li li a {
 	display: block;
-	padding-left: 10px;
-	padding-right: 10px;
+	padding-left: 5px;
+	margin-right: 10px;
 }
 
 #navigation ul li ul li a.navlnk:hover {

--- a/usr/local/www/themes/the_wall/all.css
+++ b/usr/local/www/themes/the_wall/all.css
@@ -445,8 +445,8 @@ table#marquee div#container div#scroller {
 /* textcolor in dropdownmenu */
 #navigation li li a {
 	display: block;
-	padding-left: 10px;
-	padding-right: 10px;
+	padding-left: 5px;
+	margin-right: 10px;
 	color: #000000;
 }
 /* textcolor mouseover in dropdownmenu */


### PR DESCRIPTION
Reference: http://redmine.pfsense.org/issues/2037
I just changed some padding/margin in the CSS in order to avoid wrapping the menu.
Tested with Firefox 8, Chrome 15.0.874.121 and IE 9.
