### PR TITLE
Fix for White Space causing an error with Wifi Mode 

### DIFF
--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -561,9 +561,8 @@ if ($_POST['apply']) {
 		$input_errors[] = gettext("The MSS must be greater than 576 bytes.");
 	/* Wireless interface? */
 	if (isset($wancfg['wireless'])) {
-		$reqdfields = "mode";
-		if($_POST['mode'] == 'hostap') { $reqdfields += " ssid"; }
-		$reqdfields = explode(" ", $reqdfields);
+		$reqdfields = array("mode");
+		if($_POST['mode'] == 'hostap') { array_push($reqdfields, "ssid") }
 		$reqdfieldsn = array(gettext("Mode"),gettext("SSID"));
 		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
 		check_wireless_mode();


### PR DESCRIPTION
A friend of mine was having the same issue that was stated in another pull request with the explode function and white space that was never pulled. So when you commit changes on WLAN would throw and error stating MODE must have SSID set. Dropped the explode function all together, initialized the array first and then pushed the SSID onto the array if Mode is set to Access in your wireless configuration. No more Mode set issue. :D
