### PR TITLE
Fix stale bandwidth-by-IP table entries

### DIFF
--- a/usr/local/www/status_graph.php
+++ b/usr/local/www/status_graph.php
@@ -153,32 +153,30 @@ function updateBandwidthHosts(data){
     d = document;
     //parse top ten bandwidth abuser hosts
     for (var y=0; y<10; y++){
-        if (hosts_split[y] != "" && hosts_split[y] != "no info"){
-            if (hosts_split[y]) {
-                hostinfo = hosts_split[y].split(";");
+        if ((y < hosts_split.length) && (hosts_split[y] != "") && (hosts_split[y] != "no info")) {
+			hostinfo = hosts_split[y].split(";");
 
-                //update host ip info
-                var HostIpID = "hostip" + y;
-                var hostip = d.getElementById(HostIpID);
-                hostip.innerHTML = hostinfo[0];
+			//update host ip info
+			var HostIpID = "hostip" + y;
+			var hostip = d.getElementById(HostIpID);
+			hostip.innerHTML = hostinfo[0];
 
-                //update bandwidth inbound to host
-                var hostbandwidthInID = "bandwidthin" + y;
-                var hostbandwidthin = d.getElementById(hostbandwidthInID);
-                hostbandwidthin.innerHTML = hostinfo[1] + " Bits/sec";
+			//update bandwidth inbound to host
+			var hostbandwidthInID = "bandwidthin" + y;
+			var hostbandwidthin = d.getElementById(hostbandwidthInID);
+			hostbandwidthin.innerHTML = hostinfo[1] + " Bits/sec";
 
-                //update bandwidth outbound from host
-                var hostbandwidthOutID = "bandwidthout" + y;
-                var hostbandwidthOut = d.getElementById(hostbandwidthOutID);
-                hostbandwidthOut.innerHTML = hostinfo[2] + " Bits/sec";
+			//update bandwidth outbound from host
+			var hostbandwidthOutID = "bandwidthout" + y;
+			var hostbandwidthOut = d.getElementById(hostbandwidthOutID);
+			hostbandwidthOut.innerHTML = hostinfo[2] + " Bits/sec";
 
-                //make the row appear if hidden
-                var rowid = "#host" + y;
-                if (jQuery(rowid).css('display') == "none"){
-                     //hide rows that contain no data
-                     jQuery(rowid).show(1000);
-                }
-            }
+			//make the row appear if hidden
+			var rowid = "#host" + y;
+			if (jQuery(rowid).css('display') == "none"){
+				//hide rows that contain no data
+				jQuery(rowid).show(1000);
+			}
         }
         else
         {


### PR DESCRIPTION
When the number of valid rows in the table reduced by more than 1 between updates, stale entries were left displayed at the end - e.g. 8 rows (0-7), then next update has only 5 rows (0-4). Row 5 is hidden but rows 6 and 7 remain displayed.
This "feature" looks like it has been around ever since this module was first added.
Should fix http://forum.pfsense.org/index.php/topic,59714.msg321414.html#msg321414
The functional change is making a single "if" test at line 156/157 and the removed "}" at 181. The rest of the diff listing is just changes due to code indenting.
