### PR TITLE
Add support for posix groups to LDAP auth

### DIFF
--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -872,78 +872,65 @@ function ldap_get_groups($username, $authcfg) {
 
 
 	/* Search function depends on configured search depth. */
-	if ( $ldapscope == "one" )
-	{
+	if ($ldapscope == "one") {
 		$ldapfunc = "ldap_list";
-	}
-    else
-	{
+	} else {
 		$ldapfunc = "ldap_search";
 	}
 
 	/* Search method is different if group container(s) are specified. */
-	if ( $ldapauthgroupcont != '' )
-	{
+	if ($ldapauthgroupcont != '') {
 		/*
 		 * Search for groups using the group container(s).
 		 */
 
 		/* Get LDAP Groupcontainers and split them up. */
-		$ldap_groupcontainers = split( ";", $ldapauthgroupcont );
+		$ldap_groupcontainers = split(";", $ldapauthgroupcont);
 
 		$ldapfilter = "({$ldapmemberattribute}={$username})";
 
 		/* Search each group container for the authenticating user. */
-		foreach ( $ldap_groupcontainers as $ldap_groupcontainer )
-		{
+		foreach ($ldap_groupcontainers as $ldap_groupcontainer) {
 			/* Support legacy auth container specification. */
-			if ( stristr ( $ldap_groupcontainer, "DC=" ) || empty ( $ldapbasedn ) )
-			{
+			if (stristr($ldap_groupcontainer, "DC=") || empty($ldapbasedn)) {
 				$searchbase = $ldap_groupcontainer;
-			}
-			else
-			{
+			} else {
 				$searchbase = "{$ldap_groupcontainer},{$ldapbasedn}";
 			}
 
-			log_error ( "Now searching (new) '$searchbase' for '$ldapgroupattribute' filtered by '$ldapfilter'" );
+			log_error ("Now searching (new) '$searchbase' for '$ldapgroupattribute' filtered by '$ldapfilter'");
 
 			/* Search this group container in the LDAP directory to find any groups listing the authenticating user as a member. */
-			$search	= @$ldapfunc( $ldap, $searchbase, $ldapfilter, array ( $ldapgroupattribute ) );
+			$search	= @$ldapfunc($ldap, $searchbase, $ldapfilter, array($ldapgroupattribute));
 
-			if ( false === $search)
-			{
+			if (false === $search) {
 				/* Search failed (i.e. not simply no records found), so log an error. */
-				log_error ( "LDAP authentication : Search for user groups resulted in error: " . ldap_error ( $ldap ) );
-			}
-			else
-			{
+				log_error ("LDAP authentication : Search for user groups resulted in error: " . ldap_error($ldap));
+			} else {
 				/* Get the search results that were returned from the LDAP directory. */
-				$info = @ldap_get_entries( $ldap, $search );
+				$info = @ldap_get_entries($ldap, $search);
 
 				/*
 				 * Remove the 'count' element from these	 to allow 'foreach' iteration over results.
 				*/
-				unset ( $info[ "count" ] );
+				unset ($info[ "count" ]);
 
 				/* Add any groups found for the authenticating user to $memberof. */
-				foreach ( $info as $groupdata )
+				foreach ($info as $groupdata)
 				{
-					$memberof[] = $groupdata[ $ldapgroupattribute ][ 0 ];
+					$memberof[] = $groupdata[$ldapgroupattribute][0];
 //					log_error ( "DEGUG : Groups - '$username' is a member of '" . $groupdata[ $ldapgroupattribute ][ 0 ] . "'" );
 				}
 			}
 		}
-	}
-	else
-	{
+	} else {
 		/*
 		 * Original search: Search for groups within the user record DN that was found.
 		 */
 
-		log_error ( "Now searching(old) '$ldapdn' for '$ldapmemberattribute' filtered by '$ldapfilter'" );
-		$search    = @$ldapfunc( $ldap, $ldapdn, $ldapfilter, array ( $ldapmemberattribute ) );
-		$info      = @ldap_get_entries( $ldap, $search );
+		log_error ("Now searching(old) '$ldapdn' for '$ldapmemberattribute' filtered by '$ldapfilter'");
+		$search    = @$ldapfunc($ldap, $ldapdn, $ldapfilter, array($ldapmemberattribute));
+		$info      = @ldap_get_entries($ldap, $search);
 
 		$countem = $info["count"];	
 		

--- a/usr/local/www/system_authservers.php
+++ b/usr/local/www/system_authservers.php
@@ -2,7 +2,7 @@
 /*
     system_authservers.php
 
-    Copyright (C) 2010 Ermal LuÁi
+    Copyright (C) 2010 Ermal Lu√Åi
     Copyright (C) 2008 Shrew Soft Inc.
     All rights reserved.
 
@@ -365,7 +365,7 @@ function radius_srvcschange(){
 	}
 }
 
-function select_clicked( container ) {
+function select_clicked(container) {
 	if (document.getElementById("ldap_port").value == '' ||
 	    document.getElementById("ldap_host").value == '' ||
 	    document.getElementById("ldap_scope").value == '' ||
@@ -389,8 +389,8 @@ function select_clicked( container ) {
         url += '&bindpw=' + document.getElementById("ldap_bindpw").value;
         url += '&urltype=' + document.getElementById("ldap_urltype").value;
         url += '&proto=' + document.getElementById("ldap_protver").value;
-	url += '&authcn=' + document.getElementById( container ).value;
-url += '&cnitem=' + container;
+	    url += '&authcn=' + document.getElementById(container).value;
+        url += '&cnitem=' + container;
 
         var oWin = window.open(url,"pfSensePop","width=620,height=400,top=150,left=150");
         if (oWin==null || typeof(oWin)=="undefined")

--- a/usr/local/www/system_usermanager_settings_ldapacpicker.php
+++ b/usr/local/www/system_usermanager_settings_ldapacpicker.php
@@ -74,16 +74,16 @@ if($_GET) {
             </STYLE>
         </head>
 <script language="JavaScript">
-function post_choices( container ) {
+function post_choices(container) {
 
 	var ous = <?php echo count($ous); ?>;
 	var i;
-		opener.document.getElementById( container ).value="";
+		opener.document.getElementById(container).value="";
 	for (i = 0; i < ous; i++) {
 		if (document.forms[0].ou[i].checked) {
-			if (opener.document.getElementById( container ).value != "")
-				opener.document.getElementById( container ).value+=";";
-			opener.document.getElementById( container ).value+=document.forms[0].ou[i].value;
+			if (opener.document.getElementById(container).value != "")
+				opener.document.getElementById(container).value+=";";
+			opener.document.getElementById(container).value+=document.forms[0].ou[i].value;
 		}
 	}
 	window.close();


### PR DESCRIPTION
The changes to:

/etc/inc/auth.inc
/usr/local/www/system_authservers.php
/usr/local/www/system_usermanager_settings_ldapacpicker.php

allow an ldap container to be used to provide user group membership information.

For example, ou=Groups,dc=localdomain can be used as a container for a set of posixGroup items that define groups and group membership (via the memberUid attribute, for example).

These changes are compatible with 2.0-RELEASE and have been tested against OpenLDAP running under CentOS 6.0. The original group membership method is still supported, but I do not have a suitable system to test this. Also known to work with OpenVPN under pfSense.
