### PR TITLE
Services status widget display 1st sentence of description 

### DIFF
--- a/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/usr/local/www/widgets/widgets/services_status.widget.php
@@ -1,6 +1,6 @@
 <?php
 /*
-    services_status.php
+    services_status.widget.php
     Copyright (C) 2004, 2005 Scott Ullrich
     All rights reserved.
 
@@ -72,8 +72,9 @@ if (count($services) > 0) {
 			continue;
 		if (empty($service['description']))
 			$service['description'] = get_pkg_descr($service['name']);
+		$service_desc = explode(".",$service['description']);
 		echo '<tr><td class="listlr">' . $service['name'] . '</td>' . "\n";
-		echo '<td class="listr">' . $service['description'] . '</td>' . "\n";
+		echo '<td class="listr">' . $service_desc[0] . '</td>' . "\n";
 		echo get_service_status_icon($service, false, true);
 		echo '<td valign="middle" class="list" nowrap>';
 		echo get_service_control_links($service);


### PR DESCRIPTION
Some packages (e.g. bandwidthd, dansguardian, HAVP, nmap, squid3...) have a very verbose package description. This is displayed in the description column of the services status widget. That makes it take a lot of space on the dashboard. IMHO the first sentence gives a good concise description, so this change just displays the first sentence (text before a "."). Note: I purposely left the "." out of the string, I think it looks neater along with the descriptions of other built-in services - "DHCP Service" "DNS Forwarder"...
