### PR TITLE
Fix get_staticroutes() function to handle IPv6 subnets properly

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -1754,8 +1754,10 @@ function get_staticroutes($returnsubnetsonly = false) {
 		if (is_alias($route['network'])) {
 			$subnets = filter_expand_alias_array($route['network']);
 			foreach ($subnets as $net) {
-				if (is_ipaddr($net))
+				if (is_ipaddrv4($net))
 					$net .= "/32";
+				if (is_ipaddrv6($net) && !is_subnetv6($net))
+					$net .= "/128";
 				/* This must be a hostname, we can't use it. */
 				if (!is_subnet($net))
 					continue;


### PR DESCRIPTION
This patch fixes the problem with using IPv6 subnets in static routes. Before, it was appending "/32" to ipv6 subnets so "2001:ffff:ffff::/64" becomes "2001:ffff:ffff::/64/32" thus filter fails parse and reload static routes.
