### PR TITLE
Do not translate keywords like "default"

### DIFF
--- a/usr/local/www/services_captiveportal.php
+++ b/usr/local/www/services_captiveportal.php
@@ -849,11 +849,11 @@ function enable_change(enable_change) {
         </select></br>
         <?=gettext("This option changes the MAC address format used in the whole RADIUS system. Change this if you also"); ?>
         <?=gettext("need to change the username format for RADIUS MAC authentication."); ?><br>
-        <?="default:" ?> 00:11:22:33:44:55<br>
-        <?="singledash:"; ?> 001122-334455<br>
-        <?="ietf:"; ?> 00-11-22-33-44-55<br>
-        <?="cisco:"; ?> 0011.2233.4455<br>
-        <?="unformatted:"; ?> 001122334455
+        default: 00:11:22:33:44:55<br>
+        singledash: 001122-334455<br>
+        ietf: 00-11-22-33-44-55<br>
+        cisco: 0011.2233.4455<br>
+        unformatted: 001122334455
     </tr>
 	<tr>
       <td valign="top" class="vncell"><?=gettext("HTTPS login"); ?></td>


### PR DESCRIPTION
Keywords that are in drop-down lists that get put straight into the config files and passed into conf files should not be translated. They are not really "English", they are keywords for the pieces of software that use them.
These ones were causing problems when trying to setup Captive Portal in Portuguese.
Fixes the issue at http://forum.pfsense.org/index.php/topic,51988.msg281131.html#msg281131
