### PR TITLE
system_ntp_configure add is_array check

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -1271,7 +1271,7 @@ function system_ntp_configure($start_ntpd=true) {
 	$ntpcfg .= "driftfile {$driftfile}\n";
 
 	if (empty($config['ntpd']['interface']))
-		if (!empty($config['installedpackages']['openntpd']['config'][0]['interface']))
+		if (is_array($config['installedpackages']['openntpd']) && !empty($config['installedpackages']['openntpd']['config'][0]['interface']))
 			$interfaces = explode(",", $config['installedpackages']['openntpd']['config'][0]['interface']);
 		else
 			$interfaces = array();


### PR DESCRIPTION
Crash report detail:

i386
8.3-RELEASE-p3
FreeBSD 8.3-RELEASE-p3 #0: Sat Jul  7 21:34:19 EDT 2012     root@FreeBSD_8.3_pfSense_2.1.snaps.pfsense.org:/usr/obj./usr/pfSensesrc/src/sys/pfSense_wrap.8.i386

Crash report details:

PHP Errors:
[08-Jul-2012 14:51:29 UTC] PHP Fatal error:  Cannot use string offset as an array in /etc/inc/system.inc on line 1274
