### PR TITLE
Additional RIP options

### DIFF
--- a/usr/local/pkg/routed.inc
+++ b/usr/local/pkg/routed.inc
@@ -78,6 +78,14 @@ function setup_etc_gateways($iface="", $mode="") {
 			if ($passwd != "") {
 				$ret .= "passwd={$passwd} ";
 			}
+                        $add_no_ag = $config['installedpackages']['routed']['config'][0]['enable_no_ag'];
+                        $add_no_super_ag = $config['installedpackages']['routed']['config'][0]['enable_no_super_ag'];
+                        if($add_no_ag == "on") {
+                                $ret .= "no_ag ";
+                        }
+                        if($add_no_super_ag == "on") {
+                                $ret .= "no_super_ag ";
+                        }
 		}
 		break;
 	case "disable":

--- a/usr/local/pkg/routed.xml
+++ b/usr/local/pkg/routed.xml
@@ -64,7 +64,7 @@
 			<fieldname>enable</fieldname>
 			<description>Enables the Routing Information Protocol daemon</description>
 			<type>checkbox</type>
-      <enablefields>iface_array[],ripversion,passwd</enablefields>
+      <enablefields>iface_array[],ripversion,passwd,enable_no_ag,enable_no_super_ag</enablefields>
 		</field>
 		<field>
 			<fielddescr>Interfaces</fielddescr>
@@ -96,6 +96,18 @@
 			</description>
 			<type>input</type>
 		</field>
+                <field>
+                        <fielddescr>no_ag</fielddescr>
+                        <fieldname>enable_no_ag</fieldname>
+                        <description>turns off aggregation of subnets in RIPv1 and RIPv2 responses.</description>
+                        <type>checkbox</type>
+                </field>
+                <field>
+                        <fielddescr>no_super_ag</fielddescr>
+                        <fieldname>enable_no_super_ag</fieldname>
+                        <description>turns off aggregation of networks into supernets in RIPv2 responses.</description>
+                        <type>checkbox</type>
+                </field>
 	</fields>
 	<aftersaveredirect>pkg_edit.php?xml=routed.xml&amp;id=0</aftersaveredirect>
         <custom_php_command_before_form>


### PR DESCRIPTION
Added fields for no_ag and no_super_ag routed parameters.  This allows disabling of auto-summary/supernet RIP announcements.
