### PR TITLE
Handle case with no server or no client OpenVPN 

### DIFF
--- a/etc/rc.openvpn
+++ b/etc/rc.openvpn
@@ -47,15 +47,21 @@
 		log_error("OpenVPN: One or more OpenVPN tunnel endpoints may have changed its IP. Reloading.");
 	
 	$gwgroups = return_gateway_groups_array();
-	foreach($config['openvpn']['openvpn-server'] as &$server) {
-		if(is_array($gwgroups[$server['interface']])) {
-			openvpn_resync('server', $server);
+	if(is_array($config['openvpn']['openvpn-server'])) {
+		foreach($config['openvpn']['openvpn-server'] as &$server) {
+			if(is_array($gwgroups[$server['interface']])) {
+				openvpn_resync('server', $server);
+			}
 		}
 	}
-	foreach($config['openvpn']['openvpn-client'] as &$client) {
-		if(is_array($gwgroups[$client['interface']])) {
-			openvpn_resync('client', $client);
+	
+	if(is_array($config['openvpn']['openvpn-client'])) {
+		foreach($config['openvpn']['openvpn-client'] as &$client) {
+			if(is_array($gwgroups[$client['interface']])) {
+				openvpn_resync('client', $client);
+			}
 		}
 	}
+
 	unlock($openvpnlck);
 ?>


### PR DESCRIPTION
If there are OpenVPN servers but not clients, this warning is emitted:
Warning: Invalid argument supplied for foreach() in /etc/rc.openvpn on line 55
This fixes handles that case, and the case of OpenVPN clients but no servers.
