### PR TITLE
Bug #2284: rc.newwanip handle case when gifs config is null

### DIFF
--- a/etc/rc.newwanip
+++ b/etc/rc.newwanip
@@ -118,17 +118,19 @@ if (!empty($bridgetmp))
 system_routing_configure($interface);
 
 /* Check Gif tunnels */
-foreach($config['gifs']['gif'] as $gif) {
-	if($gif['if'] == $interface) {
-		foreach($config['interfaces'] as $ifname => $ifparent) {
-			// echo "interface $ifparent, ifname $ifname, gif {$gif['gifif']}\n";
-			if(($ifparent['if'] == $gif['gifif']) && (isset($ifparent['enable']))) {
-				// echo "Running routing configure for $ifname\n";
-				$gif['gifif'] = interface_gif_configure($gif);
-				$confif = convert_real_interface_to_friendly_interface_name($gif['gifif']);
-				if ($confif <> "")
-					interface_configure($confif);
-				system_routing_configure($ifname);
+if($config['gifs']['gif'] != ""){
+	foreach($config['gifs']['gif'] as $gif) {
+		if($gif['if'] == $interface) {
+			foreach($config['interfaces'] as $ifname => $ifparent) {
+				// echo "interface $ifparent, ifname $ifname, gif {$gif['gifif']}\n";
+				if(($ifparent['if'] == $gif['gifif']) && (isset($ifparent['enable']))) {
+					// echo "Running routing configure for $ifname\n";
+					$gif['gifif'] = interface_gif_configure($gif);
+					$confif = convert_real_interface_to_friendly_interface_name($gif['gifif']);
+					if ($confif <> "")
+						interface_configure($confif);
+					system_routing_configure($ifname);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This handles the case when there are no 'gifs' in the config. 
Prior to this change, if there are no 'gifs' to process, a warning appears in /tmp/PHP_errors.log :
Warning: Invalid argument supplied for foreach() in /etc/newwanip on line 122
After the change is applied, this warning no longer appears.
