### PR TITLE
Remove return value of interface_bridge_configure

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -442,16 +442,16 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 	global $config, $g;
 
 	if (!is_array($bridge))
-	        return -1;
+		return;
 
 	if (empty($bridge['members'])) {
 		log_error(sprintf(gettext("No members found on %s"), $bridge['bridgeif']));
-		return -1;
+		return;
 	}
 
 	$members = explode(',', $bridge['members']);
 	if (!count($members))
-		return -1;
+		return;
 
 	/* Calculate smaller mtu and enforce it */
 	$smallermtu = 0;
@@ -634,8 +634,6 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 		interfaces_bring_up($bridge['bridgeif']);
 	else
 		log_error(gettext("bridgeif not defined -- could not bring interface up"));
-
-	return $bridge['bridgeif'];
 }
 
 function interface_bridge_add_member($bridgeif, $interface) {

--- a/usr/local/www/interfaces_bridge_edit.php
+++ b/usr/local/www/interfaces_bridge_edit.php
@@ -212,7 +212,7 @@ if ($_POST) {
 			$bridge['autoptp'] = implode(',', $_POST['autoptp']);
 
 		$bridge['bridgeif'] = $_POST['bridgeif'];
-		$bridge['bridgeif'] = interface_bridge_configure($bridge);
+		interface_bridge_configure($bridge);
 		if ($bridge['bridgeif'] == "" || !stristr($bridge['bridgeif'], "bridge"))
 			$input_errors[] = gettext("Error occured creating interface, please retry.");
 		else {


### PR DESCRIPTION
interfaces_bridge_edit.php was the only file that made use of the return value of the interface_bridge_configure function. With the $bridge['bridgeif'] variable now being set using reference passing there is no need for it anymore.
