### PR TITLE
Tidy package cleanup output

### DIFF
--- a/etc/inc/pkg-utils.inc
+++ b/etc/inc/pkg-utils.inc
@@ -391,6 +391,8 @@ function uninstall_package($pkg_name) {
 		mwexec("/usr/bin/tar xzPfk /tmp/pkg_bins.tgz -C /", true);
 		@unlink("/tmp/pkg_libs.tgz");
 		@unlink("/tmp/pkg_bins.tgz");
+		$static_output .= gettext("done.") . "\n";
+		update_output_window($static_output);
 	}
 }
 


### PR DESCRIPTION
Add a "done." and newline after "Cleaning up..."
Then when output is going to the serial console the next line will start cleanly and %age figures will not write over the top of "Clean".
Another little OCD enhancement to try and get the firmware upgrade/package reinstall console output to look neat.
