### PR TITLE
Added description text for IPSec tunnel status in "Status: IPsec" page

### DIFF
--- a/usr/local/www/diag_ipsec.php
+++ b/usr/local/www/diag_ipsec.php
@@ -126,7 +126,7 @@ $sad = ipsec_dump_sad();
 						<td class="listr"><?=htmlspecialchars($ph2ent['descr']);?></td>
 						<td class="listr">
 							<center>
-								<img src ="/themes/<?=$g['theme']?>/images/icons/icon_<?=$icon?>.gif"> <?=$status?>
+								<img src ="/themes/<?=$g['theme']?>/images/icons/icon_<?=$icon?>.gif" title="<?=$status?>">
 							</center>
 						</td>
 						<td class="list">


### PR DESCRIPTION
This way it's easier to see the status for color blind people like me :)
