### PR TITLE
use session_write_close() to allow loading of a second page while waiting

### DIFF
--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -1413,6 +1413,10 @@ function session_auth() {
 		unset($_SESSION['NO_AJAX']);
 
 	$HTTP_SERVER_VARS['AUTH_USER'] = $_SESSION['Username'];
+	
+	if (!defined('DONT_CLOSE_SESSION'))
+		session_write_close();// close the session, so while 'waiting' for the processing to complete allow processing for possible loading other pages that are waiting for the 'session-lock'
+
 	return true;
 }
 


### PR DESCRIPTION
use session_write_close() to allow loading of a second page while the first is 'waiting' for a long action. (for example while performing 10 ping's on diagnostics page, you cannot load another page without this change)
also seams to be beneficial for when the WAN is down, pfSense sometimes used to be quite unresponsive...

for possible 'conflicts' a variable DONT_CLOSE_SESSION can be set to stop this new behavior
