### PR TITLE
Fix out packet count reporting

### DIFF
--- a/etc/inc/pfsense-utils.inc
+++ b/etc/inc/pfsense-utils.inc
@@ -1199,7 +1199,7 @@ function get_interface_info($ifdescr) {
 	$ifinfo['inbytes'] = $in4_pass + $in4_block;
 	$ifinfo['outbytes'] = $out4_pass + $out4_block;
 	$ifinfo['inpkts'] = $in4_pass_packets + $in4_block_packets;
-	$ifinfo['outpkts'] = $in4_pass_packets + $out4_block_packets;
+	$ifinfo['outpkts'] = $out4_pass_packets + $out4_block_packets;
 		
 	$ifconfiginfo = "";
 	$link_type = $config['interfaces'][$ifdescr]['ipaddr'];


### PR DESCRIPTION
This is a little tiny fix, for the similar issue that was fixed in 2.1 a month ago (the 2.1 fix had a mix of v4 and v6 packet counting fixUPS). The 2.0 IPv4-only code just had this 1 little error.
The 2.1 commit was at https://github.com/bsdperimeter/pfsense/commit/4bdfa5dde01c9fe7f84db252ed654d326b8b30f2
