### PR TITLE
Prevent "no such file" message when pid file does not exist

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -41,11 +41,13 @@ function killbypid($pidfile) {
 	return sigkillbypid($pidfile, "TERM");
 }
 
-function isvalidpid($pid) {
+function isvalidpid($pidfile) {
 	$output = "";
-	exec("/bin/pgrep -nF {$pid}", $output, $retval);
-
-	return (intval($retval) == 0);
+	if (file_exists($pidfile)) {
+		exec("/bin/pgrep -nF {$pidfile}", $output, $retval);
+		return (intval($retval) == 0);
+	}
+	return false;
 }
 
 function is_process_running($process) {


### PR DESCRIPTION
Recent filterdns script changes resulted in the following "noise" on the console at boot:
Syncing OpenVPN settings...done.
Configuring firewall.....pgrep: Cannot open pidfile `/var/run/filterdns.pid': No such file or directory
.done.
Starting PFLOG...done.

I think there are also occasions when other code calls isvalidpid($pidfile), passing a pid file name that might not currently exist.
This change first checks to see if the pidfile actually exists, before passing it to pgrep. That gets rid of the pgrep "error" message.
