### PR TITLE
Display gateways with matching IP protocol in Gateways list

### DIFF
--- a/usr/local/www/firewall_rules_edit.php
+++ b/usr/local/www/firewall_rules_edit.php
@@ -1364,9 +1364,9 @@ $i--): ?>
 					foreach($gateways as $gwname => $gw) {
 						if(($pconfig['ipprotocol'] == "inet46"))
 							continue;
-						if(($pconfig['ipprotocol'] == "inet6") && !is_ipaddrv6($gw['gateway']))
+						if(($pconfig['ipprotocol'] == "inet6") && !(($gw['ipprotocol'] == "inet6") || (is_ipaddrv6($gw['gateway']))))
 							continue;
-						if(($pconfig['ipprotocol'] == "inet") && !is_ipaddrv4($gw['gateway']))
+						if(($pconfig['ipprotocol'] == "inet") && !(($gw['ipprotocol'] == "inet") || (is_ipaddrv4($gw['gateway']))))
 							continue;
 						if($gw == "") 
 							continue;


### PR DESCRIPTION
Some gateways do not have traditional addresses hard-coded into them - e.g. for OpenVPN dynamic gateways are created in software on-the-fly (they are not actually entries in the config). So traditional tests like is_ipaddrv4 are not useful to determine if the gateway is IPv4 or IPv6.
return_gateways_array() fills in an "ipprotocol" entry for each returned gateway ("inet" or "inet6"), as well as the "gateway" address field. This can be used to determine if the gateway is for IPv4 or IPv6.
