### PR TITLE
Typo in variable name

### DIFF
--- a/etc/inc/pfsense-utils.inc
+++ b/etc/inc/pfsense-utils.inc
@@ -1911,7 +1911,7 @@ function version_compare_dates($a, $b) {
 	} else {
 		if ($a_time < $b_time)
 			return -1;
-		elseif ($$a_time == $b_time)
+		elseif ($a_time == $b_time)
 			return 0;
 		else
 			return 1;


### PR DESCRIPTION
Self explanatory typo, pfsense-utils.inc
