### PR TITLE
Modern games added to Traffic Shaper Wizard

### DIFF
--- a/etc/inc/wizardapp.inc
+++ b/etc/inc/wizardapp.inc
@@ -254,9 +254,9 @@ $gamesplist['steam'] = array();
 
 $gamesplist['tigerwoods2004ps2'] = array();
 	/* tiger woods 2004 ps2 */
-	$gamesplist['tigerwoods2004ps2'][] = array('Outbound2Player', 'udp', '3658', '3658', 'both');
-	$gamesplist['tigerwoods2004ps2'][] = array('Outbound2Player2', 'udp', '6000', '6000', 'both');
-	$gamesplist['tigerwoods2004ps2'][] = array('Outbound2EA', 'tcp', '10300', '10301', 'both');
+	$gamesplist['tigerwoods2004ps2'][] = array('TigerWoods2004-Player', 'udp', '3658', '3658', 'both');
+	$gamesplist['tigerwoods2004ps2'][] = array('TigerWoods2004-Player2', 'udp', '6000', '6000', 'both');
+	$gamesplist['tigerwoods2004ps2'][] = array('TigerWoods2004-EA', 'tcp', '10300', '10301', 'both');
 
 $gamesplist['tribesascend'] = array();
 	/* Tribes Ascend */

--- a/usr/local/www/wizards/traffic_shaper_wizard.xml
+++ b/usr/local/www/wizards/traffic_shaper_wizard.xml
@@ -568,7 +568,7 @@
 			<field>
 				<name>HalfLife</name>
 				<type>checkbox</type>
-				<typehint>HalfLife</typehint>
+				<typehint>Half-Life</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;halflife</bindstofield>
 			</field>
 			<field>
@@ -646,7 +646,7 @@
 			<field>
 				<name>Steam</name>
 				<type>checkbox</type>
-				<typehint>Steam (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Halflife 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2)</typehint>
+				<typehint>Steam (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Half-Life 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2)</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;steam</bindstofield>
 			</field>
 			<field>

--- a/usr/local/www/wizards/traffic_shaper_wizard_dedicated.xml
+++ b/usr/local/www/wizards/traffic_shaper_wizard_dedicated.xml
@@ -573,7 +573,7 @@
 			<field>
 				<name>HalfLife</name>
 				<type>checkbox</type>
-				<typehint>HalfLife</typehint>
+				<typehint>Half-Life</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;halflife</bindstofield>
 			</field>
 			<field>
@@ -651,7 +651,7 @@
 			<field>
 				<name>Steam</name>
 				<type>checkbox</type>
-				<typehint>Steam (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Halflife 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2)</typehint>
+				<typehint>Steam (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Half-Life 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2)</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;steam</bindstofield>
 			</field>
 			<field>

--- a/usr/local/www/wizards/traffic_shaper_wizard_multi_all.xml
+++ b/usr/local/www/wizards/traffic_shaper_wizard_multi_all.xml
@@ -581,7 +581,7 @@
 			<field>
 				<name>HalfLife</name>
 				<type>checkbox</type>
-				<typehint>HalfLife</typehint>
+				<typehint>Half-Life</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;halflife</bindstofield>
 			</field>
 			<field>
@@ -659,7 +659,7 @@
 			<field>
 				<name>Steam</name>
 				<type>checkbox</type>
-				<typehint>Steam (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Halflife 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2)</typehint>
+				<typehint>Steam (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Half-Life 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2)</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;steam</bindstofield>
 			</field>
 			<field>

--- a/usr/local/www/wizards/traffic_shaper_wizard_multi_lan.xml
+++ b/usr/local/www/wizards/traffic_shaper_wizard_multi_lan.xml
@@ -632,7 +632,7 @@
 			<field>
 				<name>HalfLife</name>
 				<type>checkbox</type>
-				<typehint>HalfLife</typehint>
+				<typehint>Half-Life</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;halflife</bindstofield>
 			</field>
 			<field>
@@ -710,7 +710,7 @@
 			<field>
 				<name>Steam</name>
 				<type>checkbox</type>
-				<typehint>Steam (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Halflife 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2)</typehint>
+				<typehint>Steam (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Half-Life 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2)</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;steam</bindstofield>
 			</field>
 			<field>


### PR DESCRIPTION
I added several games to the wizard game list.  Also, I modified current game listings for better clarity and functionality.

New:
ARMA 2
Crysis 2
Battlefield 3
Battlefiled Bad Company 2
Borderlands
Dirt 3
Eve Online
FarCry 2
FarCry 3
League of Legends
Mech Warrior Online
Minecraft
Operation Flashpoint Dragon Rising
PlanetSide 2
Playstation 3
Quake 4
StarWars the Old Republic
Steam - This rule works for America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Half-Life 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2 and probably more
Tribes Ascend

Modified;
Battle.net according to documentation found on blizzard's website
CounterStrike - Renamed rules for clarity
Tiger Woods - Renamed rules for clarity
Xbox 360 - Description now includes reference to these rules also being for Games for Windows Live
WoW - Added in game voice ports

Removed:
Half-Life2 - Steam rules now cover it

I also alphabetized the game listings in the files for better clarity in the future.
