### PR TITLE
Added IE Mobile for WP8 to list of mobile browsers

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -1932,7 +1932,7 @@ function get_current_theme() {
 	 *  If this device is an apple ipod/iphone
 	 *  switch the theme to one that works with it.
 	 */
-	$lowres_ua = array("iPhone", "iPod", "iPad", "Android", "BlackBerry", "Opera Mini", "Opera Mobi", "PlayBook");
+	$lowres_ua = array("iPhone", "iPod", "iPad", "Android", "BlackBerry", "Opera Mini", "Opera Mobi", "PlayBook", "IEMobile");
 	foreach($lowres_ua as $useragent)
 		if(strstr($_SERVER['HTTP_USER_AGENT'], $useragent))
 			$theme = (empty($g['theme_lowres']) && (is_dir($g["www_path"].'/themes/'.$g['theme_lowres']))) ? "pfsense" : $g['theme_lowres'];


### PR DESCRIPTION
Added Internet Explorer Mobile to the list of browsers that doesn't work with drop-down menus.
Tested and working on own 2.0.2 system.
