### PR TITLE
Add scrollbar in dropdown menu

### DIFF
--- a/usr/local/www/themes/pfsense_ng/all.css
+++ b/usr/local/www/themes/pfsense_ng/all.css
@@ -319,6 +319,8 @@ div#marquee-text {
 	font-weight: normal;
 	font-style: italic;
 	color: #000000;
+	margin-top: 2px;
+	margin-left: 25px;
 }
 table#marquee div#container {
 	position: relative;


### PR DESCRIPTION
Improve menu css style removing some gifs, including more effects and automatic scroolbars to menus with more then 260px

Tested in:  Firefox 12, Chrome 19.0.1084.46 m, IE 8 and 9
