### PR TITLE
trim ping host

### DIFF
--- a/usr/local/www/diag_ping.php
+++ b/usr/local/www/diag_ping.php
@@ -61,7 +61,7 @@ if ($_POST || $_REQUEST['host']) {
 
 	if (!$input_errors) {
 		$do_ping = true;
-		$host = $_REQUEST['host'];
+		$host = trim($_REQUEST['host']);
 		$interface = $_REQUEST['interface'];
 		$count = $_POST['count'];
 		if (preg_match('/[^0-9]/', $count) )


### PR DESCRIPTION
Added trim() function to the $host variable. If whitespace is in front
of the host or IP address the ping command will fail.
