### PR TITLE
Update usr/local/www/services_dhcp.php

### DIFF
--- a/usr/local/www/services_dhcp.php
+++ b/usr/local/www/services_dhcp.php
@@ -891,7 +891,7 @@ include("head.inc");
 			<td width="22%" valign="top" class="vncell"><?=gettext("Failover peer IP:");?></td>
 			<td width="78%" class="vtable">
 				<input name="failover_peerip" type="text" class="formfld host" id="failover_peerip" size="20" value="<?=htmlspecialchars($pconfig['failover_peerip']);?>"><br>
-				<?=gettext("Leave blank to disable.  Enter the interface IP address of the other machine.  Machines must be using CARP.");?>
+				<?=gettext("Leave blank to disable.  Enter the interface IP address of the other machine.  Machines must be using CARP. Interface's advskew determines whether the DHCPd process is Primary or Secondary. Ensure one machine's advskew<20 (and the other is >20).");?>
 			</td>
 			</tr>
 			<?php endif; ?>


### PR DESCRIPTION
Inform user how the Primary/Secondary DHCPd process is determined in a failover pair so they don't end up with two secondary servers. For example, when using advskew=64 (and advskew=164 if using settings sync to peer for carp ips) on the carp master machine which they _think_ will be the DHCP primary.

![pfsense_dhcp_failover_advskew_note](https://f.cloud.github.com/assets/2997504/34473/8303e3e6-511f-11e2-8f26-61974afcd32b.PNG)
