### PR TITLE
Fix hardcodded alias type so alias suggestion works as expected while creating nested aliases.

### DIFF
--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -704,7 +704,7 @@ EOD;
 	typesel_change();
 	update_box_type();
 
-	var addressarray = <?= json_encode(array_exclude($pconfig['name'], get_alias_list("port"))) ?>;
+	var addressarray = <?= json_encode(array_exclude($pconfig['name'], get_alias_list($pconfig['type']))) ?>;
 
 	function createAutoSuggest() {
 		<?php  


### PR DESCRIPTION
This patch works as expected when user saves the alias then edit it. It doesn't filter immediately when user changes alias type. It should be neat to do so but it needs some ajax code or page refresh on type change. But its better than having nothing.
