### PR TITLE
Update usr/local/www/services_captiveportal_hostname.php

### DIFF
--- a/usr/local/www/services_captiveportal_hostname.php
+++ b/usr/local/www/services_captiveportal_hostname.php
@@ -73,6 +73,7 @@ if ($_GET['act'] == "del" && !empty($cpzone)) {
 				$ipent['ip'] .= "/{$ipent['sn']}";
 			$ip = gethostbyname($ipent['ip']);
 			if(is_ipaddr($ip)) {
+				$ipfw = pfSense_ipfw_getTablestats($cpzone, 3, $ip);
 				if (is_array($ipfw)) {
 					captiveportal_free_dn_ruleno($ipfw['dnpipe']);
 					pfSense_pipe_action("pipe delete {$ipfw['dnpipe']}");


### PR DESCRIPTION
The following line was lost in commit https://github.com/bsdperimeter/pfsense/commit/287f7e26199a323f0f4cd08f9e0a94073b7d5112

```
$ipfw = pfSense_ipfw_getTablestats($cpzone, 3, $ip);
```
