### PR TITLE
ARP Table Static Entries from Individual DHCP Static Mappings

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -4609,6 +4609,13 @@ function interfaces_staticarp_configure($if) {
 	} else {
 		mwexec("/sbin/ifconfig " . escapeshellarg($ifcfg['if']) . " -staticarp " );
 		mwexec("/usr/sbin/arp -d -i " . escapeshellarg($ifcfg['if']) . " -a > /dev/null 2>&1 ");
+		if (is_array($config['dhcpd'][$if]['staticmap'])) {
+			foreach ($config['dhcpd'][$if]['staticmap'] as $arpent) {
+				if (isset($arpent['arp_table_static_entry'])) {
+					mwexec("/usr/sbin/arp -s " . escapeshellarg($arpent['ipaddr']) . " " . escapeshellarg($arpent['mac']));
+				}
+			}
+		}
 	}
 
 	return 0;

--- a/usr/local/www/services_dhcp.php
+++ b/usr/local/www/services_dhcp.php
@@ -1113,7 +1113,8 @@ include("head.inc");
 		</table>
 		<table class="tabcont" width="100%" border="0" cellpadding="0" cellspacing="0">
 		<tr>
-			<td width="25%" class="listhdrr"><?=gettext("MAC address");?></td>
+			<td width="7%" class="listhdrr"><?=gettext("Static ARP");?></td>
+			<td width="18%" class="listhdrr"><?=gettext("MAC address");?></td>
 			<td width="15%" class="listhdrr"><?=gettext("IP address");?></td>
 			<td width="20%" class="listhdrr"><?=gettext("Hostname");?></td>
 			<td width="30%" class="listhdr"><?=gettext("Description");?></td>
@@ -1130,6 +1131,11 @@ include("head.inc");
 			<?php $i = 0; foreach ($a_maps as $mapent): ?>
 			<?php if($mapent['mac'] <> "" or $mapent['ipaddr'] <> ""): ?>
 		<tr>
+		<td align="center" class="listlr" ondblclick="document.location='services_dhcp_edit.php?if=<?=htmlspecialchars($if);?>&id=<?=$i;?>';">
+			<?php if (isset($mapent['arp_table_static_entry'])): ?>
+				<img src="./themes/<?= $g['theme']; ?>/images/icons/icon_alert.gif" alt="ARP Table Static Entry" width="17" height="17" border="0">
+			<?php endif; ?>
+		</td>
 		<td class="listlr" ondblclick="document.location='services_dhcp_edit.php?if=<?=htmlspecialchars($if);?>&id=<?=$i;?>';">
 			<?=htmlspecialchars($mapent['mac']);?>
 		</td>
@@ -1155,7 +1161,7 @@ include("head.inc");
 		<?php $i++; endforeach; ?>
 		<?php endif; ?>
 		<tr>
-		<td class="list" colspan="4"></td>
+		<td class="list" colspan="5"></td>
 		<td class="list">
 			<table border="0" cellspacing="0" cellpadding="1">
 			<tr>

--- a/usr/local/www/services_dhcp_edit.php
+++ b/usr/local/www/services_dhcp_edit.php
@@ -90,12 +90,14 @@ if (isset($id) && $a_maps[$id]) {
 	    $pconfig['filename'] = $a_maps[$id]['filename'];
 		$pconfig['rootpath'] = $a_maps[$id]['rootpath'];
         $pconfig['descr'] = $a_maps[$id]['descr'];
+        $pconfig['arp_table_static_entry'] = isset($a_maps[$id]['arp_table_static_entry']);
 } else {
         $pconfig['mac'] = $_GET['mac'];
 		$pconfig['hostname'] = $_GET['hostname'];
 	    $pconfig['filename'] = $_GET['filename'];
 		$pconfig['rootpath'] = $_GET['rootpath'];
         $pconfig['descr'] = $_GET['descr'];
+        $pconfig['arp_table_static_entry'] = $_GET['arp_table_static_entry'];
 }
 
 if ($_POST) {
@@ -168,6 +170,7 @@ if ($_POST) {
 		$mapent['ipaddr'] = $_POST['ipaddr'];
 		$mapent['hostname'] = $_POST['hostname'];
 		$mapent['descr'] = $_POST['descr'];
+		$mapent['arp_table_static_entry'] = ($_POST['arp_table_static_entry']) ? true : false;
 		$mapent['filename'] = $_POST['filename'];
 		$mapent['rootpath'] = $_POST['rootpath'];
 
@@ -255,6 +258,13 @@ include("head.inc");
                     <input name="descr" type="text" class="formfld unknown" id="descr" size="40" value="<?=htmlspecialchars($pconfig['descr']);?>"> 
                     <br> <span class="vexpl"><?=gettext("You may enter a description here ".
                     "for your reference (not parsed).");?></span></td>
+                </tr>
+                <tr> 
+                  <td width="22%" valign="top" class="vncell"><?=gettext("ARP Table Static Entry");?></td>
+                  <td width="78%" class="vtable"> 
+                    <input name="arp_table_static_entry" id="arp_table_static_entry" type="checkbox" value="yes" <?php if ($pconfig['arp_table_static_entry']) echo "checked"; ?>> 
+                    <br> <span class="vexpl"><?=gettext("Create an ARP Table Static Entry for this MAC & IP Address pair. ".
+                    "");?></span></td>
                 </tr>
                 <tr> 
                   <td width="22%" valign="top">&nbsp;</td>


### PR DESCRIPTION
Assign individual DHCP static mappings as ARP table static entries.  
Useful / necessary for sending WoL magic packets from external services / sources, and for any other purpose that needs a static ARP table entry.
