### PR TITLE
pkg_mgr_install - only mount rw when needed

### DIFF
--- a/usr/local/www/pkg_mgr_install.php
+++ b/usr/local/www/pkg_mgr_install.php
@@ -120,11 +120,20 @@ Rounded("div#mainareapkg","bl br","#FFF","#eeeeee","smooth");
 
 ob_flush();
 
-// Write out configuration to creatae a backup prior to pkg install
-write_config(gettext("Creating restore point before package installation."));
-
-/* mount rw fs */
-conf_mount_rw();
+switch($_GET['mode']) {
+	case "showlog":
+	case "installedinfo":
+		/* These cases do not make changes. */
+		$fs_mounted_rw = false;
+		break;
+	default:
+		/* All other cases make changes, so mount rw fs */
+		conf_mount_rw();
+		$fs_mounted_rw = true;
+		/* Write out configuration to create a backup prior to pkg install. */
+		write_config(gettext("Creating restore point before package installation."));
+		break;
+}
 
 switch($_GET['mode']) {
 	case "delete":
@@ -213,7 +222,8 @@ rmdir_recursive("/var/tmp/instmp*");
 if($fd_log)
         fclose($fd_log);
 
-/* read only fs */
-conf_mount_ro();
-
+if($fs_mounted_rw) {
+	/* Restore to read only fs */
+	conf_mount_ro();
+}
 ?>


### PR DESCRIPTION
When entering pkg_mgr_install the filesystem was being mounted rw and a backup made of the config, even if the case was "showlog" or "installedinfo". This resulted in:
a) an extra "backup" of the config being made after an install - it could be seen in Diagnostics, Backup Restore, Config History
b) Unnecessary conf_mount_rw and conf_mount_ro calls. These slow down the process on nanobsd-like systems.
This change fixes both these issues.
