### PR TITLE
Use unescaped variable in if condition

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -630,7 +630,7 @@ function interface_bridge_configure(&$bridge, $checkmember = 0) {
 		}
 	}
 
-	if ($bridgeif)
+	if ($bridge['bridgeif'])
 		interfaces_bring_up($bridge['bridgeif']);
 	else
 		log_error(gettext("bridgeif not defined -- could not bring interface up"));


### PR DESCRIPTION
The $bridgeif variable may have been escaped using escapeshellarg() resulting in a string that is never equal to false.
