### PR TITLE
Make filter_configure() available to interfaces.inc

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -47,6 +47,7 @@ require_once("globals.inc");
 require_once("cmd_chain.inc");
 require_once("util.inc");
 require_once("gwlb.inc");
+require_once("filter.inc");
 
 function interfaces_bring_up($interface) {
 	if(!$interface) {
@@ -785,7 +786,7 @@ function interface_gre_configure(&$gre, $grekey = "") {
 	if((is_ipaddrv6($gre['tunnel-local-addr'])) || (is_ipaddrv6($gre['tunnel-remote-addr']))) {
 		mwexec("/sbin/ifconfig {$greif} inet6 {$gre['tunnel-local-addr']} {$gre['tunnel-remote-addr']} prefixlen /{$gre['tunnel-remote-net']} ");
 	} else {
-		mwexec("/sbin/ifconfig {$greif} {$gif['tunnel-local-addr']} {$gre['tunnel-remote-addr']} netmask " . gen_subnet_mask($gre['tunnel-remote-net']));
+		mwexec("/sbin/ifconfig {$greif} {$gre['tunnel-local-addr']} {$gre['tunnel-remote-addr']} netmask " . gen_subnet_mask($gre['tunnel-remote-net']));
 	}
 	if (isset($gre['link0']) && $gre['link0'])
 		pfSense_interface_flags($greif, IFF_LINK0);


### PR DESCRIPTION
interfaces.inc does not know about filter_configure()
Fatal error: Call to undefined function filter_configure() in /etc/inc/interfaces.inc on line 3350 
after release then renew of a DHCP interface from the Status:Interface GUI.
Forum topic http://forum.pfsense.org/index.php/topic,52046.0.html
