### PR TITLE
Separate backend keywords from GUI language display in captive portal

### DIFF
--- a/usr/local/www/services_captiveportal.php
+++ b/usr/local/www/services_captiveportal.php
@@ -816,7 +816,7 @@ function enable_change(enable_change) {
 			<tr>
 				<td class="vncell" valign="top"><?=gettext("Type"); ?></td>
 				<td class="vtable"><select name="radiusvendor" id="radiusvendor">
-				<option><?=gettext("default"); ?></option>
+				<option value="default"><?php echo gettext("default"); ?></option>
 				<?php
 				$radiusvendors = array("cisco");
 				foreach ($radiusvendors as $radiusvendor){
@@ -836,14 +836,14 @@ function enable_change(enable_change) {
         <td class="vncell" valign="top"><?=gettext("MAC address format"); ?></td>
         <td class="vtable">
         <select name="radmac_format" id="radmac_format">
-        <option><?=gettext("default"); ?></option>
+        <option value="default"><?php echo gettext("default"); ?></option>
         <?php
-        $macformats = array(gettext("singledash"),gettext("ietf"),gettext("cisco"),gettext("unformatted"));
+        $macformats = array("singledash","ietf","cisco","unformatted");
         foreach ($macformats as $macformat) {
             if ($pconfig['radmac_format'] == $macformat)
-                echo "<option selected value=\"$macformat\">$macformat</option>\n";
+                echo "<option selected value=\"$macformat\">",gettext($macformat),"</option>\n";
             else
-                echo "<option value=\"$macformat\">$macformat</option>\n";
+                echo "<option value=\"$macformat\">",gettext($macformat),"</option>\n";
         }
         ?>
         </select></br>


### PR DESCRIPTION
When the GUI language was set to Portuguese, keywords like "default" and "unformatted" would be translated into Portuguese and written to config.xml - causing problems downstream in starting Captive Portal. Now the displayed values are in the GUI language but the underlying keywords stay in "computer-speak" (English) in config.xml - forum http://forum.pfsense.org/index.php/topic,51988.msg281131.html#msg281131
After switching to Portuguese, radius vendor and radmac_format fields display "default" in Portuguese, but in config.xml "default" is correctly saved in computer-speak:
            <radiusvendor>default</radiusvendor>
            <radiussrcip_attribute>wan</radiussrcip_attribute>
            <radmac_format>default</radmac_format>
radac_format "unformatted" displays on the GUI in Portuguese, but is saved correctly in config.xml in computer-speak:
            <radiusvendor>default</radiusvendor>
            <radiussrcip_attribute>wan</radiussrcip_attribute>
            <radmac_format>unformatted</radmac_format>

Thanks Jim for the hint to make the GUI language really independent of the backend config keywords.
