### PR TITLE
Bug #2284: rc.newwanip handle case when gifs config is null

### DIFF
--- a/etc/rc.newwanip
+++ b/etc/rc.newwanip
@@ -118,7 +118,7 @@ if (!empty($bridgetmp))
 system_routing_configure($interface);
 
 /* Check Gif tunnels */
-if($config['gifs']['gif'] != ""){
+if(is_array($config['gifs']['gif'])){
 	foreach($config['gifs']['gif'] as $gif) {
 		if($gif['if'] == $interface) {
 			foreach($config['interfaces'] as $ifname => $ifparent) {


### PR DESCRIPTION
This has the better is_array test as suggested.
