### PR TITLE
Add support for posix groups to LDAP auth [Resubmit]

### DIFF
--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -1,7 +1,7 @@
 <?php
 /* $Id$ */
 /*
-	Copyright (C) 2010 Ermal Luçi
+	Copyright (C) 2010 Ermal LuÃi
 	All rights reserved.
 
 	Copyright (C) 2007, 2008 Scott Ullrich <sullrich@gmail.com>
@@ -815,8 +815,10 @@ function ldap_get_groups($username, $authcfg) {
                 $ldapbindun         = $authcfg['ldap_binddn'];
                 $ldapbindpw         = $authcfg['ldap_bindpw'];
                 $ldapauthcont       = $authcfg['ldap_authcn'];
+				$ldapauthgroupcont  = $authcfg['ldap_authgroupcn'];
                 $ldapnameattribute  = strtolower($authcfg['ldap_attr_user']);
-                $ldapgroupattribute  = strtolower($authcfg['ldap_attr_member']);
+				$ldapgroupattribute = strtolower($authcfg['ldap_attr_group']);
+                $ldapmemberattribute= strtolower($authcfg['ldap_attr_member']);
                 $ldapfilter         = "({$ldapnameattribute}={$username})";
                 $ldaptype           = "";
                 $ldapver            = $authcfg['ldap_protver'];
@@ -833,7 +835,9 @@ function ldap_get_groups($username, $authcfg) {
 	$ldapdn             = $_SESSION['ldapdn'];
 
 	/*Convert attribute to lowercase.  php ldap arrays put everything in lowercase */
-	$ldapgroupattribute = strtolower($ldapgroupattribute);
+	$ldapgroupattribute		= strtolower( $ldapgroupattribute	);
+	$ldapmemberattribute	= strtolower( $ldapmemberattribute	);
+
 	$memberof = array();
 
 	/* connect and see if server is up */
@@ -866,30 +870,94 @@ function ldap_get_groups($username, $authcfg) {
 		return memberof;
 	}
 
-	/* get groups from DN found */
-	/* use ldap_read instead of search so we don't have to do a bunch of extra work */
-	/* since we know the DN is in $_SESSION['ldapdn'] */
-	//$search    = ldap_read($ldap, $ldapdn, "(objectclass=*)", array($ldapgroupattribute));
-	if ($ldapscope == "one")
-                $ldapfunc = "ldap_list";
-        else
-                $ldapfunc = "ldap_search";
 
-	$search    = @$ldapfunc($ldap, $ldapdn, $ldapfilter, array($ldapgroupattribute));
-	$info      = @ldap_get_entries($ldap, $search);
+	/* Search function depends on configured search depth. */
+	if ( $ldapscope == "one" )
+	{
+		$ldapfunc = "ldap_list";
+	}
+    else
+	{
+		$ldapfunc = "ldap_search";
+	}
 
-	$countem = $info["count"];	
-	
-	if(is_array($info[0][$ldapgroupattribute])) {
-		/* Iterate through the groups and throw them into an array */
-		foreach ($info[0][$ldapgroupattribute] as $member) {
-			if (stristr($member, "CN=") !== false) {
-				$membersplit = split(",", $member);
-				$memberof[] = preg_replace("/CN=/i", "", $membersplit[0]);
+	/* Search method is different if group container(s) are specified. */
+	if ( $ldapauthgroupcont != '' )
+	{
+		/*
+		 * Search for groups using the group container(s).
+		 */
+
+		/* Get LDAP Groupcontainers and split them up. */
+		$ldap_groupcontainers = split( ";", $ldapauthgroupcont );
+
+//		$ldapfilter = "({$ldapmemberattribute}={$username})";
+
+		/* Search each group container for the authenticating user. */
+		foreach ( $ldap_groupcontainers as $ldap_groupcontainer )
+		{
+			/* Support legacy auth container specification. */
+			if ( stristr ( $ldap_groupcontainer, "DC=" ) || empty ( $ldapbasedn ) )
+			{
+				$searchbase = $ldap_groupcontainer;
+			}
+			else
+			{
+				$searchbase = "{$ldap_groupcontainer},{$ldapbasedn}";
+			}
+
+			log_error ( "Now searching (new) '$searchbase' for '$ldapgroupattribute' filtered by '$ldapfilter'" );
+
+			/* Search this group container in the LDAP directory to find any groups listing the authenticating user as a member. */
+			$search	= @$ldapfunc( $ldap, $searchbase, $ldapfilter, array ( $ldapgroupattribute ) );
+
+			if ( false === $search)
+			{
+				/* Search failed (i.e. not simply no records found), so log an error. */
+				log_error ( "LDAP authentication : Search for user groups resulted in error: " . ldap_error ( $ldap ) );
+			}
+			else
+			{
+				/* Get the search results that were returned from the LDAP directory. */
+				$info = @ldap_get_entries( $ldap, $search );
+
+				/*
+				 * Remove the 'count' element from these	 to allow 'foreach' iteration over results.
+				*/
+				unset ( $info[ "count" ] );
+
+				/* Add any groups found for the authenticating user to $memberof. */
+				foreach ( $info as $groupdata )
+				{
+					$memberof[] = $groupdata[ $ldapgroupattribute ][ 0 ];
+//					log_error ( "DEGUG : Groups - '$username' is a member of '" . $groupdata[ $ldapgroupattribute ][ 0 ] . "'" );
+				}
 			}
 		}
 	}
-	
+	else
+	{
+		/*
+		 * Original search: Search for groups within the user record DN that was found.
+		 */
+
+		log_error ( "Now searching(old) '$ldapdn' for '$ldapmemberattribute' filtered by '$ldapfilter'" );
+		$search    = @$ldapfunc( $ldap, $ldapdn, $ldapfilter, array ( $ldapmemberattribute ) );
+		$info      = @ldap_get_entries( $ldap, $search );
+
+		$countem = $info["count"];	
+		
+		if(is_array($info[0][$ldapmemberattribute])) {
+			/* Iterate through the groups and throw them into an array */
+			foreach ($info[0][$ldapmemberattribute] as $member) {
+				if (stristr($member, "CN=") !== false) {
+					$membersplit = split(",", $member);
+					$memberof[] = preg_replace("/CN=/i", "", $membersplit[0]);
+				}
+			}
+		}
+	}
+
 	/* Time to close LDAP connection */
 	@ldap_unbind($ldap);
 	

--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -891,7 +891,7 @@ function ldap_get_groups($username, $authcfg) {
 		/* Get LDAP Groupcontainers and split them up. */
 		$ldap_groupcontainers = split( ";", $ldapauthgroupcont );
 
-//		$ldapfilter = "({$ldapmemberattribute}={$username})";
+		$ldapfilter = "({$ldapmemberattribute}={$username})";
 
 		/* Search each group container for the authenticating user. */
 		foreach ( $ldap_groupcontainers as $ldap_groupcontainer )

--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -872,78 +872,65 @@ function ldap_get_groups($username, $authcfg) {
 
 
 	/* Search function depends on configured search depth. */
-	if ( $ldapscope == "one" )
-	{
+	if ($ldapscope == "one") {
 		$ldapfunc = "ldap_list";
-	}
-    else
-	{
+	} else {
 		$ldapfunc = "ldap_search";
 	}
 
 	/* Search method is different if group container(s) are specified. */
-	if ( $ldapauthgroupcont != '' )
-	{
+	if ($ldapauthgroupcont != '') {
 		/*
 		 * Search for groups using the group container(s).
 		 */
 
 		/* Get LDAP Groupcontainers and split them up. */
-		$ldap_groupcontainers = split( ";", $ldapauthgroupcont );
+		$ldap_groupcontainers = split(";", $ldapauthgroupcont);
 
 		$ldapfilter = "({$ldapmemberattribute}={$username})";
 
 		/* Search each group container for the authenticating user. */
-		foreach ( $ldap_groupcontainers as $ldap_groupcontainer )
-		{
+		foreach ($ldap_groupcontainers as $ldap_groupcontainer) {
 			/* Support legacy auth container specification. */
-			if ( stristr ( $ldap_groupcontainer, "DC=" ) || empty ( $ldapbasedn ) )
-			{
+			if (stristr($ldap_groupcontainer, "DC=") || empty($ldapbasedn)) {
 				$searchbase = $ldap_groupcontainer;
-			}
-			else
-			{
+			} else {
 				$searchbase = "{$ldap_groupcontainer},{$ldapbasedn}";
 			}
 
-			log_error ( "Now searching (new) '$searchbase' for '$ldapgroupattribute' filtered by '$ldapfilter'" );
+			log_error ("Now searching (new) '$searchbase' for '$ldapgroupattribute' filtered by '$ldapfilter'");
 
 			/* Search this group container in the LDAP directory to find any groups listing the authenticating user as a member. */
-			$search	= @$ldapfunc( $ldap, $searchbase, $ldapfilter, array ( $ldapgroupattribute ) );
+			$search	= @$ldapfunc($ldap, $searchbase, $ldapfilter, array($ldapgroupattribute));
 
-			if ( false === $search)
-			{
+			if (false === $search) {
 				/* Search failed (i.e. not simply no records found), so log an error. */
-				log_error ( "LDAP authentication : Search for user groups resulted in error: " . ldap_error ( $ldap ) );
-			}
-			else
-			{
+				log_error ("LDAP authentication : Search for user groups resulted in error: " . ldap_error($ldap));
+			} else {
 				/* Get the search results that were returned from the LDAP directory. */
-				$info = @ldap_get_entries( $ldap, $search );
+				$info = @ldap_get_entries($ldap, $search);
 
 				/*
 				 * Remove the 'count' element from these	 to allow 'foreach' iteration over results.
 				*/
-				unset ( $info[ "count" ] );
+				unset ($info[ "count" ]);
 
 				/* Add any groups found for the authenticating user to $memberof. */
-				foreach ( $info as $groupdata )
+				foreach ($info as $groupdata)
 				{
-					$memberof[] = $groupdata[ $ldapgroupattribute ][ 0 ];
+					$memberof[] = $groupdata[$ldapgroupattribute][0];
 //					log_error ( "DEGUG : Groups - '$username' is a member of '" . $groupdata[ $ldapgroupattribute ][ 0 ] . "'" );
 				}
 			}
 		}
-	}
-	else
-	{
+	} else {
 		/*
 		 * Original search: Search for groups within the user record DN that was found.
 		 */
 
-		log_error ( "Now searching(old) '$ldapdn' for '$ldapmemberattribute' filtered by '$ldapfilter'" );
-		$search    = @$ldapfunc( $ldap, $ldapdn, $ldapfilter, array ( $ldapmemberattribute ) );
-		$info      = @ldap_get_entries( $ldap, $search );
+		log_error ("Now searching(old) '$ldapdn' for '$ldapmemberattribute' filtered by '$ldapfilter'");
+		$search    = @$ldapfunc($ldap, $ldapdn, $ldapfilter, array($ldapmemberattribute));
+		$info      = @ldap_get_entries($ldap, $search);
 
 		$countem = $info["count"];	
 		

--- a/usr/local/www/system_authservers.php
+++ b/usr/local/www/system_authservers.php
@@ -94,6 +94,7 @@ if ($act == "edit") {
 			$pconfig['ldap_scope'] = $a_server[$id]['ldap_scope'];
 			$pconfig['ldap_basedn'] = $a_server[$id]['ldap_basedn'];
 			$pconfig['ldap_authcn'] = $a_server[$id]['ldap_authcn'];
+			$pconfig['ldap_authgroupcn'] = $a_server[$id]['ldap_authgroupcn'];
 			$pconfig['ldap_binddn'] = $a_server[$id]['ldap_binddn'];
 			$pconfig['ldap_bindpw'] = $a_server[$id]['ldap_bindpw'];
 			$pconfig['ldap_attr_user'] = $a_server[$id]['ldap_attr_user'];
@@ -229,6 +230,7 @@ if ($_POST) {
 			$server['ldap_scope'] = $pconfig['ldap_scope'];
 			$server['ldap_basedn'] = $pconfig['ldap_basedn'];
 			$server['ldap_authcn'] = $pconfig['ldapauthcontainers'];
+			$server['ldap_authgroupcn'] = $pconfig['ldapauthgroupcontainers'];
 			$server['ldap_attr_user'] = $pconfig['ldap_attr_user'];
 			$server['ldap_attr_group'] = $pconfig['ldap_attr_group'];
 			$server['ldap_attr_member'] = $pconfig['ldap_attr_member'];
@@ -363,12 +365,11 @@ function radius_srvcschange(){
 	}
 }
 
-function select_clicked() {
+function select_clicked( container ) {
 	if (document.getElementById("ldap_port").value == '' ||
 	    document.getElementById("ldap_host").value == '' ||
 	    document.getElementById("ldap_scope").value == '' ||
-	    document.getElementById("ldap_basedn").value == '' ||
-	    document.getElementById("ldapauthcontainers").value == '') {
+	    document.getElementById("ldap_basedn").value == '' ) {
 		alert("<?=gettext("Please fill the required values.");?>");
 		return;
 	}
@@ -388,7 +389,8 @@ function select_clicked() {
         url += '&bindpw=' + document.getElementById("ldap_bindpw").value;
         url += '&urltype=' + document.getElementById("ldap_urltype").value;
         url += '&proto=' + document.getElementById("ldap_protver").value;
-	url += '&authcn=' + document.getElementById("ldapauthcontainers").value;
+	url += '&authcn=' + document.getElementById( container ).value;
+url += '&cnitem=' + container;
 
         var oWin = window.open(url,"pfSensePop","width=620,height=400,top=150,left=150");
         if (oWin==null || typeof(oWin)=="undefined")
@@ -538,16 +540,35 @@ function select_clicked() {
 							<td width="22%" valign="top" class="vncellreq"><?=gettext("Authentication containers");?></td>
 							<td width="78%" class="vtable">
 								<table border="0" cellspacing="0" cellpadding="2">
-									<tr>
-										<td><?=gettext("Containers:");?> &nbsp;</td>
+<tr>
+<td></td>
+<td>
+      <?=gettext("NOTE: Semi-Colon separated. This will be prepended to the search base dn above or you can specify full container path.");?>
+<br /><?=gettext("EXAMPLE: CN=Users;DC=example");?>
+<br /><?=gettext("EXAMPLE: CN=Users,DC=example,DC=com;OU=OtherUsers,DC=example,DC=com ");?>
+</td>
+</tr>
+<tr>
+										<td><?=gettext("Users:");?> &nbsp;</td>
 										<td>
 											<input name="ldapauthcontainers" type="text" class="formfld unknown" id="ldapauthcontainers" size="40" value="<?=htmlspecialchars($pconfig['ldap_authcn']);?>"/>
-											<input type="button" onClick="select_clicked();" value="<?=gettext("Select");?>">
-											<br /><?=gettext("NOTE: Semi-Colon separated. This will be prepended to the search base dn above or you can specify full container path.");?>
-											<br /><?=gettext("EXAMPLE: CN=Users;DC=example");?>
-											<br /><?=gettext("EXAMPLE: CN=Users,DC=example,DC=com;OU=OtherUsers,DC=example,DC=com ");?>
+											<input type="button" onClick="select_clicked('ldapauthcontainers');" value="<?=gettext("Select");?>">
 										</td>
 									</tr>
+<tr>
+<td></td>
+<td>
+<?=gettext("NOTE: Leave the following empty if group information is stored");?>
+<br /><?=gettext("within an attribute of the user's DN record.");?>
+</td>
+</tr>
+<tr>
+	<td><?=gettext("Groups:");?> &nbsp;</td>
+	<td>
+		<input name="ldapauthgroupcontainers" type="text" class="formfld unknown" id="ldapauthgroupcontainers" size="40" value="<?=htmlspecialchars($pconfig['ldap_authgroupcn']);?>"/>
+		<input type="button" onClick="select_clicked('ldapauthgroupcontainers');" value="<?=gettext("Select");?>">
+	</td>
+</tr>
 								</table>
 							</td>
 						</tr>

--- a/usr/local/www/system_authservers.php
+++ b/usr/local/www/system_authservers.php
@@ -2,7 +2,7 @@
 /*
     system_authservers.php
 
-    Copyright (C) 2010 Ermal LuÁi
+    Copyright (C) 2010 Ermal Lu√Åi
     Copyright (C) 2008 Shrew Soft Inc.
     All rights reserved.
 
@@ -365,7 +365,7 @@ function radius_srvcschange(){
 	}
 }
 
-function select_clicked( container ) {
+function select_clicked(container) {
 	if (document.getElementById("ldap_port").value == '' ||
 	    document.getElementById("ldap_host").value == '' ||
 	    document.getElementById("ldap_scope").value == '' ||
@@ -389,8 +389,8 @@ function select_clicked( container ) {
         url += '&bindpw=' + document.getElementById("ldap_bindpw").value;
         url += '&urltype=' + document.getElementById("ldap_urltype").value;
         url += '&proto=' + document.getElementById("ldap_protver").value;
-	url += '&authcn=' + document.getElementById( container ).value;
-url += '&cnitem=' + container;
+	    url += '&authcn=' + document.getElementById(container).value;
+        url += '&cnitem=' + container;
 
         var oWin = window.open(url,"pfSensePop","width=620,height=400,top=150,left=150");
         if (oWin==null || typeof(oWin)=="undefined")

--- a/usr/local/www/system_authservers.php
+++ b/usr/local/www/system_authservers.php
@@ -540,35 +540,35 @@ url += '&cnitem=' + container;
 							<td width="22%" valign="top" class="vncellreq"><?=gettext("Authentication containers");?></td>
 							<td width="78%" class="vtable">
 								<table border="0" cellspacing="0" cellpadding="2">
-<tr>
-<td></td>
-<td>
-      <?=gettext("NOTE: Semi-Colon separated. This will be prepended to the search base dn above or you can specify full container path.");?>
-<br /><?=gettext("EXAMPLE: CN=Users;DC=example");?>
-<br /><?=gettext("EXAMPLE: CN=Users,DC=example,DC=com;OU=OtherUsers,DC=example,DC=com ");?>
-</td>
-</tr>
-<tr>
+									<tr>
+										<td></td>
+										<td>
+											<?=gettext("NOTE: Semi-Colon separated. This will be prepended to the search base dn above or you can specify full container path.");?>
+											<br /><?=gettext("EXAMPLE: CN=Users;DC=example");?>
+											<br /><?=gettext("EXAMPLE: CN=Users,DC=example,DC=com;OU=OtherUsers,DC=example,DC=com ");?>
+										</td>
+									</tr>
+									<tr>
 										<td><?=gettext("Users:");?> &nbsp;</td>
 										<td>
 											<input name="ldapauthcontainers" type="text" class="formfld unknown" id="ldapauthcontainers" size="40" value="<?=htmlspecialchars($pconfig['ldap_authcn']);?>"/>
 											<input type="button" onClick="select_clicked('ldapauthcontainers');" value="<?=gettext("Select");?>">
 										</td>
 									</tr>
-<tr>
-<td></td>
-<td>
-<?=gettext("NOTE: Leave the following empty if group information is stored");?>
-<br /><?=gettext("within an attribute of the user's DN record.");?>
-</td>
-</tr>
-<tr>
-	<td><?=gettext("Groups:");?> &nbsp;</td>
-	<td>
-		<input name="ldapauthgroupcontainers" type="text" class="formfld unknown" id="ldapauthgroupcontainers" size="40" value="<?=htmlspecialchars($pconfig['ldap_authgroupcn']);?>"/>
-		<input type="button" onClick="select_clicked('ldapauthgroupcontainers');" value="<?=gettext("Select");?>">
-	</td>
-</tr>
+									<tr>
+										<td></td>
+										<td>
+											<?=gettext("NOTE: Leave the following empty if group information is stored");?>
+											<br /><?=gettext("within an attribute of the user's DN record.");?>
+										</td>
+									</tr>
+									<tr>
+										<td><?=gettext("Groups:");?> &nbsp;</td>
+										<td>
+											<input name="ldapauthgroupcontainers" type="text" class="formfld unknown" id="ldapauthgroupcontainers" size="40" value="<?=htmlspecialchars($pconfig['ldap_authgroupcn']);?>"/>
+											<input type="button" onClick="select_clicked('ldapauthgroupcontainers');" value="<?=gettext("Select");?>">
+										</td>
+									</tr>
 								</table>
 							</td>
 						</tr>

--- a/usr/local/www/system_usermanager_settings_ldapacpicker.php
+++ b/usr/local/www/system_usermanager_settings_ldapacpicker.php
@@ -47,6 +47,7 @@ if($_GET) {
 	$authcfg['ldap_urltype'] = $_GET['urltype'];
 	$authcfg['ldap_protver'] = $_GET['proto'];
 	$authcfg['ldap_authcn'] = explode(";", $_GET['authcn']);
+	$authcfg['ldap_authcnitem'] = $_GET['cnitem'];
 	$ous = ldap_get_user_ous(true, $authcfg);
 }
 
@@ -73,16 +74,16 @@ if($_GET) {
             </STYLE>
         </head>
 <script language="JavaScript">
-function post_choices() {
+function post_choices( container ) {
 
 	var ous = <?php echo count($ous); ?>;
 	var i;
-		opener.document.forms[0].ldapauthcontainers.value="";
+		opener.document.getElementById( container ).value="";
 	for (i = 0; i < ous; i++) {
 		if (document.forms[0].ou[i].checked) {
-			if (opener.document.forms[0].ldapauthcontainers.value != "")
-				opener.document.forms[0].ldapauthcontainers.value+=";";
-			opener.document.forms[0].ldapauthcontainers.value+=document.forms[0].ou[i].value;
+			if (opener.document.getElementById( container ).value != "")
+				opener.document.getElementById( container ).value+=";";
+			opener.document.getElementById( container ).value+=document.forms[0].ou[i].value;
 		}
 	}
 	window.close();
@@ -120,7 +121,9 @@ function post_choices() {
 
 	<p/>
 
-	<input type='button' value='<?=gettext("Save");?>' onClick="post_choices();">
+<?php
+	echo "<input type='button' value='Save' onClick=\"post_choices( '{$authcfg['ldap_authcnitem']}' );\"";
+?>
 <?php endif; ?>
  </form>
  </body>

--- a/usr/local/www/system_usermanager_settings_ldapacpicker.php
+++ b/usr/local/www/system_usermanager_settings_ldapacpicker.php
@@ -74,16 +74,16 @@ if($_GET) {
             </STYLE>
         </head>
 <script language="JavaScript">
-function post_choices( container ) {
+function post_choices(container) {
 
 	var ous = <?php echo count($ous); ?>;
 	var i;
-		opener.document.getElementById( container ).value="";
+		opener.document.getElementById(container).value="";
 	for (i = 0; i < ous; i++) {
 		if (document.forms[0].ou[i].checked) {
-			if (opener.document.getElementById( container ).value != "")
-				opener.document.getElementById( container ).value+=";";
-			opener.document.getElementById( container ).value+=document.forms[0].ou[i].value;
+			if (opener.document.getElementById(container).value != "")
+				opener.document.getElementById(container).value+=";";
+			opener.document.getElementById(container).value+=document.forms[0].ou[i].value;
 		}
 	}
 	window.close();


### PR DESCRIPTION
The changes to:

/etc/inc/auth.inc
/usr/local/www/system_authservers.php
/usr/local/www/system_usermanager_settings_ldapacpicker.php

allow an ldap container to be used to provide user group membership information.

For example, ou=Groups,dc=localdomain can be used as a container for a set of posixGroup items that define groups and group membership (via the memberUid attribute, for example).

These changes are compatible with 2.0-RELEASE and have been tested against OpenLDAP running under CentOS 6.0. The original group membership method is still supported, but I do not have a suitable system to test this. Also known to work with OpenVPN under pfSense.
