### PR TITLE
Remove the -S $SRCIP to ping and added a timeout.

### DIFF
--- a/usr/local/bin/ping_hosts.sh
+++ b/usr/local/bin/ping_hosts.sh
@@ -75,7 +75,7 @@ for TOPING in $PINGHOSTS ; do
 	fi
 	echo Processing $DSTIP
 	# Look for a service being down
-	$PINGCMD -c $COUNT -S $SRCIP $DSTIP
+	$PINGCMD -c $COUNT -t 2 $DSTIP
 	if [ $? -eq 0 ]; then
 		# Host is up
 		# Read in previous status
@@ -104,7 +104,7 @@ for TOPING in $PINGHOSTS ; do
 	fi
 	echo "Checking ping time $DSTIP"
 	# Look at ping values themselves
-	PINGTIME=`$PINGCMD -c 1 -S $SRCIP $DSTIP | awk '{ print $7 }' | grep time | cut -d "=" -f2`
+	PINGTIME=`$PINGCMD -c 1 -t 2 $DSTIP | awk '{ print $7 }' | grep time | cut -d "=" -f2`
 	echo "Ping returned $?"
 	echo $PINGTIME > /var/db/pingmsstatus/$DSTIP
 	if [ "$THRESHOLD" != "" ]; then


### PR DESCRIPTION
For whatever reason, the file is populated with the wrong SRCIP in some situation. The behaviour was that my machine was pinging a host on internet with an ip address 10.x.x.x/8

I also added a timeout of 2 seconds in case we have a lot to ping and the scripts queue many ping command.
