### PR TITLE
Add version check to package install

### DIFF
--- a/etc/inc/pkg-utils.inc
+++ b/etc/inc/pkg-utils.inc
@@ -440,9 +440,9 @@ function sync_package($pkg_name, $sync_depends = true, $show_message = false) {
 		if(empty($config['installedpackages']['package'][$pkg_id]))
 			return;  // No package belongs to the pkg_id passed to this function.
 	}
-        if (is_array($config['installedpackages']['package'][$pkg_id]))
+	if (is_array($config['installedpackages']['package'][$pkg_id]))
 		$package =& $config['installedpackages']['package'][$pkg_id];
-        else
+	else
 		return; /* empty package tag */
 	if(!file_exists("/usr/local/pkg/" . $package['configurationfile'])) {
 		log_error(sprintf(gettext("The %s package is missing its configuration file and must be reinstalled."), $package['name']));
@@ -587,7 +587,7 @@ function pkg_fetch_recursive($pkgname, $filename, $dependlevel = 0, $base_url = 
 	return true;
 }
 
-function install_package($package, $pkg_info = "") {
+function install_package($package, $pkg_info = "", $force_install = false) {
 	global $g, $config, $static_output, $pkg_interface;
 
 	/* safe side. Write config below will send to ro again. */
@@ -600,6 +600,24 @@ function install_package($package, $pkg_info = "") {
 		$pkg_info = get_pkg_info(array($package));
 		$pkg_info = $pkg_info[$package]; // We're only dealing with one package, so we can strip away the extra array.
 		if (empty($pkg_info)) {
+			conf_mount_ro();
+			return -1;
+		}
+	}
+	if (!$force_install) {
+		$compatible = true;
+		$version = rtrim(file_get_contents("/etc/version"));
+		
+		if (isset($pkg_info['required_version']))
+			$compatible = (pfs_version_compare("", $version, $pkg_info['required_version']) >= 0);
+		if (isset($pkg_info['maximum_version']))
+			$compatible = $compatible && (pfs_version_compare("", $version, $pkg_info['maximum_version']) <= 0);
+		
+		if (!$compatible) {
+			log_error(sprintf(gettext('Package %s is not supported on this version.'), $pkg_info['name']));
+			$static_output .= sprintf(gettext("Package %s is not supported on this version."), $pkg_info['name']);
+			update_status($static_output);
+			
 			conf_mount_ro();
 			return -1;
 		}
@@ -794,7 +812,7 @@ function install_package_xml($pkg) {
 					system("/bin/chmod {$pkg_chmod} {$prefix}{$filename}");
 				}
 				$static_output = $static_orig;
-                                update_output_window($static_output);
+				update_output_window($static_output);
 			}
 			$static_output .= gettext("done.") . "\n";
 			update_output_window($static_output);
@@ -1123,7 +1141,7 @@ function delete_package_xml($pkg) {
 		if($pkg_config['include_file'] <> "") {
 			$static_output .= gettext("Removing package instructions...");
 			update_output_window($static_output);
-                        pkg_debug(sprintf(gettext("Remove '%s'"), $pkg_config['include_file']) . "\n");
+			pkg_debug(sprintf(gettext("Remove '%s'"), $pkg_config['include_file']) . "\n");
 			unlink_if_exists("/usr/local/pkg/" . $pkg_config['include_file']);
 			$static_output .= gettext("done.") . "\n";
 			update_output_window($static_output);
@@ -1245,31 +1263,29 @@ function pkg_reinstall_all() {
 	global $g, $config;
 
 	@unlink('/conf/needs_package_sync');
-	$pkg_id = 0;
-	$todo = array();
-	if (is_array($config['installedpackages']['package']))
+	if (is_array($config['installedpackages']['package'])) {
+		echo "One moment please, reinstalling packages...\n";
+		echo " >>> Trying to fetch package info...";
+		$pkg_info = get_pkg_info();
+		if ($pkg_info) {
+			echo " Done.\n";
+		} else {
+			$xmlrpc_base_url = isset($config['system']['altpkgrepo']['enable']) ? $config['system']['altpkgrepo']['xmlrpcbaseurl'] : $g['xmlrpcbaseurl'];
+			echo "\n" . sprintf(gettext(' >>> Unable to communicate with %1$s. Please verify DNS and interface configuration, and that %2$s has functional Internet connectivity.'), $xmlrpc_base_url, $g['product_name']) . "\n";
+			return;
+		}
+		$todo = array();
 		foreach($config['installedpackages']['package'] as $package)
 			$todo[] = array('name' => $package['name'], 'version' => $package['version']);
-	echo "One moment please, reinstalling packages...\n";
-	echo " >>> Trying to fetch package info...";
-	$pkg_info = get_pkg_info();
-	if ($pkg_info) {
-		echo " Done.\n";
-	} else {
-		$xmlrpc_base_url = isset($config['system']['altpkgrepo']['enable']) ? $config['system']['altpkgrepo']['xmlrpcbaseurl'] : $g['xmlrpcbaseurl'];
-		echo "\n" . sprintf(gettext(' >>> Unable to communicate with %1$s. Please verify DNS and interface configuration, and that %2$s has functional Internet connectivity.'), $xmlrpc_base_url, $g['product_name']) . "\n";
-		return;
-	}
-	if(is_array($todo)) {
 		foreach($todo as $pkgtodo) {
 			$static_output = "";
 			if($pkgtodo['name']) {
 				uninstall_package($pkgtodo['name']);
 				install_package($pkgtodo['name']);
-				$pkg_id++;
 			}
 		}
-	}
+	} else
+		echo "No packages are installed.";
 }
 
 function stop_packages() {

--- a/usr/local/www/pkg_mgr_install.php
+++ b/usr/local/www/pkg_mgr_install.php
@@ -1,32 +1,32 @@
 <?php
 /* $Id$ */
 /*
-    pkg_mgr_install.php
-    part of pfSense (http://www.pfSense.com)
-    Copyright (C) 2004-2010 Scott Ullrich <sullrich@gmail.com>
+	pkg_mgr_install.php
+	part of pfSense (http://www.pfSense.com)
+	Copyright (C) 2004-2010 Scott Ullrich <sullrich@gmail.com>
  	Copyright (C) 2005 Colin Smith
-    All rights reserved.
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_BUILDER_BINARIES:	/bin/rm
@@ -51,8 +51,6 @@ require_once("pkg-utils.inc");
 $static_output = "";
 $static_status = "";
 $sendto = "output";
-
-$todo = array();
 
 $pgtitle = array(gettext("System"),gettext("Package Manager"),gettext("Install Package"));
 include("head.inc");
@@ -175,23 +173,24 @@ switch($_GET['mode']) {
 			update_output_window(sprintf(gettext("Could not find %s."), htmlspecialchars($_GET['pkg'])));
 		break;
 	case "reinstallall":
-		if (is_array($config['installedpackages']['package']))
+		if (is_array($config['installedpackages']['package'])) {
+			$todo = array();
 			foreach($config['installedpackages']['package'] as $package)
 				$todo[] = array('name' => $package['name'], 'version' => $package['version']);
-		$pkg_id = 0;
-		foreach($todo as $pkgtodo) {
-			$static_output = "";
-			if($pkgtodo['name']) {
-				update_output_window($static_output);
-				uninstall_package($pkgtodo['name']);
-				install_package($pkgtodo['name']);
-				$pkg_id++;
+			foreach($todo as $pkgtodo) {
+				$static_output = "";
+				if($pkgtodo['name']) {
+					update_output_window($static_output);
+					uninstall_package($pkgtodo['name']);
+					install_package($pkgtodo['name']);
+				}
 			}
-		}
-		update_status(gettext("All packages reinstalled."));
-		$static_output .= "\n" . gettext("All packages reinstalled.");
-		update_output_window($static_output);
-		filter_configure();
+			update_status(gettext("All packages reinstalled."));
+			$static_output .= "\n" . gettext("All packages reinstalled.");
+			update_output_window($static_output);
+			filter_configure();
+		} else
+			update_output_window(gettext("No packages are installed."));
 		break;
 	default:
 		$pkgid = htmlspecialchars($_GET['id']);
@@ -221,7 +220,7 @@ rmdir_recursive("/var/tmp/instmp*");
 
 // close log
 if($fd_log)
-        fclose($fd_log);
+	fclose($fd_log);
 
 if($fs_mounted_rw) {
 	/* Restore to read only fs */


### PR DESCRIPTION
Add required_version and maximum_version checks to the install_package function to prevent incompatible packages from being installed on upgrade. e.g. widescreen package. A new argument is added to the function to override the version checks.

Also the commit contains some minor restructurings and corrections of indentations.

Implements #2690
