### PR TITLE
Fix issue in version_compare that can cause versions to be wrongly marked incompatible

### DIFF
--- a/etc/inc/pfsense-utils.inc
+++ b/etc/inc/pfsense-utils.inc
@@ -1926,7 +1926,8 @@ function version_get_string_value($a) {
 		5 => "C",
 		6 => "D",
 		7 => "RC",
-		8 => "RELEASE"
+		8 => "RELEASE",
+		9 => "*"			// Matches all release levels
 	);
 	$major = 0;
 	$minor = 0;
@@ -1942,7 +1943,12 @@ function version_get_string_value($a) {
 	return "{$major}.{$minor}";
 }
 function version_compare_string($a, $b) {
-	return version_compare_numeric(version_get_string_value($a), version_get_string_value($b));
+	// Only compare string parts if both versions give a specific release
+	// (If either version lacks a string part, assume intended to match all release levels)
+	if (isset($a) && isset($b)) 
+        	return version_compare_numeric(version_get_string_value($a), version_get_string_value($b));
+        else
+        	return 0;
 }
 function version_compare_numeric($a, $b) {
 	$a_arr = explode('.', rtrim($a, '.0'));


### PR DESCRIPTION
In 2.0.1 an Unbound update marked as compatible with "2.0.1" was deemed incompatible with "2.0.1-RELEASE" pfsense. 

This change improves version matching and fixes the issue more correctly, by
1. allowing an optional explicit \* (2.1-*) to match any release level;
2. in the absence of compatibility only to a specific release level, work on the basis the most likely intention is for the package to be compatible with all release levels. (Cannot mind read so if no release level is given we pretty much have to assume this)
