### PR TITLE
Bug #2301: Mixed-case package names and package deletion

### DIFF
--- a/etc/inc/pkg-utils.inc
+++ b/etc/inc/pkg-utils.inc
@@ -816,7 +816,7 @@ function install_package_xml($pkg) {
 				// e.g. "squidguard-1.4_4-i386" so feed lowercase to pbi_info below.
 				// Also add the "-" so that examples like "squid-" do not match "squidguard-".
 				$pkg_name_for_pbi_match = strtolower($pkg) . "-";
-				exec("/usr/local/sbin/pbi_info | grep {$pkg_name_for_pbi_match}- | xargs /usr/local/sbin/pbi_info | awk '/Prefix/ {print $2}'",$pbidirarray);
+				exec("/usr/local/sbin/pbi_info | grep {$pkg_name_for_pbi_match} | xargs /usr/local/sbin/pbi_info | awk '/Prefix/ {print $2}'",$pbidirarray);
 				$pbidir0 = $pbidirarray[0];
 				exec("find /usr/local/etc/ -name *.conf | grep {$pkg}",$files);
 				foreach($files as $f) {


### PR DESCRIPTION
Handle installation of packages with mixed-case names like "squidGuard".
Correct the passing of PBI package names from uninstall_package to delete_package to remove_freebsd_package.
I have successfully installed squid and squidGuard then removed them both on a 2.1-DEV nanobsd build from 19-Mar-2012, including doing install/remove with and without a reboot in between.
Note: there is still the design issue that PBI stores its database in /var/db/pbi, but (at least on nanobsd) /var is not preserved across boots. So PBI's memory of what FreeBSD packages are installed is lost. This means that PBI package files are not being cleaned up from /usr/pbi - I will put in a separate Redmine issue about this.
