### PR TITLE
Make not LAN address etc rules work 

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -1953,6 +1953,8 @@ function filter_generate_address(& $rule, $target = "source", $isnat = false) {
 							$src = "{$pppoesav6}/{$pppoesnv6}";
 						}
 					}
+				if(isset($rule[$target]['not']))
+					$src = " !{$src}";
 			} else {
 				switch ($rule[$target]['network']) {
 					case 'wan':
@@ -1989,6 +1991,8 @@ function filter_generate_address(& $rule, $target = "source", $isnat = false) {
 						}
 						break;
 				}
+				if(isset($rule[$target]['not']))
+					$src = " !{$src}";
 			}
 		}
 	} else if($rule[$target]['address']) {


### PR DESCRIPTION
Forum: http://forum.pfsense.org/index.php/topic,58449.0.html
I cannot understand how this worked anywhere in the recent past, which really surprises me. The code fragment:
if(isset($rule[$target]['not']))
    $src = " !{$src}";$src = " !{$src}";
Appeared in multiple if/else clauses but was missing in 2 places, which I have added.
Actually, it is now duplicated in every part of the filter_generate_address if/else structure, and so it could be applied once at the end of the routine.
I have taken the minimal risk approach here, since I am not in a position to test every if/else case properly. But I can easily create a version that removes the code duplication, and someone else can test it well before committing (this is a fundamental bit of rule code that everyone uses, so I don't want to accidenatally break it worse for some poor sod.)
