### PR TITLE
Fix warnings at startup in /tmp/PHP_errors.log

### DIFF
--- a/usr/local/www/preload.php
+++ b/usr/local/www/preload.php
@@ -25,9 +25,8 @@ $files=array("functions.inc",
 	"filter.inc",
 	"upgrade_config.inc",
 	"openvpn.inc",
-	"authgui.inc",
-	"vpfsense-utils.inc",
-	"vuuid.php",
+	"pfsense-utils.inc",
+	"uuid.php",
 	"captiveportal.inc",
 	"voucher.inc",
 	"certs.inc",
@@ -59,6 +58,7 @@ foreach($files as $file)
 	require_once($file);
 
 require("guiconfig.inc");
+require_once("authgui.inc");
 include('/usr/local/www/includes/functions.inc.php');
 include("fbegin.inc");
 include("fend.inc"); 


### PR DESCRIPTION
authgui needs to come after guiconfig, as guiconfig spits out some header statements, then authgui can spit out some real HTML.
There were also a couple of typos in here (extra "v" in front of 2 filenames). These were only flagged as errors when I moved authgui. So I guess that authgui was doing something "real" and the system never got further down the list? Now it does, and the non-existent file name problems were logged.
guiconfig already does a require_once of authgui, so it seems that the require_once("authgui.inc"); is not strictly necessary, but it seems good to have it in here after guiconfig.
My system boots clean with this change - there is not even an empty /tmp/PHP_errors.log
I checked that other errors are logged OK - by purposely putting a syntax error in another script - and PHP_errors.log appeared with the error in it, and the dashboard reported the "crash". So that functionality still works fine.
I have used the ebGUI for a few things, and nothing obvious has gone wrong, so maybe this is the fix.
(Note: I have also been running with Ermal's recent little move of a Header(); from auth.inc to guiconfig.inc which has not caused any problems)
