### PR TITLE
Update etc/inc/filter.inc

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -230,8 +230,8 @@ function filter_configure_sync($delete_states_if_needed = true) {
 	$maxtables = is_numeric($config['system']['maximumtables']) ? $config['system']['maximumtables'] : "3000";
 	$limitrules .= "set limit tables {$maxtables}\n";
 	/* User defined maximum table entries in Advanced menu. */
-	if ($config['system']['maximumtableentries'] <> "" && is_numeric($config['system']['maximumtableentries']))
-		$limitrules .= "set limit table-entries {$config['system']['maximumtableentries']}\n";
+	$maxentries = is_numeric($config['system']['maximumtableentries']) ? $config['system']['maximumtableentries'] : "200000";
+	$limitrules .= "set limit table-entries {$maxentries}\n";
 
 	if ($config['system']['optimization'] <> "") {
 		$limitrules .= "set optimization {$config['system']['optimization']}\n";


### PR DESCRIPTION
Fixes the "Cannot allocate memory" error [1].

For systems with more than 100MB of RAM the default value should be 200000, but pf fails to correctly determine the amount of RAM when using more than 2GB due to FreeBSD using a 32-bit integer.

This patch sets the default value to 200000 as a 100000 may not be enough when using the IPv4 and IPv6 fullbogon tables.

[1] http://forum.pfsense.org/index.php/topic,57286.0.html
