### PR TITLE
Fix system_routing_configure() function so it does not try to add static routes ipv6 subnets to ipv4 gateways or ipv4 subnets to ipv6 gateways while using aliases that includes both ipv4 and ipv6 subnets.

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -470,10 +470,10 @@ function system_routing_configure($interface = "") {
 			if(preg_match("/^Null/i", $rtent['gateway']))
 				$blackhole = "-blackhole";
 
-			if (is_ipaddr($gatewayip)) {
+			if (is_ipaddr($gatewayip) && ((is_ipaddrv6($gatewayip) && is_subnetv6($rtent['network'])) || (is_ipaddrv4($gatewayip) && is_subnetv4($rtent['network'])))) {
 				mwexec("/sbin/route change {$inetfamily} {$blackhole} " . escapeshellarg($rtent['network']) .
 					" " . escapeshellarg($gatewayip));
-			} else if (!empty($interfacegw)) {
+			} else if (!empty($interfacegw) &&  ((is_ipaddrv6($gatewayip) && is_subnetv6($rtent['network'])) || (is_ipaddrv4($gatewayip) && is_subnetv4($rtent['network'])))) {
 				mwexec("/sbin/route change {$inetfamily} {$blackhole} " . escapeshellarg($rtent['network']) .
 					" -iface " . escapeshellarg($interfacegw));
 			}


### PR DESCRIPTION
Fix system_routing_configure() function so it does not try to add static routes ipv6 subnets to ipv4 gateways or ipv4 subnets to ipv6 gateways while using aliases that includes both ipv4 and ipv6 subnets.

Before this fix php was throwing multiple errors like : 

Jul  6 08:35:39 mx1 php: : The command '/sbin/route change -inet6  '10.61.2.0/24' '2001:fff:fff:fff::2'' returned exit code '1', the output was '10.61.2.0: hostname nor servname provided, or not known'  

Jul  6 08:26:33 mx1 php: : The command '/sbin/route change -inet  '2001:fff:fff:fff::/64' '192.168.30.2'' returned exit code '68', the output was 'route: bad address: 2001:fff:fff:fff::/64'  
