### PR TITLE
Partly revert commit 4c45712f

### DIFF
--- a/etc/rc.newwanipv6
+++ b/etc/rc.newwanipv6
@@ -65,9 +65,9 @@ $argument = str_replace("\n", "", $argv[1]);
 log_error("rc.newwanipv6: Informational is starting {$argument}.");
 
 if(empty($argument)) {
-	$curwanipv6 = get_interface_ipv6();
 	$interface = "wan";
-	$interface_real = get_real_interface();
+	$interface_real = get_real_interface($interface);
+	$curwanipv6 = get_interface_ipv6($interface);
 } else {
 	$interface_real = $argument;
 	$interface = convert_real_interface_to_friendly_interface_name($interface_real);
@@ -75,6 +75,19 @@ if(empty($argument)) {
 	if($curwanipv6 == "")
 		$curwanipv6 = get_interface_ipv6($interface);
 }
+
+$name_servers = explode(" ", $_ENV['new_domain_name_servers']);
+$valid_ns = array();
+foreach($name_servers as $ns) {
+	if(is_ipaddrv6(trim($ns)))
+		$valid_ns[] = trim($ns);
+}
+
+if(count($valid_ns > 0))
+	file_put_contents("{$g['varetc_path']}/nameserver_v6{$interface}", implode("\n", $valid_ns));
+
+if(!empty($_ENV['new_domain_name'])) {
+	file_put_contents("{$g['varetc_path']}/searchdomain_v6{$interface}", $_ENV['new_domain_name']);
 
 log_error("rc.newwanipv6: on (IP address: {$curwanipv6}) (interface: {$interface}) (real interface: {$interface_real}).");
 
@@ -103,10 +116,6 @@ system_resolvconf_generate(true);
 
 /* write current WAN IPv6 to file */
 file_put_contents("{$g['vardb_path']}/{$interface}_ipv6", $curwanipv6);
-
-/* pickup ipv6 router advertisements */
-pickup_ipv6_router_advertisement($interface_real);
-sleep(3);
 
 /* check native IPv6 interface tracking */
 switch($config['interfaces'][$interface]['ipaddrv6']) {
@@ -148,6 +157,9 @@ services_dnsupdate_process($interface);
 
 /* signal dyndns update */
 services_dyndns_configure($interface);
+
+/* wait for the dhcp6c process to configure the LAN interface */
+sleep(5);
 
 /* reconfigure IPsec tunnels */
 vpn_ipsec_force_reload();


### PR DESCRIPTION
I believe that https://github.com/bsdperimeter/pfsense/commit/4c45712f made some accidental changes to rc.newwanipv6.

I made a few changes that should bring back the code for the nameservers and searchdomain but someone will probably have to look at that again.
