### PR TITLE
Select a valid interface when WAN is disabled

### DIFF
--- a/usr/local/www/status_graph.php
+++ b/usr/local/www/status_graph.php
@@ -79,7 +79,14 @@ if ($_GET['if']) {
 		exit;
 	}
 } else {
-	$curif = "wan";
+	if (empty($ifdescrs["wan"])) {
+		/* Handle the case when WAN has been disabled. Use the first key in ifdescrs. */
+		reset($ifdescrs);
+		$curif = key($ifdescrs);
+	}
+	else {
+		$curif = "wan";
+	}
 }
 if ($_GET['sort']) {
 	$cursort = $_GET['sort'];


### PR DESCRIPTION
If WAN is disabled, then the Traffic Graph does not default to a valid interface when it first displays. This fix selects the first valid interface if WAN is not there.
e.g. at one site there used to be 2 ISPs, on WAN and OPT1. Now the ISP on WAN has been turned off, and the interface marked disabled. The default gateway etc is all on OPT1. After a bit of history at a site, it can happen like this that WAN is disabled in the config.
