### PR TITLE
Tidy up HTML Colour Names

### DIFF
--- a/usr/local/www/firewall_schedule_edit.php
+++ b/usr/local/www/firewall_schedule_edit.php
@@ -234,7 +234,7 @@ function repeatExistingDays(){
 		tempstr = 'w' + week + 'p' + daypos;
 		daycell = eval('document.getElementById(tempstr)');
 		if (daydone == "-1"){
-			if (daycell.style.backgroundColor == "lightcoral")
+			if (daycell.style.backgroundColor == "#F08080")  // lightcoral
 				daytogglerepeating(week,daypos,true);
 			else
 				daytogglerepeating(week,daypos,false);
@@ -257,11 +257,11 @@ function daytogglerepeating(week,daypos,bExists){
 		if (daycell != null)
 		{
 			if (bExists){	
-				daycell.style.backgroundColor = "WHITE";
+				daycell.style.backgroundColor = "#FFFFFF";  // white
 			}
 			else
 			{
-				daycell.style.backgroundColor = "lightcoral";		
+				daycell.style.backgroundColor = "#F08080";  // lightcoral		
 			}	
 	
 			if (dayoriginalpos != "-1")
@@ -302,12 +302,12 @@ function daytoggle(id) {
 		var daycell = document.getElementById(idmod);		
 	
 		if (daycell != null){
-			if (daycell.style.backgroundColor == "RED"){
-				daycell.style.backgroundColor = "WHITE";
+			if (daycell.style.backgroundColor == "#FF0000"){  // red
+				daycell.style.backgroundColor = "#FFFFFF";  // white
 				str = id + ",";
 				daysSelected = daysSelected.replace(str, "");
 			}
-			else if (daycell.style.backgroundColor == "lightcoral")
+			else if (daycell.style.backgroundColor == "#F08080")  // lightcoral
 			{
 				daytogglerepeating(week,daypos,true);
 			}
@@ -315,11 +315,11 @@ function daytoggle(id) {
 			{
 				if (!runrepeat)
 				{
-					daycell.style.backgroundColor = "RED";
+					daycell.style.backgroundColor = "#FF0000";  // red
 				}
 				else
 				{
-					daycell.style.backgroundColor = "lightcoral";
+					daycell.style.backgroundColor = "#F08080";  // lightcoral
 					daytogglerepeating(week,daypos,false);								
 				}
 				daysSelected += id + ",";
@@ -654,7 +654,7 @@ function clearCalendar(){
 			tempstr = 'w' + j + 'p' + k;
 			daycell = eval('document.getElementById(tempstr)');
 			if (daycell != null){
-				daycell.style.backgroundColor = "WHITE";	
+				daycell.style.backgroundColor = "#FFFFFF";  // white	
 			}	
 		}
 	}	

--- a/usr/local/www/includes/functions.inc.php
+++ b/usr/local/www/includes/functions.inc.php
@@ -42,19 +42,19 @@ function get_gatewaystats() {
 			switch(strtolower($gws['status'])) {
 			case "none":
 				$online = "Online";
-				$bgcolor = "lightgreen";
+				$bgcolor = "#90EE90";  // lightgreen
 				break;
 			case "down":
 				$online = "Offline";
-				$bgcolor = "lightcoral";
+				$bgcolor = "#F08080";  // lightcoral
 				break;
 			case "delay":
 				$online = "Latency";
-				$bgcolor = "khaki";
+				$bgcolor = "#F0E68C";  // khaki
 				break;
 			case "loss":
 				$online = "Packetloss";
-				$bgcolor = "khaki";
+				$bgcolor = "#F0E68C";  // khaki
 				break;
 			default:
 				$online = "Pending";
@@ -65,10 +65,10 @@ function get_gatewaystats() {
 			$gws['delay'] = "~";
 			$gws['loss'] = "~";
 			$online = "Unknown";
-			$bgcolor = "lightblue";
+			$bgcolor = "#ADD8E6";  // lightblue
 		}
 		$data .= ($online == "Pending") ? "{$online},{$online}," : "{$gws['delay']},{$gws['loss']},";
-		$data .= "<table><tr><td bgcolor=\"$bgcolor\" > $online </td></td></tr></table>";
+		$data .= "<table><tr><td bgcolor=\"$bgcolor\">&nbsp;$online&nbsp;</td></td></tr></table>";
 	}
 	return $data;
 }

--- a/usr/local/www/status_gateway_groups.php
+++ b/usr/local/www/status_gateway_groups.php
@@ -122,21 +122,21 @@ include("head.inc");
 							$status = $gateways_status[$monitor]['status'];
 							if (stristr($status, "down")) {
                                         			$online = gettext("Offline");
-                                        			$bgcolor = "lightcoral";
+                                        			$bgcolor = "#F08080";  // lightcoral
                                 			} elseif (stristr($status, "loss")) {
                                         			$online = gettext("Warning, Packetloss");
-                                        			$bgcolor = "khaki";
+                                        			$bgcolor = "#F0E68C";  // khaki
                                 			} elseif (stristr($status, "delay")) {
                                         			$online = gettext("Warning, Latency");
-                                        			$bgcolor = "khaki";
+                                        			$bgcolor = "#F0E68C";  // khaki
                                 			} elseif ($status == "none") {
                                         			$online = gettext("Online");
-                                        			$bgcolor = "lightgreen";
+                                        			$bgcolor = "#90EE90";  // lightgreen
                                 			} else {
 								$online = gettext("Gathering data");
-								$bgcolor = "lightblue";
+								$bgcolor = "#ADD8E6";  // lightblue
 							}
-							echo "<td bgcolor='$bgcolor'>". htmlspecialchars($member) .", $online</td>";
+							echo "<td bgcolor='$bgcolor'>&nbsp;". htmlspecialchars($member) .", $online&nbsp;</td>";
 						} else {
 							echo "<td>&nbsp;</td>";
 						}

--- a/usr/local/www/status_gateways.php
+++ b/usr/local/www/status_gateways.php
@@ -117,25 +117,25 @@ include("head.inc");
 					$status = $gateways_status[$gname];
 					if (stristr($status['status'], "down")) {
 						$online = gettext("Offline");
-						$bgcolor = "lightcoral";
+						$bgcolor = "#F08080";  // lightcoral
 					} elseif (stristr($status['status'], "loss")) {
 						$online = gettext("Warning, Packetloss").': '.$status['loss'];
-						$bgcolor = "khaki";
+						$bgcolor = "#F0E68C";  // khaki
 					} elseif (stristr($status['status'], "delay")) {
 						$online = gettext("Warning, Latency").': '.$status['delay'];
-						$bgcolor = "khaki";
+						$bgcolor = "#F0E68C";  // khaki
 					} elseif ($status['status'] == "none") {
 						$online = gettext("Online");
-						$bgcolor = "lightgreen";
+						$bgcolor = "#90EE90";  // lightgreen
 					}
 				} else if (isset($gateway['monitor_disable'])) {
 						$online = gettext("Online");
-						$bgcolor = "lightgreen";
+						$bgcolor = "#90EE90";  // lightgreen
 				} else {
 					$online = gettext("Pending");
-					$bgcolor = "lightgray";
+					$bgcolor = "#D3D3D3";  // lightgray
 				}
-				echo "<tr><td><table width='100%'><tr><td bgcolor=\"$bgcolor\" > $online </td></tr><tr><td>";
+				echo "<tr><td><table width='100%'><tr><td bgcolor=\"$bgcolor\">&nbsp;$online&nbsp;</td></tr><tr><td>";
 				$lastchange = $gateways_status[$gname]['lastcheck'];
 				if(!empty($lastchange)) {
 					echo gettext("Last check:") . '<br/>' . $lastchange;

--- a/usr/local/www/status_lb_pool.php
+++ b/usr/local/www/status_lb_pool.php
@@ -174,7 +174,7 @@ if ($_POST) {
 			if($server['ip']['addr']!="") {
 				switch ($server['ip']['state']) {
 					case 'up':
-						$bgcolor = "lightgreen";
+						$bgcolor = "#90EE90";  // lightgreen
 						$checked = "checked";
 						break;
 					case 'disabled':
@@ -182,7 +182,7 @@ if ($_POST) {
 						$checked = "";
 						break;
 					default:
-						$bgcolor = "lightcoral";
+						$bgcolor = "#F08080";  // lightcoral
 						$checked = "checked";
 				}
 				echo "<tr>";
@@ -194,11 +194,11 @@ if ($_POST) {
 						echo "<td><input type='radio' name='{$pool['name']}' value='{$server['ip']['addr']}' {$checked}></td>\n";
 						break;
 				}
-				echo "<td bgcolor={$bgcolor}> {$server['ip']['addr']}:{$pool['port']} </td><td bgcolor={$bgcolor}>";
-#				echo "<td bgcolor={$bgcolor}> {$server['ip']['addr']}:{$pool['port']} ";
+				echo "<td bgcolor={$bgcolor}>&nbsp;{$server['ip']['addr']}:{$pool['port']}&nbsp;</td><td bgcolor={$bgcolor}>&nbsp;";
+#				echo "<td bgcolor={$bgcolor}>&nbsp;{$server['ip']['addr']}:{$pool['port']} ";
 				if($server['ip']['avail'])
 				  echo " ({$server['ip']['avail']}) ";
-				echo "</td></tr>";
+				echo "&nbsp;</td></tr>";
 			}
 		}
 		?>

--- a/usr/local/www/status_lb_vs.php
+++ b/usr/local/www/status_lb_vs.php
@@ -105,16 +105,16 @@ include("head.inc");
                   <?php
                   switch (trim($rdr_a[$vsent['name']]['status'])) {
                     case 'active':
-                      $bgcolor = "lightgreen";
-					  $rdr_a[$vsent['name']]['status'] = "Active";
+                      $bgcolor = "#90EE90";  // lightgreen
+                      $rdr_a[$vsent['name']]['status'] = "Active";
                       break;
                     case 'down':
-                      $bgcolor = "lightcoral";
-					  $rdr_a[$vsent['name']]['status'] = "Down";
-					  break;
-					default:
-                      $bgcolor = "lightgray";
-					  $rdr_a[$vsent['name']]['status'] = 'Unknown - relayd not running?';
+                      $bgcolor = "#F08080";  // lightcoral
+                      $rdr_a[$vsent['name']]['status'] = "Down";
+                      break;
+                    default:
+                      $bgcolor = "#D3D3D3";  // lightgray
+                      $rdr_a[$vsent['name']]['status'] = 'Unknown - relayd not running?';
                   }
                   ?>
                   <td class="listr" nowrap>

--- a/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/usr/local/www/widgets/widgets/gateways.widget.php
@@ -87,25 +87,25 @@ $counter = 1;
 		<?php	if ($gateways_status[$gname]) {
 				if (stristr($gateways_status[$gname]['status'], "down")) {
                                         $online = "Offline";
-                                        $bgcolor = "lightcoral";
+                                        $bgcolor = "#F08080";  // lightcoral
                                 } elseif (stristr($gateways_status[$gname]['status'], "loss")) {
                                         $online = "Packetloss";
-                                        $bgcolor = "khaki";
+                                        $bgcolor = "#F0E68C";  // khaki
                                 } elseif (stristr($gateways_status[$gname]['status'], "delay")) {
                                         $online = "Latency";
-                                        $bgcolor = "khaki";
+                                        $bgcolor = "#F0E68C";  // khaki
                                 } elseif ($gateways_status[$gname]['status'] == "none") {
                                         $online = "Online";
-                                        $bgcolor = "lightgreen";
+                                        $bgcolor = "#90EE90";  // lightgreen
                                 } elseif ($gateways_status[$gname]['status'] == "") {
                                         $online = "Pending";
-                                        $bgcolor = "lightgray";
+                                        $bgcolor = "#D3D3D3";  // lightgray
 				}
 			} else {
 				$online = gettext("Unknown");
-                                $bgcolor = "lightblue";
+                                $bgcolor = "#ADD8E6";  // lightblue
 			}
-			echo "<tr><td bgcolor=\"$bgcolor\">$online</td></tr>\n";
+			echo "<tr><td bgcolor=\"$bgcolor\">&nbsp;$online&nbsp;</td></tr>\n";
 			$counter++;
 		?>
                         </table>

--- a/usr/local/www/widgets/widgets/load_balancer_status.widget.php
+++ b/usr/local/www/widgets/widgets/load_balancer_status.widget.php
@@ -73,15 +73,15 @@ if (!$nentries)
 		<?php
 		switch (trim($rdr_a[$vsent['name']]['status'])) {
 			case 'active':
-				$bgcolor = "lightgreen";
+				$bgcolor = "#90EE90";  // lightgreen
 				$rdr_a[$vsent['name']]['status'] = "Active";
 				break;
 			case 'down':
-				$bgcolor = "lightcoral";
+				$bgcolor = "#F08080";  // lightcoral
 				$rdr_a[$vsent['name']]['status'] = "Down";
 				break;
 			default:
-				$bgcolor = "lightgray";
+				$bgcolor = "#D3D3D3";  // lightgray
 				 $rdr_a[$vsent['name']]['status'] = 'Unknown - relayd not running?';
 		}
 		?>
@@ -113,22 +113,22 @@ if (!$nentries)
 					if($server['ip']['addr']!="") {
 						switch ($server['ip']['state']) {
 							case 'up':
-								$bgcolor = "lightgreen";
+								$bgcolor = "#90EE90";  // lightgreen
 								$checked = "checked";
 								break;
 							case 'disabled':
-								$bgcolor = "white";
+								$bgcolor = "#FFFFFF";  // white
 								$checked = "";
 								break;
 							default:
-								$bgcolor = "lightcoral";
+								$bgcolor = "#F08080";  // lightcoral
 								$checked = "checked";
 						}
 						echo "<tr>";
-						echo "<td bgcolor={$bgcolor}> {$server['ip']['addr']}:{$pool['port']} </td><td bgcolor={$bgcolor}>";
+						echo "<td bgcolor={$bgcolor}>&nbsp;{$server['ip']['addr']}:{$pool['port']}&nbsp;</td><td bgcolor={$bgcolor}>&nbsp;";
 						if($server['ip']['avail'])
 						  echo " ({$server['ip']['avail']}) ";
-						echo "</td></tr>";
+						echo "&nbsp;</td></tr>";
 					}
 				}
 			}


### PR DESCRIPTION
With XHTML 1.0, the extended colour names are invalid, to make pfSense more compliant with W3C standards, need to go back to using the HEX code.
