### PR TITLE
require filter.inc so filter_configure is defined

### DIFF
--- a/usr/local/www/status_interfaces.php
+++ b/usr/local/www/status_interfaces.php
@@ -43,6 +43,7 @@
 ##|-PRIV
 
 require_once("guiconfig.inc");
+require_once("filter.inc");
 
 if ($_GET['if']) {
 	$interface = $_GET['if'];


### PR DESCRIPTION
The "renew" button on a DHCP connection ends up calling function interface_dhcpv6_configure() in interfaces.inc, which in turn calls filter_configure() (in filter.inc) but gives the error:
Fatal error: Call to undefined function filter_configure() in /etc/inc/interfaces.inc on line 3350
See forum post: http://forum.pfsense.org/index.php/topic,52046.0.html
