### PR TITLE
Update usr/local/www/vpn_ipsec_phase2.php

### DIFF
--- a/usr/local/www/vpn_ipsec_phase2.php
+++ b/usr/local/www/vpn_ipsec_phase2.php
@@ -560,7 +560,7 @@ function change_protocol() {
 											?>
 											<option value="<?=$ifname; ?>" <?php if ($pconfig['natlocalid_type'] == $ifname ) echo "selected";?>><?=sprintf(gettext("%s subnet"), $ifdescr); ?></option>
 											<?php endforeach; ?>
-											<option value="none" <?php if ($pconfig['natlocalid_type'] == "none" ) echo "selected";?>><?=gettext("None"); ?></option>
+											<option value="none" <?php if (!isset($pconfig['natlocalid_type'])) echo "selected";?>><?=gettext("None"); ?></option>
 										</select>
 									</td>
 								</tr>


### PR DESCRIPTION
The 'natlocalid_type' entry does not exists for settings where the 'natlocalid_address' is not set. (i.e. 'none')
