### PR TITLE
Bandwidth by IP - display static map names also when FQDN selected

### DIFF
--- a/usr/local/www/bandwidth_by_ip.php
+++ b/usr/local/www/bandwidth_by_ip.php
@@ -40,7 +40,7 @@ $hostipformat = $_GET['hostipformat'];
 $iplookup = array();
 // If hostname display is requested and the DNS forwarder does not already have DHCP static names registered,
 // then load the DHCP static mappings into an array keyed by IP address.
-if (($hostipformat == "hostname") && (!isset($config['dnsmasq']['regdhcpstatic']))) {
+if (($hostipformat != "") && (!isset($config['dnsmasq']['regdhcpstatic']))) {
 	if (is_array($config['dhcpd'])) {
 		foreach ($config['dhcpd'] as $ifdata) {
 			if (is_array($ifdata['staticmap'])) {


### PR DESCRIPTION
If display FQDN was selected, and an IP had no reverse lookup FQDN, but did have a DHCP static mapping, the static map name was not displayed - just 1 line I overlooked when adding the FQDN option.
