### PR TITLE
Fix login form username field focus

### DIFF
--- a/etc/inc/authgui.inc
+++ b/etc/inc/authgui.inc
@@ -216,7 +216,7 @@ $have_cookies = isset($_COOKIE["cookie_test"]);
 		<script type="text/javascript">
 		//<![CDATA[
 		$(document).ready(function() { jQuery('#usernamefld').focus(); });
-		/]]>
+		//]]>
 		</script>
 
 		<title><?=gettext("Login"); ?></title>


### PR DESCRIPTION
The Username field was no longer getting focus - just a missing "/" in a critical place.
