### PR TITLE
Fixed problem with "mode" is required when AP is selected since without ...

### DIFF
--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -563,7 +563,6 @@ if ($_POST['apply']) {
 	if (isset($wancfg['wireless'])) {
 		$reqdfields = "mode";
 		if($_POST['mode'] == 'hostap') { $reqdfields += " ssid"; }
-		$reqdfields = explode(" ", $reqdfields);
 		$reqdfieldsn = array(gettext("Mode"),gettext("SSID"));
 		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
 		check_wireless_mode();


### PR DESCRIPTION
Fixed problem with "mode" is required when AP is selected since without whitespace the string can't be exploded
