### PR TITLE
Added true PPTP client functionality, separate to the PPTP function already present for ISP connectivity

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -3,7 +3,7 @@
 /*
 	interfaces.inc
 	Copyright (C) 2004-2008 Scott Ullrich
-	Copyright (C) 2008-2009 Ermal Lu?i
+	Copyright (C) 2008-2009 Ermal Luçi
 	All rights reserved.
 
 	function interfaces_wireless_configure is
@@ -37,7 +37,6 @@
 
 	pfSense_BUILDER_BINARIES:	/sbin/dhclient	/bin/sh	/usr/bin/grep	/usr/bin/xargs	/usr/bin/awk	/usr/local/sbin/choparp
 	pfSense_BUILDER_BINARIES:	/sbin/ifconfig	/sbin/route	/usr/sbin/ngctl	/usr/sbin/arp	/bin/kill	/usr/local/sbin/mpd5
-	pfSense_BUILDER_BINARIES:	/usr/local/sbin/dhcp6c
 	pfSense_MODULE:	interfaces
 
 */
@@ -45,11 +44,10 @@
 /* include all configuration functions */
 require_once("globals.inc");
 require_once("cmd_chain.inc");
-require_once("util.inc");
 
 function interfaces_bring_up($interface) {
 	if(!$interface) {
-		log_error(gettext("interfaces_bring_up() was called but no variable defined."));
+		log_error("interfaces_bring_up() was called but no variable defined.");
 		log_error( "Backtrace: " . debug_backtrace() );
 		return;
 	}
@@ -64,7 +62,7 @@ function get_interface_arr($flush = false) {
 
         /* If the cache doesn't exist, build it */
         if (!isset($interface_arr_cache) or $flush)
-                $interface_arr_cache = pfSense_interface_listget();
+                $interface_arr_cache = explode(" ", trim(`/sbin/ifconfig -l`));
 
         return $interface_arr_cache;
 }
@@ -151,6 +149,7 @@ function interface_netgraph_needed($interface = "wan") {
 			case "ppp":
 			case "pppoe":
 			case "l2tp":
+			case "pptp-client":
 			case "pptp":
 				$found = true;
 				break;
@@ -206,23 +205,19 @@ This block of code is only entered for OPTx interfaces that are configured for P
 }
 
 function interfaces_loopback_configure() {
-	global $g;
-
-	if ($g['platform'] == 'jail')
-		return;
 	if($g['booting'])
-		echo gettext("Configuring loopback interface...");
+		echo "Configuring loopback interface...";
 	pfSense_interface_setaddress("lo0", "127.0.0.1");
 	interfaces_bring_up("lo0");
 	if($g['booting'])
-		echo gettext("done.") . "\n";
+		echo "done.\n";
 	return 0;
 }
 
 function interfaces_vlan_configure() {
 	global $config, $g;
 	if($g['booting'])
-		echo gettext("Configuring VLAN interfaces...");
+		echo "Configuring VLAN interfaces...";
 	if (is_array($config['vlans']['vlan']) && count($config['vlans']['vlan'])) {
 		foreach ($config['vlans']['vlan'] as $vlan) {
 			if(empty($vlan['vlanif']))
@@ -232,14 +227,14 @@ function interfaces_vlan_configure() {
 		}
 	}
 	if($g['booting'])
-		echo gettext("done.") . "\n";
+		echo "done.\n";
 }
 
 function interface_vlan_configure(&$vlan) {
         global $config, $g;
 
 	if (!is_array($vlan)) {
-		log_error(gettext("VLAN: called with wrong options. Problems with config!"));
+		log_error("VLAN: called with wrong options. Problems with config!");
 		return;
 	}
 	$if = $vlan['if'];
@@ -247,7 +242,7 @@ function interface_vlan_configure(&$vlan) {
 	$tag = $vlan['tag'];
 
 	if (empty($if)) {
-		log_error(gettext("interface_vlan_confgure called with if undefined."));
+		log_error("interface_vlan_confgure called with if undefined.");
 		return;
 	}
 
@@ -281,14 +276,14 @@ function interface_qinq_configure(&$vlan, $fd = NULL) {
         global $config, $g;
 
         if (!is_array($vlan)) {
-                log_error(sprintf(gettext("QinQ compat VLAN: called with wrong options. Problems with config!%s"), "\n"));
+                log_error("QinQ compat VLAN: called with wrong options. Problems with config!\n");
                 return;
         }
 
         $qinqif = $vlan['if'];
         $tag = $vlan['tag'];
         if(empty($qinqif)) {
-                log_error(sprintf(gettext("interface_qinq_confgure called with if undefined.%s"), "\n"));
+                log_error("interface_qinq_confgure called with if undefined.\n");
                 return;
         }
 	$vlanif = interface_vlan_configure($vlan);
@@ -350,7 +345,7 @@ function interface_qinq_configure(&$vlan, $fd = NULL) {
 function interfaces_qinq_configure() {
 	global $config, $g;
 	if($g['booting'])
-		echo gettext("Configuring QinQ interfaces...");
+		echo "Configuring QinQ interfaces...";
 	if (is_array($config['qinqs']['qinqentry']) && count($config['qinqs']['qinqentry'])) {
 		foreach ($config['qinqs']['qinqentry'] as $qinq) {
 			/* XXX: Maybe we should report any errors?! */
@@ -358,14 +353,14 @@ function interfaces_qinq_configure() {
 		}
 	}
 	if($g['booting'])
-		echo gettext( "done.") . "\n";
+		echo "done.\n";
 }
 
 function interface_qinq2_configure(&$qinq, $fd, $macaddr) {
         global $config, $g;
 
         if (!is_array($qinq)) {
-                log_error(sprintf(gettext("QinQ compat VLAN: called with wrong options. Problems with config!%s"), "\n"));
+                log_error("QinQ compat VLAN: called with wrong options. Problems with config!\n");
                 return;
         }
 
@@ -373,7 +368,7 @@ function interface_qinq2_configure(&$qinq, $fd, $macaddr) {
         $tag = $qinq['tag'];
         $vlanif = "{$if}_{$tag}";
         if(empty($if)) {
-                log_error(sprintf(gettext("interface_qinq_confgure called with if undefined.%s"), "\n"));
+                log_error("interface_qinq_confgure called with if undefined.\n");
                 return;
         }
 
@@ -394,7 +389,7 @@ function interfaces_create_wireless_clones() {
 	global $config;
 
 	if($g['booting'])
-		echo gettext("Creating other wireless clone interfaces...");
+		echo "Creating other wireless clone interfaces...";
 	if (is_array($config['wireless']['clone']) && count($config['wireless']['clone'])) {
 		foreach ($config['wireless']['clone'] as $clone) {
 			if(empty($clone['cloneif']))
@@ -408,8 +403,7 @@ function interfaces_create_wireless_clones() {
 		}
 	}
 	if($g['booting'])
-		echo " " . gettext("done.") . "\n";
-
+		echo " done.\n";
 }
 
 function interfaces_bridge_configure($checkmember = 0) {
@@ -420,21 +414,25 @@ function interfaces_bridge_configure($checkmember = 0) {
                 foreach ($config['bridges']['bridged'] as $bridge) {
                         if(empty($bridge['bridgeif']))
                                 $bridge['bridgeif'] = "bridge{$i}";
+			if ($checkmember == 1 && (strstr($bridge['members'], "gif") || strstr($bridge['members'], "gre")))
+				continue;
+			if ($checkmember == 2 && !strstr($bridge['members'], "gif") && !strstr($bridge['members'], "gre"))
+				continue;
                         /* XXX: Maybe we should report any errors?! */
-                        interface_bridge_configure($bridge, $checkmember);
+                        interface_bridge_configure($bridge);
                         $i++;
                 }
         }
 }
 
-function interface_bridge_configure(&$bridge, $checkmember = 0) {
+function interface_bridge_configure(&$bridge) {
 	global $config, $g;
 
 	if (!is_array($bridge))
 	        return -1;
 
 	if (empty($bridge['members'])) {
-		log_error(sprintf(gettext("No members found on %s"), $bridge['bridgeif']));
+		log_error("No members found on {$bridge['bridgeif']}");
 		return -1;
 	}
 
@@ -442,22 +440,25 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 	if (!count($members))
 		return -1;
 
+	$checklist = get_configured_interface_list();
+
+	if ($g['booting'] || !empty($bridge['bridgeif'])) {
+		pfSense_interface_destroy($bridge['bridgeif']);
+		pfSense_interface_create($bridge['bridgeif']);
+		$bridgeif = $bridge['bridgeif'];
+	} else
+		$bridgeif = pfSense_interface_create("bridge");
+
 	/* Calculate smaller mtu and enforce it */
 	$smallermtu = 0;
 	$commonrx = true;
 	$commontx = true;
-	$foundgif = false;
 	foreach ($members as $member) {
 		$realif = get_real_interface($member);
 		$opts = pfSense_get_interface_addresses($realif);
 		$mtu = $opts['mtu'];
-		if (substr($realif, 0, 3) == "gif") {
-			$foundgif = true;
-			if ($checkmember == 1)
-				return;
-			if ($mtu <= 1500)
-				continue;
-		}
+		if (substr($realif, 0, 3) == "gif" && $mtu <= 1500)
+			continue;
 		if (!isset($opts['encaps']['txcsum']))
 			$commontx = false;
 		if (!isset($opts['encaps']['rxcsum']))
@@ -473,9 +474,7 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 		else if (!empty($mtu) && $mtu < $smallermtu)
 			$smallermtu = $mtu;
 	}
-	if ($foundgif == false && $checkmember == 2)
-		return;
-
+	 
 	/* Just in case anything is not working well */
 	if ($smallermtu == 0)
 		$smallermtu = 1500; 
@@ -491,16 +490,7 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 		$flags |= IFCAP_TSO6;
 	if ($commonlro === false)
 		$flags |= IFCAP_LRO;
-
-	if ($g['booting'] || !empty($bridge['bridgeif'])) {
-		pfSense_interface_destroy($bridge['bridgeif']);
-		pfSense_interface_create($bridge['bridgeif']);
-		$bridgeif = $bridge['bridgeif'];
-	} else
-		$bridgeif = pfSense_interface_create("bridge");
-
-	$checklist = get_configured_interface_list();
-
+		
 	/* Add interfaces to bridge */
 	foreach ($members as $member) {
 		if (!array_key_exists($member, $checklist))
@@ -508,14 +498,14 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 		$realif1 = get_real_interface($member);
 		$realif =  escapeshellarg($realif1);
 		if (!$realif) {
-			log_error(gettext("realif not defined in interfaces bridge - up"));
+			log_error("realif not defined in interfaces bridge - up");
 			continue;
 		}
 		/* make sure the parent interface is up */
 		pfSense_interface_mtu($realif1, $smallermtu);
 		pfSense_interface_capabilities($realif1, -$flags);
 		interfaces_bring_up($realif1);
-		pfSense_bridge_add_member($bridgeif, $realif);
+		mwexec("/sbin/ifconfig {$bridgeif} addm {$realif}");	
 	}
 
 	if (isset($bridge['enablestp'])) {
@@ -531,19 +521,19 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 		}
 		if (!empty($bridge['maxage']))
 			mwexec("/sbin/ifconfig {$bridgeif} maxage {$bridge['maxage']}");
-		if (!empty($bridge['fwdelay']))
+		if (!empty($brige['fwdelay']))
 			mwexec("/sbin/ifconfig {$bridgeif} fwddelay {$bridge['fwdelay']}");
-		if (!empty($bridge['hellotime']))
+		if (!empty($brige['hellotime']))
                         mwexec("/sbin/ifconfig {$bridgeif} hellotime {$bridge['hellotime']}");
-		if (!empty($bridge['priority']))
+		if (!empty($brige['priority']))
                         mwexec("/sbin/ifconfig {$bridgeif} priority {$bridge['priority']}");
-		if (!empty($bridge['holdcount']))
+		if (!empty($brige['holdcount']))
                         mwexec("/sbin/ifconfig {$bridgeif} holdcnt {$bridge['holdcnt']}");
 		if (!empty($bridge['ifpriority'])) {
 			$pconfig = explode(",", $bridge['ifpriority']);
 			$ifpriority = array();
 			foreach ($pconfig as $cfg) {
-				$embcfg = explode_assoc(":", $cfg);
+				$embcfg = explode(":", $cfg);
 				foreach ($embcfg as $key => $value)
 					$ifpriority[$key] = $value;
 			}
@@ -553,10 +543,10 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 			}
 		}
 		if (!empty($bridge['ifpathcost'])) {
-			$pconfig = explode(",", $bridge['ifpathcost']);
+			$pconfig = explode(",", $bridges['ifpathcost']);
 			$ifpathcost = array();
 			foreach ($pconfig as $cfg) {
-				$embcfg = explode_assoc(":", $cfg);
+				$embcfg = explode(":", $cfg);
 				foreach ($embcfg as $key => $value)
 					$ifpathcost[$key] = $value;
 			}
@@ -621,7 +611,7 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 	if($bridgeif)
 		interfaces_bring_up($bridgeif);	
 	else 
-		log_error(gettext("bridgeif not defined -- could not bring interface up"));
+		log_error("bridgeif not defined -- could not bring interface up");
 
 	return $bridgeif;
 }
@@ -631,7 +621,7 @@ function interface_bridge_add_member($bridgeif, $interface) {
 	if (!does_interface_exist($bridgeif) || !does_interface_exist($interface))
 		return;
 
-	$mtu = get_interface_mtu($bridgeif);
+	$mtu = get_interface_mtu($brigeif);
 	$mtum = get_interface_mtu($interface);
 	
 	if ($mtu != $mtum && !(substr($interface, 0, 3) == "gif" && $mtu <= 1500))
@@ -648,14 +638,14 @@ function interface_bridge_add_member($bridgeif, $interface) {
 	pfSense_interface_capabilities($interface, -$flags);
 
 	interfaces_bring_up($interface);
-	pfSense_bridge_add_member($bridgeif, $interface);
+	mwexec("/sbin/ifconfig {$bridgeif} addm {$interface}");
 }
 
 function interfaces_lagg_configure() 
 {
         global $config, $g;
 		if($g['booting']) 
-			echo gettext("Configuring LAGG interfaces...");
+			echo "Configuring LAGG interfaces...";
         $i = 0;
 		if (is_array($config['laggs']['lagg']) && count($config['laggs']['lagg'])) {
 			foreach ($config['laggs']['lagg'] as $lagg) {
@@ -667,7 +657,7 @@ function interfaces_lagg_configure()
 			}
 		}
 		if($g['booting']) 
-			echo gettext("done.") . "\n";
+			echo "done.\n";
 }
 
 function interface_lagg_configure(&$lagg) {
@@ -680,6 +670,8 @@ function interface_lagg_configure(&$lagg) {
 	if (!count($members))
 		return -1;
 	
+	$checklist = get_interface_list();
+
 	if ($g['booting'] || !(empty($lagg['laggif']))) {
 		pfSense_interface_destroy($lagg['laggif']);
 		pfSense_interface_create($lagg['laggif']);
@@ -723,8 +715,6 @@ function interface_lagg_configure(&$lagg) {
                 $flags |= IFCAP_TSO6;
         if ($commonlro === false)
                 $flags |= IFCAP_LRO;
-
-	$checklist = get_interface_list();
 
 	foreach ($members as $member) {
 		if (!array_key_exists($member, $checklist))
@@ -782,11 +772,7 @@ function interface_gre_configure(&$gre, $grekey = "") {
 
 	/* Do not change the order here for more see gre(4) NOTES section. */
 	mwexec("/sbin/ifconfig {$greif} tunnel {$realifip} {$gre['remote-addr']}");
-	if((is_ipaddrv6($gre['tunnel-local-addr'])) || (is_ipaddrv6($gre['tunnel-remote-addr']))) {
-		mwexec("/sbin/ifconfig {$greif} inet6 {$gre['tunnel-local-addr']} {$gre['tunnel-remote-addr']} prefixlen /{$gre['tunnel-remote-net']} ");
-	} else {
-		mwexec("/sbin/ifconfig {$greif} {$gif['tunnel-local-addr']} {$gre['tunnel-remote-addr']} netmask " . gen_subnet_mask($gre['tunnel-remote-net']));
-	}
+	mwexec("/sbin/ifconfig {$greif} {$gre['tunnel-local-addr']} {$gre['tunnel-remote-addr']} netmask " . gen_subnet_mask($gre['tunnel-remote-net']));
 	if (isset($gre['link0']) && $gre['link0'])
 		pfSense_interface_flags($greif, IFF_LINK0);
 	if (isset($gre['link1']) && $gre['link1'])
@@ -797,14 +783,11 @@ function interface_gre_configure(&$gre, $grekey = "") {
 	if($greif)
 		interfaces_bring_up($greif);
 	else 
-		log_error(gettext("Could not bring greif up -- variable not defined."));
+		log_error("Could not bring greif up -- variable not defined.");
 
 	if (isset($gre['link1']) && $gre['link1'])
 		mwexec("/sbin/route add {$gre['tunnel-remote-addr']}/{$gre['tunnel-remote-net']} {$gre['tunnel-local-addr']}");
-	if(is_ipaddrv4($gre['tunnel-remote-addr']))
-		file_put_contents("{$g['tmp_path']}/{$greif}_router", $gre['tunnel-remote-addr']);
-	if(is_ipaddrv6($gre['tunnel-remote-addr']))
-		file_put_contents("{$g['tmp_path']}/{$greif}_routerv6", $gre['tunnel-remote-addr']);
+	file_put_contents("{$g['tmp_path']}/{$greif}_router", $gre['tunnel-remote-addr']);
 
 	return $greif;
 }
@@ -840,7 +823,7 @@ function interface_gif_configure(&$gif, $gifkey = "") {
 	if($realif)
 		interfaces_bring_up($realif);
 	else 
-		log_error(gettext("could not bring realif up -- variable not defined -- interface_gif_configure()"));
+		log_error("could not bring realif up -- variable not defined -- interface_gif_configure()");
 
 	if ($g['booting'] || !(empty($gif['gifif']))) {
 		pfSense_interface_destroy($gif['gifif']);
@@ -851,11 +834,7 @@ function interface_gif_configure(&$gif, $gifkey = "") {
 
 	/* Do not change the order here for more see gif(4) NOTES section. */
 	mwexec("/sbin/ifconfig {$gifif} tunnel {$realifip} {$gif['remote-addr']}");
-	if((is_ipaddrv6($gif['tunnel-local-addr'])) || (is_ipaddrv6($gif['tunnel-remote-addr']))) {
-		mwexec("/sbin/ifconfig {$gifif} inet6 {$gif['tunnel-local-addr']} {$gif['tunnel-remote-addr']} prefixlen /{$gif['tunnel-remote-net']} ");
-	} else {
-		mwexec("/sbin/ifconfig {$gifif} {$gif['tunnel-local-addr']} {$gif['tunnel-remote-addr']} netmask " . gen_subnet_mask($gif['tunnel-remote-net']));
-	}
+	mwexec("/sbin/ifconfig {$gifif} {$gif['tunnel-local-addr']} {$gif['tunnel-remote-addr']} netmask " . gen_subnet_mask($gif['tunnel-remote-net']));
 	if (isset($gif['link0']) && $gif['link0'])
 		pfSense_interface_flags($gifif, IFF_LINK0);
 	if (isset($gif['link1']) && $gif['link1'])
@@ -863,36 +842,17 @@ function interface_gif_configure(&$gif, $gifkey = "") {
 	if($gifif)
 		interfaces_bring_up($gifif);
 	else
-		log_error(gettext("could not bring gifif up -- variable not defined"));
+		log_error("could not bring gifif up -- variable not defined");
 
-	$iflist = get_configured_interface_list();
-	foreach($iflist as $ifname) {
-		if($config['interfaces'][$ifname]['if'] == $gifif) {
-			if(get_interface_gateway($ifname)) {
-				system_routing_configure($ifname);
-				break;
-			}
-			if(get_interface_gateway_v6($ifname)) {
-				system_routing_configure($ifname);
-				break;
-			}
-		}
-	}
-
-
-	if(is_ipaddrv4($gif['tunnel-remote-addr']))
-		file_put_contents("{$g['tmp_path']}/{$gifif}_router", $gif['tunnel-remote-addr']);
-	if(is_ipaddrv6($gif['tunnel-remote-addr']))
-		file_put_contents("{$g['tmp_path']}/{$gifif}_routerv6", $gif['tunnel-remote-addr']);
+	/* XXX: Needed?! */
+	//mwexec("/sbin/route add {$gif['tunnel-remote-addr']}/{$gif['tunnel-remote-net']} -iface {$gifif}");
+	file_put_contents("{$g['tmp_path']}/{$gifif}_router", $gif['tunnel-remote-addr']);
 
 	return $gifif;
 }
 
 function interfaces_configure() {
 	global $config, $g;
-
-	if ($g['platform'] == 'jail')
-		return;
 
 	/* Set up our loopback interface */
 	interfaces_loopback_configure();
@@ -927,13 +887,12 @@ function interfaces_configure() {
 			continue;
 		} else {
 			if ($g['booting'])
-				printf(gettext("Configuring %s interface..."), $ifname);
-
+				echo "Configuring {$ifname} interface...";
 			if($g['debug'])
-				log_error(sprintf(gettext("Configuring %s"), $ifname));
+				log_error("Configuring {$ifname}");
 			interface_configure($if, $reload);
 			if ($g['booting']) 
-				echo gettext( "done.") . "\n";
+				echo "done.\n";
 		}
 	}
 
@@ -966,14 +925,14 @@ function interfaces_configure() {
 
 	foreach ($delayed_list as $if => $ifname) {
 		if ($g['booting'])
-			printf(gettext("Configuring %s interface..."), $ifname);
+			echo "Configuring {$ifname} interface...";
         	if ($g['debug'])
-        		log_error(sprintf(gettext("Configuring %s"), $ifname));
+        		log_error("Configuring {$ifname}");
 
 		interface_configure($if, $reload);
 
 		if ($g['booting'])
-			echo gettext("done.") . "\n";
+			echo "done.\n";
 	}
 
 	/* set up BRIDGe virtual interfaces */
@@ -981,14 +940,14 @@ function interfaces_configure() {
 
 	foreach ($bridge_list as $if => $ifname) {
 		if ($g['booting'])
-			printf(gettext("Configuring %s interface..."), $ifname);
+			echo "Configuring {$ifname} interface...";
 		if($g['debug'])
-			log_error(sprintf(gettext("Configuring %s"), $ifname));
+			log_error("Configuring {$ifname}");
 
 		interface_configure($if, $reload);
 
 		if ($g['booting'])
-			echo gettext("done.") . "\n";
+			echo "done.\n";
 	}
 
 	/* configure interface groups */
@@ -1052,8 +1011,6 @@ function interface_bring_down($interface = "wan", $destroy = false) {
 	if (!isset($config['interfaces'][$interface]))
 		return; 
 
-	log_error("Calling interface down for interface {$interface}, destroy is {$destroy}");
-
 	$ifcfg = $config['interfaces'][$interface];
 
 	$realif = get_real_interface($interface);
@@ -1062,6 +1019,7 @@ function interface_bring_down($interface = "wan", $destroy = false) {
 	case "ppp":
 	case "pppoe":
 	case "pptp":
+	case "pptp-client":
 	case "l2tp":
 		if (is_array($config['ppps']['ppp']) && count($config['ppps']['ppp'])) {
 			foreach ($config['ppps']['ppp'] as $pppid => $ppp) {
@@ -1108,44 +1066,10 @@ function interface_bring_down($interface = "wan", $destroy = false) {
 		break;
 	}
 
-	switch ($ifcfg['ipaddrv6']) {
-	case "dhcp6":
-		$pidv6 = find_dhcp6c_process($realif);
-		if($pidv6)
-			mwexec("/bin/kill {$pidv6}");
-		sleep(1);
-		unlink_if_exists("{$g['varetc_path']}/dhcp6c_{$interface}.conf");
-		if(does_interface_exist("$realif")) {
-			mwexec("/sbin/ifconfig " . escapeshellarg($realif) . " delete", true);
-			if ($destroy == true)
-				pfSense_interface_flags($realif, -IFF_UP);
-			mwexec("/usr/sbin/arp -d -i {$realif} -a");
-		}
-		break;
-	case "6rd":
-		if(does_interface_exist("$realif")) {
-			mwexec("/sbin/ifconfig " . escapeshellarg($realif) . " delete", true);
-			if ($destroy == true)
-				pfSense_interface_flags($realif, -IFF_UP);
-		}		
-		break;
-	default:
-		if(does_interface_exist("$realif")) {
-			mwexec("/sbin/ifconfig " . escapeshellarg($realif) . " delete", true);
-			if ($destroy == true)
-				pfSense_interface_flags($realif, -IFF_UP);
-			mwexec("/usr/sbin/arp -d -i {$realif} -a");
-		}
-		break;
-	}
-
-
 	/* remove interface up file if it exists */
 	unlink_if_exists("{$g['tmp_path']}/{$realif}up");
 	unlink_if_exists("{$g['vardb_path']}/{$interface}ip");
-	unlink_if_exists("{$g['vardb_path']}/{$interface}ipv6");
 	unlink_if_exists("{$g['tmp_path']}/{$realif}_router");
-	unlink_if_exists("{$g['tmp_path']}/{$realif}_routerv6");
 	unlink_if_exists("{$g['varetc_path']}/nameserver_{$realif}");
 	unlink_if_exists("{$g['varetc_path']}/searchdomain_{$realif}");
 	
@@ -1315,7 +1239,7 @@ function interface_ppps_configure($interface) {
 		}
 	}
 	if (!$ppp || $ifcfg['if'] != $ppp['if']){
-		log_error(sprintf(gettext("Can't find PPP config for %s in interface_ppps_configure()."), $ifcfg['if']));
+		log_error("Can't find PPP config for {$ifcfg['if']} in interface_ppps_configure().");
 		return 0;
 	}
 	$pppif = $ifcfg['if'];
@@ -1353,6 +1277,7 @@ function interface_ppps_configure($interface) {
 				pfSense_ngctl_attach(".", $port);
 				break;
 			case "pptp":
+			case "pptp-client":
 			case "l2tp":
 				/* configure interface */
 				if(is_ipaddr($localips[$pid])){
@@ -1378,19 +1303,19 @@ function interface_ppps_configure($interface) {
 					*/
 				}
 				if(!is_ipaddr($gateways[$pid])){
-					log_error(sprintf(gettext('Could not get a PPTP/L2TP Remote IP address from %1$s for %2$s in interfaces_ppps_configure.'), $dhcp_gateway, $gway));
+					log_error("Could not get a PPTP/L2TP Remote IP address from {$dhcp_gateway} for {$gway} in interfaces_ppps_configure.");
 					return 0;
 				}
 				pfSense_ngctl_attach(".", $port);
 				break;
 			case "ppp":
 				if (!file_exists("{$port}")) {
-					log_error(sprintf(gettext("Device %s does not exist. PPP link cannot start without the modem device."), $port));
+					log_error("Device {$port} does not exist. PPP link cannot start without the modem device.");
 					return 0;
 				}
 				break;
 			default:
-				log_error(sprintf(gettext("Unkown %s configured as ppp interface."), $type));
+				log_error("Unkown {$type} configured as ppp interface.");
 				break;
 		}
 	}
@@ -1439,22 +1364,17 @@ function interface_ppps_configure($interface) {
 
 	if (isset($ppp['mrru']))
 		$mrrus = explode(',',$ppp['mrru']);
+		
+//##########################################
 
-	// Construct the mpd.conf file
-	$mpdconf = <<<EOD
-startup:
-	# configure the console
-	set console close
-	# configure the web server
-	set web close
-
-default:
-{$ppp['type']}client:
-	create bundle static {$interface}
-	set bundle enable ipv6cp
-	set iface name {$pppif}
-
-EOD;
+	if (isset($ppp['ondemand']))
+	   $ondemand = "enable";
+	else
+	   $ondemand = "disable";
+	
+	if (isset($ppp['idletimeout']))
+	   $timeout = "set iface idle {$ppp['idletimeout']}";
+	
 	$setdefaultgw = false;
 	$founddefaultgw = false;
 	if (is_array($config['gateways']['gateway_item'])) {
@@ -1471,59 +1391,531 @@ EOD;
 	
 	if (($interface == "wan" && $founddefaultgw == false) || $setdefaultgw == true){
 		$setdefaultgw = true;
-		$mpdconf .= <<<EOD
-	set iface route default
-
-EOD;
+		$netroute = "default";
+	} else if ($type == "pptp-client"){
+		$netroute  = "{$ppp['routenet']}/{$ppp['routesubnet']}";
 	}
-	$mpdconf .= <<<EOD
-	set iface {$ondemand} on-demand
-	set iface idle {$ppp['idletimeout']}
-
-EOD;
-
-	if (isset($ppp['ondemand']))
-		$mpdconf .= <<<EOD
-	set iface addrs 10.10.1.1 10.10.1.2
-
-EOD;
 	
 	if (isset($ppp['tcpmssfix']))
 		$tcpmss = "disable";
 	else
 		$tcpmss = "enable";
-		$mpdconf .= <<<EOD
+	
+	if (isset($config['system']['dnsallowoverride']))
+		$dns_override = "enable";
+	else
+		$dns_override = "disable";
+	
+	if (isset($ppp['vjcomp']))
+		$vjco = "disable";
+	else
+		$vjco = "enable";
+		
+	if (!isset($ppp['verbose_log']))
+		$do_logging = "log -bund -ccp -chat -iface -ipcp -lcp -link";
+	
+	###############################################################################################################################################
+	###############################################################################################################################################
+	###############################################################################################################################################
+	###############################################################################################################################################
+	###############################################################################################################################################
+	
+	if ($ppp['type'] == 'pptp-client') {	
+
+		foreach($ports as $pid => $port){
+			$port = get_real_interface($port);
+			
+			// Construct the mpd.conf file
+			$mpdconf = <<<EOD
+			
+startup:
+	# configure the console
+	set console close
+
+	# configure the web server
+	set web close
+
+{$ppp['type']}client:
+
+	# Assign friendly name for firewall rules.
+	create bundle static {$interface}
+
+	# Set the low level interface name to
+	set iface name {$pppif}
+
+	# Enable on-demand dialing
+	set iface {$ondemand} on-demand
+
+	# Set idle timeout disconnect
+	{$timeout}
+		
+EOD;
+		
+			$mpdconf .= <<<EOD
+				
+	# Create local route to remote network
+	set iface route {$netroute}
+
+EOD;
+			
+			$mpdconf .= <<<EOD
+		
+	# Enable maximum segment size (MSS) clamping
+	set iface {$tcpmss} tcpmssfix
+
+	# Scripts to run on up/down events
+	set iface up-script /usr/local/sbin/ppp-linkup
+	set iface down-script /usr/local/sbin/ppp-linkdown
+		
+EOD;
+		
+			if (isset($ppp['proxyarp'])) {
+				$mpdconf .= <<<EOD
+			
+	set iface enable proxy-arp
+			
+EOD;
+			}
+			
+		  if (!empty($ppp['remote_ep'])){
+				$loc_ep = "{$ppp['local_ep']}/{$ppp['local_ep_sn']}";
+				$rem_ep = "{$ppp['remote_ep']}/{$ppp['remote_ep_sn']}";
+				$mpdconf .= <<<EOD
+				
+	# Define how flexible we are about what end point addresses we will allow. We don't care in this case.
+	set ipcp ranges {$loc_ep} {$rem_ep}
+		
+EOD;
+		  } else {
+				$loc_ep = "0.0.0.0/0";
+				$rem_ep = "0.0.0.0/0";
+							$mpdconf .= <<<EOD
+				
+	# Define how flexible we are about what end point addresses we will allow. We don't care in this case.
+	set ipcp ranges {$loc_ep} {$rem_ep}
+		
+EOD;
+			}
+			
+			$mpdconf .= <<<EOD
+			
+	# Allow DNS server address exchange (not sure this is required in client mode....)
+	set ipcp {$dns_override} req-pri-dns req-sec-dns
+
+	# Disable Van Jacobson TCP header compression. Required for compatability with some Windows clients & servers
+	set ipcp {$vjco} vjcomp
+		
+EOD;
+			if (isset($ppp['bundle-comp-enable'])) {
+				$mpdconf .= <<<EOD
+				
+	# Enable compression auto negotiation
+	set bundle enable compression
+			
+EOD;
+			} 
+			
+			if (!isset($ppp['bundle-comp-enable'])) {
+				$mpdconf .= <<<EOD
+				
+	# Disable compression auto negotiation
+	set bundle disable compression
+		
+EOD;
+			}
+			
+			if (!isset($ppp['bundle-crypt-enable']) || isset($ppp['mppe-enable']) || isset($ppp['mppe-40']) || isset($ppp['mppe-56']) || isset($ppp['mppe-128'])) {
+				unset($ppp['bundle-crypt-enable']);
+				$mpdconf .= <<<EOD
+				
+	# Enable encryption auto negotiation
+	set bundle disable encryption
+			
+EOD;
+			} 
+			
+			if (isset($ppp['bundle-crypt-enable']) && !isset($ppp['mppe-enable']) && !isset($ppp['mppe-40']) && !isset($ppp['mppe-56']) && !isset($ppp['mppe-128'])) {
+				$mpdconf .= <<<EOD
+						
+	# Enable encryption auto negotiation
+	set bundle enable encryption
+			
+EOD;
+			}
+			
+			if (isset($ppp['mppe-enforce'])) {
+				$mpdconf .= <<<EOD
+				
+	# Require encryption from the server
+	set bundle yes crypt-reqd
+	
+EOD;
+			}
+
+			if (isset($ppp['mppc-enable']))
+				$compset_en = "{$compset_en} mppc";
+			if (isset($ppp['pred1']))
+				$compset_en = "{$compset_en} pred1";
+			if (isset($ppp['deflate']))
+				$compset_en = "{$compset_en} deflate";
+			if (isset($ppp['mppc-enable']) || isset($ppp['pred1']) || isset($ppp['deflate'])) {
+				$mpdconf .= <<<EOD
+				
+	# Enabled Microsoft Point to Point Compression Options
+	set ccp yes${compset_en}
+			
+EOD;
+			}
+			
+			if (!isset($ppp['mppc-enable']))
+				$compset_dis = "{$compset_dis} mppc";
+			if (!isset($ppp['pred1']))
+				$compset_dis = "{$compset_dis} pred1";
+			if (!isset($ppp['deflate']))
+				$compset_dis = "{$compset_dis} deflate";
+			if (!isset($ppp['mppc-enable']) || !isset($ppp['pred1']) || !isset($ppp['deflate'])) {
+				$mpdconf .= <<<EOD
+				
+	# Disabled Microsoft Point to Point Compression options
+	set ccp no{$compset_dis}
+			
+EOD;
+			}
+		
+			if (isset($ppp['mppe-40']))
+				$cryptset_en = "{$cryptset_en} e40";
+			if (isset($ppp['mppe-56']))
+				$cryptset_en = "{$cryptset_en} e56";
+			if (isset($ppp['mppe-128']))
+				$cryptset_en = "{$cryptset_en} e128";
+			if (isset($ppp['mppe-40']) || isset($ppp['mppe-56']) || isset($ppp['mppe-128'])) {
+				$mpdconf .= <<<EOD
+			
+	# Enabled Microsoft Point to Point Encryption Options
+	set mppc yes{$cryptset_en}
+		
+EOD;
+			}
+
+			if (!isset($ppp['mppe-40']))
+				$cryptset_dis = "{$cryptset_dis} e40";
+			if (!isset($ppp['mppe-56']))
+				$cryptset_dis = "{$cryptset_dis} e56";
+			if (!isset($ppp['mppe-128']))
+				$cryptset_dis = "{$cryptset_dis} e128";	
+			if (!isset($ppp['mppe-40']) || !isset($ppp['mppe-56']) || !isset($ppp['mppe-128'])) {
+				$mpdconf .= <<<EOD
+			
+	# Disabled Microsoft Point to Point Encryption Options
+	set mppc no{$cryptset_dis}
+		
+EOD;
+			}
+
+			if (isset($ppp['mppec-stateless']))
+				$mppec_opt_en = "{$mppec_opt_en} stateless";
+			if (isset($ppp['mppec-policy']))
+				$mppec_opt_en = "{$mppec_opt_en} policy";
+			if (isset($ppp['mppec-policy']) || isset($ppp['mppec-stateless'])) {
+				$mpdconf .= <<<EOD
+				
+	# Other MPPC and MPPE options
+	set mppc yes{$mppec_opt_en}
+			
+EOD;
+			}
+			
+			if (isset($ppp['dese-bis']))
+				$dese_opt_en = "{$dese_opt_en} dese-bis";
+			if (isset($ppp['dese-old']))
+				$dese_opt_en = "{$dese_opt_en} dese-old";
+			if (isset($ppp['dese-bis']) || isset($ppp['dese-old'])) {
+				$mpdconf .= <<<EOD
+			
+	# Enabled RFC 1969 encryption options
+	set ecp yes{$dese_opt_en}
+		
+EOD;
+			}
+
+			if (!isset($ppp['dese-bis']))
+				$dese_opt_dis = "{$dese_opt_dis} dese-bis";
+			if (!isset($ppp['dese-old']))
+				$dese_opt_dis = "{$dese_opt_dis} dese-old";
+			if (!isset($ppp['dese-bis']) || !isset($ppp['dese-old'])) {
+				$mpdconf .= <<<EOD
+			
+	# Disabled RFC 1969 encryption options
+	set ecp no{$dese_opt_dis}
+		
+EOD;
+			}
+		
+			$mpdconf .= <<<EOD
+				
+	create link static {$interface}_link{$pid} pptp
+	set link action bundle {$interface}
+		
+EOD;
+			
+			if (isset($ppp['shortseq'])) {
+				$mpdconf .= <<<EOD
+			
+	set link no shortseq;
+				
+EOD;
+			}
+		
+			if (isset($ppp['acfcomp'])) {
+				$mpdconf .= <<<EOD
+				
+	# Address and control field compression
+	set link disable acfcomp
+		
+EOD;
+			}
+			
+			if (isset($ppp['protocomp'])) {
+				$mpdconf .= <<<EOD
+				
+	# Protocol field compression
+	set link disable protocomp
+		
+EOD;
+			}
+		
+			$mpdconf .= <<<EOD
+			
+	# Disable aggregated links
+	set link {$multilink} multilink
+		
+EOD;
+		
+			if (!empty($ppp['keep-alive-int']) && !empty($ppp['keep-alive-max'])) {
+				$mpdconf .= <<<EOD
+			
+	# Dead peer detection
+	set link keep-alive {$ppp['keep-alive-int']} {$ppp['keep-alive-max']}
+			
+EOD;
+			} else {
+				$mpdconf .= <<<EOD
+				
+	# Dead peer detection
+	set link keep-alive 10 60
+		
+EOD;
+			}
+			
+			if (!empty($ppp['max-redial'])) {
+				$mpdconf .= <<<EOD
+
+	# Maximum number of re-dial attempts. 0 = unlimited
+	set link max-redial {$ppp['max-redial']}
+			
+EOD;
+			} else {
+				$mpdconf .= <<<EOD
+
+	# Maximum number of re-dial attempts. 0 = unlimited
+	set link max-redial 0
+			
+EOD;
+			}
+			
+			if (!isset($ppp['pap']))
+				$auth_type_dis = "{$auth_type_dis} pap";
+			if (!isset($ppp['mschap_v1']))
+				$auth_type_dis = "{$auth_type_dis} chap-msv1";
+			if (!isset($ppp['mschap_v2']))
+				$auth_type_dis = "{$auth_type_dis} chap-msv2";
+			if (!isset($ppp['mschap_md5']))
+				$auth_type_dis = "{$auth_type_dis} chap-md5";
+			if (!isset($ppp['pap']) || !isset($ppp['mschap_v1']) || !isset($ppp['mschap_v2']) || !isset($ppp['mschap_md5'])) {
+				$mpdconf .= <<<EOD
+			
+	# Disabled Authentication Options
+	set link deny{$auth_type_dis}
+		
+EOD;
+			}
+		
+			if (isset($ppp['pap']))
+				$auth_type_en = "{$auth_type_en} pap";
+			if (isset($ppp['mschap_v1']))
+				$auth_type_en = "{$auth_type_en} chap-msv1";
+			if (isset($ppp['mschap_v2']))
+				$auth_type_en = "{$auth_type_en} chap-msv2";
+			if (isset($ppp['mschap_md5']))
+				$auth_type_en = "{$auth_type_en} chap-md5";
+			if ($type == 'pptp-client' && isset($ppp['pap']) || isset($ppp['mschap_v1']) || isset($ppp['mschap_v2']) || isset($ppp['mschap_md5'])) {
+				$mpdconf .= <<<EOD
+			
+	# Enabled Authentication Options
+	set link accept{$auth_type_en}
+		
+EOD;
+			}
+			
+			$mpdconf .= <<<EOD
+			
+	# Deny external connection attempts on this instance of PPP/PPTP
+	set link disable incoming
+		
+EOD;
+			if (!empty($bandwidths[$pid]))
+				$mpdconf .= <<<EOD
+				
+	# Bandwidth Limiting 
+	set link bandwidth {$bandwidths[$pid]}
+		
+EOD;
+			if (empty($mtus[$pid]))
+				$mtus[$pid] = "1492";
+				$mpdconf .= <<<EOD
+			
+	# Set maximu transmission unit in bytes
+	set link mtu {$mtus[$pid]}
+		
+EOD;
+			if (!empty($mrus[$pid]))
+				$mpdconf .= <<<EOD
+			set link mru {$mrus[$pid]}
+		
+EOD;
+			if (!empty($mrrus[$pid]))
+				$mpdconf .= <<<EOD
+					
+			set link mrru {$mrrus[$pid]}
+		
+EOD;
+			$mpdconf .= <<<EOD
+			
+	# Authentication credentials
+	set auth authname "{$ppp['username']}"
+	set auth password {$passwd}
+			
+EOD;
+			
+			$mpdconf .= <<<EOD
+		
+	# Clients external WAN IP
+	set pptp self {$localips[$pid]}
+
+	# Servers external WAN IP
+	set pptp peer {$gateways[$pid]}
+		
+EOD;
+		
+			$mpdconf .= <<<EOD
+		
+	# Enable Logging	
+	{$do_logging}
+
+	# Open the tunnel and establish the connection.
+	open
+		
+EOD;
+		
+		} //end foreach($port)
+		
+##################################################################################################################
+##################################################################################################################
+
+	} else {
+			// Construct the mpd.conf file
+			$mpdconf = <<<EOD
+startup:
+	# configure the console
+	set console close
+	# configure the web server
+	set web close
+
+default:
+
+{$ppp['type']}client:
+
+	create bundle static {$interface}
+	set iface name {$pppif}
+
+EOD;
+			$setdefaultgw = false;
+			$founddefaultgw = false;
+			if (is_array($config['gateways']['gateway_item'])) {
+				foreach($config['gateways']['gateway_item'] as $gateway) {
+					if($interface == $gateway['interface'] && isset($gateway['defaultgw'])) {
+						$setdefaultgw = true;
+						break;
+					} else if (isset($gateway['defaultgw']) && !empty($gateway['interface'])) {
+						$founddefaultgw = true;
+						break;
+					}
+				}
+			}
+			
+			if (($interface == "wan" && $founddefaultgw == false) || $setdefaultgw == true) {
+				$setdefaultgw = true;
+				$mpdconf .= <<<EOD
+	set iface route default
+
+EOD;
+			}
+			
+			$mpdconf .= <<<EOD
+	set iface {$ondemand} on-demand
+	set iface idle {$ppp['idletimeout']}
+
+EOD;
+			
+			if (isset($ppp['ondemand'])) {
+				$mpdconf .= <<<EOD
+	set iface addrs 10.10.1.1 10.10.1.2
+
+EOD;
+			}
+			
+			if (isset($ppp['tcpmssfix'])) {
+				$tcpmss = "disable";
+			} else {
+				$tcpmss = "enable";
+				$mpdconf .= <<<EOD
 	set iface {$tcpmss} tcpmssfix
 
 EOD;
-
-	$mpdconf .= <<<EOD
+			}
+			
+			$mpdconf .= <<<EOD
 	set iface up-script /usr/local/sbin/ppp-linkup
 	set iface down-script /usr/local/sbin/ppp-linkdown
 	set ipcp ranges {$ranges}
 
 EOD;
-	if (isset($ppp['vjcomp']))
-		$mpdconf .= <<<EOD
+			if (isset($ppp['vjcomp'])) {
+				$mpdconf .= <<<EOD
 	set ipcp no vjcomp
 
 EOD;
-
-	if (isset($config['system']['dnsallowoverride']))
-		$mpdconf .= <<<EOD
+			}
+			
+			if (isset($config['system']['dnsallowoverride'])) {
+				$mpdconf .= <<<EOD
 	set ipcp enable req-pri-dns
 	set ipcp enable req-sec-dns
 
 EOD;
-	if (!isset($ppp['verbose_log']))
-		$mpdconf .= <<<EOD
+			}
+			
+			if (!isset($ppp['verbose_log'])) {
+				$mpdconf .= <<<EOD
 	#log -bund -ccp -chat -iface -ipcp -lcp -link
-
+		
 EOD;
-	foreach($ports as $pid => $port){
-		$port = get_real_interface($port);
-		$mpdconf .= <<<EOD
-
+			}
+			
+			foreach($ports as $pid => $port){
+				$port = get_real_interface($port);
+				$mpdconf .= <<<EOD
+		
 	create link static {$interface}_link{$pid} {$type}
 	set link action bundle {$interface}
 	set link {$multilink} multilink
@@ -1531,64 +1923,64 @@ EOD;
 	set link max-redial 0
 
 EOD;
-		if (isset($ppp['shortseq']))
-			$mpdconf .= <<<EOD
+			if (isset($ppp['shortseq']))
+				$mpdconf .= <<<EOD
 	set link no shortseq
 
 EOD;
-
-		if (isset($ppp['acfcomp']))
-			$mpdconf .= <<<EOD
+		
+			if (isset($ppp['acfcomp']))
+				$mpdconf .= <<<EOD
 	set link no acfcomp
 
 EOD;
-
-		if (isset($ppp['protocomp']))
-			$mpdconf .= <<<EOD
+		
+			if (isset($ppp['protocomp']))
+					$mpdconf .= <<<EOD
 	set link no protocomp
 
 EOD;
-
-		$mpdconf .= <<<EOD
+		
+			$mpdconf .= <<<EOD
 	set link disable chap pap
 	set link accept chap pap eap
 	set link disable incoming
 
 EOD;
-
-
-		if (!empty($bandwidths[$pid]))
-			$mpdconf .= <<<EOD
+			
+			
+			if (!empty($bandwidths[$pid]))
+				$mpdconf .= <<<EOD
 	set link bandwidth {$bandwidths[$pid]}
 
 EOD;
-
-		if (empty($mtus[$pid]))
-			$mtus[$pid] = "1492";
-			$mpdconf .= <<<EOD
+			
+			if (empty($mtus[$pid]))
+				$mtus[$pid] = "1492";
+				$mpdconf .= <<<EOD
 	set link mtu {$mtus[$pid]}
 
 EOD;
-
-		if (!empty($mrus[$pid]))
-			$mpdconf .= <<<EOD
+		
+			if (!empty($mrus[$pid]))
+				$mpdconf .= <<<EOD
 	set link mru {$mrus[$pid]}
 
 EOD;
-
-		if (!empty($mrrus[$pid]))
-			$mpdconf .= <<<EOD
+		
+			if (!empty($mrrus[$pid]))
+				$mpdconf .= <<<EOD
 	set link mrru {$mrrus[$pid]}
 
 EOD;
-
-		$mpdconf .= <<<EOD
+		
+			$mpdconf .= <<<EOD
 	set auth authname "{$ppp['username']}"
 	set auth password {$passwd}
 
 EOD;
-		if ($type == "modem") {
-			$mpdconf .= <<<EOD
+			if ($type == "modem") {
+				$mpdconf .= <<<EOD
 	set modem device {$ppp['ports']}
 	set modem script DialPeer
 	set modem idle-script Ringback
@@ -1597,59 +1989,72 @@ EOD;
 	set modem var \$Telephone "{$ppp['phone']}"
 
 EOD;
-		}
-		if (isset($ppp['connect-timeout']) && $type == "modem") {
-			$mpdconf .= <<<EOD
+			}
+				
+			if (isset($ppp['connect-timeout']) && $type == "modem") {
+				$mpdconf .= <<<EOD
 	set modem var \$ConnectTimeout "{$ppp['connect-timeout']}"
 
 EOD;
-		}
-		if (isset($ppp['initstr']) && $type == "modem") {
-			$initstr = base64_decode($ppp['initstr']);
-			$mpdconf .= <<<EOD
+			}
+				
+			if (isset($ppp['initstr']) && $type == "modem") {
+				$initstr = base64_decode($ppp['initstr']);
+				$mpdconf .= <<<EOD
 	set modem var \$InitString "{$initstr}"
 
 EOD;
-		}
-		if (isset($ppp['simpin']) && $type == "modem") {
-			$mpdconf .= <<<EOD
+			}
+				
+			if (isset($ppp['simpin']) && $type == "modem") {
+				$mpdconf .= <<<EOD
 	set modem var \$SimPin "{$ppp['simpin']}"
 	set modem var \$PinWait "{$ppp['pin-wait']}"
 
 EOD;
-		}
-		if (isset($ppp['apn']) && $type == "modem") {
-			$mpdconf .= <<<EOD
+			}
+				
+			if (isset($ppp['apn']) && $type == "modem") {
+				$mpdconf .= <<<EOD
 	set modem var \$APN "{$ppp['apn']}"
 	set modem var \$APNum "{$ppp['apnum']}"
 
 EOD;
-		}
-		if ($type == "pppoe") {
-			// Send a null service name if none is set.
-			$provider = isset($ppp['provider']) ? $ppp['provider'] : "";
-			$mpdconf .= <<<EOD
+			}
+				
+			if ($type == "pppoe") {
+				// Send a null service name if none is set.
+				$provider = isset($ppp['provider']) ? $ppp['provider'] : "";
+				$mpdconf .= <<<EOD
 	set pppoe service "{$provider}"
 
 EOD;
-		}
-		if ($type == "pppoe")
-			$mpdconf .= <<<EOD
+			}
+				
+			if ($type == "pppoe")
+				$mpdconf .= <<<EOD
 	set pppoe iface {$port}
 
 EOD;
-
-		if ($type == "pptp" || $type == "l2tp") {
-			$mpdconf .= <<<EOD
+		
+			if ($type == "pptp" || $type == "l2tp") {
+				$mpdconf .= <<<EOD
 	set {$type} self {$localips[$pid]}
 	set {$type} peer {$gateways[$pid]}
 
 EOD;
-		}
+			}
+			
+			$mpdconf .= "\topen\r\n";
+		} //end foreach($port)
 		
-		$mpdconf .= "\topen\r\n";
-	} //end foreach($port)
+	} //end if $type statement
+	
 
+###############################################################################################################################################
+###############################################################################################################################################
+###############################################################################################################################################
+###############################################################################################################################################
 
 	/* Generate mpd.conf. If mpd_[interface].conf exists in the conf path, then link to it instead of generating a fresh conf file. */
 	if (file_exists("{$g['conf_path']}/mpd_{$interface}.conf"))
@@ -1657,7 +2062,7 @@ EOD;
 	else {
 		$fd = fopen("{$g['varetc_path']}/mpd_{$interface}.conf", "w");
 		if (!$fd) {
-			log_error(sprintf(gettext("Error: cannot open mpd_%s.conf in interface_ppps_configure().%s"), $interface, "\n"));
+			log_error("Error: cannot open mpd_{$interface}.conf in interface_ppps_configure().\n");
 			return 0;
 		}
 		// Write out mpd_ppp.conf
@@ -1690,15 +2095,6 @@ EOD;
 		else
 			setup_pppoe_reset_file($ppp['if']);
 	}
-	/* wait for upto 10 seconds for the interface to appear (ppp(oe)) */
-	$i = 0;
-	while($i < 10) {
-		exec("/sbin/ifconfig {$ppp['if']} 2>&1", $out, $ret);
-		if($ret == 0)
-			break;
-		sleep(1);
-		$i++;
-	}
 
 	return 1;
 }
@@ -1718,16 +2114,20 @@ function interfaces_carp_setup() {
 	$cmdchain = new CmdCHAIN();	
 
 	if ($g['booting']) {
-		echo gettext("Configuring CARP settings...");
+		echo "Configuring CARP settings...";
 		mute_kernel_msgs();
 	}
 
 	/* suck in configuration items */
-	if($config['hasync']) {
-		$pfsyncenabled = $config['hasync']['pfsyncenabled'];
-		$balanacing = $config['hasync']['balancing'];
-		$pfsyncinterface = $config['hasync']['pfsyncinterface'];
-		$pfsyncpeerip = $config['hasync']['pfsyncpeerip'];
+	if($config['installedpackages']['carpsettings']) {
+		if($config['installedpackages']['carpsettings']['config']) {
+			foreach($config['installedpackages']['carpsettings']['config'] as $carp) {
+				$pfsyncenabled = $carp['pfsyncenabled'];
+				$balanacing = $carp['balancing'];
+				$pfsyncinterface = $carp['pfsyncinterface'];
+				$pfsyncpeerip = $carp['pfsyncpeerip'];
+			}
+		}
 	} else {
 		unset($pfsyncinterface);
 		unset($balanacing);
@@ -1735,12 +2135,12 @@ function interfaces_carp_setup() {
 	}
 
 	if($balanacing) {
-		$cmdchain->add(gettext("Enable CARP ARP-balancing"), "/sbin/sysctl net.inet.carp.arpbalance=1", true);
-		$cmdchain->add(gettext("Disallow CARP preemption"), "/sbin/sysctl net.inet.carp.preempt=0", true);
+		$cmdchain->add("Enable CARP ARP-balancing", "/sbin/sysctl net.inet.carp.arpbalance=1", true);
+		$cmdchain->add("Disallow CARP preemption", "/sbin/sysctl net.inet.carp.preempt=0", true);
 	} else
-		$cmdchain->add(gettext("Enable CARP preemption"), "/sbin/sysctl net.inet.carp.preempt=1", true);		
+		$cmdchain->add("Enable CARP preemption", "/sbin/sysctl net.inet.carp.preempt=1", true);		
 
-	$cmdchain->add(gettext("Enable CARP logging"), "/sbin/sysctl net.inet.carp.log=1", true);
+	$cmdchain->add("Enable CARP logging", "/sbin/sysctl net.inet.carp.log=1", true);
 	if (!empty($pfsyncinterface))
 		$carp_sync_int = get_real_interface($pfsyncinterface);
 
@@ -1756,17 +2156,17 @@ function interfaces_carp_setup() {
 			fclose($fd);
 			mwexec("/sbin/pfctl -f {$g['tmp_path']}/rules.boot");
 		} else
-			log_error(gettext("Could not create rules.boot file!"));
+			log_error("Could not create rules.boot file!");
 	}
 
 	/* setup pfsync interface */
 	if($carp_sync_int and $pfsyncenabled) {
 		if (is_ipaddr($pfsyncpeerip))
-			$cmdchain->add(gettext("Bring up pfsync0 syncpeer"), "/sbin/ifconfig pfsync0 syncdev {$carp_sync_int} syncpeer {$pfsyncpeerip} up", false);						
+			$cmdchain->add("Bring up pfsync0 syncpeer", "/sbin/ifconfig pfsync0 syncdev {$carp_sync_int} syncpeer {$pfsyncpeerip} up", false);						
 		else
-			$cmdchain->add(gettext("Bring up pfsync0 syncdev"), "/sbin/ifconfig pfsync0 syncdev {$carp_sync_int} up", false);			
+			$cmdchain->add("Bring up pfsync0 syncdev", "/sbin/ifconfig pfsync0 syncdev {$carp_sync_int} up", false);			
 	} else
-		$cmdchain->add(gettext("Bring up pfsync0"), "/sbin/ifconfig pfsync0 syncdev lo0 up", false);						
+		$cmdchain->add("Bring up pfsync0", "/sbin/ifconfig pfsync0 syncdev lo0 up", false);						
 
 	sleep(1);
 
@@ -1780,9 +2180,9 @@ function interfaces_carp_setup() {
 	}
 
 	if($config['virtualip']['vip'])
-		$cmdchain->add(gettext("Allow CARP."), "/sbin/sysctl net.inet.carp.allow=1", true);				
+		$cmdchain->add("Allow CARP.", "/sbin/sysctl net.inet.carp.allow=1", true);				
 	else
-		$cmdchain->add(gettext("Disallow CARP."), "/sbin/sysctl net.inet.carp.allow=0", true);		
+		$cmdchain->add("Disallow CARP.", "/sbin/sysctl net.inet.carp.allow=0", true);		
 	
 	if($g['debug'])
 		$cmdchain->setdebug(); // optional for verbose logging
@@ -1792,7 +2192,7 @@ function interfaces_carp_setup() {
 
 	if ($g['booting']) {
 		unmute_kernel_msgs();
-		echo gettext("done.") . "\n";
+		echo "done.\n";
 	}
 }
 
@@ -1975,27 +2375,16 @@ function interface_carp_configure(&$vip) {
 	 */
 	$realif = get_real_interface($vip['interface']);
 	if (!does_interface_exist($realif)) {
-		file_notice("CARP", sprintf(gettext("Interface specified for the virtual IP address %s does not exist. Skipping this VIP."), $vip['subnet']), "Firewall: Virtual IP", "");
+		file_notice("CARP", "Interface specified for the virtual IP address {$vip['subnet']} does not exist. Skipping this VIP.", "Firewall: Virtual IP", "");
 		return;
 	}
 
-	if(is_ipaddrv4($vip['subnet'])) {
-		/* Ensure CARP IP really exists prior to loading up. */
-		$ww_subnet_ip = find_interface_ip($realif);
-		$ww_subnet_bits = find_interface_subnet($realif);
-		if (!ip_in_subnet($vip['subnet'], gen_subnet($ww_subnet_ip, $ww_subnet_bits) . "/" . $ww_subnet_bits) && !ip_in_interface_alias_subnet($vip['interface'], $vip['subnet'])) {
-			file_notice("CARP", sprintf(gettext("Sorry but we could not find a matching real interface subnet for the virtual IP address %s."), $vip['subnet']), "Firewall: Virtual IP", "");
-			return;
-		}
-	}
-	if(is_ipaddrv6($vip['subnet'])) {
-		/* Ensure CARP IP really exists prior to loading up. */
-		$ww_subnet_ip = find_interface_ipv6($realif);
-		$ww_subnet_bits = find_interface_subnetv6($realif);
-		if (!ip_in_subnet($vip['subnet'], gen_subnetv6($ww_subnet_ip, $ww_subnet_bits) . "/" . $ww_subnet_bits) && !ip_in_interface_alias_subnet($vip['interface'], $vip['subnet'])) {
-			file_notice("CARP", sprintf(gettext("Sorry but we could not find a matching real interface subnet for the virtual IPv6 address %s."), $vip['subnet']), "Firewall: Virtual IP", "");
-			return;
-		}
+	/* Ensure CARP IP really exists prior to loading up. */
+	$ww_subnet_ip = find_interface_ip($realif);
+	$ww_subnet_bits = find_interface_subnet($realif);
+	if (!ip_in_subnet($vip['subnet'], gen_subnet($ww_subnet_ip, $ww_subnet_bits) . "/" . $ww_subnet_bits) && !ip_in_interface_alias_subnet($vip['interface'], $vip['subnet'])) {
+		file_notice("CARP", "Sorry but we could not find a matching real interface subnet for the virtual IP address {$vip['subnet']}.", "Firewall: Virtual IP", "");
+		return;
 	}
 
 	/* create the carp interface and setup */
@@ -2010,21 +2399,11 @@ function interface_carp_configure(&$vip) {
 	/* invalidate interface cache */
 	get_interface_arr(true);
 
-
+	$broadcast_address = gen_subnet_max($vip['subnet'], $vip['subnet_bits']);
 	$advbase = "";
 	if (!empty($vip['advbase']))
 		$advbase = "advbase {$vip['advbase']}";
-
-	if(is_ipaddrv4($vip['subnet'])) {
-		$broadcast_address = gen_subnet_max($vip['subnet'], $vip['subnet_bits']);
-		mwexec("/sbin/ifconfig {$vipif} {$vip['subnet']}/{$vip['subnet_bits']} vhid {$vip['vhid']} advskew {$vip['advskew']} {$advbase} {$password}");
-	}
-	if(is_ipaddrv6($vip['subnet'])) {
-		$broadcast_address = gen_subnet_max($vip['subnet'], $vip['subnet_bits']);
-		mwexec("/sbin/ifconfig {$vipif} inet6 {$vip['subnet']} prefixlen {$vip['subnet_bits']} vhid {$vip['vhid']} advskew {$vip['advskew']} {$advbase} {$password}");
-		/* make sure to add a link local address too */
-		mwexec("/sbin/ifconfig {$vipif} inet6 fe80::5:{$vip['vhid']} vhid {$vip['vhid']} advskew {$vip['advskew']} {$advbase} {$password}");
-	}
+	mwexec("/sbin/ifconfig {$vipif} {$vip['subnet']}/{$vip['subnet_bits']} vhid {$vip['vhid']} advskew {$vip['advskew']} {$advbase} {$password}");
 
 	interfaces_bring_up($vipif);
 	
@@ -2053,7 +2432,7 @@ function interface_carpdev_configure(&$vip) {
 	 * prevents a panic if the interface is missing or invalid
 	 */
 	if (!does_interface_exist($realif)) {
-		file_notice("CARP", sprintf(gettext("Interface specified for the virtual IP address %s does not exist. Skipping this VIP."), $vip['subnet']), "Firewall: Virtual IP", "");
+		file_notice("CARP", "Interface specified for the virtual IP address {$vip['subnet']} does not exist. Skipping this VIP.", "Firewall: Virtual IP", "");
 		return;
 	}
 
@@ -2099,7 +2478,7 @@ EOD;
 		/* fire up dhclient */
 		mwexec("/sbin/dhclient -c {$g['varetc_path']}/dhclient_{$vipif}.conf {$vipif} >{$g['tmp_path']}/{$vipif}_output 2>{$g['tmp_path']}/{$vipif}_error_output", false);
 	} else {
-		log_error(sprintf(gettext("Error: cannot open dhclient_%s.conf in interfaces_carpdev_configure() for writing.%s"), $vipif, "\n"));
+		log_error("Error: cannot open dhclient_{$vipif}.conf in interfaces_carpdev_configure() for writing.\n");
 		mwexec("/sbin/dhclient -b {$vipif}");
 	}
 
@@ -2132,15 +2511,15 @@ function interface_wireless_clone($realif, $wlcfg) {
 		exec("/sbin/ifconfig {$realif}", $output, $ret);
 		$ifconfig_str = implode($output);
 		if(($wlcfg_mode == "hostap") && (! preg_match("/hostap/si", $ifconfig_str))) {
-			log_error(sprintf(gettext("Interface %s changed to hostap mode"), $realif));
+			log_error("Interface {$realif} changed to hostap mode");
 			$needs_clone = true;
 		}
 		if(($wlcfg_mode == "adhoc") && (! preg_match("/adhoc/si", $ifconfig_str))) {
-			log_error(sprintf(gettext("Interface %s changed to adhoc mode"), $realif));
+			log_error("Interface {$realif} changed to adhoc mode");
 			$needs_clone = true;
 		}
 		if(($wlcfg_mode == "bss") && (preg_match("/hostap|adhoc/si", $ifconfig_str))) {
-			log_error(sprintf(gettext("Interface %s changed to infrastructure mode"), $realif));
+			log_error("Interface {$realif} changed to infrastructure mode");
 			$needs_clone = true;
 		}
 	} else {
@@ -2152,12 +2531,12 @@ function interface_wireless_clone($realif, $wlcfg) {
 		if(does_interface_exist($realif))
 			pfSense_interface_destroy($realif);
 
-		log_error(sprintf(gettext("Cloning new wireless interface %s"), $realif));
+		log_error("Cloning new wireless interface {$realif}");
 		// Create the new wlan interface. FreeBSD returns the new interface name.
 		// example:  wlan2
 		exec("/sbin/ifconfig wlan create wlandev {$baseif} {$mode} bssid 2>&1", $out, $ret);
 		if($ret <> 0) {
-			log_error(sprintf(gettext('Failed to clone interface %1$s with error code %2$s, output %3$s'), $baseif, $ret, $out[0]));
+			log_error("Failed to clone interface {$baseif} with error code {$ret}, output {$out[0]}");
 			return false;
 		}
 		$newif = trim($out[0]);
@@ -2479,18 +2858,12 @@ EOD;
 					$auth_server_port = "1812";
 					if($wlcfg['auth_server_port']) 
 						$auth_server_port = $wlcfg['auth_server_port'];
-					$auth_server_port2 = "1812";
-					if($wlcfg['auth_server_port2']) 
-						$auth_server_port2 = $wlcfg['auth_server_port2'];
 					$wpa .= <<<EOD
 
 ieee8021x=1
 auth_server_addr={$wlcfg['auth_server_addr']}
 auth_server_port={$auth_server_port}
 auth_server_shared_secret={$wlcfg['auth_server_shared_secret']}
-auth_server_addr={$wlcfg['auth_server_addr2']}
-auth_server_port={$auth_server_port2}
-auth_server_shared_secret={$wlcfg['auth_server_shared_secret2']}
 
 EOD;
 				} else {
@@ -2671,19 +3044,9 @@ function find_dhclient_process($interface) {
 	return intval($pid);
 }
 
-function find_dhcp6c_process($interface) {
-	if ($interface)
-		$pid = `/bin/ps auxw|grep "dhcp6c" |grep "{$interface}"|awk '{print $2}'`;
-	else
-		$pid = 0;
-
-	return intval($pid);
-}
-
 function interface_configure($interface = "wan", $reloadall = false, $linkupevent = false) {
 	global $config, $g;
 	global $interface_sn_arr_cache, $interface_ip_arr_cache;
-	global $interface_snv6_arr_cache, $interface_ipv6_arr_cache;
 
 	$wancfg = $config['interfaces'][$interface];
 
@@ -2692,27 +3055,21 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 	// Need code to handle MLPPP if we ever use $realhwif for MLPPP handling
 	$realhwif = $realhwif_array[0];
 
-	/* Disable Accepting router advertisements unless specifically requested */
-	log_error("Deny router advertisements for interface {$interface}");
-	mwexec("/sbin/ifconfig " . escapeshellarg($realif) . " inet6 -accept_rtadv");
 			
 	if (!$g['booting'] && !substr($realif, 0, 4) == "ovpn") {
-		/* remove all IPv4 and IPv6 addresses */
+		/* remove all IPv4 addresses */
 		while (mwexec("/sbin/ifconfig " . escapeshellarg($realif) . " -alias", true) == 0);
-		while (mwexec("/sbin/ifconfig " . escapeshellarg($realif) . " inet6 -alias", true) == 0);
 
-		/* only bring down the interface when both v4 and v6 are set to NONE */
-		if(($wancfg['ipaddr'] <> "none") && ($wancfg['ipaddrv6'] <> "none")) {
-
-
-
-
-
-
-
-
-			interface_bring_down($interface);
-
+		switch ($wancfg['ipaddr']) {
+			case 'pppoe':
+			case 'l2tp':
+			case 'pptp':
+			case 'pptp-client':
+			case 'ppp':
+				break;
+			default:
+				interface_bring_down($interface);
+				break;
 		}
 	}
 
@@ -2741,18 +3098,17 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
                         }
                 }
 	}  else {
-
 		if ($mac == "ff:ff:ff:ff:ff:ff") {
 			/*   this is not a valid mac address.  generate a
 			 *   temporary mac address so the machine can get online.
 			 */
-			echo gettext("Generating new MAC address.");
+			echo "Generating new MAC address.";
 			$random_mac = generate_random_mac_address();
 			mwexec("/sbin/ifconfig " . escapeshellarg($realhwif) .
 				" link " . escapeshellarg($random_mac));
 			$wancfg['spoofmac'] = $random_mac;
 			write_config();
-			file_notice("MAC Address altered", sprintf(gettext('The INVALID MAC address (ff:ff:ff:ff:ff:ff) on interface %1$s has been automatically replaced with %2$s'), $realif, $random_mac), "Interfaces");
+			file_notice("MAC Address altered", "The INVALID MAC address (ff:ff:ff:ff:ff:ff) on interface {$realif} has been automatically replaced with {$random_mac}", "Interfaces");
 		}
 	}
 
@@ -2827,8 +3183,6 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 	get_interface_arr(true);
 	unset($interface_ip_arr_cache[$realif]);
 	unset($interface_sn_arr_cache[$realif]);
-	unset($interface_ipv6_arr_cache[$realif]);
-	unset($interface_snv6_arr_cache[$realif]);
 
 	switch ($wancfg['ipaddr']) {
 		case 'carpdev-dhcp':
@@ -2840,11 +3194,12 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 		case 'pppoe':
 		case 'l2tp':
 		case 'pptp':
+		case 'pptp-client':
 		case 'ppp':
 			interface_ppps_configure($interface);
 			break;
 		default:
-			if (is_ipaddr($wancfg['ipaddr']) && $wancfg['subnet'] <> "") {
+			if ($wancfg['ipaddr'] <> "" && $wancfg['subnet'] <> "") {
 				pfSense_interface_setaddress($realif, "{$wancfg['ipaddr']}/{$wancfg['subnet']}");
 			} else if (substr($realif, 0, 3) == "gre") {
 				if (is_array($config['gres']['gre'])) {
@@ -2860,22 +3215,6 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 				}
 			} else if (substr($realif, 0, 4) == "ovpn") {
 				/* XXX: Should be done anything?! */
-			}
-			break;
-	}
-
-	switch ($wancfg['ipaddrv6']) {
-		case 'dhcp6':
-			interface_dhcpv6_configure($interface);
-			break;
-		case '6rd':
-			interface_6rd_configure($interface);
-			break;
-		default:
-			if (is_ipaddr($wancfg['ipaddrv6']) && $wancfg['subnetv6'] <> "") {
-				pfSense_interface_setaddress($realif, "{$wancfg['ipaddrv6']}/{$wancfg['subnetv6']}");
-				// FIXME: Add IPv6 Support to the pfSense module
-				mwexec("/sbin/ifconfig {$realif} inet6 {$wancfg['ipaddrv6']} prefixlen {$wancfg['subnetv6']} ");
 			}
 			break;
 	}
@@ -2896,7 +3235,7 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 		unset($gif);
 		$gif = link_interface_to_gif($interface);
 		if (!empty($gif))
-			array_walk($gif, 'interface_gif_configure');
+                       	array_walk($gif, 'interface_gif_configure');
 
 		if ($linkupevent == false || substr($realif, 0, 4) == "ovpn") {
 			unset($bridgetmp);
@@ -2944,203 +3283,8 @@ function interface_carpdev_dhcp_configure($interface = "wan") {
 	if($wanif)
 		interfaces_bring_up($wanif);
 	else 
-		log_error(gettext("Could not bring wanif up in terface_carpdev_dhcp_configure()"));
+		log_error("Could not bring wanif up in terface_carpdev_dhcp_configure()");
 
-	return 0;
-}
-
-function interface_6rd_configure($interface = "wan"){
-	global $config, $g;
-	$iflist = get_configured_interface_with_descr(false, true);
-
-	/* because this is a tunnel interface we can only function 
-	 *	with a public IPv4 address on the interface */
-
-	$wancfg = $config['interfaces'][$interface];
-	$wanif = $wancfg['if'];
-	if (empty($wancfg))
-		$wancfg = array();
-
-	$wanif = get_real_interface($interface);
-	
-	$ip4address = find_interface_ip($wanif);
-	if((!is_ipaddrv4($ip4address)) || (is_private_ip($ip4address))) {
-		log_error("The interface IPv4 '{$ip4address}' address on interface '{$wanif}' is not public, not configuring 6RD tunnel");
-		return false;
-	}
-	
-	if(!is_numeric($wancfg['prefix-6rd-v4plen']))
-		$v4prefixlen = 0;
-	else
-		$v4prefixlen = $wancfg['prefix-6rd-v4plen'];	
-
-	/* create the long prefix notation for math, save the prefix length */
-	$rd6prefix = explode("/", $wancfg['prefix-6rd']);
-	$rd6prefixlen = $rd6prefix[1];
-	$rd6prefix = Net_IPv6::uncompress($rd6prefix[0]);
-	$rd6arr = explode(":", $rd6prefix);
-
-	/* we need the hex form of the interface IPv4 address */
-	$ip4arr = explode(".", $ip4address);
-	$hexwanv4 = "";
-	foreach($ip4arr as $octet)
-		$hexwanv4 .= sprintf("%02x", $octet);
-
-	/* we need the hex form of the broker IPv4 address */
-	$ip4arr = explode(".", $wancfg['gateway-6rd']);
-	$hexbrv4 = "";
-	foreach($ip4arr as $octet)
-		$hexbrv4 .= sprintf("%02x", $octet);
-	
-	/* binary presentation of the prefix for all 128 bits. */
-	$rd6prefixbin = "";
-	foreach($rd6arr as $element) {
-		$rd6prefixbin .= sprintf("%016b", hexdec($element));
-	}
-	/* just save the left prefix length bits */
-	$rd6prefixstartbin = substr($rd6prefixbin, 0, $rd6prefixlen);
-
-	/* if the prefix length is not 32 bits we need to shave bits off from the left of the v4 address. */
-	$rd6brokerbin = substr(sprintf("%032b", hexdec($hexbrv4)), $v4prefixlen, 32);
-	$rd6brokerbin = str_pad($rd6prefixstartbin . $rd6brokerbin, 128, "0", STR_PAD_RIGHT);;
-
-	/* for the local subnet too. */
-	$rd6lanbin = substr(sprintf("%032b", hexdec($hexwanv4)), $v4prefixlen, 32);
-	$rd6lanbin = str_pad($rd6prefixstartbin . $rd6lanbin, 128, "0", STR_PAD_RIGHT);;
-
-	/* convert the 128 bits for the broker address back into a valid IPv6 address */ 
-	$rd6brarr = array();
-	$rd6brbinarr = array();
-	$rd6brbinarr = str_split($rd6brokerbin, 16);
-	foreach($rd6brbinarr as $bin)
-		$rd6brarr[] = dechex(bindec($bin));
-	$rd6brarr[7] = 1;
-	$rd6brgw = Net_IPv6::compress(implode(":", $rd6brarr));
-
-	/* convert the 128 bits for the broker address back into a valid IPv6 address */ 
-	$rd6lanarr = array();
-	$rd6lanbinarr = array();
-	$rd6lanbinarr = str_split($rd6lanbin, 16);
-	foreach($rd6lanbinarr as $bin)
-		$rd6lanarr[] = dechex(bindec($bin));
-	$rd6lanpr = Net_IPv6::compress(implode(":", $rd6lanarr));
-	$rd6lanarr[7] = 1;
-	$rd6lan = Net_IPv6::compress(implode(":", $rd6lanarr));
-
-	/* setup the stf interface */
-	mwexec("/sbin/ifconfig srd0 destroy");
-	mwexec("/sbin/ifconfig srd0 create");
-	mwexec("/sbin/ifconfig srd0 v4plen {$v4prefixlen} pfix {$rd6prefix} plen {$rd6prefixlen} braddr {$wancfg['gateway-6rd']}");
-	mwexec("/sbin/ifconfig srd0 inet6 {$rd6lanpr} prefixlen 128");
-
-	log_error("Created 6rd interface srd0 v4plen {$v4prefixlen} pfix {$rd6prefix} plen {$rd6prefixlen} braddr {$wancfg['gateway-6rd']}");
-	log_error("Set IPv6 address inet6 {$rd6lanpr} prefixlen 128 for srd0");
-	
-	/* Example 6RD setup steps
-	# ifconfig srd0 create
-	# ifconfig srd0
-	srd0: flags=0<> metric 0 mtu 1280
-		srd: v4plen 0 pfix :: plen 0 braddr 0.0.0.0
-	# ifconfig srd0 up
-	# ifconfig srd0 v4plen 20 pfix fc00:0:0:1000:: plen 52 braddr 10.0.0.1
-	# ifconfig srd0
-		srd0: flags=1<UP> metric 0 mtu 1280
-		srd: v4plen 20 pfix fc00:0:0:1000:: plen 52 braddr 10.0.0.1
-	*/
-
-	/* write out a default router file */
-	file_put_contents("{$g['tmp_path']}/{$wanif}_routerv6", "::1 -ifp srd0\n");
-	
-	return 0;
-}
-
-function interface_dhcpv6_configure($interface = "wan") {
-	global $config, $g;
-	$iflist = get_configured_interface_with_descr(false, true);
-
-	$wancfg = $config['interfaces'][$interface];
-	$wanif = $wancfg['if'];
-	if (empty($wancfg))
-		$wancfg = array();
-
-	$wanif = get_real_interface($interface);
-
-	/* Add ISC IPv6 dhclient here, only wide-dhcp6c works for now. */
-	$fd = fopen("{$g['varetc_path']}/dhcp6c_{$interface}.conf", "w");
-	if (!$fd) {
-		printf("Error: cannot open dhcp6c_{$interface}.conf in interfaces_wan_dhcpv6_configure() for writing.\n");
-		return 1;
-	}
-
-	$dhcp6cconf = "";
- 	$dhcp6cconf .= "interface {$wanif} {\n";
-	$dhcp6cconf .= " 	send ia-na 0;	# request stateful address\n";
-	if(is_numeric($wancfg['dhcp6-ia-pd-len'])) {
-		$dhcp6cconf .= " 	send ia-pd 0;	# request prefix delegation\n";
-	}
-	$dhcp6cconf .= "request domain-name-servers;\n";
-	$dhcp6cconf .= "request domain-name;\n";
-	$dhcp6cconf .= "script \"{$g['varetc_path']}/dhcp6c_{$interface}_script.sh\"; # we'd like some nameservers please\n";
-
-	$dhcp6cconf .= "};\n";
-	$dhcp6cconf .= "id-assoc na 0 { };\n";
-	if(is_numeric($wancfg['dhcp6-ia-pd-len'])) {
-		/* Setup the prefix delegation */
-		$dhcp6cconf .= "	id-assoc pd 0 {\n";
-		foreach($iflist as $friendly => $pdinterface) {
-			// log_error("setting up $friendly - $pdinterface - {$pdinterface['dhcp6-pd-sla-id']}");
-			if(is_numeric($config['interfaces'][$friendly]['dhcp6-pd-sla-id'])) {
-				$realif = get_real_interface($friendly);
-				$dhcp6cconf .= "	prefix-interface {$realif} {\n";
-				$dhcp6cconf .= "		sla-id {$config['interfaces'][$friendly]['dhcp6-pd-sla-id']};\n";
-				$dhcp6cconf .= "		sla-len {$wancfg['dhcp6-ia-pd-len']};\n";
-				$dhcp6cconf .= "	};\n";
-			}
-		}
-		$dhcp6cconf .= "};\n";
-	}
-
-	fwrite($fd, $dhcp6cconf);
-	fclose($fd);
-
-	/* Add wide-dhcp6c shell script here. Because we can not pass a argument to it. */
-	$fds = fopen("{$g['varetc_path']}/dhcp6c_{$interface}_script.sh", "w");
-	if (!$fds) {
-		printf("Error: cannot open dhcp6c_{$interface}_script.sh in interfaces_wan_dhcpv6_configure() for writing.\n");
-		return 1;
-	}
-	$dhcp6cscript = "#!/bin/sh\n";
-	$dhcp6cscript .= "# This shell script launches /etc/rc.newwanipv6 with a interface argument.\n";
-	$dhcp6cscript .= "/etc/rc.newwanipv6 $interface \n";
-
-	fwrite($fds, $dhcp6cscript);
-	fclose($fds);
-	chmod("{$g['varetc_path']}/dhcp6c_{$interface}_script.sh", 0755);
-
-
-	/* accept router advertisements for this interface */
-	mwexec("/sbin/sysctl -w net.inet6.ip6.accept_rtadv=1");
-	log_error("Accept router advertisements on interface {$wanif} ");
-	mwexec("/sbin/ifconfig {$wanif} inet6 accept_rtadv");
-	mwexec("/sbin/ifconfig {$wanif} inet6 defroute_rtadv");
-
-	/* fire up dhcp6c for IPv6 first, this backgrounds immediately */
-	mwexec("/usr/local/sbin/dhcp6c -d -c {$g['varetc_path']}/dhcp6c_{$interface}.conf {$wanif}");
-	exec("/sbin/rtsol -d {$wanif} 2>&1", $out, $ret);
-	if(!empty($out)) {
-		foreach($out as $line) {
-			if(stristr($line, "received")) {
-				$parts = explode(" ", $line);
-				if(is_ipaddrv6($parts[3])) {
-					log_error("Found IPv6 default gateway '{$parts[3]}' by RA.");
-					file_put_contents("{$g['tmp_path']}/{$wanif}_routerv6", "{$parts[3]}\n");
-				}
-			}
-		}
-	}
-	/* sleep a few seconds before returning to give the client some time
-	 * to configure a lan interface with a prefix */
-	sleep(5);
 	return 0;
 }
 
@@ -3148,14 +3292,13 @@ function interface_dhcp_configure($interface = "wan") {
 	global $config, $g;
 
 	$wancfg = $config['interfaces'][$interface];
-	$wanif = $wancfg['if'];
 	if (empty($wancfg))
 		$wancfg = array();
 
 	/* generate dhclient_wan.conf */
 	$fd = fopen("{$g['varetc_path']}/dhclient_{$interface}.conf", "w");
 	if (!$fd) {
-		printf(printf(gettext("Error: cannot open dhclient_%s.conf in interfaces_wan_dhcp_configure() for writing.%s"), $interface, "\n"));
+		printf("Error: cannot open dhclient_{$interface}.conf in interfaces_wan_dhcp_configure() for writing.\n");
 		return 1;
 	}
 
@@ -3168,7 +3311,7 @@ function interface_dhcp_configure($interface = "wan") {
 
 	$wanif = get_real_interface($interface);
 	if (empty($wanif)) {
-		log_error(sprintf(gettext("Invalid interface \"%s\" in interface_dhcp_configure()"), $interface));
+		log_error("Invalid interface \"{$interface}\" in interface_dhcp_configure()");
 		return 0;
 	}
  	$dhclientconf = "";
@@ -3203,7 +3346,7 @@ EOD;
 	if($wanif)
 		interfaces_bring_up($wanif);
 	else 
-		log_error(printf(gettext("Could not bring up %s interface in interface_dhcp_configure()"), $wanif));
+		log_error("Could not bring up {$wanif} interface in interface_dhcp_configure()");
 
 	/* fire up dhclient */
 	mwexec("/sbin/dhclient -c {$g['varetc_path']}/dhclient_{$interface}.conf {$wanif} > {$g['tmp_path']}/{$wanif}_output > {$g['tmp_path']}/{$wanif}_error_output");
@@ -3307,6 +3450,9 @@ function convert_friendly_interface_to_friendly_descr($interface) {
 	case "pptp":
 		$ifdesc = "PPTP";
 		break;
+	case "pptp-client":
+		$ifdesc = "pptp-client";
+		break;
 	case "pppoe":
 		$ifdesc = "PPPoE";
 		break;
@@ -3387,6 +3533,7 @@ function get_parent_interface($interface) {
 			case "ppp":
 			case "pppoe":
 			case "pptp":
+			case "pptp-client":
 			case "l2tp":
 				if (empty($parents))
 					if (is_array($config['ppps']['ppp']))
@@ -3456,6 +3603,9 @@ function get_real_interface($interface = "wan") {
 	case "pptp":
 		$wanif = "pptp";
 		break;
+	case "pptp-client":
+		$wanif = "pptp-client";
+		break;
 	case "pppoe":
 		$wanif = "pppoe";
 		break;
@@ -3512,6 +3662,7 @@ function get_real_interface($interface = "wan") {
 				break;
 			case "pppoe": 
 			case "pptp": 
+			case "pptp-client":
 			case "l2tp": 
 			case "ppp":
 				$wanif = $cfg['if'];
@@ -3531,28 +3682,13 @@ function guess_interface_from_ip($ipaddress) {
 	if(! is_ipaddr($ipaddress)) {
 		return false;
 	}
-	if(is_ipaddrv4($ipaddress)) {
-		/* create a route table we can search */
-		exec("netstat -rnWf inet", $output, $ret);
-		foreach($output as $line) {
-			if(preg_match("/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\/[0-9]+[ ]+link[#]/", $line)) {
-				$fields = preg_split("/[ ]+/", $line);
-				if(ip_in_subnet($ipaddress, $fields[0])) {
-					return $fields[6];
-				}
-			}
-		}
-	}
-	/* FIXME: This works from cursory testing, regexp might need fine tuning */
-	if(is_ipaddrv6($ipaddress)) {
-		/* create a route table we can search */
-		exec("netstat -rnWf inet6", $output, $ret);
-		foreach($output as $line) {
-			if(preg_match("/[0-9a-f]+[:]+[0-9a-f]+[:]+[\/][0-9]+/", $line)) {
-				$fields = preg_split("/[ ]+/", $line);
-				if(ip_in_subnet($ipaddress, $fields[0])) {
-					return $fields[6];
-				}
+	/* create a route table we can search */
+	exec("netstat -rnWf inet", $output, $ret);
+	foreach($output as $line) {
+		if(preg_match("/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\/[0-9]+[ ]+link[#]/", $line)) {
+			$fields = preg_split("/[ ]+/", $line);
+			if(ip_in_subnet($ipaddress, $fields[0])) {
+				return $fields[6];
 			}
 		}
 	}
@@ -3601,23 +3737,8 @@ function find_carp_interface($ip) {
 	if (is_array($config['virtualip']['vip'])) {
 		foreach ($config['virtualip']['vip'] as $vip) {
 			if ($vip['mode'] == "carp" || $vip['mode'] == "carpdev") {
-				if(is_ipaddrv4($ip)) {
-					$carp_ip = get_interface_ip($vip['interface']);
-				}
-				if(is_ipaddrv6($ip)) {
-					$carp_ip = get_interface_ipv6($vip['interface']);
-				}
-				exec("/sbin/ifconfig", $output, $return);
-				foreach($output as $line) {
-					$elements = preg_split("/[ ]+/i", $line);
-					if(strstr($elements[0], "vip"))
-						$curif = str_replace(":", "", $elements[0]);
-					if(stristr($line, $ip)) {
-						$if = $curif;
-						continue;
-					}
-				}
-
+				$carp_ip = get_interface_ip($vip['interface']);
+				$if = `ifconfig | grep '$ip ' -B1 | head -n1 | cut -d: -f1`;
 				if ($if)
 					return $if;
 			}
@@ -3805,78 +3926,6 @@ function find_interface_ip($interface, $flush = false)
 	return $interface_ip_arr_cache[$interface];
 }
 
-/*
- * find_interface_ipv6($interface): return the interface ip (first found)
- */
-function find_interface_ipv6($interface, $flush = false)
-{
-	global $interface_ipv6_arr_cache;
-	global $interface_snv6_arr_cache;
-	global $config;
-	
-	$interface = str_replace("\n", "", $interface);
-	
-	if (!does_interface_exist($interface))
-		return;
-
-	/* Setup IP cache */
-	if (!isset($interface_ipv6_arr_cache[$interface]) or $flush) {
-		$ifinfo = pfSense_get_interface_addresses($interface);
-		// FIXME: Add IPv6 support to the pfSense module
-		exec("/sbin/ifconfig {$interface} inet6", $output);
-		foreach($output as $line) {
-			if(preg_match("/inet6/", $line)) {
-				$parts = explode(" ", $line);
-				if(! preg_match("/fe80::/", $parts[1])) {
-					$ifinfo['ipaddrv6'] = $parts[1];
-					if($parts[2] == "-->") {
-						$parts[5] = "126";
-						$ifinfo['subnetbitsv6'] = $parts[5];
-					} else {
-						$ifinfo['subnetbitsv6'] = $parts[3];
-					}
-				}
-			}
-		}
-		$interface_ipv6_arr_cache[$interface] = $ifinfo['ipaddrv6'];
-		$interface_snv6_arr_cache[$interface] = $ifinfo['subnetbitsv6'];
-	}
-
-	return $interface_ipv6_arr_cache[$interface];
-}
-
-/*
- * find_interface_ipv6_ll($interface): return the interface ipv6 link local (first found)
- */
-function find_interface_ipv6_ll($interface, $flush = false)
-{
-	global $interface_llv6_arr_cache;
-	global $config;
-	
-	$interface = str_replace("\n", "", $interface);
-	
-	if (!does_interface_exist($interface))
-		return;
-
-	/* Setup IP cache */
-	if (!isset($interface_llv6_arr_cache[$interface]) or $flush) {
-		$ifinfo = pfSense_get_interface_addresses($interface);
-		// FIXME: Add IPv6 support to the pfSense module
-		exec("/sbin/ifconfig {$interface} inet6", $output);
-		foreach($output as $line) {
-			if(preg_match("/inet6/", $line)) {
-				$parts = explode(" ", $line);
-				if(preg_match("/fe80::/", $parts[1])) {
-					$partsaddress = explode("%", $parts[1]);
-					$ifinfo['linklocal'] = $partsaddress[0];
-				}
-			}
-		}
-		$interface_llv6_arr_cache[$interface] = $ifinfo['linklocal'];
-	}
-	return $interface_llv6_arr_cache[$interface];
-}
-
 function find_interface_subnet($interface, $flush = false)
 {
 	global $interface_sn_arr_cache;
@@ -3893,40 +3942,6 @@ function find_interface_subnet($interface, $flush = false)
         }
 
 	return $interface_sn_arr_cache[$interface];
-}
-
-function find_interface_subnetv6($interface, $flush = false)
-{
-	global $interface_snv6_arr_cache;
-	global $interface_ipv6_arr_cache;
-
-	$interface = str_replace("\n", "", $interface);
-	if (does_interface_exist($interface) == false)
-		return;
-
-	if (!isset($interface_snv6_arr_cache[$interface]) or $flush) {
-		$ifinfo = pfSense_get_interface_addresses($interface);
-		// FIXME: Add IPv6 support to the pfSense module
-		exec("/sbin/ifconfig {$interface} inet6", $output);
-		foreach($output as $line) {
-			if(preg_match("/inet6/", $line)) {
-				$parts = explode(" ", $line);
-				if(! preg_match("/fe80::/", $parts[1])) {
-					$ifinfo['ipaddrv6'] = $parts[1];
-					if($parts[2] == "-->") {
-						$parts[5] = "126";
-						$ifinfo['subnetbitsv6'] = $parts[5];
-					} else {
-						$ifinfo['subnetbitsv6'] = $parts[3];
-					}
-				}
-			}
-		}
-		$interface_ipv6_arr_cache[$interface] = $ifinfo['ipaddrv6'];
-		$interface_snv6_arr_cache[$interface] = $ifinfo['subnetbitsv6'];
-        }
-
-	return $interface_snv6_arr_cache[$interface];
 }
 
 function ip_in_interface_alias_subnet($interface, $ipalias) {
@@ -3969,44 +3984,6 @@ function get_interface_ip($interface = "wan")
 		return null;
 }
 
-function get_interface_ipv6($interface = "wan")
-{
-	$realif = get_real_interface($interface);
-	if (!$realif) {
-		if (preg_match("/^carp/i", $interface))
-			$realif = $interface;
-		else if (preg_match("/^vip/i", $interface))
-			$realif = $interface;
-		else
-			return null;
-	}
-
-	$curip = find_interface_ipv6($realif);
-	if ($curip && is_ipaddrv6($curip) && ($curip != "::"))
-		return $curip;
-	else
-		return null;
-}
-
-function get_interface_linklocal($interface = "wan")
-{
-	$realif = get_real_interface($interface);
-	if (!$realif) {
-		if (preg_match("/^carp/i", $interface))
-			$realif = $interface;
-		else if (preg_match("/^vip/i", $interface))
-			$realif = $interface;
-		else
-			return null;
-	}
-
-	$curip = find_interface_ipv6_ll($realif);
-	if ($curip && is_ipaddrv6($curip) && ($curip != "::"))
-		return $curip;
-	else
-		return null;
-}
-
 function get_interface_subnet($interface = "wan")
 {
 	$realif = get_real_interface($interface);
@@ -4020,25 +3997,6 @@ function get_interface_subnet($interface = "wan")
         }
 
 	$cursn = find_interface_subnet($realif);
-	if (!empty($cursn))
-		return $cursn;
-
-	return null;
-}
-
-function get_interface_subnetv6($interface = "wan")
-{
-	$realif = get_real_interface($interface);
-	if (!$realif) {
-                if (preg_match("/^carp/i", $interface))
-                        $realif = $interface;
-                else if (preg_match("/^vip/i", $interface))
-                        $realif = $interface;
-                else
-                        return null;
-        }
-
-	$cursn = find_interface_subnetv6($realif);
 	if (!empty($cursn))
 		return $cursn;
 
@@ -4059,6 +4017,7 @@ function get_interfaces_with_gateway() {
 			case "ppp";
 			case "pppoe":
 			case "pptp":
+			case "pptp-client":
 			case "l2tp":
 			case "ppp";
 				$ints[$ifdescr] = $ifdescr;
@@ -4084,6 +4043,7 @@ function interface_has_gateway($friendly) {
 			case "carpdev-dhcp":
 			case "pppoe":
 			case "pptp":
+			case "pptp-client":
 			case "l2tp":
 			case "ppp";
 				return true;
@@ -4092,31 +4052,6 @@ function interface_has_gateway($friendly) {
 				if (substr($ifname['if'], 0, 5) ==  "ovpnc")
 					return true;
 				if (!empty($ifname['gateway']))
-					return true;
-			break;
-		}
-	}
-
-	return false;
-}
-
-/* return true if interface has a gateway */
-function interface_has_gatewayv6($friendly) {
-	global $config;
-
-	if (!empty($config['interfaces'][$friendly])) {
-		$ifname = &$config['interfaces'][$friendly];
-		switch ($ifname['ipaddrv6']) {
-			case "dhcp6":
-				return true;
-			break;
-			case "6rd":
-				return true;
-			break;
-			default:
-				if (substr($ifname['if'], 0, 5) ==  "ovpnc")
-					return true;
-				if (!empty($ifname['gatewayv6']))
 					return true;
 			break;
 		}
@@ -4144,7 +4079,7 @@ function is_altq_capable($int) {
 			"hme", "igb", "ipw", "iwi", "jme", "le", "lem", "msk", "mxge", "my", "nfe",
 			"npe", "nve", "ral", "re", "rl", "rum", "run", "bwn", "sf", "sis", "sk",
 			"ste", "stge", "txp", "udav", "ural", "vge", "vr", "wi", "xl",
-			"ndis", "tun", "ovpns", "ovpnc", "vlan", "pppoe", "pptp", "ng",
+			"ndis", "tun", "ovpns", "ovpnc", "vlan", "pppoe", "pptp", "pptp-client", "ng",
 			"l2tp", "ppp");
 
         $int_family = preg_split("/[0-9]+/", $int);
@@ -4290,19 +4225,15 @@ function generate_random_mac_address() {
  * RESULT
  *   boolean          - true or false
  ******/
-function is_jumbo_capable($iface) {
+function is_jumbo_capable($int) {
+        global $g;
 
+        $int_family = preg_split("/[0-9]+/", $int);
 
-	$iface = trim($iface);
-	$capable = pfSense_get_interface_addresses($iface);
-	if (isset($capable['caps']['vlanmtu']))
+        if (in_array($int_family[0], $g['vlan_long_frame']))
                 return true;
-
-
-
-
-
-	return false;
+        else
+                return false;
 }
 
 function setup_pppoe_reset_file($pppif, $iface="") {

--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -96,7 +96,7 @@ function mark_subsystem_dirty($subsystem = "") {
 	global $g;
 
 	if (!file_put_contents("{$g['varrun_path']}/{$subsystem}.dirty", "DIRTY"))
-		log_error(sprintf(gettext("WARNING: Could not mark subsystem: %s dirty"), $subsystem));
+		log_error("WARNING: Could not mark subsystem: {$subsytem} dirty");
 }
 
 function clear_subsystem_dirty($subsystem = "") {
@@ -116,7 +116,7 @@ function config_unlock() {
 function lock($lock, $op = LOCK_SH) {
 	global $g, $cfglckkeyconsumers;
 	if (!$lock)
-		die(gettext("WARNING: You must give a name as parameter to lock() function."));
+		die("WARNING: You must give a name as parameter to lock() function.");
 	if (!file_exists("{$g['tmp_path']}/{$lock}.lock"))
 		@touch("{$g['tmp_path']}/{$lock}.lock");
 	$cfglckkeyconsumers++;
@@ -166,9 +166,16 @@ function send_multiple_events($cmds) {
 			
 	if (!is_array($cmds))
 		return;
-
-	foreach ($cmds as $cmd)
-		send_event($cmd);
+	$fd = fsockopen($g['event_address']);
+	if ($fd) {
+		foreach ($cmds as $cmd) {
+			fwrite($fd, $cmd);
+			$resp = fread($fd, 4096);
+			if ($resp != "OK\n")
+				log_error("send_event: sent {$cmd} got {$resp}");
+		}
+		fclose($fd);
+	}
 }
 
 function refcount_init($reference) {
@@ -179,19 +186,21 @@ function refcount_init($reference) {
 
 function refcount_reference($reference) {
 	try {
-		$shmid = @shmop_open($reference, "w", 0644, 10);
+		$shmid = @shmop_open($reference, "w", 0, 0);
 		if (!$shmid) {
 			refcount_init($reference);
 			$shmid = @shmop_open($reference, "w", 0, 0);
 		}
 		$shm_data = @shmop_read($shmid, 0, 10);
+		if (intval($shm_data) < 0)
+			$shm_data = 0;
 		$shm_data = intval($shm_data) + 1;
 		@shmop_write($shmid, $shm_data, 0);
 		@shmop_close($shmid);
 	} catch (Exception $e) {
 		log_error($e->getMessage());
 	}
-
+		
 	return $shm_data;
 }
 
@@ -202,15 +211,15 @@ function refcount_unreference($reference) {
 		$shm_data = @shmop_read($shmid, 0, 10);
 		$shm_data = intval($shm_data) - 1;
 		if ($shm_data < 0) {
-			//debug_backtrace();
-			log_error(sprintf(gettext("Reference %s is going negative, not doing unreference."), $reference));
+			//log_error("MISUAGE OF REFCOUNT_API: trace " . print_r(debug_backtrace(), true));
+			log_error("Reference {$reference} is going negative, not doing unreference.");
 		} else
 			@shmop_write($shmid, $shm_data, 0);
 		@shmop_close($shmid);
 	} catch (Exception $e) {
 		log_error($e->getMessage());
 	}
-
+	
 	return $shm_data;
 }
 
@@ -226,16 +235,8 @@ function is_module_loaded($module_name) {
 function gen_subnet($ipaddr, $bits) {
 	if (!is_ipaddr($ipaddr) || !is_numeric($bits))
 		return "";
+
 	return long2ip(ip2long($ipaddr) & gen_subnet_mask_long($bits));
-}
-
-/* return the subnet address given a host address and a subnet bit count */
-function gen_subnetv6($ipaddr, $bits) {
-	if (!is_ipaddrv6($ipaddr) || !is_numeric($bits))
-		return "";
-
-	$address = Net_IPv6::getNetmask($ipaddr, $bits);
-	return $address;
 }
 
 /* return the highest (broadcast) address in the subnet given a host address and a subnet bit count */
@@ -244,21 +245,6 @@ function gen_subnet_max($ipaddr, $bits) {
 		return "";
 
 	return long2ip32(ip2long($ipaddr) | ~gen_subnet_mask_long($bits));
-}
-
-/* Generate end number for a given ipv6 subnet mask */
-function gen_subnetv6_max($ipaddr, $bits) {
-	if(!is_ipaddrv6($ipaddr))
-		return false;
-	
-	$mask = Net_IPv6::getNetmask('FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF',$bits);
-	
-	$inet_ip = (binary)inet_pton($ipaddr);
-	$inet_mask = (binary)inet_pton($mask);
-
-	$inet_end = $inet_ip | ~$inet_mask;
-
-	return(Net_IPv6::uncompress(inet_ntop($inet_end)));
 }
 
 /* returns a subnet mask (long given a bit count) */
@@ -411,26 +397,8 @@ function is_numericint($arg) {
 	return (preg_match("/[^0-9]/", $arg) ? false : true);
 }
 
-
-/* returns true if $ipaddr is a valid dotted IPv4 address or a IPv6 */
-function is_ipaddr($ipaddr) {
-	if(is_ipaddrv4($ipaddr)) {
-		return true;
-	}
-	if(is_ipaddrv6($ipaddr)) {
-		return true;
-	}
-	return false;
-}
-
-/* returns true if $ipaddr is a valid IPv6 address */
-function is_ipaddrv6($ipaddr) {
-	$result = Net_IPv6::checkIPv6($ipaddr);
-	return $result;
-}
-
 /* returns true if $ipaddr is a valid dotted IPv4 address */
-function is_ipaddrv4($ipaddr) {
+function is_ipaddr($ipaddr) {
 	if (!is_string($ipaddr))
 		return false;
 
@@ -441,28 +409,6 @@ function is_ipaddrv4($ipaddr) {
 		return true;
 	else
 		return false;
-}
-
-function is_ipaddrwithport($ipport) {
-	$parts = explode(":", $ipport);
-	$port = array_pop($parts);
-	if (count($parts) == 1) {
-		return is_ipaddrv4($parts[0]) && is_port($port);
-	} elseif (count($parts) > 1) {
-		return is_ipaddrv6(implode(":", $parts)) && is_port($port);
-	} else {
-		return false;
-	}
-}
-
-function is_hostnamewithport($hostport) {
-	$parts = explode(":", $hostport);
-	$port = array_pop($parts);
-	if (count($parts) == 1) {
-		return is_hostname($parts[0]) && is_port($port);
-	} else {
-		return false;
-	}
 }
 
 /* returns true if $ipaddr is a valid dotted IPv4 address or an alias thereof */
@@ -482,25 +428,14 @@ function is_ipaddroralias($ipaddr) {
 
 }
 
-/* returns true if $subnet is a valid IPv4 or IPv6 subnet in CIDR format */
+/* returns true if $subnet is a valid subnet in CIDR format */
 function is_subnet($subnet) {
-	if(is_subnetv4($subnet)) {
-		return true;
-	}
-	if(is_subnetv6($subnet)) {
-		return true;
-	}
-	return false;
-}
-
-/* returns true if $subnet is a valid IPv4 subnet in CIDR format */
-function is_subnetv4($subnet) {
 	if (!is_string($subnet))
 		return false;
 
 	list($hp,$np) = explode('/', $subnet);
 
-	if (!is_ipaddrv4($hp))
+	if (!is_ipaddr($hp))
 		return false;
 
 	if (!is_numeric($np) || ($np < 1) || ($np > 32))
@@ -508,23 +443,6 @@ function is_subnetv4($subnet) {
 
 	return true;
 }
-
-/* returns true if $subnet is a valid IPv6 subnet in CIDR format */
-function is_subnetv6($subnet) {
-	if (!is_string($subnet))
-		return false;
-
-	list($hp,$np) = explode('/', $subnet);
-
-	if (!is_ipaddrv6($hp))
-		return false;
-
-	if (!is_numeric($np) || ($np < 1) || ($np > 128))
-		return false;
-
-	return true;
-}
-
 
 /* returns true if $subnet is a valid subnet in CIDR format or an alias thereof */
 function is_subnetoralias($subnet) {
@@ -684,6 +602,9 @@ function get_configured_interface_list($only_opt = false, $withdisabled = false)
 
 	$iflist = array();
 
+	if(!is_array($config['interfaces']))
+		$config = parse_config(true);
+
 	/* if list */
 	foreach($config['interfaces'] as $if => $ifdetail) {
 		if ($only_opt && ($if == "wan" || $if == "lan"))
@@ -759,28 +680,6 @@ function get_configured_ip_addresses() {
 }
 
 /*
- *   get_configured_ipv6_addresses() - Return a list of all configured
- *   interfaces IPv6 Addresses
- *
- */
-function get_configured_ipv6_addresses() {
-	require_once("interfaces.inc");
-	$ipv6_array = array();
-	$interfaces = get_configured_interface_list();
-	if(is_array($interfaces)) {
-		foreach($interfaces as $int) {
-			$ipaddrv6 = get_interface_ipv6($int);
-			$ipv6_array[$int] = $ipaddrv6;
-		}
-	}
-	$interfaces = get_configured_carp_interface_list();
-	if(is_array($interfaces)) 
-		foreach($interfaces as $int => $ipaddrv6) 
-			$ipv6_array[$int] = $ipaddrv6;
-	return $ipv6_array;
-}
-
-/*
  *   get_interface_list() - Return a list of all physical interfaces
  *   along with MAC and status.
  *
@@ -798,6 +697,7 @@ function get_interface_list($mode = "active", $keyby = "physical", $vfaces = "")
 				'ppp',
 				'pppoe',
 				'pptp',
+				'pptp-client',
 				'l2tp',
 				'sl',
 				'gif',
@@ -820,10 +720,10 @@ function get_interface_list($mode = "active", $keyby = "physical", $vfaces = "")
 	}
 	switch($mode) {
 	case "active":
-                $upints = pfSense_interface_listget(IFF_UP);
+                $upints = explode(" ", trim(shell_exec("/sbin/ifconfig -lu")));
         	break;
 	case "media":
-		$intlist = pfSense_interface_listget();
+                $intlist = explode(" ", trim(shell_exec("/sbin/ifconfig -l")));
                 $ifconfig = "";
                 exec("/sbin/ifconfig -a", $ifconfig);
                 $regexp = '/(' . implode('|', $intlist) . '):\s/';
@@ -834,7 +734,7 @@ function get_interface_list($mode = "active", $keyby = "physical", $vfaces = "")
 		}
 		break;
 	default:
-		$upints = pfSense_interface_listget();
+		$upints = explode(" ", trim(shell_exec("/sbin/ifconfig -l")));
 		break;
 	}
         /* build interface list with netstat */
@@ -957,7 +857,7 @@ function mwexec($command, $mute = false) {
 		$mute = false;
 	if(($retval <> 0) && ($mute === false)) {
 		$output = implode(" ", $oarr);
-		log_error(sprintf(gettext("The command '%1\$s' returned exit code '%2\$d', the output was '%3\$s' "), $command, $retval, $output));
+		log_error("The command '$command' returned exit code '$retval', the output was '$output' ");
 	}
 	return $retval;
 }
@@ -997,25 +897,11 @@ function alias_make_table($config) {
 		}
 	}
 }
-
 /* check if an alias exists */
 function is_alias($name) {
 	global $aliastable;
 
 	return isset($aliastable[$name]);
-}
-
-function alias_get_type($name) {
-        global $config;
-        
-	if (is_array($config['aliases']['alias'])) {
-		foreach ($config['aliases']['alias'] as $alias) {
-			if ($name == $alias['name'])
-				return $alias['type'];
-		}
-	}
-
-        return "";
 }
 
 /* expand a host or network alias, if necessary */
@@ -1035,14 +921,12 @@ function alias_expand_urltable($name) {
 	$urltable_prefix = "/var/db/aliastables/";
 	$urltable_filename = $urltable_prefix . $name . ".txt";
 
-	if (is_array($config['aliases']['alias'])) {
-		foreach ($config['aliases']['alias'] as $alias) {
-			if (($alias['type'] == 'urltable') && ($alias['name'] == $name)) {
-				if (is_URL($alias["url"]) && file_exists($urltable_filename) && filesize($urltable_filename))
-					return $urltable_filename;
-				else if (process_alias_urltable($name, $alias["url"], 0, true))
-					return $urltable_filename;
-			}
+	foreach ($config['aliases']['alias'] as $alias) {
+		if (($alias['type'] == 'urltable') && ($alias['name'] == $name)) {
+			if (is_URL($alias["url"]) && file_exists($urltable_filename) && filesize($urltable_filename))
+				return $urltable_filename;
+			else if (process_alias_urltable($name, $alias["url"], 0, true))
+				return $urltable_filename;
 		}
 	}
 	return null;
@@ -1082,13 +966,6 @@ function ipcmp($a, $b) {
 
 /* return true if $addr is in $subnet, false if not */
 function ip_in_subnet($addr,$subnet) {
-	if(is_ipaddrv6($addr)) {
-		$result = Net_IPv6::IsInNetmask($addr, $subnet);
-		if($result)
-			return true;
-		else
-			return false;
-	}
 	list($ip, $mask) = explode('/', $subnet);
 	$mask = (0xffffffff << (32 - $mask)) & 0xffffffff;
 	return ((ip2long($addr) & $mask) == (ip2long($ip) & $mask));
@@ -1132,26 +1009,28 @@ function xml_safe_fieldname($fieldname) {
 }
 
 function mac_format($clientmac) {
+    $mac =explode(":", $clientmac);
+
     global $config;
 
-    $mac = explode(":", $clientmac);
     $mac_format = $config['captiveportal']['radmac_format'] ? $config['captiveportal']['radmac_format'] : false;
 
     switch($mac_format) {
+
         case 'singledash':
-		return "$mac[0]$mac[1]$mac[2]-$mac[3]$mac[4]$mac[5]";
+        return "$mac[0]$mac[1]$mac[2]-$mac[3]$mac[4]$mac[5]";
 
         case 'ietf':
-		return "$mac[0]-$mac[1]-$mac[2]-$mac[3]-$mac[4]-$mac[5]";
+        return "$mac[0]-$mac[1]-$mac[2]-$mac[3]-$mac[4]-$mac[5]";
 
         case 'cisco':
-		return "$mac[0]$mac[1].$mac[2]$mac[3].$mac[4]$mac[5]";
+        return "$mac[0]$mac[1].$mac[2]$mac[3].$mac[4]$mac[5]";
 
         case 'unformatted':
-		return "$mac[0]$mac[1]$mac[2]$mac[3]$mac[4]$mac[5]";
+        return "$mac[0]$mac[1]$mac[2]$mac[3]$mac[4]$mac[5]";
 
         default:
-		return $clientmac;
+        return $clientmac;
     }
 }
 
@@ -1160,9 +1039,8 @@ function resolve_retry($hostname, $retries = 5) {
 	if (is_ipaddr($hostname))
 		return $hostname;
 
-       for ($i = 0; $i < $retries; $i++) {
-		// FIXME: gethostbyname does not work for AAAA hostnames, boo, hiss
-               $ip = gethostbyname($hostname);
+	for ($i = 0; $i < $retries; $i++) {
+		$ip = gethostbyname($hostname);
 
 		if ($ip && $ip != $hostname) {
 			/* success */
@@ -1350,11 +1228,8 @@ function mute_kernel_msgs() {
 	global $config;
 	// Do not mute serial console.  The kernel gets very very cranky
 	// and will start dishing you cannot control tty errors.
-	switch (trim(file_get_contents("/etc/platform"))) {
-		case "nanobsd":
-		case "jail":
-			return;
-	}
+	if(trim(file_get_contents("/etc/platform")) == "nanobsd") 
+		return;
 	if($config['system']['enableserial']) 
 		return;			
 	exec("/sbin/conscontrol mute on");
@@ -1364,19 +1239,14 @@ function unmute_kernel_msgs() {
 	global $config;
 	// Do not mute serial console.  The kernel gets very very cranky
 	// and will start dishing you cannot control tty errors.
-	switch (trim(file_get_contents("/etc/platform"))) {
-		case "nanobsd":
-		case "jail":
-			return;
-	}
+	if(trim(file_get_contents("/etc/platform")) == "nanobsd") 
+		return;
 	exec("/sbin/conscontrol mute off");
 }
 
 function start_devd() {
 	global $g;
 
-	if ($g['platform'] == 'jail')
-		return;
 	exec("/sbin/devd");
 	sleep(1);
 }
@@ -1401,7 +1271,7 @@ function is_interface_mismatch() {
 	$i = 0;
 	if (is_array($config['interfaces'])) {
 		foreach ($config['interfaces'] as $ifname => $ifcfg) {
-			if (preg_match("/^enc|^cua|^tun|^l2tp|^pptp|^ppp|^ovpn|^gif|^gre|^lagg|^bridge|vlan|_wlan/i", $ifcfg['if'])) {
+			if (preg_match("/^enc|^cua|^tun|^l2tp|^pptp|^pptp-client|^ppp|^ovpn|^gif|^gre|^lagg|^bridge|vlan|_wlan/i", $ifcfg['if'])) {
 				// Do not check these interfaces.
 				$i++;
 				continue;
@@ -1639,20 +1509,6 @@ function array_merge_recursive_unique($array0, $array1) {
 				}
 			}
 		}
-	}
-	return $result;
-}
-
-/*
- * converts a string like "a,b,c,d"
- * into an array like array("a" => "b", "c" => "d")
- */
-function explode_assoc($delimiter, $string) {
-	$array = explode($delimiter, $string);
-	$result = array();
-	$numkeys = floor(count($array) / 2);
-	for ($i = 0; $i < $numkeys; $i += 1) {
-		$result[$array[$i * 2]] = $array[$i * 2 + 1];
 	}
 	return $result;
 }

--- a/usr/local/www/guiconfig.inc
+++ b/usr/local/www/guiconfig.inc
@@ -78,15 +78,6 @@ foreach($apple_ua as $useragent)
 	if(strstr($_SERVER['HTTP_USER_AGENT'], $useragent))
 		$g['theme'] = "pfsense";
 
-/* Set the default interface language */
-if($config['system']['language'] <> "") {
-	$g['language'] = $config['system']['language'];
-} elseif ($g['language'] == "") {
-	$g['language'] = 'en_US';
-}
-
-set_language($g['language']);
-
 /* used by progress bar */
 $lastseen = "-1";
 
@@ -202,6 +193,7 @@ $wkports = array(
 	110 => "POP3",
 	995 => "POP3/S",
 	1723 => "PPTP",	
+	1723 => "PPTP-Client",
 	1812 => "RADIUS",
 	1813 => "RADIUS accounting",
 	5004 => "RTP",
@@ -220,7 +212,7 @@ $wkports = array(
 /* TCP flags */
 $tcpflags = array("fin", "syn", "rst", "psh", "ack", "urg");
 
-$specialnets = array("pptp" => "PPTP clients", "pppoe" => "PPPoE clients", "l2tp" => "L2TP clients");
+$specialnets = array("pptp" => "PPTP clients", "pptp-client" => "PPTP clients", "pppoe" => "PPPoE clients", "l2tp" => "L2TP clients");
 
 $spiflist = get_configured_interface_with_descr(false, true);
 foreach ($spiflist as $ifgui => $ifdesc) {
@@ -294,18 +286,14 @@ function verify_gzip_file($fname) {
 		return 1;
 }
 
-function print_info_box_np($msg, $name="apply",$value="", $showapply=false) {
+function print_info_box_np($msg, $name="apply",$value="Apply changes") {
 	global $g, $nifty_redbox, $nifty_blackbox, $nifty_background;
-
-	if(empty($value)) {
-		$value = gettext("Apply changes");
-	}
 
 	// Set the Nifty background color if one is not set already (defaults to white)
 	if($nifty_background == "")
 		$nifty_background = "#FFF";
 
-	if(stristr($msg, gettext("apply")) != false || stristr($msg, gettext("save")) != false || stristr($msg, gettext("create")) != false || $showapply) {
+	if(stristr($msg, "apply") != false || stristr($msg, "save") != false || stristr($msg, "create") != false) {
 		$savebutton = "<td class='infoboxsave'>";
 		$savebutton .= "<input name=\"{$name}\" type=\"submit\" class=\"formbtn\" id=\"${name}\" value=\"{$value}\">";
 		if($_POST['if']) 
@@ -328,7 +316,7 @@ function print_info_box_np($msg, $name="apply",$value="", $showapply=false) {
 	}	
 		
 	if(!$savebutton) {
-		$savebutton = '<td class="infoboxsave"><input value="Close" type="button" onClick="jQuery(\'#redboxtable\').hide();"></td>';
+		$savebutton = '<td class="infoboxsave"><input value="Close" type="button" onClick="$(\'redboxtable\').hide();"></td>';
 	}
 
 	echo <<<EOFnp
@@ -391,7 +379,7 @@ function print_info_box_np_undo($msg, $name="apply",$value="Apply changes", $und
 	
 		
 	if(!$savebutton) {
-		$savebutton = '<td class="infoboxsave"><input value="Close" type="button" onClick="jQuery(\'#redboxtable\').hide();"></td>';
+		$savebutton = '<td class="infoboxsave"><input value="Close" type="button" onClick="$(\'redboxtable\').hide();"></td>';
 	}
 
 	echo <<<EOFnp
@@ -1104,11 +1092,5 @@ function rule_popup($src,$srcport,$dst,$dstport){
         	return $descriptions;
   	}
 }
-
-$timezone = $syscfg['timezone'];
-if (!$timezone)
-	$timezone = "Etc/UTC";
-
-date_default_timezone_set($timezone);
 
 ?>

--- a/usr/local/www/includes/functions.inc.php
+++ b/usr/local/www/includes/functions.inc.php
@@ -86,25 +86,13 @@ function get_uptime() {
 	$uphours = (int)($uptime / 3600);
 	$uptime %= 3600;
 	$upmins = (int)($uptime / 60);
-        $uptime %= 60;
-	$upsecs = (int)($uptime);
 
 	$uptimestr = "";
 	if ($updays > 1)
-		$uptimestr .= "$updays Days ";
+		$uptimestr .= "$updays days, ";
 	else if ($updays > 0)
-		$uptimestr .= "1 Day ";
-
-        if ($uphours > 1)
-           $hours = "s";
-        
-        if ($upmins > 1)
-           $minutes = "s";
-        
-        if ($upmins > 1)
-           $seconds = "s";
-        
-	$uptimestr .= sprintf("%02d Hour$hours %02d Minute$minutes %02d Second$seconds", $uphours, $upmins, $upsecs);
+		$uptimestr .= "1 day, ";
+	$uptimestr .= sprintf("%02d:%02d", $uphours, $upmins);
 	return $uptimestr;
 }
 
@@ -160,26 +148,15 @@ function get_hwtype() {
 }
 
 function get_temp() {
-//	switch(get_hwtype()) {
-//		default:
-//			return;
-//	}
-//
-//	return $ret;
+	switch(get_hwtype()) {
+		default:
+			return;
+	}
 
-         $temp_out = "";
-	 exec("/sbin/sysctl dev.cpu.0.temperature | /usr/bin/awk '{ print $2 }' | /usr/bin/cut -d 'C' -f 1", $dfout);
-         $temp_out = trim($dfout[0]);
-         if ($temp_out == "") {
-           exec("/sbin/sysctl hw.acpi.thermal.tz0.temperature | /usr/bin/awk '{ print $2 }' | /usr/bin/cut -d 'C' -f 1", $dfout);
-   	   $temp_out = trim($dfout[0]);
-         }
-
-	 return $temp_out;
+	return $ret;
 }
 
-function disk_usage()
-{
+function disk_usage() {
 	$dfout = "";
 	exec("/bin/df -h | /usr/bin/grep -w '/' | /usr/bin/awk '{ print $5 }' | /usr/bin/cut -d '%' -f 1", $dfout);
 	$diskusage = trim($dfout[0]);
@@ -187,8 +164,7 @@ function disk_usage()
 	return $diskusage;
 }
 
-function swap_usage()
-{
+function swap_usage() {
 	$swapUsage = `/usr/sbin/swapinfo | /usr/bin/awk '{print $5;'}|/usr/bin/grep '%'`;
 	$swapUsage = ereg_replace('%', "", $swapUsage);
 	$swapUsage = rtrim($swapUsage);

--- a/usr/local/www/interfaces_ppps_edit.php
+++ b/usr/local/www/interfaces_ppps_edit.php
@@ -1,6 +1,11 @@
 <?php
 /* $Id$ */
 /*
+
+    interfaces_ppps_edit.php
+    modified by Ben Phillips
+    based on:
+    
 	interfaces_ppps_edit.php
 	part of m0n0wall (http://m0n0.ch/wall)
 
@@ -36,8 +41,8 @@
 
 ##|+PRIV
 ##|*IDENT=page-interfaces-ppps-edit
-##|*NAME=Interfaces: PPPs: Edit page
-##|*DESCR=Allow access to the 'Interfaces: PPPs: Edit' page.
+##|*NAME=Interfaces: PPTP Client: Edit page
+##|*DESCR=Allow access to the 'Interfaces: PPTP Clients: Edit' page.
 ##|*MATCH=interfaces_ppps_edit.php*
 ##|-PRIV
 
@@ -105,6 +110,44 @@ if (isset($id) && $a_ppps[$id]) {
 			$pconfig['localip'] = explode(",",$a_ppps[$id]['localip']);
 			$pconfig['subnet'] = explode(",",$a_ppps[$id]['subnet']);
 			$pconfig['gateway'] = explode(",",$a_ppps[$id]['gateway']);
+			break;
+		case "pptp-client":
+			$pconfig['localip'] = explode(",",$a_ppps[$id]['localip']);
+			$pconfig['subnet'] = explode(",",$a_ppps[$id]['subnet']);
+			$pconfig['gateway'] = explode(",",$a_ppps[$id]['gateway']);
+			
+			$pconfig['routenet'] = $a_ppps[$id]['routenet'];
+			$pconfig['routesubnet'] = $a_ppps[$id]['routesubnet'];
+			$pconfig['proxyarp'] = $a_ppps[$id]['proxyarp'];
+			$pconfig['local_ep'] = $a_ppps[$id]['local_ep'];
+			$pconfig['local_ep_sn'] = $a_ppps[$id]['local_ep_sn'];
+			$pconfig['remote_ep'] = $a_ppps[$id]['remote_ep'];
+			$pconfig['remote_ep_sn'] = $a_ppps[$id]['remote_ep_sn'];
+			$pconfig['require-dns'] = $a_ppps[$id]['require-dns'];
+			$pconfig['mppc-enable'] = $a_ppps[$id]['mppc-enable'];
+			$pconfig['pred1'] = $a_ppps[$id]['pred1'];
+			$pconfig['deflate'] = $a_ppps[$id]['deflate'];
+			$pconfig['mppe-enable'] = $a_ppps[$id]['mppe-enable'];
+			$pconfig['mppe-enforce'] = $a_ppps[$id]['mppe-enforce'];
+			$pconfig['bundle-comp-enable'] = $a_ppps[$id]['bundle-comp-enable'];
+			$pconfig['bundle-crypt-enable'] = $a_ppps[$id]['bundle-crypt-enable'];
+			$pconfig['mppe-40'] = $a_ppps[$id]['mppe-40'];
+			$pconfig['mppe-56'] = $a_ppps[$id]['mppe-56'];
+			$pconfig['mppe-128'] = $a_ppps[$id]['mppe-128'];
+			$pconfig['mppec-stateless'] = $a_ppps[$id]['mppec-stateless'];
+			$pconfig['mppec-policy'] = $a_ppps[$id]['mppec-policy'];
+			$pconfig['dese-bis'] = $a_ppps[$id]['dese-bis'];
+			$pconfig['dese-old'] = $a_ppps[$id]['dese-old'];
+			$pconfig['keep-alive-int'] = $a_ppps[$id]['keep-alive-int'];
+			$pconfig['keep-alive-max'] = $a_ppps[$id]['keep-alive-max'];
+			$pconfig['max-redial'] = $a_ppps[$id]['max-redial'];
+			$pconfig['mschap_v1'] = $a_ppps[$id]['mschap_v1'];
+			$pconfig['mschap_v2'] = $a_ppps[$id]['mschap_v2'];
+			$pconfig['mschap_md5'] = $a_ppps[$id]['mschap_md5'];
+			$pconfig['pap'] = $a_ppps[$id]['pap'];
+			$pconfig['enable-passive'] = $a_ppps[$id]['enable-passive'];
+			
+			break;
 		case "pppoe":
 			$pconfig['provider'] = $a_ppps[$id]['provider'];
 			if (isset($a_ppps[$id]['provider']) and empty($a_ppps[$id]['provider']))
@@ -124,7 +167,7 @@ if (isset($id) && $a_ppps[$id]) {
 				}
 				
 				if ($a_ppps[$id]['pppoe-reset-type'] == "custom") {
-					$resetTime_a = explode(" ", $resetTime);
+					$resetTime_a = split(" ", $resetTime);
 					$pconfig['pppoe_pr_custom'] = true;
 					$pconfig['pppoe_resetminute'] = $resetTime_a[0];
 					$pconfig['pppoe_resethour'] = $resetTime_a[1];
@@ -194,7 +237,17 @@ if ($_POST) {
 			break;
 		case "l2tp":
 		case "pptp":
-			if ($_POST['ondemand']) {
+		    if ($_POST['ondemand']) {
+				$reqdfields = explode(" ", "interfaces username password localip subnet gateway ondemand idletimeout");
+				$reqdfieldsn = array(gettext("Link Interface(s)"),gettext("Username"),gettext("Password"),gettext("Local IP address"),gettext("Subnet"),gettext("Remote IP address"),gettext("Dial on demand"),gettext("Idle timeout value"));
+			} else {
+				$reqdfields = explode(" ", "interfaces username password localip subnet gateway");
+				$reqdfieldsn = array(gettext("Link Interface(s)"),gettext("Username"),gettext("Password"),gettext("Local IP address"),gettext("Subnet"),gettext("Remote IP address"));
+			}
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+			break;
+		case "pptp-client":
+		    if ($_POST['ondemand']) {
 				$reqdfields = explode(" ", "interfaces username password localip subnet gateway ondemand idletimeout");
 				$reqdfieldsn = array(gettext("Link Interface(s)"),gettext("Username"),gettext("Password"),gettext("Local IP address"),gettext("Subnet"),gettext("Remote IP address"),gettext("Dial on demand"),gettext("Idle timeout value"));
 			} else {
@@ -328,11 +381,50 @@ if ($_POST) {
 					unset($ppp['pppoe-reset-type']);
 				
 				break;
-			case "pptp":
+			case "pptp":			
 			case "l2tp":
 				$ppp['localip'] = implode(',',$port_data['localip']);
 				$ppp['subnet'] = implode(',',$port_data['subnet']);
 				$ppp['gateway'] = implode(',',$port_data['gateway']);
+				break;
+		    case "pptp-client":
+		        $ppp['localip'] = implode(',',$port_data['localip']);
+				$ppp['subnet'] = implode(',',$port_data['subnet']);
+				$ppp['gateway'] = implode(',',$port_data['gateway']);
+				
+				$ppp['routenet'] = $_POST['routenet'];
+				$ppp['routesubnet'] = $_POST['routesubnet'];
+				$ppp['proxyarp'] = $_POST['proxyarp'] ? true : false;
+				$ppp['local_ep'] = $_POST['local_ep'];
+				$ppp['local_ep_sn'] = $_POST['local_ep_sn'];
+				$ppp['remote_ep'] = $_POST['remote_ep'];
+				$ppp['remote_ep_sn'] = $_POST['remote_ep_sn'];
+				$ppp['require-dns'] = $_POST['require-dns'] ? true : false;
+				//$ppp['enable-comp'] = $_POST['enable-comp'] ? true : false;
+				//$ppp['enable-crypt'] = $_POST['enable-crypt'] ? true : false;
+				$ppp['mppc-enable'] = $_POST['mppc-enable'] ? true : false;
+				$ppp['pred1'] = $_POST['pred1'] ? true : false;
+				$ppp['deflate'] = $_POST['deflate'] ? true : false;
+				$ppp['mppe-enable'] = $_POST['mppe-enable'] ? true : false;
+				$ppp['mppe-enforce'] = $_POST['mppe-enforce'] ? true : false;
+				$ppp['bundle-comp-enable'] = $_POST['bundle-comp-enable'] ? true : false;
+				$ppp['bundle-crypt-enable'] = $_POST['bundle-crypt-enable'] ? true : false;
+				$ppp['mppe-40'] = $_POST['mppe-40'] ? true : false;
+				$ppp['mppe-56'] = $_POST['mppe-56'] ? true : false;
+				$ppp['mppe-128'] = $_POST['mppe-128'] ? true : false;
+				$ppp['mppec-stateless'] = $_POST['mppec-stateless'] ? true : false;
+				$ppp['mppec-policy'] = $_POST['mppec-policy'] ? true : false;
+				$ppp['dese-bis'] = $_POST['dese-bis'] ? true : false;
+				$ppp['dese-old'] = $_POST['dese-old'] ? true : false;
+				$ppp['keep-alive-int'] = $_POST['keep-alive-int'];
+				$ppp['keep-alive-max'] = $_POST['keep-alive-max'];
+				$ppp['max-redial'] = $_POST['max-redial'];
+				$ppp['mschap_v1'] = $_POST['mschap_v1'] ? true : false;
+				$ppp['mschap_v2'] = $_POST['mschap_v2'] ? true : false;
+				$ppp['mschap_md5'] = $_POST['mschap_md5'] ? true : false;
+				$ppp['pap'] = $_POST['pap'] ? true : false;
+				$ppp['enable-passive'] = $_POST['enable-passive'] ? true : false;
+				
 				break;
 			default:
 				break;
@@ -378,7 +470,7 @@ $closehead = false;
 $pgtitle = array(gettext("Interfaces"),gettext("PPPs"),gettext("Edit"));
 include("head.inc");
 
-$types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE", "pptp" => "PPTP",  "l2tp" => "L2TP"/*, "tcp" => "TCP", "udp" => "UDP"*/  ); 
+$types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE", "pptp" => "PPTP", "pptp-client" => "PPTP-Client",  "l2tp" => "L2TP"/*, "tcp" => "TCP", "udp" => "UDP"*/  ); 
 
 ?>
 	<script type="text/javascript" src="/javascript/numericupdown/js/numericupdown.js"></script>
@@ -386,7 +478,7 @@ $types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE"
 	<script type="text/javascript" src="/javascript/datepicker/js/datepicker.js"></script>
 	<link href="/javascript/datepicker/css/datepicker.css" rel="stylesheet" type="text/css"/>
 	<script type="text/javascript" >
-		jQuery(document).ready(function() { updateType(<?php echo "'{$pconfig['type']}'";?>); });
+		document.observe("dom:loaded", function() { updateType(<?php echo "'{$pconfig['type']}'";?>); });
 	</script>
 </head>
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC" >
@@ -506,6 +598,7 @@ $types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE"
 				<br/><span class="vexpl"><?= gettext("Select to fill in data for your service provider."); ?></span>
 			</td>
 		</tr>
+		
 		<tr>
 			<td width="22%" valign="top" class="vncell"><?= gettext("Username"); ?></td>
 			<td width="78%" class="vtable">
@@ -644,15 +737,14 @@ $types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE"
 					</tr>
 				</table>
 			</td>
-		</tr>
-
+		</tr>		
+		
 		<?php for($j=0; $j < $port_count; $j++) : ?>
 		
 		<tr style="display:none" id="gw_fields<?=$j;?>">
 			<td width="22%" id="localiplabel<?=$j;?>" valign="top" class="vncell"><?= gettext("Local IP"); ?></td>
 			<td width="78%" class="vtable"> 
 				<input name="localip[]" type="text" class="formfld unknown" id="localip<?=$j;?>" size="20"  value="<?=htmlspecialchars($pconfig['localip'][$j]);?>">
-				/
 				<select name="subnet[]" class="formselect" id="subnet<?=$j;?>" disabled="true">
 				<?php for ($i = 31; $i > 0; $i--): ?>
 					<option value="<?=$i;?>"<?php if ($i == $pconfig['subnet'][$j]) echo " selected"; ?>><?=$i;?></option>
@@ -674,8 +766,170 @@ $types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE"
 		<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
 			<td colspan="2" valign="top" class="listtopic"><?= gettext("Advanced Options"); ?></td>
 		</tr>
+		
+		<tr style="display:none;font-size:110%;" name="pptp-client" id="pptp-client">
+			<td colspan="2" style="padding:0px;">
+				<table width="100%" border="0" cellpadding="6" cellspacing="0">
+				    
+    				<? /* Install route to remote network */ ?>
+    				<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
+            			<td width="22%" id="route" valign="top" class="vncell"><?= gettext("Route"); ?></td>
+                 		<td width="78%" class="vtable"> 
+                 			<input name="routenet" type="text" class="formfld unknown" id="rnetwork" value="<?=htmlspecialchars($pconfig['routenet']);?>">
+                 			<select name="routesubnet" class="formselect" id="rsubnet">
+                 			<?php for ($i = 31; $i > 0; $i--): ?>
+                 				<option value="<?=$i;?>"<?php if ($i == $pconfig['routesubnet']) echo " selected"; ?>><?=$i;?></option>
+                 			<?php endfor; ?>
+                 			</select> <?= gettext("Remote network"); ?>
+                 		</td>
+                 	</tr>
+                 	
+                 	<? /* Enable proxy ARP */ ?>
+                 	<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
+                	    <td valign="top" class="vncell"><?= gettext("Enable ProxyARP"); ?></td>
+                		<td class="vtable">
+                			<input type="checkbox" value="on" id="proxarp" name="proxyarp" <?php if (isset($pconfig['proxyarp'])) echo "checked"; ?>> <?= gettext("Enable ProxyARP"); ?> 
+                		</td>
+                	</tr>
+                	
+    				<? /* Acceptable local tunnel endpoint address range */ ?>
+    				<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
+            			<td width="22%" id="endpoint_ranges" valign="top" class="vncell"><?= gettext("Tunnel Endpoint IP Addresses"); ?> </td>
+                 		<td width="78%" class="vtable"> 
+                 			<input name="local_ep" type="text" class="formfld unknown" id="localep" size="20"  value="<?=htmlspecialchars($pconfig['local_ep']);?>">
+                 			<select name="local_ep_sn" class="formselect" id="localepsn">
+                 			<?php for ($i = 31; $i > 0; $i--): ?>
+                 				<option value="<?=$i;?>"<?php if ($i == $pconfig['local_ep_sn']) echo " selected"; ?>><?=$i;?></option>
+                 			<?php endfor; ?>
+                 			</select> <?= gettext("Local EP Addr "); ?>
+                 			<input name="remote_ep" type="text" class="formfld unknown" id="remoteep" size="20"  value="<?=htmlspecialchars($pconfig['remote_ep']);?>">
+                 			<select name="remote_ep_sn" class="formselect" id="remoteepsn">
+                 			<?php for ($i = 31; $i > 0; $i--): ?>
+                 				<option value="<?=$i;?>"<?php if ($i == $pconfig['remote_ep_sn']) echo " selected"; ?>><?=$i;?></option>
+                 			<?php endfor; ?>
+                 			</select> <?= gettext("Remote EP Addr "); ?>
+                 		</td>
+                 	</tr>
+                 	<? /* Require DNS Information from the PPTP server */ ?>
+                 	<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
+                	    <td valign="top" class="vncell"><?= gettext("Require DNS Exchange"); ?></td>
+                		<td class="vtable">
+                			<input type="checkbox" value="on" id="req-dns" name="require-dns" <?php if (isset($pconfig['require-dns'])) echo "checked"; ?>> <?= gettext("Require DNS Exchange"); ?> 
+                			<br/> <span class="vexpl"><?= gettext("Get DNS address from the PPTP server."); ?> </span>
+                		</td>
+                	</tr>
+                	
+                	<? /* Authentication */ ?>
+                	<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
+                	    <td width="22%" class="vncell"><?= gettext("Authentication"); ?></td>
+                		<td width="78%" class="vtable">
+                			<input type="checkbox" value="on" id="pap" name="pap" <?php if (isset($pconfig['pap'])) echo "checked"; ?>> <?= gettext("PAP"); ?> 
+                				
+                			<input type="checkbox" value="on" id="mschap_v1" name="mschap_v1" <?php if (isset($pconfig['mschap_v1'])) echo "checked"; ?>> <?= gettext("MSCHAP_v1"); ?> 
+    
+                			<input type="checkbox" value="on" id="mschap_v2" name="mschap_v2" <?php if (isset($pconfig['mschap_v2'])) echo "checked"; ?>> <?= gettext("MSCHAP_v2"); ?>
+                				
+                			<input type="checkbox" value="on" id="mschap_md5" name="mschap_md5" <?php if (isset($pconfig['mschap_md5'])) echo "checked"; ?>> <?= gettext("MSCHAP_md5"); ?>
+                			
+                			<br/> <span class="vexpl"><?= gettext("Allowed authentication methods."); ?> </span>
+                		</td>
+                	</tr>
+                		
+                	<? /* Enable payload compression */ ?>
+                	<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
+                	    <td valign="top" class="vncell"><?= gettext("Payload Compression"); ?></td>
+                		<td class="vtable">
+                			<span class="vexpl"><?= gettext("Bundle Compression options"); ?> </span> <br/>
+                			<input type="checkbox" value="on" id="bundle_comp_enable" name="bundle-comp-enable" <?php if (isset($pconfig['bundle-comp-enable'])) echo "checked"; ?>> <?= gettext("Use Bundle Compression"); ?>
+                			
+                			<br/> <br/> <span class="vexpl"><?= gettext("-------------------------------------------------------------------------------------------"); ?> </span> <br/> <br/>
+                			
+                			<span class="vexpl"><?= gettext("Microsoft Point to Point Compression options"); ?> </span> <br/>
+                			
+                			<input type="checkbox" value="on" id="mppc_enable" name="mppc-enable" <?php if (isset($pconfig['mppc-enable'])) echo "checked"; ?>/> <?= gettext("MPPC"); ?> 
+                				
+                			<input type="checkbox" value="on" id="mppc_pred1" name="pred1" <?php if (isset($pconfig['pred1'])) echo "checked"; ?>/> <?= gettext("Pred1"); ?> 
+    
+                			<input type="checkbox" value="on" id="mppc_deflate" name="deflate" <?php if (isset($pconfig['deflate'])) echo "checked"; ?>/> <?= gettext("Deflate"); ?> 
+
+                		</td>
+                	</tr>
+    									
+    				<? /* Enable payload encryption */ ?>
+    				<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
+                	    <td valign="top" class="vncell"><?= gettext("Payload Encryption"); ?></td>
+                		<td class="vtable">
+                		
+                			<span class="vexpl"><?= gettext("Bundle Encryption options"); ?> </span> <br/>
+                			<input type="checkbox" value="on" id="bundle_crypt_enable" name="bundle-crypt-enable" <?php if (isset($pconfig['bundle-crypt-enable'])) echo "checked"; ?>> <?= gettext("Use Bundle Encryption"); ?>
+                			<br/> <span class="vexpl"><?= gettext("CAUTION: This is NOT compatible with MPPE and must be disabled for MPPE to work correctly."); ?> </span> <br/> <br/>
+                			
+                			<span class="vexpl"><?= gettext("-------------------------------------------------------------------------------------------"); ?> </span> <br/> <br/>
+
+											<span class="vexpl"><?= gettext("Microsoft Point to Point Encryption options"); ?> </span> <br/>
+                			<input type="checkbox" value="on" id="mppe_enable" name="mppe-enable" <?php if (isset($pconfig['mppe-enable'])) echo "checked"; ?>> <?= gettext("Use MPPE"); ?> 
+                			
+                			<input type="checkbox" value="on" id="mppe_enforce" name="mppe-enforce" <?php if (isset($pconfig['mppe-enforce'])) echo "checked"; ?>> <?= gettext("Enforce MPPE"); ?>
+                			
+                			<br/> 
+                				
+                			<input type="checkbox" value="on" id="mppe_40" name="mppe-40" <?php if (isset($pconfig['mppe-40'])) echo "checked"; ?>> <?= gettext("40 bit"); ?> 
+    
+                			<input type="checkbox" value="on" id="mppe_56" name="mppe-56" <?php if (isset($pconfig['mppe-56'])) echo "checked"; ?>> <?= gettext("56 bit"); ?> 
+                				
+                			<input type="checkbox" value="on" id="mppe_128" name="mppe-128" <?php if (isset($pconfig['mppe-128'])) echo "checked"; ?>> <?= gettext("128 bit"); ?>
+                			
+                			<br/> 
+                			
+                			<input type="checkbox" value="on" id="mppec_policy" name="mppec-policy" <?php if (isset($pconfig['mppec-policy'])) echo "checked"; ?>/> <?= gettext("Policy"); ?>
+                			
+                			<input type="checkbox" value="on" id="mppec_stateless" name="mppec-stateless" <?php if (isset($pconfig['mppec-stateless'])) echo "checked"; ?>/> <?= gettext("Stateless"); ?>
+                			
+                			<br/> <span class="vexpl"><?= gettext("Enable Use MPPE to request MPPE encryption from the server. Use enfoce MPPE to disconnect if the server refuses MPPE negotiation."); ?> </span> <br/>
+                			
+                			<br/> <span class="vexpl"><?= gettext("-------------------------------------------------------------------------------------------"); ?> </span> <br/> <br/>
+                			
+                			<span class="vexpl"><?= gettext("DESE (rfc 1969) Encryption options"); ?> </span> <br/>
+                			
+                			<input type="checkbox" value="on" id="dese_bis" name="dese-bis" <?php if (isset($pconfig['dese-bis'])) echo "checked"; ?>> <?= gettext("Enable DESE-bis"); ?> 
+                				
+                			<input type="checkbox" value="on" id="dese_old" name="dese-old" <?php if (isset($pconfig['dese-old'])) echo "checked"; ?>> <?= gettext("Enable DESE-old"); ?> 
+                			<br/> <span class="vexpl"><?= gettext("This option enables DESE (rfc 1969) encryption. This algorithm implemented in user-level, so require much CPU power on fast (>10Mbit/s) links.
+    
+    Note: DESE protocol is deprecated. Because of data padding to the next 8 octets boundary, required by block nature of DES encryption, dese-old option can have interoperability issues with other protocols which work over it. As example, it is incompatible with Predictor-1 and Deflate compressions."); ?> </span>
+                		</td>
+                	</tr>
+                		
+                	<? /* Enable passive mode */ ?>
+    				<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
+                		<td valign="top" class="vncell"><?= gettext("Passive Mode"); ?></td>
+                		<td class="vtable">
+                			<input type="checkbox" value="on" id="enable_passive" name="enable-passive" <?php if (isset($pconfig['enable-passive'])) echo "checked"; ?>> <?= gettext("Enable passive mode"); ?> 
+                  		</td>
+                	</tr>
+    				
+    				<? /* Keep alive (Dead peer detection) */ ?>
+    				<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
+    						<td width="22%" valign="top" class="vncell"><?= gettext("Keep Alive (DPD)"); ?></td>
+    						<td width="78%" class="vtable">
+    							<input name="keep-alive-int" type="text" class="formfld unknown" id="keep_alive_int" size="6" value="<?=htmlspecialchars($pconfig['keep-alive-int']);?>"> <?= gettext("Interval"); ?>
+    							<input name="keep-alive-max" type="text" class="formfld unknown" id="keep_alive_max" size="6" value="<?=htmlspecialchars($pconfig['keep-alive-max']);?>"> <?= gettext("Timeout"); ?>
+    						</td>
+    				</tr>
+    				
+    				<? /* Redial attempts */ ?>
+    				<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
+    						<td width="22%" valign="top" class="vncell"><?= gettext("Max Redial Attempts"); ?></td>
+    						<td width="78%" class="vtable">
+    							<input name="max-redial" type="text" class="formfld unknown" id="max_redial" size="6" value="<?=htmlspecialchars($pconfig['max-redial']);?>">
+    						</td>
+    				</tr>
+				</table>
+			</td>
+		</tr>
+		
 		<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
-		<td valign="top" class="vncell"><?= gettext("Dial On Demand"); ?></td>
+		    <td valign="top" class="vncell"><?= gettext("Dial On Demand"); ?></td>
 			<td class="vtable">
 				<input type="checkbox" value="on" id="ondemand" name="ondemand" <?php if (isset($pconfig['ondemand'])) echo "checked"; ?>> <?= gettext("Enable Dial-on-Demand mode"); ?> 
 				<br/> <span class="vexpl"><?= gettext("This option causes the interface to operate in dial-on-demand mode. Do NOT enable if you want your link to be always up. " .  
@@ -690,8 +944,9 @@ $types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE"
 				<br/><?=gettext("When the idle timeout occurs, if the dial-on-demand option is enabled, mpd goes back into dial-on-demand mode. Otherwise, the interface is brought down and all associated routes removed."); ?></span>
 			</td>
 		</tr>
+				
 		<tr style="display:none" id="advanced_<?=$k;?>" name="advanced_<?=$k;$k++;?>">
-			<td width="22%" valign="top" class="vncell"><?= gettext("Compression"); ?></td>
+			<td width="22%" valign="top" class="vncell"><?= gettext("Van Jacobson Compression"); ?></td>
 			<td width="78%" class="vtable">
 				<input type="checkbox" value="on" id="vjcomp" name="vjcomp" <?php if (isset($pconfig['vjcomp'])) echo "checked"; ?>>&nbsp;<?= gettext("Disable vjcomp(compression) (auto-negotiated by default)."); ?>
 				<br/> <span class="vexpl"><?=gettext("This option enables Van Jacobson TCP header compression, which saves several bytes per TCP data packet. " .
@@ -793,3 +1048,4 @@ $types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE"
 <?php include("fend.inc"); ?>
 </body>
 </html>
+

--- a/usr/local/www/javascript/interfaces_ppps_edit/ppps_edit.js
+++ b/usr/local/www/javascript/interfaces_ppps_edit/ppps_edit.js
@@ -16,83 +16,83 @@ function update_select_list(new_options, select_list){
 
 function show_advanced(hide){
 	var select_list = document.iform["interfaces[]"].options;
-	var adv_rows = parseInt(jQuery('#adv_rows').html());
-	var adv_show = Boolean(parseInt(jQuery('#adv_show').html()));
+	var adv_rows = parseInt($('adv_rows').innerHTML);
+	var adv_show = Boolean(parseInt($('adv_show').innerHTML));
 	var status = Boolean(parseInt(hide));
 	if (status){
-		jQuery('#advanced_').hide();
+		$('advanced_').hide();
 		for(var j=0; j < adv_rows; j++){
-			var advanced = "#advanced_" + j.toString();
-			jQuery(advanced).show();
+			var advanced = "advanced_" + j.toString();
+			$(advanced).show();
 		}
-		jQuery('#adv_show').html = "1";
+		$('adv_show').innerHTML = "1";
 		show_hide_linkfields(select_list);
 	} else {
-		jQuery('#advanced_').show();
+		$('advanced_').show();
 		for(var j=0; j < adv_rows; j++){
-			var advanced = "#advanced_" + j.toString();
-			jQuery(advanced).hide();
+			var advanced = "advanced_" + j.toString();
+			$(advanced).hide();
 		}
-		jQuery('#adv_show').html("0");
+		$('adv_show').innerHTML = "0";
 		show_hide_linkfields(select_list);
 	}
 }
 
 function show_hide_linkfields(options){
 	var i = 0;
-	var port_count = parseInt(jQuery('#port_count').html());
-	var adv_show = Boolean(parseInt(jQuery('#adv_show').html()));
+	var port_count = parseInt($('port_count').innerHTML);
+	var adv_show = Boolean(parseInt($('adv_show').innerHTML));
 	for(var j=0; j < port_count; j++){
 		var count = j.toString();
-		var type = jQuery('#type').val();
-		var link = "#link" + count;
-		var lnklabel = "#linklabel" + count;
-		var bw = "#bandwidth" + count;
-		var bwlabel = "#bwlabel" + count;
-		var mtu = "#mtu" + count;
-		var mru = "#mru" + count;
-		var mrru = "#mrru" + count;
-		var ipfields = "#ip_fields" + count;
-		var gwfields = "#gw_fields" + count;
-		var localip = "#localip" + count;
-		var localiplabel = "#localiplabel" + count;
-		var subnet = "#subnet" + count;
-		var gateway = "#gateway" + count;
-		var gatewaylabel = "#gatewaylabel" + count;
+		var type = $('type').value;
+		var link = "link" + count;
+		var lnklabel = "linklabel" + count;
+		var bw = "bandwidth" + count;
+		var bwlabel = "bwlabel" + count;
+		var mtu = "mtu" + count;
+		var mru = "mru" + count;
+		var mrru = "mrru" + count;
+		var ipfields = "ip_fields" + count;
+		var gwfields = "gw_fields" + count;
+		var localip = "localip" + count;
+		var localiplabel = "localiplabel" + count;
+		var subnet = "subnet" + count;
+		var gateway = "gateway" + count;
+		var gatewaylabel = "gatewaylabel" + count;
 		
-		jQuery(ipfields + ',' + gwfields + ',' + link).hide();
-		jQuery(subnet).prop('disabled',true);
+		$(ipfields, gwfields ,link).invoke('hide');
+		$(subnet).disabled = true;
 		
-		jQuery(bw).attr("name","bandwidth[]");
-		jQuery(mtu).attr("name","mtu[]");
-		jQuery(mru).attr("name","mru[]");
-		jQuery(mrru).attr("name","mrru[]");
-		jQuery(localip).attr("name","localip[]");
-		jQuery(subnet).attr("name","subnet[]");
-		jQuery(gateway).attr("name","gateway[]");
+		$(bw).name = "bandwidth[]";
+		$(mtu).name = "mtu[]";
+		$(mru).name = "mru[]";
+		$(mrru).name = "mrru[]";
+		$(localip).name = "localip[]";
+		$(subnet).name = "subnet[]";
+		$(gateway).name = "gateway[]";
 		
 		while(i < options.length){
 			if (options[i].selected ){
-				jQuery(lnklabel).html("Link Parameters (" + options[i].value + ")");
-				jQuery(bwlabel).html("Bandwidth (" + options[i].value + ")");
-				jQuery(bw).attr("name","bandwidth[" + options[i].value + "]");
-				jQuery(mtu).attr("name","mtu[" + options[i].value + "]");
-				jQuery(mru).attr("name","mru[" + options[i].value + "]");
-				jQuery(mrru).attr("name","mrru[" + options[i].value + "]");
-				jQuery(localiplabel).html("Local IP (" + options[i].value + ")");
-				jQuery(gatewaylabel).html("Gateway (" + options[i].value + ")");
-				jQuery(localip).attr("name","localip[" + options[i].value + "]");
-				jQuery(subnet).attr("name","subnet[" + options[i].value + "]");
-				jQuery(gateway).attr("name","gateway[" + options[i].value + "]");
+				$(lnklabel).innerHTML = "Link Parameters (" + options[i].value + ")";
+				$(bwlabel).innerHTML = "Bandwidth (" + options[i].value + ")";
+				$(bw).name = "bandwidth[" + options[i].value + "]";
+				$(mtu).name = "mtu[" + options[i].value + "]";
+				$(mru).name = "mru[" + options[i].value + "]";
+				$(mrru).name = "mrru[" + options[i].value + "]";
+				$(localiplabel).innerHTML = "Local IP (" + options[i].value + ")";
+				$(gatewaylabel).innerHTML = "Gateway (" + options[i].value + ")";
+				$(localip).name = "localip[" + options[i].value + "]";
+				$(subnet).name = "subnet[" + options[i].value + "]";
+				$(gateway).name = "gateway[" + options[i].value + "]";
 				if (type == 'ppp' && adv_show){
-					jQuery(ipfields + ',' + gwfields).show();
+					$(ipfields, gwfields).invoke('show');
 				}
-				if (type == 'pptp' || type == 'l2tp'){
-					jQuery(subnet).prop("disabled",false);
-					jQuery(ipfields + ',' + gwfields).show();
+				if (type == 'pptp' || type == 'pptp-client' || type == 'l2tp'){
+					$(subnet).disabled = false;
+					$(ipfields, gwfields).invoke('show');
 				}
 				if (adv_show){
-					jQuery(link).show();
+					$(link).show();
 				}
 				i++;
 				break;
@@ -104,35 +104,40 @@ function show_hide_linkfields(options){
 
 
 function updateType(t){
-	var serialports = jQuery('#serialports').html();
-	var ports = jQuery('#ports').html();
+	var serialports = $('serialports').innerHTML;
+	var ports = $('ports').innerHTML;
 	var select_list = document.iform["interfaces[]"].options;
-	jQuery('#adv_show').html("0");
+	$('adv_show').innerHTML = "0";
 	show_advanced('0');
-	jQuery("#select").show();
 	switch(t) {
 		case "select": {
-			jQuery('#ppp,#pppoe,#ppp_provider,#phone_num,#apn_').hide();
+			$('ppp','pppoe','ppp_provider','phone_num','apn_','pptp-client','route','proxyarp','ip-ranges','require-dns','enable-comp','enable-crypt','mppc-enable','pred1','deflate','mppe-enable','mppe-40','mppe-56','mppe-128','mppec-stateless','mppec-policy','dese-bis','ese-old','keep-alive','max-redial','chap','pap','eap').invoke('hide');
 			select_list.length = 0;
 			select_list[0] = new Option("Select Link Type First","");
 			break;
 		}
 		case "ppp": {
 			update_select_list(serialports, select_list);
-			jQuery('#select,#pppoe').hide();
-			jQuery('#ppp_provider,#phone_num,#apn_').show();
+			$('select','pppoe').invoke('hide');
+			$('ppp_provider','phone_num','apn_').invoke('show');
 			country_list();
 			break;
 		}
 		case "pppoe": {
 			update_select_list(ports, select_list);
-			jQuery('#select,#ppp,#ppp_provider,#phone_num,#apn_').hide();
+			$('select','ppp','ppp_provider','phone_num','apn_').invoke('hide');
 			break;
 		}
 		case "l2tp":
 		case "pptp": {
 			update_select_list(ports, select_list);
-			jQuery('#select,#ppp,#pppoe,#ppp_provider,#phone_num,#apn_').hide();
+			$('select','ppp','pppoe','ppp_provider','phone_num','apn_','pptp-client','route','proxyarp','ip-ranges','require-dns','enable-comp','enable-crypt','mppc-enable','pred1','deflate','mppe-enable','mppe-40','mppe-56','mppe-128','mppec-stateless','mppec-policy','dese-bis','ese-old','keep-alive','max-redial','chap','pap','eap').invoke('hide');
+			break;
+		}
+		case "pptp-client": {
+			update_select_list(ports, select_list);
+			$('select','ppp','pppoe','ppp_provider','phone_num','apn_').invoke('hide');
+			$('pptp-client','route','proxyarp','ip-ranges','require-dns','enable-comp','enable-crypt','mppc-enable','pred1','deflate','mppe-enable','mppe-40','mppe-56','mppe-128','mppec-stateless','mppec-policy','dese-bis','ese-old','keep-alive','max-redial','chap','pap','eap').invoke('show');
 			break;
 		}
 		default:
@@ -141,97 +146,104 @@ function updateType(t){
 			break;
 	}
 	if (t == "pppoe" || t == "ppp"){
-		jQuery("#" + t).show();
+		$(t).show();
 	}
 }
 
 function show_reset_settings(reset_type) {
 	if (reset_type == 'preset') { 
-		jQuery('#pppoepresetwrap').show(0);
-		jQuery('#pppoecustomwrap').hide(0);
+		Effect.Appear('pppoepresetwrap', { duration: 0.0 });
+		Effect.Fade('pppoecustomwrap', { duration: 0.0 }); 
 	} 
 	else if (reset_type == 'custom') { 
-		jQuery('#pppoecustomwrap').show(0);
-		jQuery('#pppoepresetwrap').hide(0);
+		Effect.Appear('pppoecustomwrap', { duration: 0.0 });
+		Effect.Fade('pppoepresetwrap', { duration: 0.0 });
 	} else {
-		jQuery('#pppoecustomwrap').hide(0);
-		jQuery('#pppoepresetwrap').hide(0);
+		Effect.Fade('pppoecustomwrap', { duration: 0.0 });
+		Effect.Fade('pppoepresetwrap', { duration: 0.0 });
 	}
 }
 
 function country_list() {
-	jQuery('#country option').remove();
-	jQuery('#provider option').remove();
-	jQuery('#providerplan option').remove();
-	jQuery.ajax("getserviceproviders.php",{
-		success: function(responseText) {
-			var responseTextArr = responseText.split("\n");
+	$('country').childElements().each(function(node) { node.remove(); });
+	$('provider').childElements().each(function(node) { node.remove(); });
+	$('providerplan').childElements().each(function(node) { node.remove(); });
+	new Ajax.Request("getserviceproviders.php",{
+		onSuccess: function(response) {
+			var responseTextArr = response.responseText.split("\n");
 			responseTextArr.sort();
-			for(i in responseTextArr) {
-				country = responseTextArr[i].split(":");
-				jQuery('#country').append(new Option(country[0],country[1]));
-			}
+			responseTextArr.each( function(value) {
+				var option = new Element('option');
+				country = value.split(":");
+				option.text = country[0];
+				option.value = country[1];
+				$('country').insert({ bottom : option });
+			});
 		}
 	});
-	jQuery('#trcountry').css("display","table-row");
+	$('trcountry').setStyle({display : "table-row"});
 }
 
 function providers_list() {
-	jQuery('#provider option').remove();
-	jQuery('#providerplan option').remove();
-	jQuery.ajax("getserviceproviders.php",{
-		type: 'POST',
-		data: {country : jQuery('#country').val()},
-		success: function(responseText) {
-			var responseTextArr = responseText.split("\n");
+	$('provider').childElements().each(function(node) { node.remove(); });
+	$('providerplan').childElements().each(function(node) { node.remove(); });
+	new Ajax.Request("getserviceproviders.php",{
+		parameters: {country : $F('country')},
+		onSuccess: function(response) {
+			var responseTextArr = response.responseText.split("\n");
 			responseTextArr.sort();
-			for(i in responseTextArr) {
-				jQuery('#provider').append(new Option(responseTextArr[i],responseTextArr[i]));
-			}
+			responseTextArr.each( function(value) {
+				var option = new Element('option');
+				option.text = value;
+				option.value = value;
+				$('provider').insert({ bottom : option });
+			});
 		}
 	});
-	jQuery('#trprovider').css("display","table-row");
-	jQuery('#trproviderplan').css("display","none");
+	$('trprovider').setStyle({display : "table-row"});
+	$('trproviderplan').setStyle({display : "none"});
 }
 
 function providerplan_list() {
-	jQuery('#providerplan option').remove();
-	jQuery('#providerplan').append( new Option('','') );
-	jQuery.ajax("getserviceproviders.php",{
-		type: 'POST',
-		data: {country : jQuery('#country').val(), provider : jQuery('#provider').val()},
-		success: function(responseText) {
-			var responseTextArr = responseText.split("\n");
+	$('providerplan').childElements().each(function(node) { node.remove(); });
+	$('providerplan').insert( new Element('option') );
+	new Ajax.Request("getserviceproviders.php",{
+		parameters: {country : $F('country'), provider : $F('provider')},
+		onSuccess: function(response) {
+			var responseTextArr = response.responseText.split("\n");
 			responseTextArr.sort();
-			for(i in responseTextArr) {
-				if(responseTextArr[i] != "") {
-					providerplan = responseTextArr[i].split(":");
-					jQuery('#providerplan').append(new Option(providerplan[0] + " - " + providerplan[1],providerplan[1]));
+			responseTextArr.each( function(value) {
+				if(value != "") {
+					providerplan = value.split(":");
+
+					var option = new Element('option');
+					option.text = providerplan[0] + " - " + providerplan[1];
+					option.value = providerplan[1];
+					$('providerplan').insert({ bottom : option });
 				}
-			}
+			});
 		}
 	});
-	jQuery('#trproviderplan').css("display","table-row");
+	$('trproviderplan').setStyle({display : "table-row"});
 }
 
 function prefill_provider() {
-	jQuery.ajax("getserviceproviders.php",{
-		type: "POST",
-		data: {country : jQuery('#country').val(), provider : jQuery('#provider').val(), plan : jQuery('#providerplan').val()},
-		success: function(responseXML) {
-			var xmldoc = responseXML;
+	new Ajax.Request("getserviceproviders.php",{
+		parameters: {country : $F('country'), provider : $F('provider'), plan : $F('providerplan')},
+		onSuccess: function(response) {
+			var xmldoc = response.responseXML;
 			var provider = xmldoc.getElementsByTagName('connection')[0];
-			jQuery('#username').val('');
-			jQuery('#password').val('');
+			$('username').setValue('');
+			$('password').setValue('');
 			if(provider.getElementsByTagName('apn')[0].firstChild.data == "CDMA") {
-				jQuery('#phone').val('#777');
-				jQuery('#apn').val('');
+				$('phone').setValue('#777');
+				$('apn').setValue('');
 			} else {
-				jQuery('#phone').val('*99#');
-				jQuery('#apn').val(provider.getElementsByTagName('apn')[0].firstChild.data);
+				$('phone').setValue('*99#');
+				$('apn').setValue(provider.getElementsByTagName('apn')[0].firstChild.data);
 			}
-			jQuery('#username').val(provider.getElementsByTagName('username')[0].firstChild.data);
-			jQuery('#password').val(provider.getElementsByTagName('password')[0].firstChild.data);
+			$('username').setValue(provider.getElementsByTagName('username')[0].firstChild.data);
+			$('password').setValue(provider.getElementsByTagName('password')[0].firstChild.data);
 		}
 	});
 }


### PR DESCRIPTION
Hi,

I added a new PPP type that I call PPTP-Client to keep it distinct from the PPTP type that was already present in pfSense. This creates a configurable persistent PPTP tunnel to a server.

I did this:

1> as a work around to the multiple PPTP client pass-through problem.
2> because true PPTP client functionality is something that I believe pfSense should support.

These modifications make available for configuration the more common options of PPTP configuration like client authentication methods (pap/chap/mschap-v1/mschap-v2) encryption methods including MPPE (40 bit, 56 bit and 128 bit), tunnel endpoint address, local routes and much more.

I have tested this extensively and I've found that multiple simultaneous connections (using different logins) to the same PPTP server, work very well.

Please take a look and tell me what you think. If you like it then I'll proceed to add similar functionality for L2TP client connections.
