### PR TITLE
Update HTML boolean operator "nowrap"

### DIFF
--- a/usr/local/www/themes/_corporate/all.css
+++ b/usr/local/www/themes/_corporate/all.css
@@ -9,6 +9,8 @@ html, body, td, th, input, select {
 	font-size: 0.9em;
 }
 
+.nowrap { white-space: nowrap; }
+
 div.GraphLink {
 	position: relative;
 }

--- a/usr/local/www/themes/_corporate/bottom-loader.js
+++ b/usr/local/www/themes/_corporate/bottom-loader.js
@@ -1,4 +1,4 @@
-<!--
+//<![CDATA[
 
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
@@ -7,4 +7,4 @@
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
 
-//-->
+//]]>

--- a/usr/local/www/themes/_corporate/loader.js
+++ b/usr/local/www/themes/_corporate/loader.js
@@ -1,4 +1,4 @@
-<!-- 
+//<![CDATA[
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -26,4 +26,4 @@ if (version < 7) {
 
 document.write('<script type="text/javascript" src="/themes/corporate/javascript/niftyjsCode.js"></scr' + 'ipt>'); 
 
-// -->
+//]]>

--- a/usr/local/www/themes/code-red/all.css
+++ b/usr/local/www/themes/code-red/all.css
@@ -5,6 +5,8 @@ html, body, td, th, input, select {
 
 }
 
+.nowrap { white-space: nowrap; }
+
 .infobox {
 	width:100%;
 }

--- a/usr/local/www/themes/code-red/bottom-loader.js
+++ b/usr/local/www/themes/code-red/bottom-loader.js
@@ -1,4 +1,4 @@
-<!--
+//<![CDATA[
 
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
@@ -7,4 +7,4 @@
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
 
-//-->
+//]]>

--- a/usr/local/www/themes/code-red/loader.js
+++ b/usr/local/www/themes/code-red/loader.js
@@ -1,4 +1,4 @@
-<!-- 
+//<![CDATA[
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -21,9 +21,9 @@ if (version == '') {
 }
 
 if (browser == 'IE' && version < 7) {
-	document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
+	document.write('<script type="text/javascript" src="/themes/code-red/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
 }
 
-document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/niftyjsCode.js"></scr'+'ipt>'); 
+document.write('<script type="text/javascript" src="/themes/code-red/javascript/niftyjsCode.js"></scr'+'ipt>'); 
 
-// -->
+//]]>

--- a/usr/local/www/themes/code-red/wizard.css
+++ b/usr/local/www/themes/code-red/wizard.css
@@ -5,6 +5,8 @@ html, body, td, th, input, select {
 
 }
 
+.nowrap { white-space: nowrap; }
+
 /* please adjust the bgcolor to be used together with niftycorners! */
 .rtop, .artop {
         background-color: #5f0406;

--- a/usr/local/www/themes/metallic/all.css
+++ b/usr/local/www/themes/metallic/all.css
@@ -4,6 +4,8 @@ html, body, td, th, input, select {
 	font-size: 0.9em;
 }
 
+.nowrap { white-space: nowrap; }
+
 .infobox {
 	width:100%;
 }

--- a/usr/local/www/themes/metallic/bottom-loader.js
+++ b/usr/local/www/themes/metallic/bottom-loader.js
@@ -1,4 +1,4 @@
-<!--
+//<![CDATA[
 
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
@@ -7,4 +7,4 @@
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
 
-//-->
+//]]>

--- a/usr/local/www/themes/metallic/loader.js
+++ b/usr/local/www/themes/metallic/loader.js
@@ -1,4 +1,4 @@
-<!-- 
+//<![CDATA[
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -26,4 +26,4 @@ if (browser == 'IE' && version < 7) {
 
 document.write('<script type="text/javascript" src="/themes/metallic/javascript/niftyjsCode.js"></scr'+'ipt>'); 
 
-// -->
+//]]>

--- a/usr/local/www/themes/nervecenter/all.css
+++ b/usr/local/www/themes/nervecenter/all.css
@@ -5,6 +5,8 @@ html, body, td, th, input, select {
 
 }
 
+.nowrap { white-space: nowrap; }
+
 .infobox {
 	width:100%;
 }

--- a/usr/local/www/themes/nervecenter/bottom-loader.js
+++ b/usr/local/www/themes/nervecenter/bottom-loader.js
@@ -1,4 +1,4 @@
-<!--
+//<![CDATA[
 
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
@@ -7,4 +7,4 @@
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
 
-//-->
+//]]>

--- a/usr/local/www/themes/nervecenter/loader.js
+++ b/usr/local/www/themes/nervecenter/loader.js
@@ -1,4 +1,4 @@
-<!-- 
+//<![CDATA[
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -26,4 +26,4 @@ if (browser == 'IE' && version < 7) {
 
 document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/niftyjsCode.js"></scr'+'ipt>'); 
 
-// -->
+//]]>

--- a/usr/local/www/themes/nervecenter/wizard.css
+++ b/usr/local/www/themes/nervecenter/wizard.css
@@ -5,6 +5,8 @@ html, body, td, th, input, select {
 
 }
 
+.nowrap { white-space: nowrap; }
+
 /* please adjust the bgcolor to be used together with niftycorners! */
 .rtop, .artop {
         background-color: #999999;

--- a/usr/local/www/themes/pfsense-dropdown/all.css
+++ b/usr/local/www/themes/pfsense-dropdown/all.css
@@ -4,6 +4,8 @@ html, body, td, th, input, select {
 	font-size: 0.9em;
 }
 
+.nowrap { white-space: nowrap; }
+
 .infobox {
 	width:100%;
 }

--- a/usr/local/www/themes/pfsense-dropdown/bottom-loader.js
+++ b/usr/local/www/themes/pfsense-dropdown/bottom-loader.js
@@ -1,4 +1,4 @@
-<!-- 
+//<![CDATA[
 
 NiftyCheck();
 Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
@@ -8,4 +8,4 @@ Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 Rounded("div#topbox","all","#FFF","#990000","smooth");
 Rounded("div#footer","bl br tl tr","#FFF","#990000","smooth");
 
-//-->
+//]]>

--- a/usr/local/www/themes/pfsense-dropdown/loader.js
+++ b/usr/local/www/themes/pfsense-dropdown/loader.js
@@ -1,4 +1,4 @@
-<!-- 
+//<![CDATA[
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -26,4 +26,4 @@ if (browser == 'IE' && version < 7) {
 
 document.write('<script type="text/javascript" src="/themes/pfsense-dropdown/javascript/niftyjsCode.js"></scr'+'ipt>'); 
 
-// -->
+//]]>

--- a/usr/local/www/themes/pfsense/all.css
+++ b/usr/local/www/themes/pfsense/all.css
@@ -4,6 +4,8 @@ html, body, td, th, input, select {
 	font-size: 0.9em;
 }
 
+.nowrap { white-space: nowrap; }
+
 .infobox {
 	width:100%;
 }

--- a/usr/local/www/themes/pfsense/bottom-loader.js
+++ b/usr/local/www/themes/pfsense/bottom-loader.js
@@ -1,4 +1,4 @@
-<!-- 
+//<![CDATA[
 
 NiftyCheck();
 Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
@@ -9,4 +9,4 @@ Rounded("div#topbox","all","#FFF","#990000","smooth");
 Rounded("div#navigation","top bottom","#FFFFFF","#000000","smooth");
 Rounded("div#footer","bl br tl tr]","#FFF","#990000","smooth");
 
-//-->
+//]]>

--- a/usr/local/www/themes/pfsense/loader.js
+++ b/usr/local/www/themes/pfsense/loader.js
@@ -1,4 +1,4 @@
-<!-- 
+//<![CDATA[
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -25,6 +25,6 @@ if (browser == 'IE' && version < 7) {
 	document.write('<script type="text/javascript" src="/themes/metallic/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
 }
 
-document.write('<script type="text/javascript" src="/themes/pfsense-dropdown/javascript/niftyjsCode.js"></scr'+'ipt>'); 
+document.write('<script type="text/javascript" src="/themes/pfsense/javascript/niftyjsCode.js"></scr'+'ipt>'); 
 
-// -->
+//]]>

--- a/usr/local/www/themes/pfsense_ng/all.css
+++ b/usr/local/www/themes/pfsense_ng/all.css
@@ -5,6 +5,8 @@ html, body, td, th, input, select {
 
 }
 
+.nowrap { white-space: nowrap; }
+
 .infobox {
 	width:100%;
 }

--- a/usr/local/www/themes/pfsense_ng/bottom-loader.js
+++ b/usr/local/www/themes/pfsense_ng/bottom-loader.js
@@ -1,4 +1,4 @@
-<!--
+//<![CDATA[
 
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
@@ -7,4 +7,4 @@
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
 
-//-->
+//]]>

--- a/usr/local/www/themes/pfsense_ng/loader.js
+++ b/usr/local/www/themes/pfsense_ng/loader.js
@@ -1,4 +1,4 @@
-<!-- 
+//<![CDATA[
 var browser     = '';
 var version     = '';
 var entrance    = '';
@@ -21,10 +21,10 @@ if (version == '') {
 }
 
 if (browser == 'IE' && version < 7) {
-	document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
+	document.write('<script type="text/javascript" src="/themes/pfsense_ng/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
 }
 
-document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/niftyjsCode.js"></scr'+'ipt>'); 
+document.write('<script type="text/javascript" src="/themes/pfsense_ng/javascript/niftyjsCode.js"></scr'+'ipt>'); 
 
 // jQuery function to define dropdown menu size
 jQuery(document).ready(function () {
@@ -33,4 +33,4 @@ jQuery(document).ready(function () {
     // Force the size dropdown menu 
     jQuery('#navigation ul li ul').css('max-height', hwindow);
 });
-// -->
+//]]>

--- a/usr/local/www/themes/pfsense_ng/wizard.css
+++ b/usr/local/www/themes/pfsense_ng/wizard.css
@@ -5,6 +5,8 @@ html, body, td, th, input, select {
 
 }
 
+.nowrap { white-space: nowrap; }
+
 /* please adjust the bgcolor to be used together with niftycorners! */
 .rtop, .artop {
         background-color: #999999;

--- a/usr/local/www/themes/the_wall/all.css
+++ b/usr/local/www/themes/the_wall/all.css
@@ -5,6 +5,8 @@ html, body, td, th, input, select {
 
 }
 
+.nowrap { white-space: nowrap; }
+
 .infobox {
 	width:100%;
 }

--- a/usr/local/www/themes/the_wall/bottom-loader.js
+++ b/usr/local/www/themes/the_wall/bottom-loader.js
@@ -1,4 +1,4 @@
-<!--
+//<![CDATA[
 
 	NiftyCheck();
 	Rounded("div#niftyMenu","top bottom","#FFFFFF","#000000","smooth");
@@ -7,4 +7,4 @@
 	Rounded("tr#fend","bl br tl tr","#FFF","#990000","smooth");
 	Rounded("div#topbox","all","#FFF","#990000","smooth");
 
-//-->
+//]]>

--- a/usr/local/www/themes/the_wall/loader.js
+++ b/usr/local/www/themes/the_wall/loader.js
@@ -1,4 +1,4 @@
-<!-- 
+//<![CDATA[
 
 var browser     = '';
 var version     = '';
@@ -22,9 +22,9 @@ if (version == '') {
 }
 
 if (browser == 'IE' && version < 7) {
-	document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
+	document.write('<script type="text/javascript" src="/themes/the_wall/javascript/ie7/ie7-standard-p.js"></scr'+'ipt>');
 }
 
-document.write('<script type="text/javascript" src="/themes/nervecenter/javascript/niftyjsCode.js"></scr'+'ipt>'); 
+document.write('<script type="text/javascript" src="/themes/the_wall/javascript/niftyjsCode.js"></scr'+'ipt>'); 
 
-// -->
+//]]>

--- a/usr/local/www/themes/the_wall/wizard.css
+++ b/usr/local/www/themes/the_wall/wizard.css
@@ -5,6 +5,8 @@ html, body, td, th, input, select {
 
 }
 
+.nowrap { white-space: nowrap; }
+
 /* please adjust the bgcolor to be used together with niftycorners! */
 .rtop, .artop {
         background-color: #999999;


### PR DESCRIPTION
The HTML boolean operator "nowrap" has been deprecated to a "style".

This adds a new class called "nowrap" to "all.css" and "wizard.css" and start replacing "nowrap" with "class='nowrap'", if there is already a class defined then just add, "class='whatever nowrap".

Update "loader.js" and "bottom-loader.js" with CDATA sections.
