### PR TITLE
Modify low-RAM threshold for disabling PHP APC 

### DIFF
--- a/etc/rc.php_ini_setup
+++ b/etc/rc.php_ini_setup
@@ -254,7 +254,7 @@ done
 RAM=`/sbin/sysctl hw.realmem | /usr/bin/awk '{print $2/1000000}' | /usr/bin/awk -F '.' '{print $1}'`
 export RAM
 export LOWMEM
-if [  "$RAM" -gt 96 ]; then
+if [  "$RAM" -gt 135 ]; then
 
 	/bin/cat >>/usr/local/lib/php.ini <<EOF
 


### PR DESCRIPTION
Necessary for stable operation on 128MB systems,  otherwise PHP keeps getting killed due to out-of-memory.

Per bug #2063:  http://redmine.pfsense.org/issues/2063  
and discussion:  http://forum.pfsense.org/index.php/topic,44239.0.html
