### PR TITLE
Don't conf_mount_rw every time packages are listed

### DIFF
--- a/etc/inc/pkg-utils.inc
+++ b/etc/inc/pkg-utils.inc
@@ -8,7 +8,7 @@
  *   $Id$
  ******
  *
- * Copyright (C) 2010 Ermal Lu�i
+ * Copyright (C) 2010 Ermal Luci
  * Copyright (C) 2005-2006 Colin Smith (ethethlay@gmail.com)
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
@@ -81,12 +81,12 @@ $vardb = "/var/db/pkg";
 safe_mkdir($vardb);
 $g['platform'] = trim(file_get_contents("/etc/platform"));
 
-conf_mount_rw();
 if(!is_dir("/usr/local/pkg") or !is_dir("/usr/local/pkg/pf")) {
+	conf_mount_rw();
 	safe_mkdir("/usr/local/pkg");
 	safe_mkdir("/usr/local/pkg/pf");	
+	conf_mount_ro();
 }
-conf_mount_ro();
 
 /****f* pkg-utils/remove_package
  * NAME


### PR DESCRIPTION
Every time System:Packages is selected, the code does a conf_mount_rw, checks for existence of some dirs, then does conf_mount_ro. This makes navigating the package install GUI slow on nanobsd, and it is not needed.
Do is_dir checks first, then conf_mount_rw only if they need to be created. The is_dir function works fine on a read-only filesystem.
Now it is much quicker to list the installed packages.
Note: now that the shared memory "mount reference count" is protected by a lock, it is easy to see when a mount or dismount is done:
ls -l /tmp/shm1000.lock
The file gets touched each time the mount state is changed, so you can easily see when something last happened.
