### PR TITLE
System info widget on dashboard now updates CPU Frequency automatically

### DIFF
--- a/usr/local/www/includes/functions.inc.php
+++ b/usr/local/www/includes/functions.inc.php
@@ -19,6 +19,7 @@ function get_stats() {
 	$stats['interfacestatistics'] = get_interfacestats();
 	$stats['interfacestatus'] = get_interfacestatus();
 	$stats['gateways'] = get_gatewaystats();
+	$stats['cpufreq'] = get_cpufreq();
 	$stats = join("|", $stats);
 	return $stats;
 }
@@ -213,6 +214,21 @@ function update_date_time() {
 	
 	$datetime = date("D M j G:i:s T Y");
 	return $datetime;
+}
+
+function get_cpufreq() {
+	$cpufreqs = "";
+	$out = "";
+	exec("/sbin/sysctl -n dev.cpu.0.freq_levels", $cpufreqs);
+	$cpufreqs = explode(" ", trim($cpufreqs[0]));
+	$maxfreq = explode("/", $cpufreqs[0]);
+	$maxfreq = $maxfreq[0];
+	$curfreq = "";
+	exec("/sbin/sysctl -n dev.cpu.0.freq", $curfreq);
+	$curfreq = trim($curfreq[0]);
+	if ($curfreq != $maxfreq)
+		$out = "Current: {$curfreq} MHz, Max: {$maxfreq} MHz";
+	return $out;
 }
 
 function get_interfacestats() {

--- a/usr/local/www/javascript/index/ajax.js
+++ b/usr/local/www/javascript/index/ajax.js
@@ -41,6 +41,7 @@ function stats(x) {
         updateInterfaceStats(values[6]);
         updateInterfaces(values[7]);
         updateGatewayStats(values[8]);
+        updateCpuFreq(values[9]);
 }
 
 function updateMemory(x) {
@@ -98,6 +99,11 @@ function updateGatewayStats(x){
 			}
 		}
 	}
+}
+
+function updateCpuFreq(x) {
+	if(jQuery('#cpufreq'))
+		jQuery("#cpufreq").html(x);
 }
 
 function updateInterfaceStats(x){

--- a/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/usr/local/www/widgets/widgets/system_information.widget.php
@@ -135,18 +135,8 @@ $curcfg = $config['system']['firmware'];
 				exec("/sbin/sysctl -n hw.model", $cpumodel);
 				$cpumodel = implode(" ", $cpumodel);
 				echo (htmlspecialchars($cpumodel));
-
-				$cpufreqs = "";
-				exec("/sbin/sysctl -n dev.cpu.0.freq_levels", $cpufreqs);
-				$cpufreqs = explode(" ", trim($cpufreqs[0]));
-				$maxfreq = explode("/", $cpufreqs[0]);
-				$maxfreq = $maxfreq[0];
-				$curfreq = "";
-				exec("/sbin/sysctl -n dev.cpu.0.freq", $curfreq);
-				$curfreq = trim($curfreq[0]);
-				if ($curfreq != $maxfreq)
-					echo "<br/>Current: {$curfreq} MHz, Max: {$maxfreq} MHz";
 			?>
+			<div id="cpufreq"><?= get_cpufreq(); ?></div>
 			</td>
 		</tr>
 		<?php if ($hwcrypto): ?>


### PR DESCRIPTION
So when using PowerD with a dynamic mode it'll show the current frequency instead of keeping it frozen since the page was loaded.
