### PR TITLE
Update "include" files to W3C standard

### DIFF
--- a/etc/inc/authgui.inc
+++ b/etc/inc/authgui.inc
@@ -114,13 +114,13 @@ function display_error_form($http_code, $desc) {
 		<title><?=$http_code?></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 		<link rel="shortcut icon" href="/themes/<?= $g['theme'] ?>/images/icons/favicon.ico" />
-		<?php if (file_exists("{$g['www_path']}/themes/{$g['theme']}/login.css")): ?>
+		<?php if (file_exists("{$g['www_path']}/themes/{$g['theme']}/login.css")): ?> 
 		<link rel="stylesheet" type="text/css" href="/themes/<?= $g['theme'] ?>/login.css" media="all" />
-		<?php else: ?>
+		<?php else: ?> 
 		<link rel="stylesheet" type="text/css" href="/themes/<?= $g['theme'] ?>/all.css" media="all" />
-		<?php endif; ?>
+		<?php endif; ?> 
 		<script type="text/javascript">
-		<!--
+		//<![CDATA[
 			function page_load() {}
 			function clearError() {
 				if($('#inputerrors'))
@@ -130,7 +130,7 @@ function display_error_form($http_code, $desc) {
 				require("headjs.php");
 				echo getHeadJS();
 			?>
-		//-->
+		//]]>
 		</script>
 		<script type="text/javascript" src="/themes/<?= $g['theme'] ?>/javascript/niftyjsCode.js"></script>
 	</head>
@@ -213,18 +213,22 @@ $have_cookies = isset($_COOKIE["cookie_test"]);
 <html>
 	<head>
 		<script type="text/javascript" src="/javascript/jquery.js"></script>
-		<script>$(document).ready(function() { jQuery('#usernamefld').focus(); });</script>
+		<script type="text/javascript">
+		//<![CDATA[
+		$(document).ready(function() { jQuery('#usernamefld').focus(); });
+		//]]>
+		</script>
 		
 		<title><?=gettext("Login"); ?></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 		<link rel="shortcut icon" href="/themes/<?= $g['theme'] ?>/images/icons/favicon.ico" />
-		<?php if (file_exists("{$g['www_path']}/themes/{$g['theme']}/login.css")): ?>
+		<?php if (file_exists("{$g['www_path']}/themes/{$g['theme']}/login.css")): ?> 
 		<link rel="stylesheet" type="text/css" href="/themes/<?= $g['theme'] ?>/login.css" media="all" />
-		<?php else: ?>
+		<?php else: ?> 
 		<link rel="stylesheet" type="text/css" href="/themes/<?= $g['theme'] ?>/all.css" media="all" />
-		<?php endif; ?>
+		<?php endif; ?> 
 		<script type="text/javascript">
-		<!--
+		//<![CDATA[
 			function page_load() {}
 			function clearError() {
 				if($('#inputerrors'))
@@ -234,7 +238,7 @@ $have_cookies = isset($_COOKIE["cookie_test"]);
 				require("headjs.php");
 				echo getHeadJS();
 			?>
-		//-->
+		//]]>
 		</script>
 		<script type="text/javascript" src="/themes/<?= $g['theme'] ?>/javascript/niftyjsCode.js"></script>
 	</head>
@@ -246,41 +250,41 @@ $have_cookies = isset($_COOKIE["cookie_test"]);
 					print_info_box(gettext("You are accessing this router by an IP address not configured locally, which may be forwarded by NAT or other means. <br/><br/>If you did not setup this forwarding, you may be the target of a man-in-the-middle attack.")); 
 				}
 				$noautocomplete = isset($config['system']['webgui']['noautocomplete']) ? 'autocomplete="off"' : '';
-			?>
-			<form id="iform" name="login_iform" method="post" <?= $noautocomplete ?> action="<?=$_SERVER['SCRIPT_NAME'];?>">
-				<h1></h1>
+			?> 
+			<form id="login_iform" name="login_iform" method="post" <?= $noautocomplete ?> action="<?=$_SERVER['SCRIPT_NAME'];?>">
+				<h1>&nbsp;</h1>
 				<div id="inputerrors"><?=$_SESSION['Login_Error'];?></div>
 				<p>
 					<span style="text-align:left">
-						<?=gettext("Username:"); ?><br>
+						<?=gettext("Username:"); ?><br />
 						<input onclick="clearError();" onchange="clearError();" id="usernamefld" type="text" name="usernamefld" class="formfld user" tabindex="1" />
 					</span>
 				</p>
-				<br>
+				<br />
 				<p>
 					<span style="text-align:left">
-						<?=gettext("Password:"); ?> <br>
+						<?=gettext("Password:"); ?> <br />
 						<input onclick="clearError();" onchange="clearError();" id="passwordfld" type="password" name="passwordfld" class="formfld pwd" tabindex="2" />
 					</span>
 				</p>
-				<br>
+				<br />
 				<p>
 					<span style="text-align:center; font-weight: normal ; font-style: italic">
 						<?=gettext("Enter username and password to login."); ?>
 					</span>
 
-					<?php if (!$have_cookies && isset($_POST['login'])): ?>
-					<br/><br/>
+					<?php if (!$have_cookies && isset($_POST['login'])): ?> 
+					<br /><br />
 					<span style="text-align:center; font-weight: normal ; font-style: italic; color: #ff0000">
 						<?= gettext("Your browser must support cookies to login."); ?>
 					</span>
-					<?php endif; ?>
+					<?php endif; ?> 
 				</p>        
 				<p>
 					<span style="text-align:center">
 						<input type="submit" name="login" class="formbtn" value="<?=gettext("Login"); ?>" tabindex="3" />
 					</span>
-				</P>
+				</p>
 			</form>
 		</div>
 	</body>

--- a/usr/local/www/classes/maintable.inc
+++ b/usr/local/www/classes/maintable.inc
@@ -73,7 +73,7 @@ class MainTable {
 
 	function display() {
 		echo "<!-- begin content table -->\n";
-		echo "<table class=\"tabcont\" width=\"100%\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\">\n";
+		echo "<table class=\"tabcont\" width=\"100%\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" summary=\"content\">\n";
 		echo "  <!-- begin content table header -->\n";
 		echo $this->display_header();
 		echo "  <!-- end content table header -->\n";
@@ -95,10 +95,10 @@ class MainTable {
 		}
 		echo "  <td width=\"{$this->width[$this->columns - 1]}%\" class=\"listhdr\">{$this->headers[$this->columns - 1]}</td>\n";
 		echo "  <td width=\"10%\" class=\"list\">\n";
-		echo "    <table border=\"0\" cellspacing=\"0\" cellpadding=\"1\">\n";
+		echo "    <table border=\"0\" cellspacing=\"0\" cellpadding=\"1\" summary=\"header\">\n";
 		echo "      <tr>\n";
 		echo "        <td width=\"17\"></td>\n";
-		echo "         <td valign=\"middle\"><a href=\"{$this->edit_uri}\"><img src=\"/themes/{$g['theme']}/images/icons/icon_plus.gif\" width=\"17\" height=\"17\" border=\"0\"></a></td>\n";
+		echo "         <td valign=\"middle\"><a href=\"{$this->edit_uri}\"><img src=\"/themes/{$g['theme']}/images/icons/icon_plus.gif\" width=\"17\" height=\"17\" border=\"0\" alt=\"plus\" /></a></td>\n";
 		echo "      </tr>\n";
 		echo "    </table>\n";
 		echo "  </td>\n";
@@ -126,10 +126,10 @@ class MainTable {
 				}
 				echo "  </td>\n";
 			}
-			echo "  <td class=\"listbg\" onClick=\"fr_toggle({$cur_row})\" id=\"frd{$cur_row}\" ondblclick=\"document.location=\'{$this->edit_uri}?id={$cur_row}\'\">\n";
+			echo "  <td class=\"listbg\" onclick=\"fr_toggle({$cur_row})\" id=\"frd{$cur_row}\" ondblclick=\"document.location=\'{$this->edit_uri}?id={$cur_row}\'\">\n";
 			echo "    <font color=\"#FFFFFF\">{$row[$this->cname[$this->columns - 1]]}</font>\n";
 			echo "  </td>\n";
-			echo "  <td class=\"list\" nowrap>\n";
+			echo "  <td class=\"list\" style=\"white-space:nowrap;\">\n";
 			$this->display_buttons($cur_row);
 			echo "  </td>\n";
 			echo "</tr>\n";
@@ -142,17 +142,17 @@ class MainTable {
 		echo "<tr>\n";
 		echo "  <td class=\"list\" colspan=\"{$this->columns}\"></td>\n";
 		echo "  <td class=\"list\">\n";
-		echo "    <table border=\"0\" cellspacing=\"0\" cellpadding=\"1\">\n";
+		echo "    <table border=\"0\" cellspacing=\"0\" cellpadding=\"1\" summary=\"footer\">\n";
 		echo "      <tr>\n";
 		echo "        <td width=\"17\"></td>\n";
-		echo "        <td valign=\"middle\"><a href=\"{$this->edit_uri}\"><img src=\"/themes/{$g['theme']}/images/icons/icon_plus.gif\" width=\"17\" height=\"17\" border=\"0\"></a></td>\n";
+		echo "        <td valign=\"middle\"><a href=\"{$this->edit_uri}\"><img src=\"/themes/{$g['theme']}/images/icons/icon_plus.gif\" width=\"17\" height=\"17\" border=\"0\" alt=\"plus\" /></a></td>\n";
 		echo "      </tr>\n";
 		echo "    </table>\n";
 		echo "  </td>\n";
 		echo "</tr>\n";
 	}
 	private function display_buttons($row) {
-		echo "    <table border=\"0\" cellspacing=\"0\" cellpadding=\"1\">\n";
+		echo "    <table border=\"0\" cellspacing=\"0\" cellpadding=\"1\" summary=\"buttons\">\n";
 		echo "      <tr>\n";
 		if ($this->buttons['move'])
 			echo $this->display_button('move', $row);
@@ -171,19 +171,19 @@ class MainTable {
 		echo "<td valign=\"middle\">";
 		switch ($button) {
 			case "move": {
-				echo "<input name=\"move_{$row}\" type=\"image\" src=\"./themes/{$g['theme']}/images/icons/icon_left.gif\" width=\"17\" height=\"17\" title=\"Move selected entries before this entry\" onMouseOver=\"fr_insline({$row}, true)\" onMouseOut=\"fr_insline({$row}, false)\">";
+				echo "<input name=\"move_{$row}\" type=\"image\" src=\"./themes/{$g['theme']}/images/icons/icon_left.gif\" width=\"17\" height=\"17\" title=\"Move selected entries before this entry\" onMouseOver=\"fr_insline({$row}, true)\" onMouseOut=\"fr_insline({$row}, false)\" />";
 				break;
 			}
 			case "edit": {
-				echo "<a href=\"{$this->edit_uri}?id={$row}\"><img src=\"/themes/{$g['theme']}/images/icons/icon_e.gif\" width=\"17\" height=\"17\" border=\"0\" title=\"Edit entry\"></a>";
+				echo "<a href=\"{$this->edit_uri}?id={$row}\"><img src=\"/themes/{$g['theme']}/images/icons/icon_e.gif\" width=\"17\" height=\"17\" border=\"0\" title=\"Edit entry\" alt=\"Edit entry\" /></a>";
 				break;
 			}
 			case "del": {
-				echo "<a href=\"{$this->my_uri}?act=del&id={$row}\" onclick=\"return confirm(\'Do you really want to delete this entry?\')\"><img src=\"/themes/{$g['theme']}/images/icons/icon_x.gif\" width=\"17\" height=\"17\" border=\"0\" title=\"Delete entry\"></a>";
+				echo "<a href=\"{$this->my_uri}?act=del&amp;id={$row}\" onclick=\"return confirm(\'Do you really want to delete this entry?\')\"><img src=\"/themes/{$g['theme']}/images/icons/icon_x.gif\" width=\"17\" height=\"17\" border=\"0\" title=\"Delete entry\" alt=\"Delete entry\" /></a>";
 				break;
 			}
 			case "dup": {
-				echo "<a href=\"{$this->edit_uri}?act=dup&id={$row}\"><img src=\"/themes/{$g['theme']}/images/icons/icon_plus.gif\" width=\"17\" height=\"17\" border=\"0\" title=\"Duplicate entry\"></a>";			
+				echo "<a href=\"{$this->edit_uri}?act=dup&amp;id={$row}\"><img src=\"/themes/{$g['theme']}/images/icons/icon_plus.gif\" width=\"17\" height=\"17\" border=\"0\" title=\"Duplicate entry\" alt=\"Duplicate entry\" /></a>";			
 				break;
 			}
 		}

--- a/usr/local/www/fbegin.inc
+++ b/usr/local/www/fbegin.inc
@@ -1,11 +1,23 @@
 
-<script src="/javascript/sorttable.js"></script>
-<script src="/javascript/ticker.js"></script>
-<style id="antiClickjack">body{display:none}</style> <script type="text/JavaScript">
-if (self === top) { var antiClickjack = document.getElementById("antiClickjack"); antiClickjack.parentNode.removeChild(antiClickjack);
-} else { top.location = self.location;
+<script type="text/JavaScript" src="/javascript/sorttable.js"></script>
+<script type="text/JavaScript" src="/javascript/ticker.js"></script>
+
+<style id="antiClickjack">
+/*<![CDATA[*/
+body{display:none}
+/*]]>*/
+</style>
+
+<script type="text/JavaScript">
+//<![CDATA[
+if (self === top) {
+	var antiClickjack = document.getElementById("antiClickjack"); antiClickjack.parentNode.removeChild(antiClickjack);
+} else { 
+	top.location = self.location;
 }
+//]]>
 </script>
+
 <?php
 /*
 	pfSense_MODULE:	header
@@ -96,9 +108,9 @@ function output_menu($arrayitem, $target = null) {
 			if ($item['style']) {
 				$attr .= sprintf(" style=\"%s\"", htmlentities($item['style']));
 			}
-			echo "<li>\n";
-			printf("<a %s>%s</a>\n", $attr, $item[0]);
-			echo "</li>\n";
+			echo "\n\t\t\t\t\t\t\t<li>";
+			printf("<a %s>%s</a>", $attr, $item[0]);
+			echo "</li>";
 		}
 	}
 }
@@ -156,13 +168,13 @@ $services_menu[] = array(gettext("IGMP proxy"), "/services_igmpproxy.php");
 $services_menu[] = array(gettext("Load Balancer"), "/load_balancer_pool.php");
 $services_menu[] = array(gettext("NTP"), "/services_ntpd.php");
 $services_menu[] = array(gettext("PPPoE Server"), "/vpn_pppoe.php");
-$services_menu[] = array(gettext("RIP"), "/pkg_edit.php?xml=routed.xml&id=0");
+$services_menu[] = array(gettext("RIP"), "/pkg_edit.php?xml=routed.xml&amp;id=0");
 $services_menu[] = array(gettext("SNMP"), "/services_snmp.php");
 if(count($config['interfaces']) > 1) {
 	/* no use for UPnP in single-interface deployments
 	remove to reduce user confusion
 	*/
-	$services_menu[] = array(gettext("UPnP &amp; NAT-PMP"), "/pkg_edit.php?xml=miniupnpd.xml&id=0");
+	$services_menu[] = array(gettext("UPnP &amp; NAT-PMP"), "/pkg_edit.php?xml=miniupnpd.xml&amp;id=0");
 }
 $services_menu[] = array(gettext("Wake on LAN"), "/services_wol.php");
 $services_menu = msort(array_merge($services_menu, return_ext_menu("Services")),0);
@@ -264,15 +276,17 @@ if(! $g['disablehelpmenu']) {
 
 <div id="wrapper">
 	<div id="header">
-		<div id="header-left"><a href="/index.php" id="status-link"><img src="/themes/<?= $g['theme']; ?>/images/transparent.gif" border="0"></a></div>
+		<div id="header-left">
+			<a href="/index.php" id="status-link">
+				<img src="/themes/<?= $g['theme']; ?>/images/transparent.gif" border="0" alt="transparent" />
+			</a>
+		</div>
 		<div id="header-right">
 			<div class="container">
 				<div class="left">webConfigurator</div>
 				<div class="right" id="menu_messages">
-<?
-				echo get_menu_messages();
-?>
-	</div>
+					<?php echo get_menu_messages(); ?> 
+				</div>
 			</div>
 		</div>
 	</div> <!-- Header DIV -->
@@ -283,69 +297,54 @@ if(! $g['disablehelpmenu']) {
 					<li class="firstdrop">
 						<div><?php echo gettext("System"); ?></div>
 						<ul class="subdrop">
-						<?php
-							output_menu($system_menu);
-						?>
+						<?php output_menu($system_menu); ?> 
 						</ul>
 					</li>
 					<li class="drop">
 						<div><?php echo gettext("Interfaces"); ?></div>
 						<ul class="subdrop">
-						<?php
-							output_menu($interfaces_menu);
-						?>
+						<?php output_menu($interfaces_menu); ?> 
 						</ul>
 					</li>
 					<li class="drop">
 						<div><?php echo gettext("Firewall"); ?></div>
 						<ul class="subdrop">
-						<?php
-							output_menu($firewall_menu);
-						?>
+						<?php output_menu($firewall_menu); ?> 
 						</ul>
 					</li>
 					<li class="drop">
 						<div><?php echo gettext("Services"); ?></div>
 						<ul class="subdrop">
-						<?
-							output_menu($services_menu);
-						?>
+						<?php output_menu($services_menu); ?> 
 						</ul>
 					</li>
 					<li class="drop">
 						<div><?php echo gettext("VPN"); ?></div>
 						<ul class="subdrop">
-						<?php
-							output_menu($vpn_menu);
-						?>
+						<?php output_menu($vpn_menu); ?> 
 						</ul>
 					</li>
 					<li class="drop">
 						<div><?php echo gettext("Status"); ?></div>
 						<ul class="subdrop">
-						<?php
-							output_menu($status_menu);
-						?>
+						<?php output_menu($status_menu);?> 
 						</ul>
 					</li>
 					<li class="drop">
 						<div><?php echo gettext("Diagnostics"); ?></div>
 						<ul id="diag" class="subdrop">
-						<?
-							output_menu($diagnostics_menu);
-						?>
+						<?php output_menu($diagnostics_menu); ?> 
 						</ul>
 					</li>
-					<?php if(! $g['disablehelpmenu']): ?>
+					<?php if(! $g['disablehelpmenu']): ?> 
 					<li class="lastdrop">
 						<div><?php echo gettext("Help"); ?></div>
 						<ul id="help" class="subdrop">
-						<?
-							output_menu($help_menu, "_new");
-						?>
+						<?php output_menu($help_menu, "_blank"); ?> 
 						</ul>
 					</li>
-					<?php endif; ?>
+					<?php endif; ?> 
+
 				</ul>
 			</div>
 
@@ -365,14 +364,14 @@ echo "\t<script type=\"text/javascript\" src=\"javascript/domTT/fadomatic.js\"><
 		$notices = get_notices();
 		if(!$notices) {
 			$need_alert_display = true;
-			$display_text = print_notices($notices) . "<br>";
+			$display_text = print_notices($notices) . "<br />";
 		}
 	}
 	if($need_alert_display == true) {
-                echo "<div style=\"background-color:#000000\" id=\"roundalert\">";
-                echo "<table>";
+		echo "<div style=\"background-color:#000000\" id=\"roundalert\">";
+		echo "<table summary=\"alert\">";
 		echo "<tr><td><font color=\"#ffffff\">";
-		echo "&nbsp;&nbsp;<img align=\"middle\" src=\"/top_notification.gif\">&nbsp;&nbsp;&nbsp;";
+		echo "&nbsp;&nbsp;<img align=\"middle\" src=\"/top_notification.gif\" alt=\"notification\" />&nbsp;&nbsp;&nbsp;";
 		echo $display_text;
 		echo "</td>";
 		echo "</tr>";
@@ -417,7 +416,9 @@ echo get_shortcut_log_link($shortcut_section, true);
 ?>
 <?php if(! $g['disablehelpicon']): ?>
 
-<a href="<?php echo $helpurl; ?>" title="<?php echo gettext("Help for items on this page"); ?>"><img style="vertical-align:middle" src="/themes/<?php echo $g['theme']; ?>/images/icons/icon_help.gif" border="0"></a>
+<a href="<?php echo $helpurl; ?>" title="<?php echo gettext("Help for items on this page"); ?>">
+	<img style="vertical-align:middle" src="/themes/<?php echo $g['theme']; ?>/images/icons/icon_help.gif" border="0" alt="help" />
+</a>
 <?php endif; ?>
 </span>
 </div>
@@ -427,7 +428,7 @@ echo get_shortcut_log_link($shortcut_section, true);
 /* if upgrade in progress, alert user */
 if(is_subsystem_dirty('packagelock')) {
 	$pgtitle = array(gettext("System"),gettext("Package Manager"));
-	print_info_box(gettext("Packages are currently being reinstalled in the background.<p>Do not make changes in the GUI until this is complete.") . "<p><img src='/themes/{$g['theme']}/images/icons/icon_fw-update.gif'>");
+	print_info_box(gettext("Packages are currently being reinstalled in the background.<p>Do not make changes in the GUI until this is complete.") . "<p><img src=\"/themes/{$g['theme']}/images/icons/icon_fw-update.gif\" alt=\"update\" />");
 }
 	$pgtitle_output = true;
 ?>

--- a/usr/local/www/fend.inc
+++ b/usr/local/www/fend.inc
@@ -18,8 +18,10 @@
 /* Disable form autocomplete on all but the login screen. */
 if (basename($_SERVER["SCRIPT_FILENAME"] != "index.php") && !$allowautocomplete): ?>
 <script type="text/javascript">
+//<![CDATA[
 (function ($) {
 	$("input").attr("autocomplete","off");
 })(jQuery);
+//]]>
 </script>
 <?php endif; ?>

--- a/usr/local/www/guiconfig.inc
+++ b/usr/local/www/guiconfig.inc
@@ -248,29 +248,29 @@ function print_input_errors($input_errors) {
 	global $g;
 
 	print <<<EOF
-	<div id='inputerrorsdiv' name='inputerrorsdiv'>
-	<p>
-	<table border="0" cellspacing="0" cellpadding="4" width="100%">
-	<tr>
-		<td class="inputerrorsleft">
-			<img src="/themes/{$g['theme']}/images/icons/icon_error.gif">
-		</td>
-		<td class="inputerrorsright">
-			<span class="errmsg"><p>
-				The following input errors were detected:
-				<ul>
+	<div id="inputerrorsdiv">
+	<table border="0" cellspacing="0" cellpadding="4" width="100%" summary="input error">
+		<tr>
+			<td class="inputerrorsleft">
+				<img src="/themes/{$g['theme']}/images/icons/icon_error.gif" alt="error" />
+			</td>
+			<td class="inputerrorsright">
+				<span class="errmsg"><p>
+					The following input errors were detected:
+					<ul>
 EOF;
 		foreach ($input_errors as $ierr) {
 			echo "<li>" . htmlspecialchars($ierr) . "</li>";
 		}
 
 	print <<<EOF2
-				</ul>
-			</span>
-		</td></tr>
+					</ul>
+				</span>
+			</td>
+		</tr>
 	</table>
 	</div>
-	</p>&nbsp;<br>
+	&nbsp;<br />
 EOF2;
 	
 }
@@ -296,10 +296,10 @@ function print_info_box_np($msg, $name="apply",$value="", $showapply=false) {
 		$nifty_background = "#FFF";
 
 	if(stristr($msg, gettext("apply")) != false || stristr($msg, gettext("save")) != false || stristr($msg, gettext("create")) != false || $showapply) {
-		$savebutton = "<td class='infoboxsave'>";
-		$savebutton .= "<input name=\"{$name}\" type=\"submit\" class=\"formbtn\" id=\"${name}\" value=\"{$value}\">";
+		$savebutton = "<td class=\"infoboxsave\">";
+		$savebutton .= "<input name=\"{$name}\" type=\"submit\" class=\"formbtn\" id=\"${name}\" value=\"{$value}\" />";
 		if($_POST['if'])
-			$savebutton .= "<input type='hidden' name='if' value='" . htmlspecialchars($_POST['if']) . "'>";
+			$savebutton .= "<input type=\"hidden\" name=\"if\" value=\"" . htmlspecialchars($_POST['if']) . "\" />";
 		$savebutton.="</td>";
 	}
 	$nifty_redbox = "#990000";
@@ -318,20 +318,20 @@ function print_info_box_np($msg, $name="apply",$value="", $showapply=false) {
 	}	
 		
 	if(!$savebutton) {
-		$savebutton = '<td class="infoboxsave"><input value="Close" type="button" onClick="jQuery(\'#redboxtable\').hide();"></td>';
+		$savebutton = "<td class=\"infoboxsave\"><input value=\"Close\" type=\"button\" onclick=\jQuery(\'#redboxtable\').hide();\" /></td>";
 	}
 
 	echo <<<EOFnp
-	<table class='infobox' id='redboxtable'>
+	<table class="infobox" id="redboxtable" summary="red box table">
 		<tr>
 			<td>
-				<div class='infoboxnp' id='redbox'>
-					<table class='infoboxnptable2'>
+				<div class="infoboxnp" id="redbox">
+					<table class="infoboxnptable2" summary="info box">
 						<tr>
-							<td class='infoboxnptd'>
-								&nbsp;&nbsp;&nbsp;<img class='infoboxnpimg' src="/themes/{$g['theme']}/images/icons/icon_exclam.gif" >
+							<td class="infoboxnptd">
+								&nbsp;&nbsp;&nbsp;<img class="infoboxnpimg" src="/themes/{$g['theme']}/images/icons/icon_exclam.gif" alt="exclamation" />
 							</td>
-							<td class='infoboxnptd2'>
+							<td class="infoboxnptd2">
 								<b>{$msg}</b>
 							</td>
 							{$savebutton}
@@ -345,9 +345,11 @@ function print_info_box_np($msg, $name="apply",$value="", $showapply=false) {
 		</tr>
 	</table>
 	<script type="text/javascript">
+	//<![CDATA[
 		NiftyCheck();
 		Rounded("div#redbox","all","{$nifty_background}","{$nifty_redbox}","smooth");
 		Rounded("td#blackbox","all","{$nifty_background}","{$nifty_blackbox}","smooth");
+	//]]>
 	</script>
 EOFnp;
 
@@ -357,12 +359,12 @@ function print_info_box_np_undo($msg, $name="apply",$value="Apply changes", $und
 	global $g;
 	
 	if(stristr($msg, "apply") != false || stristr($msg, "save") != false || stristr($msg, "create") != false) {
-		$savebutton = "<td class='infoboxsave'><nobr>";
-		$savebutton .= " <input type=\"button\" value=\"Undo\" onClick=\"document.location='{$undo}'\">";
-		$savebutton .= " <input name=\"{$name}\" type=\"submit\" class=\"formbtn\" id=\"${name}\" value=\"{$value}\">";
-		$savebutton.="</nobr></td>";
+		$savebutton = "<td class=\"infoboxsave\" style=\"white-space:nowrap;\">";
+		$savebutton .= "<input type=\"button\" value=\"Undo\" onClick=\"document.location='{$undo}'\" />";
+		$savebutton .= "<input name=\"{$name}\" type=\"submit\" class=\"formbtn\" id=\"${name}\" value=\"{$value}\" />";
+		$savebutton .= "</td>";
 		if($_POST['if']) 
-			$savebutton .= "<input type='hidden' name='if' value='" . htmlspecialchars($_POST['if']) . "'>";
+			$savebutton .= "<input type=\"hidden\" name=\"if\" value=\"" . htmlspecialchars($_POST['if']) . "\" />";
 	}
 	$nifty_redbox = "#990000";
 	$nifty_blackbox = "#000000";
@@ -381,20 +383,20 @@ function print_info_box_np_undo($msg, $name="apply",$value="Apply changes", $und
 	
 		
 	if(!$savebutton) {
-		$savebutton = '<td class="infoboxsave"><input value="Close" type="button" onClick="jQuery(\'#redboxtable\').hide();"></td>';
+		$savebutton = "<td class=\"infoboxsave\"><input value=\"Close\" type=\"button\" onclick=\"jQuery(\'#redboxtable\').hide();\" /></td>";
 	}
 
 	echo <<<EOFnp
-	<table class='infobox' id='redboxtable'>
+	<table class="infobox" id="redboxtable" summary="red box table">
 		<tr>
 			<td>
-				<div class='infoboxnp' id='redbox'>
-					<table class='infoboxnptable2'>
+				<div class="infoboxnp" id="redbox">
+					<table class="infoboxnptable2" summary="info box">
 						<tr>
-							<td class='infoboxnptd'>
-								&nbsp;&nbsp;&nbsp;<img class='infoboxnpimg' src="/themes/{$g['theme']}/images/icons/icon_exclam.gif" >
+							<td class="infoboxnptd">
+								&nbsp;&nbsp;&nbsp;<img class="infoboxnpimg" src="/themes/{$g['theme']}/images/icons/icon_exclam.gif" alt="exclamation" />
 							</td>
-							<td class='infoboxnptd2'>
+							<td class="infoboxnptd2">
 								<b>{$msg}</b>
 							</td>
 							{$savebutton} 
@@ -409,9 +411,11 @@ function print_info_box_np_undo($msg, $name="apply",$value="Apply changes", $und
 		</tr>
 	</table>
 	<script type="text/javascript">
+	//<![CDATA[
 		NiftyCheck();
 		Rounded("div#redbox","all","#FFF","{$nifty_redbox}","smooth");
 		Rounded("td#blackbox","all","#FFF","{$nifty_blackbox}","smooth");
+	//]]>
 	</script>
 EOFnp;
 
@@ -430,7 +434,7 @@ function get_std_save_message($ok) {
 		if(stristr($_SERVER['SCRIPT_FILENAME'], $fp))
 			$filter_related = true;	
 	if($filter_related)
-		$to_return .= "<br/>You can also <a href='status_filter_reload.php'>monitor</a> the filter reload progress.";
+		$to_return .= "<br/>You can also <a href=\"status_filter_reload.php\">monitor</a> the filter reload progress.";
 	return $to_return;
 }
 
@@ -578,19 +582,19 @@ function dump_clog($logfile, $tail, $withorig = true, $grepfor = "", $grepinvert
 			$logent = preg_split("/\s+/", $logent, 6);
 			echo "<tr valign=\"top\">\n";
 			if ($withorig) {
-					if(isset($config['system']['usefifolog'])) {
-						$entry_date_time = htmlspecialchars(date("F j, Y, g:i a","" . $logent[1] . ""));
-						$entry_text = htmlspecialchars($logent[5]);
-					} else {
-						$entry_date_time = htmlspecialchars(join(" ", array_slice($logent, 0, 3)));
-						$entry_text = ($logent[3] ==  $config['system']['hostname']) ? "" : $logent[3] . " ";
-						$entry_text .= htmlspecialchars($logent[4] . " " . $logent[5]);
-					}
-					echo "<td class=\"listlr\" nowrap>{$entry_date_time}</td>\n";
-					echo "<td class=\"listr\">{$entry_text}</td>\n";
+				if(isset($config['system']['usefifolog'])) {
+					$entry_date_time = htmlspecialchars(date("F j, Y, g:i a","" . $logent[1] . ""));
+					$entry_text = htmlspecialchars($logent[5]);
+				} else {
+					$entry_date_time = htmlspecialchars(join(" ", array_slice($logent, 0, 3)));
+					$entry_text = ($logent[3] ==  $config['system']['hostname']) ? "" : $logent[3] . " ";
+					$entry_text .= htmlspecialchars($logent[4] . " " . $logent[5]);
+				}
+				echo "<td class=\"listlr\" style=\"white-space:nowrap;\">{$entry_date_time}</td>\n";
+				echo "<td class=\"listr\">{$entry_text}</td>\n";
 
 			} else {
-					echo "<td class=\"listlr\" colspan=\"2\">" . htmlspecialchars($logent[5]) . "</td>\n";
+				echo "<td class=\"listlr\" colspan=\"2\">" . htmlspecialchars($logent[5]) . "</td>\n";
 			}
 			echo "</tr>\n";
 	}
@@ -734,23 +738,25 @@ function display_widget_tabs(& $tab_array) {
 			$tabActive = "none";
 			$tabNonActive = "table-cell";
 		}
-		echo "<div id='{$ta[2]}-active' class='{$tabclass}-tabactive' style='display:{$tabActive}; background-color:#EEEEEE; color:black;'>";
-		echo "<B>&nbsp;&nbsp;&nbsp;{$ta[0]}";
-		echo "&nbsp;&nbsp;&nbsp;</B>";
+		echo "<div id=\"{$ta[2]}-active\" class=\"{$tabclass}-tabactive\" style=\"display:{$tabActive}; background-color:#EEEEEE; color:black;\">";
+		echo "<b>&nbsp;&nbsp;&nbsp;{$ta[0]}";
+		echo "&nbsp;&nbsp;&nbsp;</b>";
 		echo "</div>";
 		
-		echo "<div id='{$ta[2]}-deactive' class='{$tabclass}-tabdeactive' style='display:{$tabNonActive}; background-color:#777777; color:white; cursor: pointer;' onClick=\"return changeTabDIV('{$ta[2]}')\">";
-		echo "<B>&nbsp;&nbsp;&nbsp;{$ta[0]}";
-		echo "&nbsp;&nbsp;&nbsp;</B>";
+		echo "<div id=\"{$ta[2]}-deactive\" class=\"{$tabclass}-tabdeactive\" style=\"display:{$tabNonActive}; background-color:#777777; color:white; cursor: pointer;\" onclick=\"return changeTabDIV('{$ta[2]}')\">";
+		echo "<b>&nbsp;&nbsp;&nbsp;{$ta[0]}";
+		echo "&nbsp;&nbsp;&nbsp;</b>";
 		echo "</div>";
 	}
 	
-	echo "<script type=\"text/javascript\">";
+	echo "\n<script type=\"text/javascript\">\n";
+	echo "//<![CDATA[\n";
 	echo "NiftyCheck();\n";
 	echo "Rounded(\"div.{$tabclass}-tabactive\",\"top\",\"#CCCCCC\",\"#EEEEEE\",\"smooth\");\n";
 	echo "Rounded(\"div.{$tabclass}-tabdeactive\",\"top\",\"#CCCCCC\",\"#777777\",\"smooth\");\n";
-	echo "</script>";
-	echo "</div>";
+	echo "//]]>\n";
+	echo "</script>\n";
+	echo "</div>\n";
 }
 
 
@@ -759,8 +765,10 @@ function display_widget_tabs(& $tab_array) {
 function outputJavaScriptFileInline($javascript) {
 	if(file_exists($javascript)) {
 		echo "\n<script type=\"text/javascript\">\n";
+		echo "//<![CDATA[\n";
 		include($javascript);
-		echo "\n</script>\n";
+		echo "\n//]]>\n";
+		echo "</script>\n";
 	} else {
 		echo "\n\n<!-- Could not location file:  {$javascript} -->\n\n";
 	}
@@ -771,8 +779,10 @@ function outputJavaScriptFileInline($javascript) {
 function outputCSSPrintFileInline($css) {
 	if(file_exists($css)) {
 		echo "\n<style media=\"print\" type=\"text/css\">\n";
+		echo "/*<![CDATA[*/\n";
 		include($css);
-		echo "\n</style>\n";
+		echo "\n/*]]>*/\n";
+		echo "</style>\n";
 	} else {
 		echo "\n\n<!-- Could not location file:  {$css} -->\n\n";
 	}
@@ -782,8 +792,10 @@ function outputCSSPrintFileInline($css) {
 function outputCSSFileInline($css) {
 	if(file_exists($css)) {
 		echo "\n<style type=\"text/css\">\n";
+		echo "/*<![CDATA[*/\n";
 		include($css);
-		echo "\n</style>\n";
+		echo "\n/*]]>*/\n";
+		echo "</style>\n";
 	} else {
 		echo "\n\n<!-- Could not location file:  {$css} -->\n\n";
 	}
@@ -851,7 +863,7 @@ function print_rfc2616_select($tag, $current){
 	echo "<select id=\"{$tag}\" name=\"{$tag}\">\n";	
 	foreach($rfc2616 as $code => $message) {
 		if ($code == $current) {
-			$sel = " selected";
+			$sel = " selected=\"selected\"";
 		} else {
 			$sel = "";
 		}
@@ -952,10 +964,10 @@ function display_top_tabs(& $tab_array, $no_drop_down = false) {
         // then show a select item dropdown menubox.
          if($tabcharcount > $tab_array_char_limit) {
                 echo "Currently viewing: ";
-                echo "<select name='TabSelect' onchange='tabs_will_go(this)'>\n";
+                echo "<select name=\"TabSelect\" onchange=\"tabs_will_go(this)\">\n";
                 foreach ($tab_array as $ta) {
                         if($ta[1]=="true")
-                                $selected = " SELECTED";
+                                $selected = " selected=\"selected\"";
                         else
                                 $selected = "";
                         // Onclick in option will not work in some browser
@@ -964,18 +976,20 @@ function display_top_tabs(& $tab_array, $no_drop_down = false) {
                 }
                 echo "</select>\n<p/>";
                 echo "<script type=\"text/javascript\">";
+                echo "//<![CDATA[\n";
                 echo " function tabs_will_go(obj){ document.location = obj.value; }";
-                echo "</script>";
+                echo "//]]>\n";
+                echo "</script>\n";
         }  else {
-                echo "<div class=\"newtabmenu\" style=\"margin:{$tab_array_space}px {$tab_array_indent}px; width:775px;\">\n";
+                echo "\n<div class=\"newtabmenu\" style=\"margin:{$tab_array_space}px {$tab_array_indent}px; width:775px;\">\n";
                 echo "<!-- Tabbed bar code-->\n";
-				echo "<ul class=\"newtabmenu\">\n";
+		echo "<ul class=\"newtabmenu\">\n";
                 $tabscounter = 0;
                 foreach ($tab_array as $ta) {
                         if ($ta[1] == true) {
-								echo "  <li class=\"newtabmenu_active\"><a href=\"{$ta[2]}\"><span>{$ta[0]}</span></a></li>\n";
+				echo "  <li class=\"newtabmenu_active\"><a href=\"{$ta[2]}\"><span>{$ta[0]}</span></a></li>\n";
                         } else {
-								echo "  <li><a href=\"{$ta[2]}\"><span>{$ta[0]}</span></a></li>\n";
+				echo "  <li><a href=\"{$ta[2]}\"><span>{$ta[0]}</span></a></li>\n";
                         }
                         $tabscounter++;
                 }
@@ -1010,37 +1024,37 @@ function alias_info_popup($alias_id){
 	$close_title="title='".gettext('move mouse out this alias to hide')."'";
 	if (is_array($config['aliases']['alias'][$alias_id])){
 		$alias_name=$config['aliases']['alias'][$alias_id];
-		$alias_objects_with_details = "<table width='100%' border='0' cellpadding='2' cellspacing='0'>";
+		$alias_objects_with_details = "<table width=\"100%\" border=\"0\" cellpadding=\"2\" cellspacing=\"0\" summary=\"info popup\">";
 		if ($alias_name['url']) {
 			exec("/sbin/pfctl -t {$alias_name['name']} -T show | wc -l", $total_entries);
 			$counter=preg_replace("/\D/","",$total_entries[0]);
 			exec("/sbin/pfctl -t {$alias_name['name']} -T show | head -10002", $alias_addresses);
-			$alias_objects_with_details .= "<tr><td colspan='3' $close_title class='vncell'>{$alias_name['url']}</td></tr>";
+			$alias_objects_with_details .= "<tr><td colspan=\"3\" $close_title class=\"vncell\">{$alias_name['url']}</td></tr>";
 			$x=0;
 			foreach ($alias_addresses as $alias_ports_address ) {
 				switch ($x) {
 				case 0:
 					$x++;
-					$alias_objects_with_details .= "<tr><td $close_title class='vncell' width='33%' style='background: #FFFFFF;color: #000000;'>{$alias_ports_address}</td>";
+					$alias_objects_with_details .= "<tr><td $close_title class=\"vncell\" width=\"33%\" style=\"background: #FFFFFF;color: #000000;\">{$alias_ports_address}</td>";
 					break;
 				case 1:
 					$x++;
-					$alias_objects_with_details .= "<td $close_title class='vncell' width='33%' style='background: #FFFFFF;color: #000000;'>{$alias_ports_address}</td>";
+					$alias_objects_with_details .= "<td $close_title class=\"vncell\" width=\"33%\" style=\"background: #FFFFFF;color: #000000;\">{$alias_ports_address}</td>";
 					break;
 				default:
 					$x=0;
-					$alias_objects_with_details .= "<td  $close_title class='vncell' width='33%' style='background: #FFFFFF;color: #000000;'>{$alias_ports_address}</td><tr>";
+					$alias_objects_with_details .= "<td  $close_title class=\"vncell\" width=\"33%\" style=\"background: #FFFFFF;color: #000000;\">{$alias_ports_address}</td><tr>";
 					break;
 				}
 			}
 			for ($y = $x; $y <= $x; $y++) {
-				$alias_objects_with_details .= "<td $close_title class='vncell' width='33%'>&nbsp;</td>";
+				$alias_objects_with_details .= "<td $close_title class=\"vncell\" width=\"33%\">&nbsp;</td>";
 			}
 			if ($x > 0) {
 				$alias_objects_with_details .= "</tr>";
 			}
 			if ($counter > 10002) {
-				$alias_objects_with_details .= "<tr><td colspan='3'> listing only first 10k items</td><tr>";
+				$alias_objects_with_details .= "<tr><td colspan=\"3\">listing only first 10k items</td><tr>";
 			}
 		}
 		else{
@@ -1048,12 +1062,12 @@ function alias_info_popup($alias_id){
 			$alias_details = explode ("||", $alias_name['detail']);
 			$counter = 0;
 			foreach ($alias_addresses as $alias_ports_address) {
-				$alias_objects_with_details .= "<tr><td $close_title width='5%' class='vncell' style='background: #FFFFFF;color: #000000;'>{$alias_addresses[$counter]}</td>";
+				$alias_objects_with_details .= "<tr><td $close_title width=\"5%\" class=\"vncell\" style=\"background: #FFFFFF;color: #000000;\">{$alias_addresses[$counter]}</td>";
 				$alias_detail_default = strpos ($alias_details[$counter],"Entry added");
 				if ($alias_details[$counter] != "" && $alias_detail_default === False)
-					$alias_objects_with_details .="<td $close_title width='95%' class='vncell' style='background: #FFFFFF;color: #000000;'>{$alias_details[$counter]}</td>";
+					$alias_objects_with_details .="<td $close_title width=\"95%\" class=\"vncell\" style=\"background: #FFFFFF;color: #000000;\">{$alias_details[$counter]}</td>";
 				else
-					$alias_objects_with_details .="<td $close_title width='95%' class='vncell' style='background: #FFFFFF;color: #000000;'>&nbsp;</td>";
+					$alias_objects_with_details .="<td $close_title width=\"95%\" class=\"vncell\" style=\"background: #FFFFFF;color: #000000;\">&nbsp;</td>";
 				$alias_objects_with_details .= "</tr>";
 				$counter++;
 			}
@@ -1064,7 +1078,7 @@ function alias_info_popup($alias_id){
 	if ($strlength >= $maxlength)
 		$alias_descr_substr = substr($alias_descr_substr, 0, $maxlength) . "...";
 	$item_text = ($counter > 1 ? "items" : "item");
-	$alias_caption = "{$alias_descr_substr} - {$counter} {$item_text}<a href='/firewall_aliases_edit.php?id={$alias_id}' title='".gettext('edit this alias')."'>&nbsp;&nbsp;edit </a>";
+	$alias_caption = "{$alias_descr_substr} - {$counter} {$item_text}<a href=\"/firewall_aliases_edit.php?id={$alias_id}\" title=\"".gettext('edit this alias')."\">&nbsp;&nbsp;edit </a>";
 	$strlength = strlen ($alias_caption);
 	print "<h1>{$alias_caption}</h1>" . $alias_objects_with_details;
 }
@@ -1075,7 +1089,7 @@ function rule_popup($src,$srcport,$dst,$dstport){
 	if ($config['aliases']['alias'] <> "" and is_array($config['aliases']['alias'])) {
 		$descriptions = array ();
 		foreach ($config['aliases']['alias'] as $alias_id=>$alias_name){
-			$loading_image="<a><img src=\'/themes/{$g['theme']}/images/misc/loader.gif\'> " .gettext("loading...")."</a>";
+			$loading_image="<a><img src=\"/themes/{$g['theme']}/images/misc/loader.gif\" alt=\"loader\" /> " .gettext("loading...")."</a>";
 			switch ($alias_name['type']){
 			case "port":
 				$width="250";

--- a/usr/local/www/head.inc
+++ b/usr/local/www/head.inc
@@ -8,62 +8,67 @@ $g['theme'] = get_current_theme();
 $pagetitle = gentitle( $pgtitle );
 
 ?>
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html>
 <head>
 	<title><?php echo($config['system']['hostname'] . "." . $config['system']['domain'] . " - " . $pagetitle); ?></title>
 	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-	<link rel="apple-touch-icon" href="/themes/<?php echo $g['theme']; ?>/apple-touch-icon.png"/>
-		<?php 
+	<link rel="apple-touch-icon" href="/themes/<?php echo $g['theme']; ?>/apple-touch-icon.png" />
+	<?php 
 		if (file_exists("{$g['www_path']}/themes/{$g['theme']}/table.css")):
-			echo "<link rel=\"stylesheet\" href=\"/themes/{$g['theme']}/table.css\" />";
-        else:
-        	echo "<link rel=\"stylesheet\" href=\"/css/table.css\" media=\"all\" />";
-        endif;
-		?>
+			echo "<link rel=\"stylesheet\" type=\"text/css\" href=\"/themes/{$g['theme']}/table.css\" />";
+		else:
+			echo "<link rel=\"stylesheet\" type=\"text/css\" href=\"/css/table.css\" media=\"all\" />";
+		endif;
+	?>
 		
-		<?php if (strpos($_SERVER["SCRIPT_FILENAME"], "wizard.php") !== false &&
-                  file_exists("{$g['www_path']}/themes/{$g['theme']}/wizard.css")): ?>
-					<?php echo "<style type=\"text/css\" src=\"/themes/{$g['theme']}/wizard.css\"></style>"; ?>
-        <?php else: ?>
-        	<link rel="stylesheet" href="/themes/<?php echo $g['theme']; ?>/all.css" media="all" />
-        <?php endif; ?>
-		<link rel="stylesheet" type="text/css" href="/niftycssCode.css">
-		<link rel="stylesheet" type="text/css" href="/niftycssprintCode.css" media="print">
-		<link rel="stylesheet" type="text/css" href="/themes/<?=$g['theme']?>/new_tab_menu.css" media="all">
-		<script type="text/javascript" src="/javascript/niftyjsCode.js"></script>
-		<script type="text/javascript" src="/javascript/jquery.js"></script>
-		<script type="text/javascript" src="/javascript/jquery/jquery-ui.custom.min.js"></script>
-		<script type="text/javascript">
-			var theme = "<?php echo $g['theme']; ?>";
+	<?php if (strpos($_SERVER["SCRIPT_FILENAME"], "wizard.php") !== false &&
+		file_exists("{$g['www_path']}/themes/{$g['theme']}/wizard.css")): ?>
+	<?php echo "<style type=\"text/css\" src=\"/themes/{$g['theme']}/wizard.css\"></style>"; ?>
+	<?php else: ?>
+	
+	<link rel="stylesheet" type="text/css" href="/themes/<?php echo $g['theme']; ?>/all.css" media="all" />
+	<?php endif; ?>
+	
+	<link rel="stylesheet" type="text/css" href="/niftycssCode.css" />
+	<link rel="stylesheet" type="text/css" href="/niftycssprintCode.css" media="print" />
+	<link rel="stylesheet" type="text/css" href="/themes/<?=$g['theme']?>/new_tab_menu.css" media="all" />
 
-			jQuery.noConflict();
-		</script>
-		<?php echo "\t<script type=\"text/javascript\" src=\"/themes/{$g['theme']}/loader.js\"></script>\n"; ?>
-<?php
-		if($_GET['enablefirebuglite']) {
-			echo "\t<script type=\"text/javascript\" src=\"/javascript/pi.js\"></script>\n";
-			echo "\t<script type=\"text/javascript\" src=\"/javascript/firebug-lite.js\"></script>\n";
-		}
-		echo "\t<script type=\"text/javascript\" src=\"/javascript/scriptaculous/prototype.js\"></script>\n";
-		echo "\t<script type=\"text/javascript\" src=\"/javascript/scriptaculous/scriptaculous.js\"></script>\n";
-		echo "\t<script type=\"text/javascript\" src=\"/javascript/scriptaculous/effects.js\"></script>\n";
-		echo "\t<script type=\"text/javascript\" src=\"/javascript/scriptaculous/dragdrop.js\"></script>\n";
-		if(file_exists("{$g['www_path']}/javascript/global.js"))
-			echo "\t<script type=\"text/javascript\" src=\"/javascript/global.js\"></script>\n";
+	<script type="text/javascript" src="/javascript/niftyjsCode.js"></script>
+	<script type="text/javascript" src="/javascript/jquery.js"></script>
+	<script type="text/javascript" src="/javascript/jquery/jquery-ui.custom.min.js"></script>
+	<script type="text/javascript">
+	//<![CDATA[
+		var theme = "<?php echo $g['theme']; ?>";
+
+		jQuery.noConflict();
+	//]]>
+	</script>
+	<?php echo "\n\t<script type=\"text/javascript\" src=\"/themes/{$g['theme']}/loader.js\"></script>\n"; ?>
+	<?php
+	if($_GET['enablefirebuglite']) {
+		echo "\t<script type=\"text/javascript\" src=\"/javascript/pi.js\"></script>\n";
+		echo "\t<script type=\"text/javascript\" src=\"/javascript/firebug-lite.js\"></script>\n";
+	}
+	echo "\n\t<script type=\"text/javascript\" src=\"/javascript/scriptaculous/prototype.js\"></script>\n";
+	echo "\t<script type=\"text/javascript\" src=\"/javascript/scriptaculous/scriptaculous.js\"></script>\n";
+	echo "\t<script type=\"text/javascript\" src=\"/javascript/scriptaculous/effects.js\"></script>\n";
+	echo "\t<script type=\"text/javascript\" src=\"/javascript/scriptaculous/dragdrop.js\"></script>\n";
+	if(file_exists("{$g['www_path']}/javascript/global.js"))
+		echo "\t<script type=\"text/javascript\" src=\"/javascript/global.js\"></script>\n";
 	/*
 	 *	Find all javascript files that need to be included
 	 *	for this page ... from the arrays ... :)
 	 *	Coded by: Erik Kristensen
 	 */
-
 	$dir  = trim(basename($_SERVER["SCRIPT_FILENAME"], '.php'));
 	$path = "{$g['www_path']}/javascript/" . $dir . "/";
 	if (is_dir($path)) {
 		if ($dh = opendir($path)) {
 			while (($file = readdir($dh)) !== false) {
-		   		if (is_dir($file)) 
+				if (is_dir($file)) 
 					continue;
 				echo "\t<script type=\"text/javascript\" src=\"/javascript/{$dir}/{$file}\"></script>\n";
 			}
@@ -71,19 +76,18 @@ $pagetitle = gentitle( $pgtitle );
 		}
 	}
 
-if (!isset($closehead))
-	echo "</head>";
+	if (!isset($closehead))
+		echo "</head>";
 
-/*  If this page is being remotely managed then do not allow the loading of the contents. */
-if($config['remote_managed_pages']['item']) {
-	foreach($config['remote_managed_pages']['item'] as $rmp) {
-		if($rmp == $_SERVER['SCRIPT_NAME']) {
-			include("fbegin.inc");
-			print_info_box_np("This page is currently being managed by a remote machine.");
-			include("fend.inc");
-			exit;
-		}
-	}	
-}
-
+	/*  If this page is being remotely managed then do not allow the loading of the contents. */
+	if($config['remote_managed_pages']['item']) {
+		foreach($config['remote_managed_pages']['item'] as $rmp) {
+			if($rmp == $_SERVER['SCRIPT_NAME']) {
+				include("fbegin.inc");
+				print_info_box_np("This page is currently being managed by a remote machine.");
+				include("fend.inc");
+				exit;
+			}
+		}	
+	}
 ?>

--- a/usr/local/www/headjs.php
+++ b/usr/local/www/headjs.php
@@ -63,7 +63,7 @@ function getHeadJS() {
         
         jQuery(\"#submit\").click(submit_form);
         jQuery('#submit').click(function() {return false;});
-        var to_insert = \"<div style='visibility:hidden' id='loading' name='loading'><img src='{$loader_gif}' \/><\/div>\";
+        var to_insert = \"<div style='visibility:hidden' id='loading' name='loading'><img src='{$loader_gif}' alt='loader' \/><\/div>\";
         jQuery('#submit').before(to_insert);
       }
     }
@@ -73,7 +73,7 @@ function getHeadJS() {
       //alert(Form.serialize($('iform')));
 
       if(jQuery('#inputerrors'))
-        jQuery('#inputerrors').html('<center><b><i>Loading...</i></b></center>');
+        jQuery('#inputerrors').html('<center><b><i>Loading...<\/i><\/b><\/center>');
         
       /* dsh: Introduced because pkg_edit tries to set some hidden fields
        *      if executing submit's onclick event. The click gets deleted
@@ -134,10 +134,10 @@ function getHeadJS() {
         return;
       }
 
-      message_html = '<table height=\"32\" width=\"100%\"><tr><td>';
+      message_html = '<table height=\"32\" width=\"100%\" summary=\"message\"><tr><td>';
       message_html += '<div style=\"background-color:#990000\" id=\"redbox\">';
-      message_html += '<table width=\"100%\"><tr><td width=\"8%\">';
-      message_html += '<img style=\"vertical-align:center\" src=\"/themes/{$g['theme']}/images/icons/icon_exclam.gif\" width=\"28\" height=\"32\" \/>';
+      message_html += '<table width=\"100%\" summary=\"message\"><tr><td width=\"8%\">';
+      message_html += '<img style=\"vertical-align:center\" src=\"/themes/{$g['theme']}/images/icons/icon_exclam.gif\" width=\"28\" height=\"32\" alt=\"exclamation\" \/>';
       message_html += '<\/td><td width=\"70%\"><font color=\"white\">';
       message_html += '<b>' + message + '<\/b><\/font><\/td>';
 

--- a/usr/local/www/themes/_corporate/bottom-loader.js
+++ b/usr/local/www/themes/_corporate/bottom-loader.js
@@ -1,10 +1,6 @@
-<!--
-
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
 	Rounded("div#mainarea","bl br tr","#FFF","#DDDDDD","smooth");
 	Rounded("div#boxarea","bl br tl tr","#FFF","#DDDDDD","smooth");
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
-
-//-->

--- a/usr/local/www/themes/_corporate/loader.js
+++ b/usr/local/www/themes/_corporate/loader.js
@@ -1,4 +1,3 @@
-<!-- 
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -25,5 +24,3 @@ if (version < 7) {
 }
 
 document.write('<script type="text/javascript" src="/themes/corporate/javascript/niftyjsCode.js"></scr' + 'ipt>'); 
-
-// -->

--- a/usr/local/www/themes/code-red/bottom-loader.js
+++ b/usr/local/www/themes/code-red/bottom-loader.js
@@ -1,10 +1,6 @@
-<!--
-
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
 	Rounded("div#mainarea","bl br tr","#FFF","#DDDDDD","smooth");
 	Rounded("div#boxarea","bl br tl tr","#FFF","#DDDDDD","smooth");
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
-
-//-->

--- a/usr/local/www/themes/code-red/loader.js
+++ b/usr/local/www/themes/code-red/loader.js
@@ -1,4 +1,3 @@
-<!-- 
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -21,9 +20,7 @@ if (version == '') {
 }
 
 if (browser == 'IE' && version < 7) {
-	document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
+	document.write('<script type="text/javascript" src="/themes/code-red/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
 }
 
-document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/niftyjsCode.js"></scr'+'ipt>'); 
-
-// -->
+document.write('<script type="text/javascript" src="/themes/code-red/javascript/niftyjsCode.js"></scr'+'ipt>'); 

--- a/usr/local/www/themes/metallic/bottom-loader.js
+++ b/usr/local/www/themes/metallic/bottom-loader.js
@@ -1,10 +1,6 @@
-<!--
-
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
 	Rounded("div#mainarea","bl br tr","#FFF","#DDDDDD","smooth");
 	Rounded("div#boxarea","bl br tl tr","#FFF","#DDDDDD","smooth");
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
-
-//-->

--- a/usr/local/www/themes/metallic/loader.js
+++ b/usr/local/www/themes/metallic/loader.js
@@ -1,4 +1,3 @@
-<!-- 
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -25,5 +24,3 @@ if (browser == 'IE' && version < 7) {
 }
 
 document.write('<script type="text/javascript" src="/themes/metallic/javascript/niftyjsCode.js"></scr'+'ipt>'); 
-
-// -->

--- a/usr/local/www/themes/nervecenter/bottom-loader.js
+++ b/usr/local/www/themes/nervecenter/bottom-loader.js
@@ -1,10 +1,6 @@
-<!--
-
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
 	Rounded("div#mainarea","bl br tr","#FFF","#DDDDDD","smooth");
 	Rounded("div#boxarea","bl br tl tr","#FFF","#DDDDDD","smooth");
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
-
-//-->

--- a/usr/local/www/themes/nervecenter/loader.js
+++ b/usr/local/www/themes/nervecenter/loader.js
@@ -1,4 +1,3 @@
-<!-- 
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -25,5 +24,3 @@ if (browser == 'IE' && version < 7) {
 }
 
 document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/niftyjsCode.js"></scr'+'ipt>'); 
-
-// -->

--- a/usr/local/www/themes/pfsense-dropdown/bottom-loader.js
+++ b/usr/local/www/themes/pfsense-dropdown/bottom-loader.js
@@ -1,11 +1,7 @@
-<!-- 
-
-NiftyCheck();
-Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
-Rounded("div#mainarea","bl br tr","#FFF","#DDDDDD","smooth");
-Rounded("div#boxarea","bl br tl tr","#FFF","#DDDDDD","smooth");
-Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
-Rounded("div#topbox","all","#FFF","#990000","smooth");
-Rounded("div#footer","bl br tl tr","#FFF","#990000","smooth");
-
-//-->
+	NiftyCheck();
+	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
+	Rounded("div#mainarea","bl br tr","#FFF","#DDDDDD","smooth");
+	Rounded("div#boxarea","bl br tl tr","#FFF","#DDDDDD","smooth");
+	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
+	Rounded("div#topbox","all","#FFF","#990000","smooth");
+	Rounded("div#footer","bl br tl tr","#FFF","#990000","smooth");

--- a/usr/local/www/themes/pfsense-dropdown/loader.js
+++ b/usr/local/www/themes/pfsense-dropdown/loader.js
@@ -1,4 +1,3 @@
-<!-- 
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -25,5 +24,3 @@ if (browser == 'IE' && version < 7) {
 }
 
 document.write('<script type="text/javascript" src="/themes/pfsense-dropdown/javascript/niftyjsCode.js"></scr'+'ipt>'); 
-
-// -->

--- a/usr/local/www/themes/pfsense/bottom-loader.js
+++ b/usr/local/www/themes/pfsense/bottom-loader.js
@@ -1,12 +1,8 @@
-<!-- 
-
-NiftyCheck();
-Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
-Rounded("div#mainarea","bl br tr","#FFF","#DDDDDD","smooth");
-Rounded("div#boxarea","bl br tl tr","#FFF","#DDDDDD","smooth");
-Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
-Rounded("div#topbox","all","#FFF","#990000","smooth");
-Rounded("div#navigation","top bottom","#FFFFFF","#000000","smooth");
-Rounded("div#footer","bl br tl tr]","#FFF","#990000","smooth");
-
-//-->
+	NiftyCheck();
+	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
+	Rounded("div#mainarea","bl br tr","#FFF","#DDDDDD","smooth");
+	Rounded("div#boxarea","bl br tl tr","#FFF","#DDDDDD","smooth");
+	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
+	Rounded("div#topbox","all","#FFF","#990000","smooth");
+	Rounded("div#navigation","top bottom","#FFFFFF","#000000","smooth");
+	Rounded("div#footer","bl br tl tr]","#FFF","#990000","smooth");

--- a/usr/local/www/themes/pfsense/loader.js
+++ b/usr/local/www/themes/pfsense/loader.js
@@ -1,4 +1,3 @@
-<!-- 
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -25,6 +24,4 @@ if (browser == 'IE' && version < 7) {
 	document.write('<script type="text/javascript" src="/themes/metallic/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
 }
 
-document.write('<script type="text/javascript" src="/themes/pfsense-dropdown/javascript/niftyjsCode.js"></scr'+'ipt>'); 
-
-// -->
+document.write('<script type="text/javascript" src="/themes/pfsense/javascript/niftyjsCode.js"></scr'+'ipt>'); 

--- a/usr/local/www/themes/pfsense_ng/all.css
+++ b/usr/local/www/themes/pfsense_ng/all.css
@@ -142,19 +142,19 @@ body {
   background-color: #7f7f7f;
 }
 a:link {
-	color: #0000CC;
+	color: #550000;
 }
 
 a:visited {
-	color: #0000CC;
+	color: #550000;
 }
 
 a:active {
-	color: #0000CC;
+	color: #550000;
 }
 
 a:hover {
-	color: #0000CC;
+	color: #550000;
 }
 
 form {

--- a/usr/local/www/themes/pfsense_ng/bottom-loader.js
+++ b/usr/local/www/themes/pfsense_ng/bottom-loader.js
@@ -1,10 +1,6 @@
-<!--
-
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
 	Rounded("div#mainarea","bl br tr","#FFF","#DDDDDD","smooth");
 	Rounded("div#boxarea","bl br tl tr","#FFF","#DDDDDD","smooth");
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
-
-//-->

--- a/usr/local/www/themes/pfsense_ng/loader.js
+++ b/usr/local/www/themes/pfsense_ng/loader.js
@@ -1,4 +1,3 @@
-<!-- 
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -21,10 +20,10 @@ if (version == '') {
 }
 
 if (browser == 'IE' && version < 7) {
-	document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
+	document.write('<script type="text/javascript" src="/themes/pfsense_ng/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
 }
 
-document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/niftyjsCode.js"></scr'+'ipt>'); 
+document.write('<script type="text/javascript" src="/themes/pfsense_ng/javascript/niftyjsCode.js"></scr'+'ipt>'); 
 
 // jQuery function to define dropdown menu size
 jQuery(document).ready(function () {
@@ -33,4 +32,3 @@ jQuery(document).ready(function () {
     // Force the size dropdown menu 
     jQuery('#navigation ul li ul').css('max-height', hwindow);
 });
-// -->

--- a/usr/local/www/themes/the_wall/bottom-loader.js
+++ b/usr/local/www/themes/the_wall/bottom-loader.js
@@ -1,10 +1,6 @@
-<!--
-
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
 	Rounded("div#mainarea","bl br tr","#FFF","#DDDDDD","smooth");
 	Rounded("div#boxarea","bl br tl tr","#FFF","#DDDDDD","smooth");
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
-
-//-->

--- a/usr/local/www/themes/the_wall/loader.js
+++ b/usr/local/www/themes/the_wall/loader.js
@@ -1,5 +1,3 @@
-<!-- 
-
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -22,9 +20,7 @@ if (version == '') {
 }
 
 if (browser == 'IE' && version < 7) {
-	document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
+	document.write('<script type="text/javascript" src="/themes/the_wall/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
 }
 
-document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/niftyjsCode.js"></scr'+'ipt>'); 
-
-// -->
+document.write('<script type="text/javascript" src="/themes/the_wall/javascript/niftyjsCode.js"></scr'+'ipt>'); 


### PR DESCRIPTION
Update the "include" files so that the HTML generated is W3C standard/compliant.

This makes it easier to update all the PHP and INC files later to W3C standard/compliant.

&lt;img&gt; element not empty or not closed
&lt;img&gt; lacks "alt" attribute
&lt;table&gt; lacks "summary" attribute
&lt;br&gt; element not empty or not closed
&lt;input&gt; element not empty or not closed
&lt;a&gt; attribute "target" has invalid value "_new"

Updated the "loader.js" and "bottom-loader.js" in themes directory due to the update in "/usr/local/www/guiconfig.inc"

At the moment the &lt;body&gt; tag has "link", "alink" and "vlink" defined, but doesn't display correctly, so have updated "all.css" (will need to update all the PHP/INC files with &lt;body&gt;, but that is a lot of files to update!)
