### PR TITLE
Minimise rewriting of /etc/gettytab

### DIFF
--- a/etc/inc/pfsense-utils.inc
+++ b/etc/inc/pfsense-utils.inc
@@ -914,6 +914,29 @@ function auto_login() {
 
 	$gettytab = file_get_contents("/etc/gettytab");
 	$getty_split = explode("\n", $gettytab);
+	$getty_update_needed = false;
+	$getty_search_str = ":ht:np:sp#115200";
+	$getty_al_str = ":al=root:";
+	$getty_al_search_str = $getty_search_str . $getty_al_str;
+	/* Check if gettytab is already OK, if so then do not rewrite it. */
+	foreach($getty_split as $gs) {
+		if(stristr($gs, $getty_search_str)) {
+			if($status == true) {
+				if(!stristr($gs, $getty_al_search_str)) {
+					$getty_update_needed = true;
+				}
+			} else {
+				if(stristr($gs, $getty_al_search_str)) {
+					$getty_update_needed = true;
+				}
+			}
+		}
+	}
+
+	if (!$getty_update_needed) {
+		return;
+	}
+
 	conf_mount_rw();
 	$fd = false;
 	$tries = 0;
@@ -924,21 +947,32 @@ function auto_login() {
 	}
 	if (!$fd) {
 		conf_mount_ro();
-		log_error(gettext("Enabling auto login was not possible."));
+		if ($status) {
+			log_error(gettext("Enabling auto login was not possible."));
+		} else {
+			log_error(gettext("Disabling auto login was not possible."));
+		}
 		return;
 	}
 	foreach($getty_split as $gs) {
-		if(stristr($gs, ":ht:np:sp#115200") ) {
+		if(stristr($gs, $getty_search_str)) {
 			if($status == true) {
-				fwrite($fd, "	:ht:np:sp#115200:al=root:\n");
+				fwrite($fd, "	".$getty_al_search_str."\n");
 			} else {
-				fwrite($fd, "	:ht:np:sp#115200:\n");
+				fwrite($fd, "	".$getty_search_str."\n");
 			}
 		} else {
 			fwrite($fd, "{$gs}\n");
 		}
 	}
 	fclose($fd);
+
+	if ($status) {
+		log_error(gettext("Enabled console auto login, console menu is NOT password protected."));
+	} else {
+		log_error(gettext("Disabled console auto login, console menu is password protected."));
+	}
+	
 	conf_mount_ro();
 }
 


### PR DESCRIPTION
See forum http://forum.pfsense.org/index.php/topic,57325.0.html
Avoid possible problems with having a partial /etc/gettytab file by not rewriting it at every boot.
Also, I logged to syslog when the setting is changed and gettytab is rewritten. I think that is worth doing when the user changes the setting in System:Advanced:Console Options.
