### PR TITLE
Removed flawed HTML.

### DIFF
--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -648,10 +648,6 @@ if ($pkg['tabs'] <> "") {
 			else
 				$values  =  explode(',',  $value);
 			$ifaces["lo0"] = "loopback";
-			if(isset($pkga['advancedfield']) && $adv_enabled)
-				$advanced .="<option><name></name><value></value></option>/n";
-			else
-				echo "<option><name></name><value></value></option>/n";
 			foreach($ifaces as $ifname => $iface) {
 				$selected = (in_array($ifname, $values) ? 'selected' : '');
 				if(isset($pkga['advancedfield']) && $adv_enabled)


### PR DESCRIPTION
If the TinyDNS package requires special handling it should probably be done by the package itself where it doesn't change the behavior of other packages as well as OLSR, RIP and UPNP interface selection.
