### PR TITLE
Bug #2301: Handle case when PBI package names are substrings of each other

### DIFF
--- a/etc/inc/pkg-utils.inc
+++ b/etc/inc/pkg-utils.inc
@@ -8,7 +8,7 @@
  *   $Id$
  ******
  *
- * Copyright (C) 2010 Ermal Luçi
+ * Copyright (C) 2010 Ermal Luï¿½i
  * Copyright (C) 2005-2006 Colin Smith (ethethlay@gmail.com)
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
@@ -794,11 +794,11 @@ function install_package_xml($pkg) {
 				 *	change packages to store configs at /usr/pbi/pkg/etc and remove this
 				 */
 				eval_once($pkg_config['custom_php_install_command']);
-				exec("/usr/local/sbin/pbi_info | grep {$pkg} | xargs /usr/local/sbin/pbi_info | awk '/Prefix/ {print $2}'",$pbidir);
-				$pbidir = $pbidir[0];
+				exec("/usr/local/sbin/pbi_info | grep {$pkg}- | xargs /usr/local/sbin/pbi_info | awk '/Prefix/ {print $2}'",$pbidirarray);
+				$pbidir0 = $pbidirarray[0];
 				exec("find /usr/local/etc/ -name *.conf | grep {$pkg}",$files);
 				foreach($files as $f) {
-					$pbiconf = str_replace('/usr/local',$pbidir,$f);
+					$pbiconf = str_replace('/usr/local',$pbidir0,$f);
 					unlink($pbiconf);
 					symlink($f,$pbiconf);
 				}


### PR DESCRIPTION
When a PBI package has multiple parts that are substrings of each other (e.g. "squid" and "squid_radius_auth") then we can't just look for PBI package names that contain the base name (e.g. "squid"). That matches 2 packages and the code doesn't work. The base name is always followed by a dash, so look for the dash as well. e.g. Look for "squid-", which will match the full PBI package name for squid but will not match "squid_radius_auth".
