### PR TITLE
dynamic dns update url for dns.he.net fixed

### DIFF
--- a/etc/inc/dyndns.class
+++ b/etc/inc/dyndns.class
@@ -434,8 +434,8 @@
 					log_error("HE.net ({$this->_dnsHost}): DNS update() starting.");
 					$server = "https://dyn.dns.he.net/nic/update?";
 					curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
-					curl_setopt($ch, CURLOPT_USERPWD, $this->_dnsHost . ':' . $this->_dnsPass);
-					curl_setopt($ch, CURLOPT_URL, $server . 'hostname=' . $this->_dnsHost);
+					curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4 );
+					curl_setopt($ch, CURLOPT_URL, $server . 'hostname=' . $this->_dnsHost . '&password=' . $this->_dnsPass . '&myip=' . $this->_dnsIP);
 					break;
 				case 'he-net-tunnelbroker':
 					$needsIP = FALSE;


### PR DESCRIPTION
Added curl option to use IPv4 to fix the "CURL error: could not bind to IPADDRESS" problem since we now use php 5.3 with the needed curl option available (http://forum.pfsense.org/index.php?topic=45279.0)

Updated url schema (http://dns.he.net)
