### PR TITLE
Cisco compatible transport mode tunnels

### DIFF
--- a/etc/inc/ipsec.inc
+++ b/etc/inc/ipsec.inc
@@ -36,21 +36,21 @@
 
 /* IPsec defines */
 $my_identifier_list = array(
-	'myaddress' => array( 'desc' => gettext('My IP address'), 'mobile' => true ),
-	'address' => array( 'desc' => gettext('IP address'), 'mobile' => true ),
-	'fqdn' => array( 'desc' => gettext('Distinguished name'), 'mobile' => true ),
-	'user_fqdn' => array( 'desc' => gettext('User distinguished name'), 'mobile' => true ),
-	'asn1dn' => array( 'desc' => gettext('ASN.1 distinguished Name'), 'mobile' => true ),
-	'keyid tag' => array( 'desc' => gettext('KeyID tag'), 'mobile' => true ),
-	'dyn_dns' => array( 'desc' => gettext('Dynamic DNS'), 'mobile' => true ));
+	'myaddress' => array( 'desc' => 'My IP address', 'mobile' => true ),
+	'address' => array( 'desc' => 'IP address', 'mobile' => true ),
+	'fqdn' => array( 'desc' => 'Distinguished name', 'mobile' => true ),
+	'user_fqdn' => array( 'desc' => 'User distinguished name', 'mobile' => true ),
+	'asn1dn' => array( 'desc' => 'ASN.1 distinguished Name', 'mobile' => true ),
+	'keyid tag' => array( 'desc' => 'KeyID tag', 'mobile' => true ),
+	'dyn_dns' => array( 'desc' => 'Dynamic DNS', 'mobile' => true ));
 
 $peer_identifier_list = array(
-	'peeraddress' => array( 'desc' => gettext('Peer IP address'), 'mobile' => false ),
-	'address' => array( 'desc' => gettext('IP address'), 'mobile' => false ),
-	'fqdn' => array( 'desc' => gettext('Distinguished name'), 'mobile' => true ),
-	'user_fqdn' => array( 'desc' => gettext('User distinguished name'), 'mobile' => true ),
-	'asn1dn' => array( 'desc' => gettext('ASN.1 distinguished Name'), 'mobile' => true ),
-	'keyid tag' => array( 'desc' =>gettext('KeyID tag'), 'mobile' => true ));
+	'peeraddress' => array( 'desc' => 'Peer IP address', 'mobile' => false ),
+	'address' => array( 'desc' => 'IP address', 'mobile' => false ),
+	'fqdn' => array( 'desc' => 'Distinguished name', 'mobile' => true ),
+	'user_fqdn' => array( 'desc' => 'User distinguished name', 'mobile' => true ),
+	'asn1dn' => array( 'desc' => 'ASN.1 distinguished Name', 'mobile' => true ),
+	'keyid tag' => array( 'desc' =>'KeyID tag', 'mobile' => true ));
 
 $p1_ealgos = array(
 	'aes' => array( 'name' => 'AES', 'keysel' => array( 'lo' => 128, 'hi' => 256, 'step' => 64 ) ),
@@ -82,10 +82,14 @@ $p1_authentication_methods = array(
 	'pre_shared_key' => array( 'name' => 'Mutual PSK', 'mobile' => false ) );
 
 $p2_modes = array(
-	'tunnel' => 'Tunnel IPv4',
-	'tunnel6' => 'Tunnel IPv6',
+	'tunnel' => 'Tunnel',
 	'transport' => 'Transport');
-
+$p2_protocal = array(
+	'any' => 'Any',
+	'tcp' => 'TCP',
+	'udp' => 'UDP',
+	'gre' => 'GRE'
+	);
 $p2_protos = array(
 	'esp' => 'ESP',
 	'ah' => 'AH');
@@ -127,21 +131,14 @@ function ipsec_get_phase1_src(& $ph1ent) {
 	if ($ph1ent['interface']) {
 		if (!is_ipaddr($ph1ent['interface'])) {
 			$if = $ph1ent['interface'];
-			if($ph1ent['protocol'] == "inet6") {
-				$interfaceip = get_interface_ipv6($if);
-			} else {
-				$interfaceip = get_interface_ip($if);
-			}
+			$interfaceip = get_interface_ip($if);
 		} else {
 			$interfaceip=$ph1ent['interface'];
 		}
-	} else {
+	}
+	else {
 		$if = "wan";
-		if($ph1ent['protocol'] == "inet6") {
-			$interfaceip = get_interface_ipv6($if);
-		} else {
-			$interfaceip = get_interface_ip($if);
-		}
+		$interfaceip = get_interface_ip($if);
 	}
 
 	return $interfaceip;
@@ -152,7 +149,7 @@ function ipsec_get_phase1_src(& $ph1ent) {
  */
 function ipsec_get_phase1_dst(& $ph1ent) {
 	global $g;
-	if (empty($ph1ent['remote-gateway']))
+	if (!$ph1ent['remote-gateway'])
 		return false;
 	$rg = $ph1ent['remote-gateway'];
 	if (!is_ipaddr($rg)) {
@@ -174,33 +171,21 @@ function ipsec_idinfo_to_cidr(& $idinfo,$addrbits = false) {
 	switch ($idinfo['type'])
 	{
 		case "address":
-			if ($addrbits) {
-				if($idinfo['mode'] == "tunnel6") {
-					return $idinfo['address']."/128";
-				} else {
-					return $idinfo['address']."/32";
-				}
-			} else {
+			if ($addrbits)
+				return $idinfo['address']."/32";
+			else
 				return $idinfo['address'];
-			}
 		case "network":
 			return $idinfo['address']."/".$idinfo['netbits'];
 		case "none":
 		case "mobile":
 			return "0.0.0.0/0";
 		default:
-			if($idinfo['mode'] == "tunnel6") {
-				$address = get_interface_ipv6($idinfo['type']);
-				$netbits = get_interface_subnetv6($idinfo['type']);
-				$address = gen_subnetv6($address,$netbits);
-				return $address."/".$netbits;
-			} else {
-				$address = get_interface_ip($idinfo['type']);
-				$netbits = get_interface_subnet($idinfo['type']);
-				$address = gen_subnet($address,$netbits);
-				return $address."/".$netbits;
-			}
-	}
+			$address = get_interface_ip($idinfo['type']);
+			$netbits = get_interface_subnet($idinfo['type']);
+			$address = gen_subnet($address,$netbits);
+			return $address."/".$netbits;
+    }
 }
 
 /*
@@ -212,33 +197,22 @@ function ipsec_idinfo_to_subnet(& $idinfo,$addrbits = false) {
 	switch ($idinfo['type'])
 	{
 		case "address":
-			if ($addrbits) {
-				if($idinfo['mode'] == "tunnel6") {
-					return $idinfo['address']."/128";
-				} else {
-					return $idinfo['address']."/255.255.255.255";
-				}
-			} else {
+			if ($addrbits)
+				return $idinfo['address']."/255.255.255.255";
+			else
 				return $idinfo['address'];
-			}
 		case "none":
 		case "network":
 			return $idinfo['address']."/".gen_subnet_mask($idinfo['netbits']);
 		case "mobile":
 			return "0.0.0.0/0";
 		default:
-			if($idinfo['mode'] == "tunnel6") {
-				$address = get_interface_ipv6($idinfo['type']);
-				$netbits = get_interface_subnetv6($idinfo['type']);
-				$address = gen_subnetv6($address,$netbits);
-				return $address."/".$netbits;
-			} else {
-				$address = get_interface_ip($idinfo['type']);
-				$netbits = get_interface_subnet($idinfo['type']);
-				$address = gen_subnet($address,$netbits);
-				return $address."/".$netbits;
-			}
-	}
+			$address = get_interface_ip($idinfo['type']);
+			$netbits = get_interface_subnet($idinfo['type']);
+			$address = gen_subnet($address,$netbits);
+			$netbits = gen_subnet_mask($netbits);
+			return $address."/".netbits;
+    }
 }
 
 /*
@@ -253,9 +227,9 @@ function ipsec_idinfo_to_text(& $idinfo) {
         case "network":
             return $idinfo['address']."/".$idinfo['netbits'];
 	case "mobile":
-		return gettext("Mobile Client");
+		return "Mobile Client";
 	case "none":
-		return gettext("None");
+		return "None";
         default:
             return strtoupper($idinfo['type']);
     }
@@ -301,7 +275,7 @@ function ipsec_phase1_status(& $ph1ent) {
 function ipsec_phase2_status(& $spd,& $sad,& $ph1ent,& $ph2ent) {
 
 	$loc_ip = ipsec_get_phase1_src($ph1ent);
-	$rmt_ip = ipsec_get_phase1_dst($ph1ent);
+	$rmt_ip = gethostbyname(ipsec_get_phase1_dst($ph1ent));
 
 	$loc_id = ipsec_idinfo_to_cidr($ph2ent['localid'],true);
 	$rmt_id = ipsec_idinfo_to_cidr($ph2ent['remoteid'],true);
@@ -497,38 +471,6 @@ function ipsec_dump_sad()
 	return $sad;
 }
 
-/*
- * Return dump of mobile user list
- */
-function ipsec_dump_mobile() {
-	$command = "/usr/local/sbin/racoonctl show-users";
-	$fd = @popen($command, "r");
-	$mobile = array();
-	if ($fd) {
-		while (!feof($fd)) {
-			$user = array();
-			$line = chop(fgets($fd));
-			if (!$line)
-				continue;
-			if ($line == "User|Source|Destination|CreatedOn|SPI")
-				continue;
-
-			// jim|192.168.20.243:4500|192.168.20.5:24146|2012-05-25 09:54:39|989d10e1e2d4eca4:7243830d5fd2afe7
-			$linea = explode("|", trim($line));
-			$user['username'] = $linea[0];
-			$user['local'] = $linea[1];
-			$user['remote'] = $linea[2];
-			$user['logintime'] = $linea[3];
-			$user['spi'] = $linea[4];
-			if (!empty($user['username']))
-				$mobile[] = $user;
-		}
-		pclose($fd);
-	}
-
-	return $mobile;
-}
-
 function ipsec_mobilekey_sort() {
 	global $config;
 
@@ -554,12 +496,6 @@ function ipsec_get_number_of_phase2($ikeid) {
 	}
 
 	return $nbph2;
-}
-
-function ipsec_disconnect_mobile($username) {
-	if (empty($username))
-		return false;
-	exec("/usr/local/sbin/racoonctl logout-user " . escapeshellarg($username));
 }
 
 ?>

--- a/etc/inc/vpn.inc
+++ b/etc/inc/vpn.inc
@@ -82,8 +82,6 @@ function vpn_ipsec_configure($ipchg = false)
 {
 	global $config, $g, $sa, $sn, $p1_ealgos, $p2_ealgos;
 
-	if ($g['platform'] == 'jail')
-		return;
 	/* get the automatic ping_hosts.sh ready */
 	unlink_if_exists("{$g['vardb_path']}/ipsecpinghosts");
 	touch("{$g['vardb_path']}/ipsecpinghosts");
@@ -123,7 +121,7 @@ function vpn_ipsec_configure($ipchg = false)
 		mwexec("/sbin/sysctl net.inet.ip.ipsec_in_use=1");
 
 		if ($g['booting'])
-			echo gettext("Configuring IPsec VPN... ");
+			echo "Configuring IPsec VPN... ";
 
 		/* fastforwarding is not compatible with ipsec tunnels */
 		mwexec("/sbin/sysctl net.inet.ip.fastforwarding=0");
@@ -136,13 +134,12 @@ function vpn_ipsec_configure($ipchg = false)
 
 			$ipsecpinghosts = "";
 			/* step through each phase1 entry */
-			$ipsecpinghosts = "";
 			foreach ($a_phase1 as $ph1ent) {
 				if (isset($ph1ent['disabled']))
 					continue;
 
 				$ep = ipsec_get_phase1_src($ph1ent);
-				if (!is_ipaddr($ep))
+				if (!$ep)
 					continue;
 
 				if(!in_array($ep,$ipmap))
@@ -170,54 +167,39 @@ function vpn_ipsec_configure($ipchg = false)
 				}
 				$rgmap[$ph1ent['remote-gateway']] = $rg;
 
-				if (is_array($a_phase2)) {
-					/* step through each phase2 entry */
-					foreach ($a_phase2 as $ph2ent) {
-						$ikeid = $ph2ent['ikeid'];
+				/* step through each phase2 entry */
+				foreach ($a_phase2 as $ph2ent) {
 
-						if (isset($ph2ent['disabled']))
-							continue;
+					$ikeid = $ph2ent['ikeid'];
 
-						if ($ikeid != $ph1ent['ikeid'])
-							continue;
+					if (isset($ph2ent['disabled']))
+						continue;
 
-						$ph2ent['localid']['mode'] = $ph2ent['mode'];
-						/* add an ipsec pinghosts entry */
-						if ($ph2ent['pinghost']) {
-							$iflist = get_configured_interface_list();
-							foreach ($iflist as $ifent => $ifname) {
-								if(is_ipaddrv6($ph2ent['pinghost'])) {
-									$interface_ip = get_interface_ipv6($ifent);
-									if(!is_ipaddrv6($interface_ip))
-										continue;
-									$local_subnet = ipsec_idinfo_to_cidr($ph2ent['localid'], true);
-									if (ip_in_subnet($interface_ip, $local_subnet)) {
-										$srcip = $interface_ip;
-										break;
-									}
-								} else {
-									$interface_ip = get_interface_ip($ifent);
-									if(!is_ipaddrv4($interface_ip))
-										continue;
-									$local_subnet = ipsec_idinfo_to_cidr($ph2ent['localid'], true);
-									if (ip_in_subnet($interface_ip, $local_subnet)) {
-										$srcip = $interface_ip;
-										break;
-									}
-								}
+					if ($ikeid != $ph1ent['ikeid'])
+						continue;
+
+					/* add an ipsec pinghosts entry */
+					if ($ph2ent['pinghost']) {
+						$iflist = get_configured_interface_list();
+						foreach ($iflist as $ifent => $ifname) {
+							$interface_ip = get_interface_ip($ifent);
+							$local_subnet = ipsec_idinfo_to_cidr($ph2ent['localid'], true);
+							if (ip_in_subnet($interface_ip, $local_subnet)) {
+								$srcip = $interface_ip;
+								break;
 							}
-							$dstip = $ph2ent['pinghost'];
-							if(is_ipaddrv6($dstip)) {
-								$family = "inet6";
-							} else {
-								$family = "inet";
-							}
-							if (is_ipaddr($srcip))
-								$ipsecpinghosts[] = "{$srcip}|{$dstip}|3|||||{$family}|\n";
 						}
+						$dstip = $ph2ent['pinghost'];
+						if (is_ipaddr($srcip))
+							$ipsecpinghosts .= "{$srcip}|{$dstip}|3\n";
 					}
-					file_put_contents("{$g['vardb_path']}/ipsecpinghosts", $ipsecpinghosts);
 				}
+				$pfd = fopen("{$g['vardb_path']}/ipsecpinghosts", "w");
+				if ($pfd) {
+					fwrite($pfd, $ipsecpinghosts);
+					fclose($pfd);
+				}
+				
 			}
 		}
 
@@ -225,18 +207,18 @@ function vpn_ipsec_configure($ipchg = false)
 		if (is_array($config['ca']) && count($config['ca'])) {
 			foreach ($config['ca'] as $ca) {
 				if (!isset($ca['crt'])) {
-					log_error(sprintf(gettext("Error: Invalid certificate info for %s"), $ca['descr']));
+					log_error("Error: Invalid certificate info for {$ca['descr']}");
 					continue;
 				}
 				$cert = base64_decode($ca['crt']);
 				$x509cert = openssl_x509_parse(openssl_x509_read($cert));
 				if (!is_array($x509cert) || !isset($x509cert['hash'])) {
-					log_error(sprintf(gettext("Error: Invalid certificate hash info for %s"), $ca['descr']));
+					log_error("Error: Invalid certificate hash info for {$ca['descr']}");
 					continue;
 				}
 				$fname = $g['varetc_path']."/".$x509cert['hash'].".0";
 				if (!file_put_contents($fname, $cert)) {
-					log_error(sprintf(gettext("Error: Cannot write IPsec CA file for %s"), $ca['descr']));
+					log_error("Error: Cannot write IPsec CA file for {$ca['descr']}");
 					continue;
 				}
 			}
@@ -245,7 +227,7 @@ function vpn_ipsec_configure($ipchg = false)
 		/* generate psk.txt */
 		$fd = fopen("{$g['varetc_path']}/psk.txt", "w");
 		if (!$fd) {
-			printf(gettext("Error: cannot open psk.txt in vpn_ipsec_configure().") . "\n");
+			printf("Error: cannot open psk.txt in vpn_ipsec_configure().\n");
 			return 1;
 		}
 
@@ -308,7 +290,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 			$fd = fopen("{$g['varetc_path']}/racoon.conf", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open racoon.conf in vpn_ipsec_configure().") . "\n");
+				printf("Error: cannot open racoon.conf in vpn_ipsec_configure().\n");
 				return 1;
 			}
 
@@ -400,7 +382,7 @@ function vpn_ipsec_configure($ipchg = false)
 					$fn = "{$g['varetc_path']}/racoon.motd";
 					$fd1 = fopen($fn, "w");
 					if (!$fd1) {
-						printf(gettext("Error: cannot open server %s in vpn.\n"), $fn);
+						printf("Error: cannot open server{$fn} in vpn.\n");
 						return 1;
 					}
 
@@ -416,31 +398,6 @@ function vpn_ipsec_configure($ipchg = false)
 				$racoonconf .= "}\n\n";
 			}
 			/* end mode_cfg section */
-			
-			if ($a_client['user_source'] != "system") {
-				if (is_array($config['system']['authserver'])) {
-					foreach ($config['system']['authserver'] as $authcfg) {
-						if ($authcfg['type'] == 'ldap' and $authcfg['name'] == $a_client['user_source']) 
-							$thisauthcfg = $authcfg;
-					}
-
-					/* begin ldapcfg */                        
-					$racoonconf .= "ldapcfg {\n";
-					$racoonconf .= "\tversion 3;\n";
-					$racoonconf .= "\thost \"".$thisauthcfg['host']."\";\n";
-					$lport = "389";
-					if ($authcfg['port'] != "")
-						$lport = $authcfg['port'];
-					$racoonconf .= "\tport ".$lport.";\n";
-					$racoonconf .= "\tbase \"".$thisauthcfg['ldap_basedn']."\";\n";
-					$racoonconf .= "\tsubtree on;\n";
-					$racoonconf .= "\tbind_dn \"".$thisauthcfg['ldap_binddn']."\";\n";
-					$racoonconf .= "\tbind_pw \"".$thisauthcfg['ldap_bindpw']."\";\n";
-					$racoonconf .= "\tattr_user \"".$thisauthcfg['ldap_attr_user']."\";\n";
-					$racoonconf .= "}\n\n";
-					/* end ldapcfg */
-				}
-			}
 
 			/* begin remote sections */
 			if (is_array($a_phase1) && count($a_phase1)) {
@@ -476,7 +433,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 						case "dyn_dns":
 							$myid_type = "address";
-							$myid_data = resolve_retry($ph1ent['myid_data']);
+							$myid_data = gethostbyname($ph1ent['myid_data']);
 							break;
 
 						case "address";
@@ -556,7 +513,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 						if (!$cert)
 						{
-							log_error(sprintf(gettext("Error: Invalid phase1 certificate reference for %s"), $ph1ent['name']));
+							log_error("Error: Invalid phase1 certificate reference for {$ph1ent['name']}");
 							continue;
 						}
 
@@ -565,7 +522,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 						if (!file_put_contents($certpath, base64_decode($cert['crt'])))
 						{
-							log_error(sprintf(gettext("Error: Cannot write phase1 certificate file for %s"), $ph1ent['name']));
+							log_error("Error: Cannot write phase1 certificate file for {$ph1ent['name']}");
 							continue;
 						}
 
@@ -576,7 +533,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 						if (!file_put_contents($keypath, base64_decode($cert['prv'])))
 						{
-							log_error(sprintf(gettext("Error: Cannot write phase1 key file for %s"), $ph1ent['name']));
+							log_error("Error: Cannot write phase1 key file for {$ph1ent['name']}");
 							continue;
 						}
 
@@ -589,7 +546,7 @@ function vpn_ipsec_configure($ipchg = false)
 
 							if (!file_put_contents($capath, base64_decode($ca['crt'])))
 							{
-								log_error(sprintf(gettext("Error: Cannot write phase1 CA certificate file for %s"), $ph1ent['name']));
+								log_error("Error: Cannot write phase1 CA certificate file for {$ph1ent['name']}");
 								continue;
 							}
 
@@ -676,10 +633,9 @@ EOD;
 					if (isset($ph2ent['mobile']) && !isset($a_client['enable']))
 						continue;
 
-					if (($ph2ent['mode'] == 'tunnel') or ($ph2ent['mode'] == 'tunnel6')) {
+					if ($ph2ent['mode'] == 'tunnel') {
 
 						$localid_type = $ph2ent['localid']['type'];
-						$ph2ent['localid']['mode'] = $ph2ent['mode'];
 						$localid_data = ipsec_idinfo_to_cidr($ph2ent['localid']);
 						/* Do not print localid in some cases, such as a pure-psk or psk/xauth single phase2 mobile tunnel */
 						if (($localid_type == "none") ||
@@ -691,11 +647,6 @@ EOD;
 						else {
 							if ($localid_type != "address") {
 								$localid_type = "subnet";
-							}
-							// Don't let an empty subnet into racoon.conf, it can cause parse errors. Ticket #2201.
-							if (!is_subnet($localid_data)) {
-								log_error("Invalid IPsec Phase 2 \"{$ph2ent['descr']}\" - {$ph2ent['localid']['type']} has no subnet.");
-								continue;
 							}
 							$localid_spec = $localid_type." ".$localid_data." any";
 						}
@@ -719,12 +670,12 @@ EOD;
 							$localid_spec = " ";
 						else {
 							$localid_data = ipsec_get_phase1_src($ph1ent);
-							if($ph2ent['mode'] == 'transport') { $localid_data="$localid_data any"; }
+							if($ph2ent['mode'] == 'transport') { $localid_data=$localid_data." ".$ph2ent['protocal']; }
 							$localid_spec = "address {$localid_data}";
 						}
 						if (!isset($ph2ent['mobile'])) {
 							$remoteid_data = $rgmap[$ph1ent['remote-gateway']];
-							if($ph2ent['mode'] == 'transport') { $remoteid_data="$remoteid_data any"; }
+							if($ph2ent['mode'] == 'transport') { $remoteid_data=$remoteid_data." ".$ph2ent['protocal']; }
 							$remoteid_spec = "address {$remoteid_data}";
 						} else
 							$remoteid_spec = "anonymous";
@@ -826,7 +777,7 @@ EOD;
 		/* generate spd.conf */
 		$fd = fopen("{$g['varetc_path']}/spd.conf", "w");
 		if (!$fd) {
-			printf(gettext("Error: cannot open spd.conf in vpn_ipsec_configure().") . "\n");
+			printf("Error: cannot open spd.conf in vpn_ipsec_configure().\n");
 			return 1;
 		}
 
@@ -835,18 +786,11 @@ EOD;
 			/* Try to prevent people from locking themselves out of webgui. Just in case. */
 			if ($config['interfaces']['lan']) {
 				$lanip = get_interface_ip("lan");
-				if (!empty($lanip) && is_ipaddrv4($lanip)) {
+				if (!empty($lanip) && is_ipaddr($lanip)) {
 					$lansn = get_interface_subnet("lan");
 					$lansa = gen_subnet($lanip, $lansn);
-					$spdconf .= "spdadd -4 {$lanip}/32 {$lansa}/{$lansn} any -P out none;\n";
-					$spdconf .= "spdadd -4 {$lansa}/{$lansn} {$lanip}/32 any -P in none;\n";
-				}
-				$lanipv6 = get_interface_ipv6("lan");
-				if (!empty($lanipv6) && is_ipaddrv6($lanipv6)) {
-					$lansnv6 = get_interface_subnetv6("lan");
-					$lansav6 = gen_subnetv6($lanipv6, $lansnv6);
-					$spdconf .= "spdadd -6 {$lanipv6}/128 {$lansav6}/{$lansnv6} any -P out none;\n";
-					$spdconf .= "spdadd -6 {$lansav6}/{$lansnv6} {$lanipv6}/128 any -P in none;\n";
+					$spdconf .= "spdadd {$lanip}/32 {$lansa}/{$lansn} any -P out none;\n";
+					$spdconf .= "spdadd {$lansa}/{$lansn} {$lanip}/32 any -P in none;\n";
 				}
 			}
 
@@ -872,24 +816,15 @@ EOD;
 				if(!is_ipaddr($rgip))
 					continue;
 
-				$ph2ent['localid']['mode'] = $ph2ent['mode'];
 				$localid = ipsec_idinfo_to_cidr($ph2ent['localid'],true);
 				$remoteid = ipsec_idinfo_to_cidr($ph2ent['remoteid'],true);
 
-				// Error will be logged above, no need to log this twice. #2201
-				if (!is_subnet($localid))
-					continue;
+				if($ph2ent['mode'] == "tunnel") {
 
-				if(($ph2ent['mode'] == "tunnel") or ($ph2ent['mode'] == 'tunnel6')) {
-					if($ph2ent['mode'] == "tunnel6")
-						$family = "-6";
-					else
-						$family = "-4";
-
-					$spdconf .= "spdadd {$family} {$localid} {$remoteid} any -P out ipsec " .
+					$spdconf .= "spdadd {$localid} {$remoteid} any -P out ipsec " .
 						"{$ph2ent['protocol']}/tunnel/{$ep}-{$rgip}/unique;\n";
 
-					$spdconf .= "spdadd {$family} {$remoteid} {$localid} any -P in ipsec " .
+					$spdconf .= "spdadd {$remoteid} {$localid} any -P in ipsec " .
 						"{$ph2ent['protocol']}/tunnel/{$rgip}-{$ep}/unique;\n";
 
 				} else {
@@ -897,21 +832,21 @@ EOD;
 					$localid_data = ipsec_get_phase1_src($ph1ent);
 					$remoteid_data = $rgmap[$ph1ent['remote-gateway']];
 
-					$spdconf .= "spdadd {$localid_data} {$remoteid_data} any -P out ipsec " .
+					$spdconf .= "spdadd {$localid_data} {$remoteid_data} {$ph2ent['protocal']} -P out ipsec " .
 						"{$ph2ent['protocol']}/transport//require;\n";
-
-					$spdconf .= "spdadd {$remoteid_data} {$localid_data} any -P in ipsec " .
+					if (!isset($ph2ent['cisco'])) {
+					$spdconf .= "spdadd {$remoteid_data} {$localid_data} {$ph2ent['protocal']} -P in ipsec " .
 						"{$ph2ent['protocol']}/transport//require;\n";
-
+					}
 				}
 
 				/* static route needed? */
-				if (preg_match("/^carp|^[a-z0-9]+_vip/i", $ph1ent['interface']))
+				if (preg_match("/^carp|^vip/i", $ph1ent['interface']))
 					$parentinterface = link_carp_interface_to_parent($ph1ent['interface']);
 				else
 					$parentinterface = $ph1ent['interface'];
 
-				if (is_ipaddr($rgip)) {
+				if (($parentinterface <> "wan") && (is_ipaddr($rgip))) {
 					/* add endpoint routes to correct gateway on interface */
 					if (interface_has_gateway($parentinterface)) {
 						$gatewayip = get_interface_gateway("$parentinterface");
@@ -928,7 +863,8 @@ EOD;
 							}
 						}
 					}
-				} 
+				} else if(is_ipaddr($rgip))
+					mwexec("/sbin/route delete -host {$rgip}", true);
 			}
 
 		}
@@ -1011,7 +947,7 @@ function vpn_ipsec_force_reload() {
 
 	/* if ipsec is enabled, start up again */
 	if (isset($ipseccfg['enable'])) {
-		log_error(gettext("Forcefully reloading IPsec racoon daemon"));
+		log_error("Forcefully reloading IPsec racoon daemon");
 		vpn_ipsec_configure();
 	}
 
@@ -1019,11 +955,6 @@ function vpn_ipsec_force_reload() {
 
 /* master setup for vpn (mpd) */
 function vpn_setup() {
-	global $g;
-
-	if ($g['platform'] == 'jail')
-		return;
-
 	/* start pptpd */
 	vpn_pptpd_configure();
 
@@ -1055,7 +986,7 @@ function vpn_pptpd_configure() {
 		if (!$pptpdcfg['mode'] || ($pptpdcfg['mode'] == "off"))
 			return 0;
 
-		echo gettext("Configuring PPTP VPN service... ");
+		echo "Configuring PPTP VPN service... ";
 	} else {
 		/* kill mpd */
 		killbypid("{$g['varrun_path']}/pptp-vpn.pid");
@@ -1065,7 +996,7 @@ function vpn_pptpd_configure() {
 
 		if (is_process_running("mpd -b")) {
 			killbypid("{$g['varrun_path']}/pptp-vpn.pid");
-			log_error(gettext("Could not kill mpd within 3 seconds.   Trying again."));
+			log_error("Could not kill mpd within 3 seconds.   Trying again.");
 		}
 
 		/* remove mpd.conf, if it exists */
@@ -1088,7 +1019,7 @@ function vpn_pptpd_configure() {
 			/* write mpd.conf */
 			$fd = fopen("{$g['varetc_path']}/pptp-vpn/mpd.conf", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.conf in vpn_pptpd_configure().") . "\n");
+				printf("Error: cannot open mpd.conf in vpn_pptpd_configure().\n");
 				return 1;
 			}
 
@@ -1175,7 +1106,7 @@ EOD;
 				$authport = (isset($pptpdcfg['radius']['server2']['port']) && strlen($pptpdcfg['radius']['server2']['port']) > 1) ? $pptpdcfg['radius']['server2']['port'] : 1812;
 				$acctport = $authport + 1;
 				$mpdconf .=<<<EOD
-	set radius server {$pptpdcfg['radius']['server2']['ip']} "{$pptpdcfg['radius']['server2']['secret2']}" {$authport} {$acctport}
+	set radius server {$pptpdcfg['radius']['server2']['ip']} "{$pptpdcfg['radius']['server2']['secret']}" {$authport} {$acctport}
 
 EOD;
 			}
@@ -1201,7 +1132,7 @@ EOD;
 			/* write mpd.links */
 			$fd = fopen("{$g['varetc_path']}/pptp-vpn/mpd.links", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.links in vpn_pptpd_configure().") . "\n");
+				printf("Error: cannot open mpd.links in vpn_pptpd_configure().\n");
 				return 1;
 			}
 
@@ -1225,7 +1156,7 @@ EOD;
 			/* write mpd.secret */
 			$fd = fopen("{$g['varetc_path']}/pptp-vpn/mpd.secret", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.secret in vpn_pptpd_configure().") . "\n");
+				printf("Error: cannot open mpd.secret in vpn_pptpd_configure().\n");
 				return 1;
 			}
 
@@ -1282,7 +1213,7 @@ function vpn_pppoe_configure(&$pppoecfg) {
 		if (!$pppoecfg['mode'] || ($pppoecfg['mode'] == "off"))
 			return 0;
 
-		echo gettext("Configuring PPPoE VPN service... ");
+		echo "Configuring PPPoE VPN service... ";
 	} else {
 		/* kill mpd */
 		killbypid("{$g['varrun_path']}/pppoe{$pppoecfg['pppoeid']}-vpn.pid");
@@ -1306,7 +1237,7 @@ function vpn_pppoe_configure(&$pppoecfg) {
 			/* write mpd.conf */
 			$fd = fopen("{$g['varetc_path']}/pppoe{$pppoecfg['pppoeid']}-vpn/mpd.conf", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.conf in vpn_pppoe_configure().") . "\n");
+				printf("Error: cannot open mpd.conf in vpn_pppoe_configure().\n");
 				return 1;
 			}
 			$mpdconf = "\n\n";
@@ -1409,7 +1340,7 @@ EOD;
 			/* write mpd.links */
 			$fd = fopen("{$g['varetc_path']}/pppoe{$pppoecfg['pppoeid']}-vpn/mpd.links", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.links in vpn_pppoe_configure().") . "\n");
+				printf("Error: cannot open mpd.links in vpn_pppoe_configure().\n");
 				return 1;
 			}
 
@@ -1435,7 +1366,7 @@ EOD;
 				/* write mpd.secret */
 				$fd = fopen("{$g['varetc_path']}/pppoe{$pppoecfg['pppoeid']}-vpn/mpd.secret", "w");
 				if (!$fd) {
-					printf(gettext("Error: cannot open mpd.secret in vpn_pppoe_configure().") . "\n");
+					printf("Error: cannot open mpd.secret in vpn_pppoe_configure().\n");
 					return 1;
 				}
 
@@ -1454,10 +1385,6 @@ EOD;
 				chmod("{$g['varetc_path']}/pppoe{$pppoecfg['pppoeid']}-vpn/mpd.secret", 0600);
 			}
 
-			/* Check if previous instance is still up */
-			while (file_exists("{$g['varrun_path']}/pppoe{$pppoecfg['pppoeid']}-vpn.pid") && isvalidpid("{$g['varrun_path']}/pppoe{$pppoecfg['pppoeid']}-vpn.pid"))
-				killbypid("{$g['varrun_path']}/pppoe{$pppoecfg['pppoeid']}-vpn.pid");
-
 			/* Get support for netgraph(4) from the nic */
 			pfSense_ngctl_attach(".", $pppoe_interface);
 			/* fire up mpd */
@@ -1467,7 +1394,7 @@ EOD;
 	}
 
 	if ($g['booting'])
-		echo gettext("done") . "\n";
+		echo "done\n";
 
 	return 0;
 }
@@ -1486,7 +1413,7 @@ function vpn_l2tp_configure() {
 		if (!$l2tpcfg['mode'] || ($l2tpcfg['mode'] == "off"))
 			return 0;
 
-		echo gettext("Configuring l2tp VPN service... ");
+		echo "Configuring l2tp VPN service... ";
 	} else {
 		/* kill mpd */
 		killbypid("{$g['varrun_path']}/l2tp-vpn.pid");
@@ -1511,7 +1438,7 @@ function vpn_l2tp_configure() {
 			/* write mpd.conf */
 			$fd = fopen("{$g['varetc_path']}/l2tp-vpn/mpd.conf", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.conf in vpn_l2tp_configure().") . "\n");
+				printf("Error: cannot open mpd.conf in vpn_l2tp_configure().\n");
 				return 1;
 			}
 			$mpdconf = "\n\n";
@@ -1604,7 +1531,7 @@ EOD;
 			/* write mpd.links */
 			$fd = fopen("{$g['varetc_path']}/l2tp-vpn/mpd.links", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.links in vpn_l2tp_configure().") . "\n");
+				printf("Error: cannot open mpd.links in vpn_l2tp_configure().\n");
 				return 1;
 			}
 
@@ -1629,7 +1556,7 @@ EOD;
 			/* write mpd.secret */
 			$fd = fopen("{$g['varetc_path']}/l2tp-vpn/mpd.secret", "w");
 			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.secret in vpn_l2tp_configure().") . "\n");
+				printf("Error: cannot open mpd.secret in vpn_l2tp_configure().\n");
 				return 1;
 			}
 
@@ -1746,7 +1673,6 @@ function reload_tunnel_spd_policy($phase1, $phase2, $old_phase1, $old_phase2) {
 	$sad_arr = ipsec_dump_sad();
 
 	$ep = ipsec_get_phase1_src($phase1);
-	$phase2['localid']['mode'] = $phase2['mode'];
 	$local_subnet = ipsec_idinfo_to_cidr($phase2['localid']);
 	$remote_subnet = ipsec_idinfo_to_cidr($phase2['remoteid']);
 
@@ -1754,7 +1680,6 @@ function reload_tunnel_spd_policy($phase1, $phase2, $old_phase1, $old_phase2) {
 	$old_gw = trim($old_phase1['remote-gateway']);
 
 	$old_ep = ipsec_get_phase1_src($old_phase1);
-	$old_phase2['localid']['mode'] = $old_phase2['mode'];
 	$old_local_subnet = ipsec_idinfo_to_cidr($old_phase2['localid']);
 	$old_remote_subnet = ipsec_idinfo_to_cidr($old_phase2['remoteid']);
 
@@ -1776,30 +1701,25 @@ function reload_tunnel_spd_policy($phase1, $phase2, $old_phase1, $old_phase2) {
 		$rgip = $phase1['remote-gateway'];
 	}
 	if (!$ep) {
-		log_error(sprintf(gettext("Could not determine VPN endpoint for '%s'"), $phase1['descr']));
+		log_error("Could not determine VPN endpoint for '{$phase1['descr']}'");
 		return false;
 	}
 
 	if((!is_ipaddr($old_ep)) || (! is_ipaddr($ep))) {
-		log_error(sprintf(gettext("IPSEC: ERROR: One of the endpoints is not a IP address. Old EP '%1\$s' new EP '%2\$s'"), $old_ep, $ep));
+		log_error("IPSEC: ERROR: One of the endpoints is not a IP address. Old EP '{$old_ep}' new EP '{$ep}'");
 	}
 	if((! is_ipaddr($rgip)) || (! is_ipaddr($old_gw))) {
-		log_error(sprintf(gettext("IPSEC: ERROR: One of the remote endpoints is not a IP address. Old RG '%1\$s' new RG '%2\$s'"), $old_gw, $rgip));
+		log_error("IPSEC: ERROR: One of the remote endpoints is not a IP address. Old RG '{$old_gw}' new RG '{$rgip}'");
 	}
 
 	$spdconf = "";
 	/* Delete old SPD policies if there are changes between the old and new */
 	if(($phase1 != $old_phase1) || ($phase2 != $old_phase2)) {
-		if($old_phase2['mode'] == "tunnel6")
-			$family = "-6";
-		else
-			$family = "-4";
-
-		$spdconf .= "spddelete {$family} {$old_local_subnet} " .
+		$spdconf .= "spddelete {$old_local_subnet} " .
 			"{$old_remote_subnet} any -P out ipsec " .
 			"{$old_phase2['protocol']}/tunnel/{$old_ep}-" .
 			"{$old_gw}/unique;\n";
-		$spdconf .= "spddelete {$family} {$old_remote_subnet} " .
+		$spdconf .= "spddelete {$old_remote_subnet} " .
 			"{$old_local_subnet} any -P in ipsec " .
 			"{$old_phase2['protocol']}/tunnel/{$old_gw}-" .
 			"{$old_ep}/unique;\n";
@@ -1807,40 +1727,35 @@ function reload_tunnel_spd_policy($phase1, $phase2, $old_phase1, $old_phase2) {
 		/* zap any existing SA entries */
 		foreach($sad_arr as $sad) {
 			if(($sad['dst'] == $old_ep) && ($sad['src'] == $old_gw)) {
-				$spdconf .= "delete {$family} {$old_ep} {$old_gw} {$old_phase2['protocol']} 0x{$sad['spi']};\n";
+				$spdconf .= "delete {$old_ep} {$old_gw} {$old_phase2['protocol']} 0x{$sad['spi']};\n";
 			}
 			if(($sad['src'] == $oldep) && ($sad['dst'] == $old_gw)) {
-				$spdconf .= "delete {$family} {$old_gw} {$old_ep} {$old_phase2['protocol']} 0x{$sad['spi']};\n";
+				$spdconf .= "delete {$old_gw} {$old_ep} {$old_phase2['protocol']} 0x{$sad['spi']};\n";
 			}
 		}
 	}
-
-	if($phase2['mode'] == "tunnel6")
-		$family = "-6";
-	else
-		$family = "-4";
 
 	/* Create new SPD entries for the new configuration */
 	/* zap any existing SA entries beforehand */
 	foreach($sad_arr as $sad) {
 		if(($sad['dst'] == $ep) && ($sad['src'] == $rgip)) {
-			$spdconf .= "delete {$family} {$rgip} {$ep} {$phase2['protocol']} 0x{$sad['spi']};\n";
+			$spdconf .= "delete {$rgip} {$ep} {$phase2['protocol']} 0x{$sad['spi']};\n";
 		}
 		if(($sad['src'] == $ep) && ($sad['dst'] == $rgip)) {
-			$spdconf .= "delete {$family} {$ep} {$rgip} {$phase2['protocol']} 0x{$sad['spi']};\n";
+			$spdconf .= "delete {$ep} {$rgip} {$phase2['protocol']} 0x{$sad['spi']};\n";
 		}
 	}
 	/* add new SPD policies to replace them */
-	$spdconf .= "spdadd {$family} {$local_subnet} " .
+	$spdconf .= "spdadd {$local_subnet} " .
 		"{$remote_subnet} any -P out ipsec " .
 		"{$phase2['protocol']}/tunnel/{$ep}-" .
 		"{$rgip}/unique;\n";
-	$spdconf .= "spdadd {$family} {$remote_subnet} " .
+	$spdconf .= "spdadd {$remote_subnet} " .
 		"{$local_subnet} any -P in ipsec " .
 		"{$phase2['protocol']}/tunnel/{$rgip}-" .
 		"{$ep}/unique;\n";
 
-	log_error(sprintf(gettext("Reloading IPsec tunnel '%1\$s'. Previous IP '%2\$s', current IP '%3\$s'. Reloading policy"), $phase1['descr'], $old_gw, $rgip));
+	log_error("Reloading IPsec tunnel '{$phase1['descr']}'. Previous IP '{$old_gw}', current IP '{$rgip}'. Reloading policy");
 
 	$now = time();
 	$spdfile = tempnam("{$g['tmp_path']}", "spd.conf.reload.{$now}.");


### PR DESCRIPTION
The current state of the ipsec transport mode w/ gre tunnels is NOT compatible with Cisco routers / VPN concentrators.

Cisco expects :

1) only GRE packets should be encrypted  not ANY
2) Only outgoing packets coming from local -> remote of type GRE should match on each end (not bidirectional).

The updated php and inc files take care of making a compatible tunnel, but it appears to break the IPSec monitoring on PFSense (the tunnel DOES work though).

Feel free to email me if you have any questions, this was tested with IOS 12.4.x on both 7200 and 2921 routers.

Signed-off-by: John Grange john@sd-networks.net
