### PR TITLE
Say goodbye to routed at bootup

### DIFF
--- a/etc/rc.bootup
+++ b/etc/rc.bootup
@@ -373,10 +373,6 @@ auto_login();
 /* load graphing functions */
 enable_rrd_graphing();
 
-/* startup routed if needed */
-include_once("/usr/local/pkg/routed.inc");
-setup_routed();
-
 /* enable watchdog if supported */
 enable_watchdog();
 


### PR DESCRIPTION
Now that routed/RIP has been removed from the base system, it generates errors trying to start it in the base system boot script.
(I guess that if it is installed as a package, the package start code will bring it up at the end of the base system boot)
