### PR TITLE
outbound nat, remove non-applicable translation option 'any'

### DIFF
--- a/usr/local/www/firewall_nat_out_edit.php
+++ b/usr/local/www/firewall_nat_out_edit.php
@@ -579,7 +579,6 @@ any)");?></td>
 				<option value="<?=$alias['name'];?>" <?php if ($alias['name'] == $pconfig['target']) echo "selected"; ?>><?=htmlspecialchars("Host Alias: {$alias['name']} ({$alias['descr']})");?></option>
 <?php	endforeach; ?>
 				<option value="other-subnet"<?php if($pconfig['target'] == "other-subnet") echo " selected"; ?>><?=gettext("Other Subnet (Enter Below)");?></option>
-				<option value=""<?php if($pconfig['target'] == "any") echo " selected"; ?>><?=gettext("any");?></option>
 			  </select>
 			  </td>
 			</tr>


### PR DESCRIPTION
outbound nat, remove non-applicable translation option 'any'

option was discussed in https://github.com/bsdperimeter/pfsense/pull/260 and text explaining the option was also removed, as it is an old remnant.
