### PR TITLE
Remove unused set_time_limit in php.ini

### DIFF
--- a/etc/rc.php_ini_setup
+++ b/etc/rc.php_ini_setup
@@ -54,7 +54,7 @@ fi
 if [ "$AVAILMEM" -lt "96" ]; then
 	APCSHMEMSIZE="5M"
 fi
-if [ "$AVAILMEM" -lt "128" ]; then
+if [ "$AVAILMEM" -le "128" ]; then
 	APCSHMEMSIZE="10M"
 fi
 if [ "$AVAILMEM" -gt "128" ]; then
@@ -170,7 +170,6 @@ implicit_flush = true
 magic_quotes_gpc = Off
 max_execution_time = 900
 max_input_time = 1800
-set_time_limit = 3600
 register_argc_argv = On
 file_uploads = On
 upload_tmp_dir = ${UPLOADTMPDIR}


### PR DESCRIPTION
set_time_limit is not actually a valid parameter in php.ini - it is a PHP function.
See testing notes on redmine ticket #2552
php.ini is not parsed for bonus/unused parameter settings, so it has not been causing any actual error, just might be misleading to future readers.
Also, if available memory happens to be exactly 128MB then a set of "if" tests will fail - fix this up to handle this very rare/unlucky case.
Tested on nanobsd build:
2.1-BETA0 (i386)
built on Sat Jul 21 08:37:29 EDT 2012
FreeBSD 8.3-RELEASE-p3
