### PR TITLE
Fix holdcount/holdcnt parameter confusion

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -547,7 +547,7 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 			mwexec("/sbin/ifconfig {$bridgeif} hellotime " . escapeshellarg($bridge['hellotime']));
 		if (!empty($bridge['priority']))
 			mwexec("/sbin/ifconfig {$bridgeif} priority " . escapeshellarg($bridge['priority']));
-		if (!empty($bridge['holdcount']))
+		if (!empty($bridge['holdcnt']))
 			mwexec("/sbin/ifconfig {$bridgeif} holdcnt " . escapeshellarg($bridge['holdcnt']));
 		if (!empty($bridge['ifpriority'])) {
 			$pconfig = explode(",", $bridge['ifpriority']);

--- a/usr/local/www/interfaces_bridge_edit.php
+++ b/usr/local/www/interfaces_bridge_edit.php
@@ -73,7 +73,7 @@ if (isset($id) && $a_bridges[$id]) {
 	$pconfig['hellotime'] = $a_bridges[$id]['hellotime'];
 	$pconfig['priority'] = $a_bridges[$id]['priority'];
 	$pconfig['proto'] = $a_bridges[$id]['proto'];
-	$pconfig['holdcount'] = $a_bridges[$id]['holdcount'];
+	$pconfig['holdcnt'] = $a_bridges[$id]['holdcnt'];
 	if (!empty($a_bridges[$id]['ifpriority'])) {
 		$pconfig['ifpriority'] = explode(",", $a_bridges[$id]['ifpriority']);
 		$ifpriority = array();
@@ -178,7 +178,7 @@ if ($_POST) {
 		$bridge['hellotime'] = $_POST['hellotime'];
 		$bridge['priority'] = $_POST['priority'];
 		$bridge['proto'] = $_POST['proto'];
-		$bridge['holdcount'] = $_POST['holdcount'];
+		$bridge['holdcnt'] = $_POST['holdcnt'];
 		$i = 0;
 		$ifpriority = "";
 		$ifpathcost = "";


### PR DESCRIPTION
The form's input field name is holdcnt while in the POST array it was assumed to be holdcount.
