### PR TITLE
Widget - Firewal Logs - Filtering

### DIFF
--- a/etc/inc/filter_log.inc
+++ b/etc/inc/filter_log.inc
@@ -69,7 +69,9 @@ function conv_log_filter($logfile, $nentries, $tail = 50, $filtertext = "") {
 			break;
 
 		$flent = parse_filter_line($logent);
-		if (($flent != "") && (match_filter_line($flent, $filtertext))) {
+//		if (($flent != "") && (match_filter_line($flent, $filtertext))) {
+		if ( ( ($flent != "") && (!is_array($filtertext)) && (match_filter_line ($flent, $filtertext))) || 
+		     ( ($flent != "") && ( is_array($filtertext)) && (match_filter_field($flent, $filtertext)) ) ) {
 			$counter++;
 			$filterlog[] = $flent;
 		}
@@ -83,6 +85,19 @@ function match_filter_line($flent, $filtertext = "") {
 		return true;
 	$filtertext = str_replace(' ', '\s+', $filtertext);
 	return preg_match("/{$filtertext}/i", implode(" ", array_values($flent)));
+}
+
+function match_filter_field($flent, $fields) {
+	foreach ($fields as $field) {
+		if ($fields[$field] == "All") continue;
+		if ( !(in_arrayi($flent[$field], explode(",", str_replace(" ", ",", $fields[$field]))) ) ) return false;
+	}	
+	return true;
+}
+
+// Case Insensitive in_array function
+function in_arrayi($needle, $haystack) {
+    return in_array(strtolower($needle), array_map('strtolower', $haystack));
 }
 
 function collapse_filter_lines($logarr) {
@@ -275,7 +290,7 @@ function handle_ajax($nentries, $tail = 50) {
 					$log_row['proto'] .= ":{$log_row['tcpflags']}";
 
 				$img = "<a href=\"#\" onClick=\"javascript:getURL('diag_logs_filter.php?getrulenum={$log_row['rulenum']},{$log_row['rulenum']}', outputrule);\">{$img}</a>";
-				$new_rules .= "{$img}||{$log_row['time']}||{$log_row['interface']}||{$log_row['src']}||{$log_row['dst']}||{$log_row['proto']}||" . time() . "||\n";
+				$new_rules .= "{$img}||{$log_row['time']}||{$log_row['interface']}||{$log_row['srcip']}||{$log_row['dst']}||{$log_row['proto']}||" . time() . "||\n";
 			}
 		}
 		echo $new_rules;

--- a/usr/local/www/javascript/filter_log.js
+++ b/usr/local/www/javascript/filter_log.js
@@ -61,10 +61,25 @@ function fetch_new_rules_callback(callback_data) {
 		/* loop through rows */
 		row_split = data_split[x].split("||");
 		lastsawtime = row_split[6];
-		new_data_to_add[new_data_to_add.length] = format_log_line(row_split);
+//		new_data_to_add[new_data_to_add.length] = format_log_line(row_split);
+
+		var tmp = format_log_line(row_split);
+		if ( !(tmp) ) continue;
+
+		new_data_to_add[new_data_to_add.length] = tmp;
 	}
 	update_div_rows(new_data_to_add);
 	isBusy = false;
+}
+
+function in_arrayi(needle, haystack) {
+	var i = haystack.length;
+	while (i--) {
+		if (haystack[i].toLowerCase() === needle.toLowerCase()) {
+			return true;
+		}
+	}
+	return false;
 }
 
 function update_div_rows(data) {

--- a/usr/local/www/themes/_corporate/all.css
+++ b/usr/local/www/themes/_corporate/all.css
@@ -935,7 +935,7 @@ div#log div.log-entry {
 div#log div.log-entry span,
 div#log div.log-header span {
 	padding: 3px 2px 3px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log div.log-entry span.log-action {
@@ -1096,10 +1096,11 @@ div#log div.log-entry-mini {
 
 div#log div.log-entry-mini span {
 	padding: 2px 2px 2px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log span.log-action-mini-header,
+div#log span.log-time-mini-header,
 div#log span.log-interface-mini-header,
 div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header,
@@ -1131,14 +1132,22 @@ div#log span.log-action-mini-header {
 	width: 6%;
 }
 
+div#log span.log-time-mini,
+div#log span.log-time-mini-header {
+	width: 18%;
+}
+
 div#log span.log-interface-mini,
 div#log span.log-interface-mini-header {
 	width: 8%;
 }
 
 div#log span.log-source-mini,
+div#log span.log-source-mini-header {
+	width: 24%;
+}
+
 div#log span.log-destination-mini,
-div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header {
 	width: 31%;
 }

--- a/usr/local/www/themes/code-red/all.css
+++ b/usr/local/www/themes/code-red/all.css
@@ -1020,7 +1020,7 @@ div#log div.log-entry {
 div#log div.log-entry span,
 div#log div.log-header span {
 	padding: 3px 2px 3px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log div.log-entry span.log-action {
@@ -1182,10 +1182,11 @@ div#log div.log-entry-mini {
 
 div#log div.log-entry-mini span {
 	padding: 2px 2px 2px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log span.log-action-mini-header,
+div#log span.log-time-mini-header,
 div#log span.log-interface-mini-header,
 div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header,
@@ -1217,14 +1218,22 @@ div#log span.log-action-mini-header {
 	width: 6%;
 }
 
+div#log span.log-time-mini,
+div#log span.log-time-mini-header {
+	width: 18%;
+}
+
 div#log span.log-interface-mini,
 div#log span.log-interface-mini-header {
 	width: 8%;
 }
 
 div#log span.log-source-mini,
+div#log span.log-source-mini-header {
+	width: 24%;
+}
+
 div#log span.log-destination-mini,
-div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header {
 	width: 31%;
 }

--- a/usr/local/www/themes/metallic/all.css
+++ b/usr/local/www/themes/metallic/all.css
@@ -987,7 +987,7 @@ div#log div.log-entry {
 div#log div.log-entry span,
 div#log div.log-header span {
 	padding: 3px 2px 3px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log div.log-entry span.log-action {
@@ -1150,10 +1150,11 @@ div#log div.log-entry-mini {
 
 div#log div.log-entry-mini span {
 	padding: 2px 2px 2px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log span.log-action-mini-header,
+div#log span.log-time-mini-header,
 div#log span.log-interface-mini-header,
 div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header,
@@ -1185,14 +1186,22 @@ div#log span.log-action-mini-header {
 	width: 6%;
 }
 
+div#log span.log-time-mini,
+div#log span.log-time-mini-header {
+	width: 18%;
+}
+
 div#log span.log-interface-mini,
 div#log span.log-interface-mini-header {
 	width: 8%;
 }
 
 div#log span.log-source-mini,
+div#log span.log-source-mini-header {
+	width: 24%;
+}
+
 div#log span.log-destination-mini,
-div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header {
 	width: 31%;
 }

--- a/usr/local/www/themes/nervecenter/all.css
+++ b/usr/local/www/themes/nervecenter/all.css
@@ -1019,7 +1019,7 @@ div#log div.log-entry {
 div#log div.log-entry span,
 div#log div.log-header span {
 	padding: 3px 2px 3px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log div.log-entry span.log-action {
@@ -1181,10 +1181,11 @@ div#log div.log-entry-mini {
 
 div#log div.log-entry-mini span {
 	padding: 2px 2px 2px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log span.log-action-mini-header,
+div#log span.log-time-mini-header,
 div#log span.log-interface-mini-header,
 div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header,
@@ -1216,14 +1217,22 @@ div#log span.log-action-mini-header {
 	width: 6%;
 }
 
+div#log span.log-time-mini,
+div#log span.log-time-mini-header {
+	width: 18%;
+}
+
 div#log span.log-interface-mini,
 div#log span.log-interface-mini-header {
 	width: 8%;
 }
 
 div#log span.log-source-mini,
+div#log span.log-source-mini-header {
+	width: 24%;
+}
+
 div#log span.log-destination-mini,
-div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header {
 	width: 31%;
 }

--- a/usr/local/www/themes/pfsense-dropdown/all.css
+++ b/usr/local/www/themes/pfsense-dropdown/all.css
@@ -899,10 +899,11 @@ div#log div.log-entry-mini {
 
 div#log div.log-entry-mini span {
 	padding: 2px 2px 2px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log span.log-action-mini-header,
+div#log span.log-time-mini-header,
 div#log span.log-interface-mini-header,
 div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header,
@@ -934,14 +935,22 @@ div#log span.log-action-mini-header {
 	width: 6%;
 }
 
+div#log span.log-time-mini,
+div#log span.log-time-mini-header {
+	width: 18%;
+}
+
 div#log span.log-interface-mini,
 div#log span.log-interface-mini-header {
 	width: 8%;
 }
 
 div#log span.log-source-mini,
+div#log span.log-source-mini-header {
+	width: 24%;
+}
+
 div#log span.log-destination-mini,
-div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header {
 	width: 31%;
 }

--- a/usr/local/www/themes/pfsense/all.css
+++ b/usr/local/www/themes/pfsense/all.css
@@ -809,10 +809,11 @@ div#log div.log-entry-mini {
 
 div#log div.log-entry-mini span {
 	padding: 2px 2px 2px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log span.log-action-mini-header,
+div#log span.log-time-mini-header,
 div#log span.log-interface-mini-header,
 div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header,
@@ -844,14 +845,22 @@ div#log span.log-action-mini-header {
 	width: 6%;
 }
 
+div#log span.log-time-mini,
+div#log span.log-time-mini-header {
+	width: 18%;
+}
+
 div#log span.log-interface-mini,
 div#log span.log-interface-mini-header {
 	width: 8%;
 }
 
 div#log span.log-source-mini,
+div#log span.log-source-mini-header {
+	width: 24%;
+}
+
 div#log span.log-destination-mini,
-div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header {
 	width: 31%;
 }

--- a/usr/local/www/themes/pfsense_ng/all.css
+++ b/usr/local/www/themes/pfsense_ng/all.css
@@ -1130,7 +1130,7 @@ div#log div.log-entry {
 div#log div.log-entry span,
 div#log div.log-header span {
 	padding: 3px 2px 3px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log div.log-entry span.log-action {
@@ -1292,10 +1292,11 @@ div#log div.log-entry-mini {
 
 div#log div.log-entry-mini span {
 	padding: 2px 2px 2px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log span.log-action-mini-header,
+div#log span.log-time-mini-header,
 div#log span.log-interface-mini-header,
 div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header,
@@ -1327,14 +1328,22 @@ div#log span.log-action-mini-header {
 	width: 6%;
 }
 
+div#log span.log-time-mini,
+div#log span.log-time-mini-header {
+	width: 18%;
+}
+
 div#log span.log-interface-mini,
 div#log span.log-interface-mini-header {
 	width: 8%;
 }
 
 div#log span.log-source-mini,
+div#log span.log-source-mini-header {
+	width: 24%;
+}
+
 div#log span.log-destination-mini,
-div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header {
 	width: 31%;
 }

--- a/usr/local/www/themes/the_wall/all.css
+++ b/usr/local/www/themes/the_wall/all.css
@@ -1023,7 +1023,7 @@ div#log div.log-entry {
 div#log div.log-entry span,
 div#log div.log-header span {
 	padding: 3px 2px 3px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log div.log-entry span.log-action {
@@ -1189,10 +1189,11 @@ div#log div.log-entry-mini {
 
 div#log div.log-entry-mini span {
 	padding: 2px 2px 2px 2px;
-	padding-left: 8px;
+	padding-left: 6px;
 }
 
 div#log span.log-action-mini-header,
++div#log span.log-time-mini-header,
 div#log span.log-interface-mini-header,
 div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header,
@@ -1224,14 +1225,22 @@ div#log span.log-action-mini-header {
 	width: 6%;
 }
 
+div#log span.log-time-mini,
+div#log span.log-time-mini-header {
+	width: 18%;
+}
+
 div#log span.log-interface-mini,
 div#log span.log-interface-mini-header {
 	width: 8%;
 }
 
 div#log span.log-source-mini,
+div#log span.log-source-mini-header {
+	width: 24%;
+}
+
 div#log span.log-destination-mini,
-div#log span.log-source-mini-header,
 div#log span.log-destination-mini-header {
 	width: 31%;
 }

--- a/usr/local/www/widgets/widgets/log.widget.php
+++ b/usr/local/www/widgets/widgets/log.widget.php
@@ -41,7 +41,22 @@ require_once("functions.inc");
 require_once("filter_log.inc");
 
 if($_POST['filterlogentries']) {
-	$config['widgets']['filterlogentries'] = $_POST['filterlogentries'];
+// Passed / Blocked / Rejected Interfaces Filter Selection - Added 20120619
+	unset($config['widgets']['filterlogentries']);
+	if( ($_POST['filterlogentries']) and ($_POST['filterlogentries'] != ' ') ) $config['widgets']['filterlogentries'] = $_POST['filterlogentries'];
+
+	unset($config['widgets']['filterlogentriesacts']);
+	if($_POST['actpass'])   $config['widgets']['filterlogentriesacts'] .= $_POST['actpass']   . " ";
+	if($_POST['actblock'])  $config['widgets']['filterlogentriesacts'] .= $_POST['actblock']  . " ";
+	if($_POST['actreject']) $config['widgets']['filterlogentriesacts'] .= $_POST['actreject'] . " ";
+	if (isset($config['widgets']['filterlogentriesacts'])) $config['widgets']['filterlogentriesacts'] = trim($config['widgets']['filterlogentriesacts']);
+
+	unset($config['widgets']['filterlogentriesinterfaces']);
+	if( ($_POST['filterlogentriesinterfaces']) and ($_POST['filterlogentriesinterfaces'] != "All") ) $config['widgets']['filterlogentriesinterfaces'] = $_POST['filterlogentriesinterfaces'];
+	if (isset($config['widgets']['filterlogentriesinterfaces'])) $config['widgets']['filterlogentriesinterfaces'] = trim($config['widgets']['filterlogentriesinterfaces']);
+// Passed / Blocked / Rejected Interfaces Filter Selection - Added 20120619
+
+//	$config['widgets']['filterlogentries'] = $_POST['filterlogentries'];
 	write_config("Saved Filter Log Entries via Dashboard");
   $filename = $_SERVER['HTTP_REFERER'];
   if(headers_sent($file, $line)){
@@ -58,8 +73,20 @@ if($_POST['filterlogentries']) {
 $nentries = isset($config['widgets']['filterlogentries']) ? $config['widgets']['filterlogentries'] : 5;
 
 //set variables for log
+//$filter_logfile = "{$g['varlog_path']}/filter.log";
+//$filterlog = conv_log_filter($filter_logfile, $nentries);
+
+// Passed / Blocked / Rejected Interfaces Filter Selection - Added 20120619
+$nentriesacts       = isset($config['widgets']['filterlogentriesacts'])       ? $config['widgets']['filterlogentriesacts']       : 'All';
+$nentriesinterfaces = isset($config['widgets']['filterlogentriesinterfaces']) ? $config['widgets']['filterlogentriesinterfaces'] : 'All';
+
+$filterfieldsarray = array("act", "interface");
+$filterfieldsarray['act'] = $nentriesacts;
+$filterfieldsarray['interface'] = $nentriesinterfaces;
+
 $filter_logfile = "{$g['varlog_path']}/filter.log";
-$filterlog = conv_log_filter($filter_logfile, $nentries);
+$filterlog = conv_log_filter($filter_logfile, $nentries, 50, $filterfieldsarray);        //Get        log entries
+// Passed / Blocked / Rejected Interfaces Filter Selection - Added 20120619
 
 /* AJAX related routines */
 handle_ajax($nentries, $nentries + 20);
@@ -85,11 +112,22 @@ else
 /* Called by the AJAX updater */
 function format_log_line(row) {
 	var line = '';
-	line = '  <span class="log-action-mini" nowrap>&nbsp;' + row[0] + '&nbsp;</span>';
-	line += '  <span class="log-interface-mini" nowrap>' + row[2] + '</span>';
-	line += '  <span class="log-source-mini" nowrap>' + row[3] + '</span>';
-	line += '  <span class="log-destination-mini" nowrap>' + row[4] + '</span>';
-	line += '  <span class="log-protocol-mini" nowrap>' + row[5] + '</span>';
+	line  = '  <span class="log-action-mini" nowrap>&nbsp;'	+ row[0]				+ '&nbsp;</span>';
+	line += '  <span class="log-time-mini" nowrap>'			+ row[1].slice(0,-3)	+ '</span>';
+	line += '  <span class="log-interface-mini" nowrap>'	+ row[2]				+ '</span>';
+	line += '  <span class="log-source-mini" nowrap>'		+ row[3]				+ '</span>';
+	line += '  <span class="log-destination-mini" nowrap>'	+ row[4]				+ '</span>';
+//	line += '  <span class="log-protocol-mini" nowrap>'		+ row[5]				+ '</span>';
+
+	var nentriesacts = "<?php echo $nentriesacts; ?>";
+	var nentriesinterfaces = "<?php echo $nentriesinterfaces; ?>";
+
+	var Action = row[0].match(/alt=.*?(pass|block|reject)/i).join("").match(/pass|block|reject/i).join("");
+	var Interface = row[2];
+
+	if ( !(in_arrayi(Action,	nentriesacts.replace      (/\s+/g, ',').split(',') ) ) && (nentriesacts != 'All') )			return false;
+	if ( !(in_arrayi(Interface,	nentriesinterfaces.replace(/\s+/g, ',').split(',') ) ) && (nentriesinterfaces != 'All') )	return false;
+
 	return line;
 }
 </script>
@@ -100,33 +138,50 @@ function format_log_line(row) {
 	<form action="/widgets/widgets/log.widget.php" method="post" name="iforma">
 		Number of lines to display: 
 		<select name="filterlogentries" class="formfld unknown" id="filterlogentries">
-		<?php for ($i = 1; $i <= 20; $i++) { ?>
-			<option value="<?php echo $i;?>" <?php if ($nentries == $i) echo "SELECTED";?>><?php echo $i;?></option>
+		<?php for ($i = 0; $i <= 20; $i++) { ?>
+			<option value="<?php if ($i > 0) echo $i; else echo ' ';?>" <?php if ($nentries == $i) echo "SELECTED";?>><?php if ($i > 0) echo ' ' . $i; else echo ' ';?></option>
 		<?php } ?>
-		</select><br/>
-        <input id="submita" name="submita" type="submit" class="formbtn" value="Save" />
+		</select>
+
+<!-- // Passed / Blocked / Rejected Interfaces Filter Selection - Added 20120619 -->
+<?php 
+		$Include_Act = explode(",", str_replace(" ", ",", $nentriesacts));
+		if ($nentriesinterfaces == "All") $nentriesinterfaces = "";
+?>
+		<input id="actpass"   name="actpass"   type="checkbox" value="Pass"   <?php if (in_arrayi('Pass',   $Include_Act)) echo "checked"; ?> /> Pass
+		<input id="actblock"  name="actblock"  type="checkbox" value="Block"  <?php if (in_arrayi('Block',  $Include_Act)) echo "checked"; ?> /> Block
+		<input id="actreject" name="actreject" type="checkbox" value="Reject" <?php if (in_arrayi('Reject', $Include_Act)) echo "checked"; ?> /> Reject
+		<br/>
+		Interfaces: 
+		<input id="filterlogentriesinterfaces" name="filterlogentriesinterfaces" class="formfld unknown" type="text" size="20" class="formfld unknown" value="<?= $nentriesinterfaces ?>" />
+        &nbsp &nbsp &nbsp 
+<!-- // Passed / Blocked / Rejected Interfaces Filter Selection - Added 20120619 -->
+
+		<input id="submita" name="submita" type="submit" class="formbtn" value="Save" />
 	</form>
 </div>
 
 <div class="log-header">
     <span class="log-action-mini-header">Act</span>
+    <span class="log-time-mini-header">Time</span>
     <span class="log-interface-mini-header">IF</span>
     <span class="log-source-mini-header">Source</span>
     <span class="log-destination-mini-header">Destination</span>
-    <span class="log-protocol-mini-header">Prot</span>
+<!--    <span class="log-protocol-mini-header">Prot</span> -->
 </div>
 <?php $counter=0; foreach ($filterlog as $filterent): ?>
 <div class="log-entry-mini" <?php echo is_first_row($counter, count($filterlog)); ?> style="clear:both;">
 	<span class="log-action-mini" nowrap>
 	&nbsp;<a href="#" onClick="javascript:getURL('diag_logs_filter.php?getrulenum=<?php echo "{$filterent['rulenum']},{$filterent['act']}"; ?>', outputrule);"><img border="0" src="<?php echo find_action_image($filterent['act']);?>" alt="<?php echo $filterent['act'];?>" title="<?php echo $filterent['act'];?>" /></a>&nbsp;</span>
-	<span class="log-interface-mini"><?php echo htmlspecialchars($filterent['interface']);?>&nbsp;</span>
-	<span class="log-source-mini"><?php echo htmlspecialchars($filterent['src']);?>&nbsp;</span>
-	<span class="log-destination-mini"><?php echo htmlspecialchars($filterent['dst']);?>&nbsp;</span>
+	<span class="log-time-mini"><?php echo substr(htmlspecialchars($filterent['time']), 0, -3);?></span>
+	<span class="log-interface-mini"><?php echo htmlspecialchars($filterent['interface']);?></span>
+	<span class="log-source-mini"><?php echo htmlspecialchars($filterent['srcip']);?></span>
+	<span class="log-destination-mini"><?php echo htmlspecialchars($filterent['dst']);?></span>
 	<?php
 	if ($filterent['proto'] == "TCP")
 		$filterent['proto'] .= ":{$filterent['tcpflags']}";
 	?>
-	<span class="log-protocol-mini"><?php echo htmlspecialchars($filterent['proto']);?>&nbsp;</span>
+<!--	<span class="log-protocol-mini"><?php echo htmlspecialchars($filterent['proto']);?></span> -->
 </div>
 <?php $counter++; endforeach; ?>
 


### PR DESCRIPTION
Adds additional configuration options to filter on firewall actions
'pass', 'block', 'reject', and network interfaces.

Changes Overview:

/usr/local/www/widget/widget/log.widget.php

```
Several code changes and aditions (tagged with date 20120619)
```

/usr/local/www/javascript/filter_log.js

   function fetch_new_rules_callback
      var tmp = format_log_line(row_split);
      if ( !(tmp) ) continue;

   function in_arrayi(needle, haystack)

/etc/inc/filter_log.inc

   test and call match_filter_\* functions

   function match_filter_field($flent, $fields)

   function in_arrayi($needle, $haystack)

For each/most of the following themes

/usr/local/www/themes/_corporate/all.css
/usr/local/www/themes/code-red/all.css
/usr/local/www/themes/metallic/all.css
/usr/local/www/themes/nervecenter/all.css
/usr/local/www/themes/pfsense/all.css   **
/usr/local/www/themes/pfsense_ng/all.css
/usr/local/www/themes/pfsense-dropdown/all.css   **
/usr/local/www/themes/the_wall/all.css

Themes all.css Additions / Changes

div#log div.log-entry span,   **
div#log div.log-header span {
   padding: 3px 2px 3px 2px;
   padding-left: 6px;
}

div#log div.log-entry-mini span {
   padding: 2px 2px 2px 2px;
   padding-left: 6px;
}

div#log span.log-time-mini-header,   *

div#log span.log-time-mini,
div#log span.log-time-mini-header {
   width: 18%;
}

ddiv#log span.log-source-mini,
div#log span.log-source-mini-header {
   width: 24%;
}
-  Added to All Themes
  *\* Does Not Exist.
