### PR TITLE
Fixed problem with "mode" is required when AP is selected since without ...

### DIFF
--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -561,8 +561,8 @@ if ($_POST['apply']) {
 		$input_errors[] = gettext("The MSS must be greater than 576 bytes.");
 	/* Wireless interface? */
 	if (isset($wancfg['wireless'])) {
-		$reqdfields = "mode";
-		if($_POST['mode'] == 'hostap') { $reqdfields += " ssid"; }
+		$reqdfields = array("mode");
+		if($_POST['mode'] == 'hostap') { $reqdfields[] = "ssid"; }
 		$reqdfields = explode(" ", $reqdfields);
 		$reqdfieldsn = array(gettext("Mode"),gettext("SSID"));
 		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);


### PR DESCRIPTION
Fixed problem with "mode" is required when AP is selected since without whitespace the string can't be exploded
