### PR TITLE
Limiter addBwRowTo plus icon syntax

### DIFF
--- a/etc/inc/shaper.inc
+++ b/etc/inc/shaper.inc
@@ -1,6 +1,6 @@
 <?php
 /*
-	Copyright (C) 2008 Ermal Luçi
+	Copyright (C) 2008 Ermal Luï¿½i
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -3182,7 +3182,7 @@ EOD;
 		}
 		$form .= "</tbody></table>";
 		$form .= "<a onclick=\"javascript:addBwRowTo('maintable'); return false;\" href='#'>";
-		$form .= "<img border='0' src='/themes/{$g['theme']}/images/icons/icon_plus.gif' alt='' title='" . gettext("add another schedule") . "/></a>";
+		$form .= "<img border='0' src='/themes/{$g['theme']}/images/icons/icon_plus.gif' alt='' title='" . gettext("add another schedule") . "' /></a>";
 		$form .= "</td></tr>";
 		$form .= "<tr><td valign=\"center\" class=\"vncellreq\">" . gettext("Mask") . "</td>";
 		$form .= "<td class=\"vncellreq\">";


### PR DESCRIPTION
Fix the syntax so that the GUI Limiter, Creat new limiter, Bandwidth "+" icon has the correct title text, and the Mask field gets displayed.
Note that clicking the "+" icon still does not make an empty first row when creating a new limiter.
Once I can create limiters successfully on a test system, then I can also try and see why there are errors loading the limiter rules.
See this thread for ongoing discussion of the bugs - http://forum.pfsense.org/index.php/topic,54595.0.html
