### PR TITLE
Fix do_input_validation call-time pass by reference

### DIFF
--- a/usr/local/www/diag_dns.php
+++ b/usr/local/www/diag_dns.php
@@ -92,7 +92,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "host");
 	$reqdfieldsn = explode(",", "Host");
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	$host = trim($_POST['host'], " \t\n\r\0\x0B[]");
 	$host_esc = escapeshellarg($host);
 	

--- a/usr/local/www/diag_ping.php
+++ b/usr/local/www/diag_ping.php
@@ -53,7 +53,7 @@ if ($_POST || $_REQUEST['host']) {
 	/* input validation */
 	$reqdfields = explode(" ", "host count");
 	$reqdfieldsn = array(gettext("Host"),gettext("Count"));
-	do_input_validation($_REQUEST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_REQUEST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (($_REQUEST['count'] < 1) || ($_REQUEST['count'] > MAX_COUNT)) {
 		$input_errors[] = sprintf(gettext("Count must be between 1 and %s"), MAX_COUNT);

--- a/usr/local/www/diag_testport.php
+++ b/usr/local/www/diag_testport.php
@@ -58,7 +58,7 @@ if ($_POST || $_REQUEST['host']) {
 	/* input validation */
 	$reqdfields = explode(" ", "host port");
 	$reqdfieldsn = array(gettext("Host"),gettext("Port"));
-	do_input_validation($_REQUEST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_REQUEST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (!is_ipaddr($_REQUEST['host']) && !is_hostname($_REQUEST['host'])) {
 		$input_errors[] = gettext("Please enter a valid IP or hostname.");

--- a/usr/local/www/diag_traceroute.php
+++ b/usr/local/www/diag_traceroute.php
@@ -60,7 +60,7 @@ if ($_POST || $_REQUEST['host']) {
 	/* input validation */
 	$reqdfields = explode(" ", "host ttl");
 	$reqdfieldsn = array(gettext("Host"),gettext("ttl"));
-	do_input_validation($_REQUEST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_REQUEST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (($_REQUEST['ttl'] < 1) || ($_REQUEST['ttl'] > MAX_TTL)) {
 		$input_errors[] = sprintf(gettext("Maximum number of hops must be between 1 and %s"), MAX_TTL);

--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -133,7 +133,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "name");
 	$reqdfieldsn = array(gettext("Name"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	$x = is_validaliasname($_POST['name']);
 	if (!isset($x)) {

--- a/usr/local/www/firewall_aliases_import.php
+++ b/usr/local/www/firewall_aliases_import.php
@@ -58,7 +58,7 @@ if($_POST['aliasimport'] <> "") {
 	$reqdfields = explode(" ", "name aliasimport");
 	$reqdfieldsn = array(gettext("Name"),gettext("Aliases"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 		
 	if (is_validaliasname($_POST['name']) == false)
 		$input_errors[] = gettext("The alias name may only consist of the characters") . " a-z, A-Z, 0-9, _.";

--- a/usr/local/www/firewall_nat_1to1_edit.php
+++ b/usr/local/www/firewall_nat_1to1_edit.php
@@ -121,7 +121,7 @@ if ($_POST) {
                 $reqdfieldsn[] = gettext("Destination address");
         }
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ($_POST['external'])
 		$_POST['external'] = trim($_POST['external']);

--- a/usr/local/www/firewall_nat_edit.php
+++ b/usr/local/www/firewall_nat_edit.php
@@ -198,7 +198,7 @@ if ($_POST) {
 		$reqdfieldsn[] = gettext("Redirect target IP");
 	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (!$_POST['srcbeginport']) {
 		$_POST['srcbeginport'] = 0;

--- a/usr/local/www/firewall_nat_npt_edit.php
+++ b/usr/local/www/firewall_nat_npt_edit.php
@@ -107,7 +107,7 @@ if ($_POST) {
         $reqdfields[] = "dst";
         $reqdfieldsn[] = gettext("Destination prefix");
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (!$input_errors) {
 		$natent = array();

--- a/usr/local/www/firewall_nat_out_edit.php
+++ b/usr/local/www/firewall_nat_out_edit.php
@@ -129,7 +129,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "interface protocol source source_subnet destination destination_subnet");
 	$reqdfieldsn = array(gettext("Interface"),gettext("Protocol"),gettext("Source"),gettext("Source bit count"),gettext("Destination"),gettext("Destination bit count"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	$protocol_uses_ports = in_array($_POST['protocol'], explode(" ", "any tcp udp tcp/udp"));
 

--- a/usr/local/www/firewall_rules_edit.php
+++ b/usr/local/www/firewall_rules_edit.php
@@ -330,7 +330,7 @@ if ($_POST) {
 		$reqdfieldsn[] = gettext("Destination bit count");
 	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (!$_POST['srcbeginport']) {
 		$_POST['srcbeginport'] = 0;

--- a/usr/local/www/firewall_virtual_ip_edit.php
+++ b/usr/local/www/firewall_virtual_ip_edit.php
@@ -105,7 +105,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "mode");
 	$reqdfieldsn = array(gettext("Type"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ($_POST['subnet'])
 		$_POST['subnet'] = trim($_POST['subnet']);

--- a/usr/local/www/guiconfig.inc
+++ b/usr/local/www/guiconfig.inc
@@ -228,7 +228,7 @@ $wlan_modes = array("bss" => "Infrastructure (BSS)", "adhoc" => "Ad-hoc (IBSS)",
 /* platforms that support firmware updating */
 $fwupplatforms = array('pfSense', 'net45xx', 'net48xx', 'generic-pc', 'embedded', 'wrap', 'nanobsd');
 
-function do_input_validation($postdata, $reqdfields, $reqdfieldsn, $input_errors) {
+function do_input_validation($postdata, $reqdfields, $reqdfieldsn, &$input_errors) {
 
 	/* check for bad control characters */
 	foreach ($postdata as $pn => $pd) {

--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -449,7 +449,7 @@ if ($_POST['apply']) {
 		case "staticv4":
 			$reqdfields = explode(" ", "ipaddr subnet gateway");
 			$reqdfieldsn = array(gettext("IPv4 address"),gettext("Subnet bit count"),gettext("Gateway"));
-			do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 			break;
 		case "none":
 			if(is_array($config['virtualip']['vip'])) {
@@ -465,7 +465,7 @@ if ($_POST['apply']) {
 		case "ppp":
 			$reqdfields = explode(" ", "port phone");
 			$reqdfieldsn = array(gettext("Modem Port"),gettext("Phone Number"));
-			do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 			break;
 		case "pppoe":
 			if ($_POST['pppoe_dialondemand']) {
@@ -475,7 +475,7 @@ if ($_POST['apply']) {
 				$reqdfields = explode(" ", "pppoe_username pppoe_password");
 				$reqdfieldsn = array(gettext("PPPoE username"),gettext("PPPoE password"));
 			}
-			do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 			break;
 		case "pptp":
 			if ($_POST['pptp_dialondemand']) {
@@ -485,7 +485,7 @@ if ($_POST['apply']) {
 				$reqdfields = explode(" ", "pptp_username pptp_password pptp_local pptp_subnet pptp_remote");
 				$reqdfieldsn = array(gettext("PPTP username"),gettext("PPTP password"),gettext("PPTP local IP address"),gettext("PPTP subnet"),gettext("PPTP remote IP address"));
 			}
-			do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 			break;
 		case "l2tp":
 			if ($_POST['pptp_dialondemand']) {
@@ -495,14 +495,14 @@ if ($_POST['apply']) {
 				$reqdfields = explode(" ", "pptp_username pptp_password pptp_remote");
 				$reqdfieldsn = array(gettext("L2TP username"),gettext("L2TP password"),gettext("L2TP remote IP address"));
 			}
-			do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 			break;
 	}
 	switch(strtolower($_POST['type6'])) {
 		case "staticv6":
 			$reqdfields = explode(" ", "ipaddrv6 subnetv6 gatewayv6");
 			$reqdfieldsn = array(gettext("IPv6 address"),gettext("Subnet bit count"),gettext("Gateway"));
-			do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 			break;
 		case "none":
 			if(is_array($config['virtualip']['vip'])) {
@@ -616,7 +616,7 @@ if ($_POST['apply']) {
 			$reqdfields[] = "ssid";
 			$reqdfieldsn[] = gettext("SSID");
 		}
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 		check_wireless_mode();
 		/* loop through keys and enforce size */
 		for ($i = 1; $i <= 4; $i++) {

--- a/usr/local/www/interfaces_bridge_edit.php
+++ b/usr/local/www/interfaces_bridge_edit.php
@@ -118,7 +118,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "members");
 	$reqdfieldsn = array(gettext("Member Interfaces"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ($_POST['maxage'] && !is_numeric($_POST['maxage']))
 		$input_errors[] = gettext("Maxage needs to be an integer between 6 and 40.");

--- a/usr/local/www/interfaces_gif_edit.php
+++ b/usr/local/www/interfaces_gif_edit.php
@@ -74,7 +74,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "if tunnel-remote-addr tunnel-remote-net tunnel-local-addr");
 	$reqdfieldsn = array(gettext("Parent interface,Local address, Remote tunnel address, Remote tunnel network, Local tunnel address"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ((!is_ipaddr($_POST['tunnel-local-addr'])) || (!is_ipaddr($_POST['tunnel-remote-addr'])) ||
 			(!is_ipaddr($_POST['remote-addr']))) {

--- a/usr/local/www/interfaces_gre_edit.php
+++ b/usr/local/www/interfaces_gre_edit.php
@@ -73,7 +73,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "if tunnel-remote-addr tunnel-remote-net tunnel-local-addr");
 	$reqdfieldsn = array(gettext("Parent interface"),gettext("Local address"),gettext("Remote tunnel address"),gettext("Remote tunnel network"), gettext("Local tunnel address"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ((!is_ipaddr($_POST['tunnel-local-addr'])) || (!is_ipaddr($_POST['tunnel-remote-addr'])) ||
 			(!is_ipaddr($_POST['remote-addr']))) {

--- a/usr/local/www/interfaces_lagg_edit.php
+++ b/usr/local/www/interfaces_lagg_edit.php
@@ -85,7 +85,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "members proto");
 	$reqdfieldsn = array(gettext("Member interfaces"), gettext("Lagg protocol"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (!$input_errors) {
 		$lagg = array();

--- a/usr/local/www/interfaces_ppps_edit.php
+++ b/usr/local/www/interfaces_ppps_edit.php
@@ -186,7 +186,7 @@ if ($_POST) {
 		case "ppp":
 			$reqdfields = explode(" ", "interfaces phone");
 			$reqdfieldsn = array(gettext("Link Interface(s)"),gettext("Phone Number"));
-			do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 			break;
 		case "pppoe":
 			if ($_POST['ondemand']) {
@@ -196,7 +196,7 @@ if ($_POST) {
 				$reqdfields = explode(" ", "interfaces username password");
 				$reqdfieldsn = array(gettext("Link Interface(s)"),gettext("Username"),gettext("Password"));
 			}
-			do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 			break;
 		case "l2tp":
 		case "pptp":
@@ -207,7 +207,7 @@ if ($_POST) {
 				$reqdfields = explode(" ", "interfaces username password localip subnet gateway");
 				$reqdfieldsn = array(gettext("Link Interface(s)"),gettext("Username"),gettext("Password"),gettext("Local IP address"),gettext("Subnet"),gettext("Remote IP address"));
 			}
-			do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 			break;
 		default:
 			$input_errors[] = gettext("Please choose a Link Type.");

--- a/usr/local/www/interfaces_vlan_edit.php
+++ b/usr/local/www/interfaces_vlan_edit.php
@@ -74,7 +74,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "if tag");
 	$reqdfieldsn = array(gettext("Parent interface"),gettext("VLAN tag"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ($_POST['tag'] && (!is_numericint($_POST['tag']) || ($_POST['tag'] < '1') || ($_POST['tag'] > '4094'))) {
 		$input_errors[] = gettext("The VLAN tag must be an integer between 1 and 4094.");

--- a/usr/local/www/interfaces_wireless_edit.php
+++ b/usr/local/www/interfaces_wireless_edit.php
@@ -85,7 +85,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "if mode");
 	$reqdfieldsn = array(gettext("Parent interface"),gettext("Mode"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (!$input_errors) {
 		$clone = array();

--- a/usr/local/www/load_balancer_monitor_edit.php
+++ b/usr/local/www/load_balancer_monitor_edit.php
@@ -87,7 +87,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "name type descr");
 	$reqdfieldsn = array(gettext("Name"),gettext("Type"),gettext("Description"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	/* Ensure that our monitor names are unique */
 	for ($i=0; isset($config['load_balancer']['monitor_type'][$i]); $i++)

--- a/usr/local/www/load_balancer_pool_edit.php
+++ b/usr/local/www/load_balancer_pool_edit.php
@@ -75,7 +75,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "name mode port monitor servers");
 	$reqdfieldsn = array(gettext("Name"),gettext("Mode"),gettext("Port"),gettext("Monitor"),gettext("Server List"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	/* Ensure that our pool names are unique */
 	for ($i=0; isset($config['load_balancer']['lbpool'][$i]); $i++)

--- a/usr/local/www/load_balancer_relay_action_edit.php
+++ b/usr/local/www/load_balancer_relay_action_edit.php
@@ -116,7 +116,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "name protocol direction action descr");
 	$reqdfieldsn = array(gettext("Name"),gettext("Protocol"),gettext("Direction"),gettext("Action"),gettext("Description"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	/* Ensure that our monitor names are unique */
 	for ($i=0; isset($config['load_balancer']['lbactions'][$i]); $i++)

--- a/usr/local/www/load_balancer_relay_protocol_edit.php
+++ b/usr/local/www/load_balancer_relay_protocol_edit.php
@@ -78,7 +78,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "name type descr");
 	$reqdfieldsn = array(gettext("Name"),gettext("Type"),gettext("Description"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	/* Ensure that our monitor names are unique */
 	for ($i=0; isset($config['load_balancer']['lbprotocol'][$i]); $i++)

--- a/usr/local/www/load_balancer_virtual_server_edit.php
+++ b/usr/local/www/load_balancer_virtual_server_edit.php
@@ -79,7 +79,7 @@ if ($_POST) {
     }
   }
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	for ($i=0; isset($config['load_balancer']['virtual_server'][$i]); $i++)
 		if (($_POST['name'] == $config['load_balancer']['virtual_server'][$i]['name']) && ($i != $id))

--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -137,7 +137,7 @@ if ($_POST) {
 				$reqfieldsn[] = $field['fielddescr'];
 		}
 	}
-	do_input_validation($_POST, $reqfields, $reqfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqfields, $reqfieldsn, $input_errors);
 
 	if ($pkg['custom_php_validation_command'])
 		eval($pkg['custom_php_validation_command']);

--- a/usr/local/www/services_captiveportal.php
+++ b/usr/local/www/services_captiveportal.php
@@ -152,7 +152,7 @@ if ($_POST) {
 		$reqdfields = explode(" ", "zone cinterface");
 		$reqdfieldsn = array(gettext("Zone name"), gettext("Interface"));
 
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 		/* make sure no interfaces are bridged or used on other zones */
 		if (is_array($_POST['cinterface'])) {

--- a/usr/local/www/services_captiveportal_hostname_edit.php
+++ b/usr/local/www/services_captiveportal_hostname_edit.php
@@ -99,7 +99,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "hostname");
 	$reqdfieldsn = array(gettext("Allowed Hostname"));
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	
 	if (($_POST['hostname'] && !is_hostname($_POST['hostname']))) 
 		$input_errors[] = sprintf(gettext("A valid Hostname must be specified. [%s]"), $_POST['hostname']);

--- a/usr/local/www/services_captiveportal_ip_edit.php
+++ b/usr/local/www/services_captiveportal_ip_edit.php
@@ -98,7 +98,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "ip");
 	$reqdfieldsn = array(gettext("Allowed IP address"));
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	
 	if (($_POST['ip'] && !is_ipaddr($_POST['ip']))) 
 		$input_errors[] = sprintf(gettext("A valid IP address must be specified. [%s]"), $_POST['ip']);

--- a/usr/local/www/services_captiveportal_mac_edit.php
+++ b/usr/local/www/services_captiveportal_mac_edit.php
@@ -95,7 +95,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "mac");
 	$reqdfieldsn = array(gettext("MAC address"));
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	
 	$_POST['mac'] = str_replace("-", ":", $_POST['mac']);
 	

--- a/usr/local/www/services_captiveportal_vouchers.php
+++ b/usr/local/www/services_captiveportal_vouchers.php
@@ -204,7 +204,7 @@ if ($_POST) {
 			$reqdfieldsn = array(gettext("Synchronize Voucher Database IP"),gettext("Sync port"),gettext("Sync password"),gettext("Sync username"));
 		}
 		
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	}
 	
 	if (!$_POST['vouchersyncusername']) { 

--- a/usr/local/www/services_captiveportal_vouchers_edit.php
+++ b/usr/local/www/services_captiveportal_vouchers_edit.php
@@ -91,7 +91,7 @@ if ($_POST) {
     $reqdfields = explode(" ", "number count minutes");
     $reqdfieldsn = array(gettext("Number"),gettext("Count"),gettext("minutes"));
 
-    do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+    do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	// Look for duplicate roll #
 	foreach($a_roll as $re) {

--- a/usr/local/www/services_captiveportal_zones_edit.php
+++ b/usr/local/www/services_captiveportal_zones_edit.php
@@ -58,7 +58,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "zone");
 	$reqdfieldsn = array(gettext("Zone name"));
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (preg_match('/[^A-Za-z0-9_]/', $_POST['zone'])) {
 		$input_errors[] = gettext("The zone name can only contain letters, digits, and underscores (_).");

--- a/usr/local/www/services_dhcp.php
+++ b/usr/local/www/services_dhcp.php
@@ -240,7 +240,7 @@ if ($_POST) {
 		$reqdfields = explode(" ", "range_from range_to");
 		$reqdfieldsn = array(gettext("Range begin"),gettext("Range end"));
 
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 		if (($_POST['range_from'] && !is_ipaddrv4($_POST['range_from'])))
 			$input_errors[] = gettext("A valid range must be specified.");

--- a/usr/local/www/services_dhcp_edit.php
+++ b/usr/local/www/services_dhcp_edit.php
@@ -112,7 +112,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "mac");
 	$reqdfieldsn = array(gettext("MAC address"));
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	/* normalize MAC addresses - lowercase and convert Windows-ized hyphenated MACs to colon delimited */
 	$_POST['mac'] = strtolower(str_replace("-", ":", $_POST['mac']));

--- a/usr/local/www/services_dhcp_relay.php
+++ b/usr/local/www/services_dhcp_relay.php
@@ -71,7 +71,7 @@ if ($_POST) {
 		$reqdfields = explode(" ", "server interface");
 		$reqdfieldsn = array(gettext("Destination Server"), gettext("Interface"));
 
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 		if ($_POST['server']) {
 			$checksrv = explode(",", $_POST['server']);

--- a/usr/local/www/services_dhcpv6.php
+++ b/usr/local/www/services_dhcpv6.php
@@ -174,7 +174,7 @@ if ($_POST) {
 		$reqdfields = explode(" ", "range_from range_to");
 		$reqdfieldsn = array(gettext("Range begin"),gettext("Range end"));
 
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 		if (($_POST['prefixrange_from'] && !is_ipaddrv6($_POST['prefixrange_from'])))
 			$input_errors[] = gettext("A valid range must be specified.");

--- a/usr/local/www/services_dhcpv6_edit.php
+++ b/usr/local/www/services_dhcpv6_edit.php
@@ -110,7 +110,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "duid");
 	$reqdfieldsn = array(gettext("DUID Identifier"));
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ($_POST['hostname']) {
 		preg_match("/\-\$/", $_POST['hostname'], $matches);

--- a/usr/local/www/services_dhcpv6_relay.php
+++ b/usr/local/www/services_dhcpv6_relay.php
@@ -72,7 +72,7 @@ if ($_POST) {
 		$reqdfields = explode(" ", "server interface");
 		$reqdfieldsn = array(gettext("Destination Server"), gettext("Interface"));
 
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 		if ($_POST['server']) {
 			$checksrv = explode(",", $_POST['server']);

--- a/usr/local/www/services_dnsmasq_domainoverride_edit.php
+++ b/usr/local/www/services_dnsmasq_domainoverride_edit.php
@@ -71,7 +71,7 @@ if ($_POST) {
        $reqdfields = explode(" ", "domain ip");
        $reqdfieldsn = array(gettext("Domain"),gettext("IP address"));
 
-       do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+       do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
        function String_Begins_With($needle, $haystack) {
            return (substr($haystack, 0, strlen($needle))==$needle);

--- a/usr/local/www/services_dnsmasq_edit.php
+++ b/usr/local/www/services_dnsmasq_edit.php
@@ -80,7 +80,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "domain ip");
 	$reqdfieldsn = array(gettext("Domain"),gettext("IP address"));
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	
 	if (($_POST['host'] && !is_hostname($_POST['host']))) 
 		$input_errors[] = gettext("The hostname can only contain the characters A-Z, 0-9 and '-'.");
@@ -119,7 +119,7 @@ if ($_POST) {
 		$aliasreqdfieldsn = array(gettext("Alias Domain"));
 
 		var_dump(array('fields' => $aliasreqdfields, 'names' => $aliasreqdfieldsn, 'alias' => $alias));
-		do_input_validation($_POST, $aliasreqdfields, $aliasreqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $aliasreqdfields, $aliasreqdfieldsn, $input_errors);
 		if (($alias['host'] && !is_hostname($alias['host']))) {
 			$input_errors[] = gettext("Hostnames in alias list can only contain the characters A-Z, 0-9 and '-'.");
 		}

--- a/usr/local/www/services_dyndns_edit.php
+++ b/usr/local/www/services_dyndns_edit.php
@@ -102,7 +102,7 @@ if ($_POST) {
 		$reqdfieldsn[] = gettext("Update URL");
  	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (($_POST['mx'] && !is_domain($_POST['mx']))) 
 		$input_errors[] = gettext("The MX contains invalid characters.");

--- a/usr/local/www/services_rfc2136_edit.php
+++ b/usr/local/www/services_rfc2136_edit.php
@@ -70,7 +70,7 @@ if ($_POST) {
 	$reqdfields = array_merge($reqdfields, explode(" ", "host ttl keyname keydata"));
 	$reqdfieldsn = array_merge($reqdfieldsn, array(gettext("Hostname"), gettext("TTL"), gettext("Key name"), gettext("Key")));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (($_POST['host'] && !is_domain($_POST['host'])))  
 		$input_errors[] = gettext("The DNS update host name contains invalid characters.");

--- a/usr/local/www/services_snmp.php
+++ b/usr/local/www/services_snmp.php
@@ -94,11 +94,11 @@ if ($_POST) {
 
 		$reqdfields = explode(" ", "rocommunity");
 		$reqdfieldsn = array(gettext("Community"));
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 		$reqdfields = explode(" ", "pollport");
 		$reqdfieldsn = array(gettext("Polling Port"));
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 		
 	
 	}
@@ -108,15 +108,15 @@ if ($_POST) {
 
 		$reqdfields = explode(" ", "trapserver");
 		$reqdfieldsn = array(gettext("Trap server"));
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 		$reqdfields = explode(" ", "trapserverport");
 		$reqdfieldsn = array(gettext("Trap server port"));
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 		$reqdfields = explode(" ", "trapstring");
 		$reqdfieldsn = array(gettext("Trap string"));
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	}
 
 
@@ -124,7 +124,7 @@ if ($_POST) {
 	if ($_POST['rwenable']) {
                $reqdfields = explode(" ", "rwcommunity");
                $reqdfieldsn = explode(",", "Write community string");
-               do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+               do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	}
 */
 

--- a/usr/local/www/services_wol_edit.php
+++ b/usr/local/www/services_wol_edit.php
@@ -81,7 +81,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "interface mac");
 	$reqdfieldsn = array(gettext("Interface"),gettext("MAC address"));
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
         /* normalize MAC addresses - lowercase and convert Windows-ized hyphenated MACs to colon delimited */
         $_POST['mac'] = strtolower(str_replace("-", ":", $_POST['mac']));

--- a/usr/local/www/system.php
+++ b/usr/local/www/system.php
@@ -106,7 +106,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "hostname domain");
 	$reqdfieldsn = array(gettext("Hostname"),gettext("Domain"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ($_POST['hostname'] && !is_hostname($_POST['hostname'])) {
 		$input_errors[] = gettext("The hostname may only contain the characters a-z, 0-9 and '-'.");

--- a/usr/local/www/system_authservers.php
+++ b/usr/local/www/system_authservers.php
@@ -204,7 +204,7 @@ if ($_POST) {
 		}
 	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (preg_match("/[^a-zA-Z0-9\.\-_]/", $_POST['host']))
 		$input_errors[] = gettext("The host name contains invalid characters.");

--- a/usr/local/www/system_camanager.php
+++ b/usr/local/www/system_camanager.php
@@ -201,7 +201,7 @@ if ($_POST) {
 				gettext("Distinguished name Common Name"));
 	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	if ($pconfig['method'] != "existing")
 		/* Make sure we do not have invalid characters in the fields for the certificate */
 		for ($i = 0; $i < count($reqdfields); $i++) {

--- a/usr/local/www/system_certmanager.php
+++ b/usr/local/www/system_certmanager.php
@@ -235,7 +235,7 @@ if ($_POST) {
 		}
 
 		$altnames = array();
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 		if ($pconfig['method'] != "import") {
 			/* subjectAltNames */
 			foreach ($_POST as $key => $value) {
@@ -394,7 +394,7 @@ if ($_POST) {
 			gettext("Descriptive name"),
 			gettext("Final Certificate data"));
 
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 //		old way
 		/* make sure this csr and certificate subjects match */

--- a/usr/local/www/system_crlmanager.php
+++ b/usr/local/www/system_crlmanager.php
@@ -200,7 +200,7 @@ if ($_POST) {
 				gettext("Certificate Authority"));
 	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	/* if this is an AJAX caller then handle via JSON */
 	if (isAjax() && is_array($input_errors)) {

--- a/usr/local/www/system_gateway_groups_edit.php
+++ b/usr/local/www/system_gateway_groups_edit.php
@@ -82,7 +82,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "name");
 	$reqdfieldsn = explode(",", "Name");
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	
 	if (! isset($_POST['name'])) {
 		$input_errors[] = gettext("A valid gateway group name must be specified.");

--- a/usr/local/www/system_gateways_edit.php
+++ b/usr/local/www/system_gateways_edit.php
@@ -99,7 +99,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "name interface");
 	$reqdfieldsn = array(gettext("Name"), gettext("Interface"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (! isset($_POST['name'])) {
 		$input_errors[] = "A valid gateway name must be specified.";

--- a/usr/local/www/system_groupmanager.php
+++ b/usr/local/www/system_groupmanager.php
@@ -116,7 +116,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "groupname");
 	$reqdfieldsn = array(gettext("Group Name"));
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	
 	if (preg_match("/[^a-zA-Z0-9\.\-_ ]/", $_POST['groupname']))
 		$input_errors[] = gettext("The group name contains invalid characters.");

--- a/usr/local/www/system_groupmanager_addprivs.php
+++ b/usr/local/www/system_groupmanager_addprivs.php
@@ -78,7 +78,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "sysprivs");
 	$reqdfieldsn = array(gettext("Selected priveleges"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	/* if this is an AJAX caller then handle via JSON */
 	if(isAjax() && is_array($input_errors)) {

--- a/usr/local/www/system_routes_edit.php
+++ b/usr/local/www/system_routes_edit.php
@@ -91,7 +91,7 @@ if ($_POST) {
 			gettext("Destination network bit count") . "," .
 			gettext("Gateway"));		
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	
 	if (($_POST['network'] && !is_ipaddr($_POST['network']) && !is_alias($_POST['network']))) {
 		$input_errors[] = gettext("A valid IPv4 or IPv6 destination network must be specified.");

--- a/usr/local/www/system_usermanager.php
+++ b/usr/local/www/system_usermanager.php
@@ -193,7 +193,7 @@ if ($_POST) {
 		}
 	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (preg_match("/[^a-zA-Z0-9\.\-_]/", $_POST['usernamefld']))
 		$input_errors[] = gettext("The username contains invalid characters.");

--- a/usr/local/www/system_usermanager_addprivs.php
+++ b/usr/local/www/system_usermanager_addprivs.php
@@ -83,7 +83,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "sysprivs");
 	$reqdfieldsn = array(gettext("Selected priveleges"));
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	/* if this is an AJAX caller then handle via JSON */
 	if(isAjax() && is_array($input_errors)) {

--- a/usr/local/www/system_usermanager_passwordmg.php
+++ b/usr/local/www/system_usermanager_passwordmg.php
@@ -48,7 +48,7 @@ if (isset($_POST['save'])) {
 
 	$reqdfields = explode(" ", "passwordfld1");
 	$reqdfieldsn = array(gettext("Password"));
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ($_POST['passwordfld1'] != $_POST['passwordfld2'])
 		$input_errors[] = gettext("The passwords do not match.");

--- a/usr/local/www/vpn_ipsec_keys_edit.php
+++ b/usr/local/www/vpn_ipsec_keys_edit.php
@@ -68,7 +68,7 @@ if ($_POST) {
 	$reqdfields = explode(" ", "ident psk");
 	$reqdfieldsn = array(gettext("Identifier"),gettext("Pre-Shared Key"));
 	
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	
 	if (preg_match("/[^a-zA-Z0-9@\.\-]/", $_POST['ident']))
 		$input_errors[] = gettext("The identifier contains invalid characters.");

--- a/usr/local/www/vpn_ipsec_mobile.php
+++ b/usr/local/www/vpn_ipsec_mobile.php
@@ -131,7 +131,7 @@ if ($_POST['submit']) {
 	$reqdfields = explode(" ", "user_source group_source");
 	$reqdfieldsn =  array(gettext("User Authentication Source"),gettext("Group Authentication Source"));
 
-    do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+    do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if ($pconfig['pool_enable'])
 		if (!is_ipaddr($pconfig['pool_address']))

--- a/usr/local/www/vpn_ipsec_phase1.php
+++ b/usr/local/www/vpn_ipsec_phase1.php
@@ -171,7 +171,7 @@ if ($_POST) {
 		$reqdfieldsn[] = gettext("Remote gateway");
 	}
 
-	do_input_validation($pconfig, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($pconfig, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (($pconfig['lifetime'] && !is_numeric($pconfig['lifetime'])))
 		$input_errors[] = gettext("The P1 lifetime must be an integer.");

--- a/usr/local/www/vpn_ipsec_phase2.php
+++ b/usr/local/www/vpn_ipsec_phase2.php
@@ -118,7 +118,7 @@ if ($_POST) {
 		$reqdfieldsn[] = gettext("Remote network type");
 	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if(($pconfig['mode'] == "tunnel") || ($pconfig['mode'] == "tunnel6")) 
 	{

--- a/usr/local/www/vpn_l2tp.php
+++ b/usr/local/www/vpn_l2tp.php
@@ -79,7 +79,7 @@ if ($_POST) {
 				array(gettext("RADIUS server address"),gettext("RADIUS shared secret")));
 		}
 
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 		if (($_POST['localip'] && !is_ipaddr($_POST['localip']))) {
 			$input_errors[] = gettext("A valid server address must be specified.");

--- a/usr/local/www/vpn_l2tp_users_edit.php
+++ b/usr/local/www/vpn_l2tp_users_edit.php
@@ -82,7 +82,7 @@ if ($_POST) {
 		$reqdfieldsn = array(gettext("Username"),gettext("Password"));
 	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (preg_match("/[^a-zA-Z0-9\.\-_]/", $_POST['usernamefld']))
 		$input_errors[] = gettext("The username contains invalid characters.");

--- a/usr/local/www/vpn_openvpn_client.php
+++ b/usr/local/www/vpn_openvpn_client.php
@@ -235,7 +235,7 @@ if ($_POST) {
 		$reqdfieldsn = array(gettext('Shared key'));
 	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	
 	if (!$input_errors) {
 

--- a/usr/local/www/vpn_openvpn_csc.php
+++ b/usr/local/www/vpn_openvpn_csc.php
@@ -162,7 +162,7 @@ if ($_POST) {
 	$reqdfields[] = 'common_name';
 	$reqdfieldsn[] = 'Common name';
 
-    do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+    do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (!$input_errors) {
 

--- a/usr/local/www/vpn_openvpn_server.php
+++ b/usr/local/www/vpn_openvpn_server.php
@@ -319,7 +319,7 @@ if ($_POST) {
 		if (ip2ulong($pconfig['serverbridge_dhcp_start']) > ip2ulong($pconfig['serverbridge_dhcp_end']))
 			$input_errors[] = gettext("The Server Bridge DHCP range is invalid (start higher than end).");
 	}
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	
 	if (!$input_errors) {
 

--- a/usr/local/www/vpn_pppoe_edit.php
+++ b/usr/local/www/vpn_pppoe_edit.php
@@ -117,7 +117,7 @@ if ($_POST) {
 				array(gettext("RADIUS server address"),gettext("RADIUS shared secret")));
 		}
 
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 		if (($_POST['localip'] && !is_ipaddr($_POST['localip'])))
 			$input_errors[] = gettext("A valid server address must be specified.");

--- a/usr/local/www/vpn_pptp.php
+++ b/usr/local/www/vpn_pptp.php
@@ -87,7 +87,7 @@ if ($_POST) {
 				array(gettext("RADIUS server address"),gettext("RADIUS shared secret")));
 		}
 		
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 		
 		if (($_POST['localip'] && !is_ipaddr($_POST['localip']))) {
 			$input_errors[] = gettext("A valid server address must be specified.");
@@ -116,7 +116,7 @@ if ($_POST) {
 		$reqdfields = explode(" ", "redir");
 		$reqdfieldsn = array(gettext("PPTP redirection target address"));
 		
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 		
 		if (($_POST['redir'] && !is_ipaddr($_POST['redir']))) {
 			$input_errors[] = gettext("A valid target address must be specified.");

--- a/usr/local/www/vpn_pptp_users_edit.php
+++ b/usr/local/www/vpn_pptp_users_edit.php
@@ -79,7 +79,7 @@ if ($_POST) {
 		$reqdfieldsn = array(gettext("Username"),gettext("Password"));
 	}
 
-	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (preg_match("/[^a-zA-Z0-9\.\-_]/", $_POST['username']))
 		$input_errors[] = gettext("The username contains invalid characters.");


### PR DESCRIPTION
Call-time pass-by-reference has been removed in PHP 5.4 [1]. There is also an existing todo entry in redmine [2].
Ticket #2565

[1] http://php.net/manual/en/language.references.pass.php
[2] http://redmine.pfsense.org/issues/2565
