### PR TITLE
Remove ca reference

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -2912,9 +2912,6 @@ function upgrade_088_to_089() {
           
           /* add ca reference to certificate */
           $cert['caref'] = $ca['refid'];
-          
-          /* create ca reference */
-          $setting['caref'] = $ca['refid'];
         }
         
         $config['cert'][] = $cert;


### PR DESCRIPTION
The ca reference does not have to be stored in the configuration when using certificate chains.
