### PR TITLE
Fix deleting DHCP leases

### DIFF
--- a/usr/local/www/status_dhcp_leases.php
+++ b/usr/local/www/status_dhcp_leases.php
@@ -56,16 +56,17 @@ if (($_GET['deleteip']) && (is_ipaddr($_GET['deleteip']))) {
 	killbyname("dhcpd");
 
 	/* Read existing leases */
+	/* $leases_contents has the lines of the file, including the newline char at the end of each line. */
 	$leases_contents = file($leasesfile);
 	$newleases_contents = array();
 	$i=0;
 	while ($i < count($leases_contents)) {
 		/* Find the lease(s) we want to delete */
-		if ($leases_contents[$i] == "lease {$_GET['deleteip']} {") {
+		if ($leases_contents[$i] == "lease {$_GET['deleteip']} {\n") {
 			/* Skip to the end of the lease declaration */
 			do {
 				$i++;
-			} while ($leases_contents[$i] != "}");
+			} while ($leases_contents[$i] != "}\n");
 		} else {
 			/* It's a line we want to keep, copy it over. */
 			$newleases_contents[] = $leases_contents[$i];


### PR DESCRIPTION
This broke when the code was changed to suck the whole leases file into an array with:
$leases_contents = file($leasesfile);
Each array entry has the text of a line in the file AND the newline at the end of the line. So when matching array entries, the match has to expect the "\n" on the end.
