### PR TITLE
Set correct netmask for IPv6 addresses when creating an easy rule: pass

### DIFF
--- a/etc/inc/easyrule.inc
+++ b/etc/inc/easyrule.inc
@@ -275,6 +275,8 @@ function easyrule_pass_rule_add($int, $proto, $srchost, $dsthost, $dstport, $ipp
 		list($srchost, $srcmask) = explode("/", $srchost);
 	} elseif (is_specialnet($srchost)) {
 		$srcmask = 0;
+	} elseif (is_ipaddrv6($srchost)) {
+		$srcmask = 128;
 	} else {
 		$srcmask = 32;
 	}
@@ -283,6 +285,8 @@ function easyrule_pass_rule_add($int, $proto, $srchost, $dsthost, $dstport, $ipp
 		list($dsthost, $dstmask) = explode("/", $dsthost);
 	} elseif (is_specialnet($dsthost)) {
 		$dstmask = 0;
+	} elseif (is_ipaddrv6($dsthost)) {
+		$dstmask = 128;
 	} else {
 		$dstmask = 32;
 	}


### PR DESCRIPTION
The easyrule_pass_rule_add() now checks for an IPv6 address and sets the
netmask accordingly.
This is the fix for bug: http://redmine.pfsense.org/issues/2843
