### PR TITLE
Thermal Sensors Widget (for pfSense v2.1-BETA1 and up).

### DIFF
--- a/usr/local/www/widgets/include/thermal_sensors.inc
+++ b/usr/local/www/widgets/include/thermal_sensors.inc
@@ -1,0 +1,27 @@
+<?php
+/*
+	$Id: thermal_sensors.inc
+	File location: 
+		\usr\local\www\widgets\include\
+
+	Used by:
+		\usr\local\www\widgets\widgets\thermal_sensors.widget.php
+
+
+*/
+
+//set variable for custom title
+$thermal_sensors_widget_title = "Thermal Sensors";
+//$thermal_sensors_widget_link = "thermal_sensors.php";
+
+
+//returns core temp data (from coretemp.ko or amdtemp.ko driver) as "|"-delimited string.
+//NOTE: depends on proper cofing in System >> Advanced >> Miscellaneous tab >> Thermal Sensors section.
+function getThermalSensorsData() {
+
+	exec("/sbin/sysctl -a | grep temperature", $dfout);
+	$thermalSensorsData = join("|", $dfout);
+	return $thermalSensorsData;
+	
+}
+?>

--- a/usr/local/www/widgets/javascript/thermal_sensors.js
+++ b/usr/local/www/widgets/javascript/thermal_sensors.js
@@ -1,0 +1,312 @@
+/*
+	$Id: thermal_sensors.js
+	Description:	
+		Javascript functions to get and show thermal sensors data in thermal_sensors.widget.php.
+		NOTE: depends on proper cofing in System >> Advanced >> Miscellaneous tab >> Thermal Sensors section.
+	File location: 
+		\usr\local\www\widgets\javascript\
+	Used by:
+		\usr\local\www\widgets\widgets\thermal_sensors.widget.php
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+
+//should be called from "thermal_sensors.widget.php"
+function showThermalSensorsData() {
+
+	//get data from thermal_sensors.widget.php
+	url = "/widgets/widgets/thermal_sensors.widget.php?getThermalSensorsData=1" 
+			//IE fix to disable cache when using http:// , just append timespan
+			+ new Date().getTime();
+
+	jQuery.ajax(url, {
+		type: 'get',
+		success: function(data) {
+			var thermalSensorsData = data || "";
+			buildThermalSensorsData(thermalSensorsData);
+		},
+		error: function(jqXHR, status, error){
+			buildThermalSensorsDataRaw(
+				"Error getting data from [thermal_sensors.widget.php] - |" + 
+				"status: [" + (status || "") + "]|" + 
+				"error: [" + (error || "") + "]");
+		}
+	});
+	
+	//call itself in 11 seconds
+	window.setTimeout(showThermalSensorsData, 11000);
+}
+
+function buildThermalSensorsData(thermalSensorsData) {
+	//NOTE: variable thermal_sensors_widget_showRawOutput is declared/set in "thermal_sensors.widget.php"
+	if (thermal_sensors_widget_showRawOutput) {
+		buildThermalSensorsDataRaw(thermalSensorsData);
+	}
+	else {
+		buildThermalSensorsDataGraph(thermalSensorsData);
+	}
+}
+
+function buildThermalSensorsDataRaw(thermalSensorsData) {
+	
+	var thermalSensorsContent = "";
+	
+	if (thermalSensorsData && thermalSensorsData != "") {
+		thermalSensorsContent = thermalSensorsData.replace(/\|/g, "<br />");
+		//rawData = thermalSensorsData.split("|").join("<br />");
+	}
+	
+	loadThermalSensorsContainer(thermalSensorsContent);
+}
+
+function loadThermalSensorsContainer (thermalSensorsContent) {
+
+	if (thermalSensorsContent && thermalSensorsContent != "") {
+		//load generated graph (or raw data) into thermalSensorsContainer (thermalSensorsContainer DIV defined in "thermal_sensors.widget.php")
+		jQuery('#thermalSensorsContainer').html(thermalSensorsContent);
+	} else {
+		jQuery('#thermalSensorsContainer').html("No Thermal Sensors data available.<br /><br />");
+		jQuery('<div/>').html(
+				"<span>* You can configure a proper Thermal Sensor / Module under <br />" + 
+				"&nbsp;&nbsp;&nbsp;<a href='system_advanced_misc.php'>System &gt; Advanced &gt; Miscellaneous : Thermal Sensors section</a>.</span>"
+				).appendTo('#thermalSensorsContainer');
+	}
+}
+
+function buildThermalSensorsDataGraph(thermalSensorsData) {
+
+	//local constants
+	var normalColor = "LimeGreen";
+	var normalColorShadowTop = "Lime";
+	var normalColorShadowBottom = "Green";
+	
+	var warningColor = "Orange";
+	var warningColorShadowBottom = "Chocolate";
+	
+	var criticalColor = "Red";
+	var criticalColorShadowBottom = "DarkRed";
+	
+	//local variables
+	var barBgColor = normalColor; //green/normal as default
+	var barBgColorShadowTop = normalColorShadowTop; //green/normal as default
+	var barBgColorShadowBottom = normalColorShadowBottom; //green/normal as default
+		
+	var thermalSensorsArray = new Array();
+	
+	if (thermalSensorsData && thermalSensorsData != ""){
+		thermalSensorsArray = thermalSensorsData.split("|");
+	}
+
+	var thermalSensorsHTMLContent = "";
+	var itemsToPulsate = new Array();
+	
+	//generate graph for each temperature sensor and append to thermalSensorsHTMLContent string
+	for (var i = 0; i < thermalSensorsArray.length; i++) {
+	
+		var sensorDataArray = thermalSensorsArray[i].split(":");
+		var sensorName = sensorDataArray[0].trim();
+		var thermalSensorValue = getThermalSensorValue(sensorDataArray[1]);
+
+		var pulsateTimes = 0;
+		var pulsateDuration = 0;
+		
+		var warningTempThresholdPosition = 0;
+		var criticalTempThresholdPosition = 0;
+		
+		//NOTE: the following variables are declared/set in "thermal_sensors.widget.php": 
+		//		thermal_sensors_widget_coreWarningTempThreshold, thermal_sensors_widget_coreCriticalTempThreshold, 
+		//		thermal_sensors_widget_zoneWarningTempThreshold, thermal_sensors_widget_zoneCriticalTempThreshold
+		//		thermal_sensors_widget_pulsateWarning, thermal_sensors_widget_pulsateCritical
+		
+		//set graph color and pulsate parameters
+		if (sensorName.indexOf("cpu") > -1) { //check CPU Threshold config settings
+			
+			warningTempThresholdPosition = thermal_sensors_widget_coreWarningTempThreshold;
+			criticalTempThresholdPosition = thermal_sensors_widget_coreCriticalTempThreshold;
+			
+			if (thermalSensorValue < thermal_sensors_widget_coreWarningTempThreshold) {
+				barBgColor = normalColor;
+				barBgColorShadowTop = normalColorShadowTop;
+				barBgColorShadowBottom = normalColorShadowBottom;
+				pulsateTimes = 0;
+				pulsateDuration = 0;
+			} else if (thermalSensorValue >= thermal_sensors_widget_coreWarningTempThreshold && thermalSensorValue < thermal_sensors_widget_coreCriticalTempThreshold) {
+				barBgColor = warningColor;
+				barBgColorShadowTop = warningColor;
+				barBgColorShadowBottom = warningColorShadowBottom;
+				pulsateTimes = thermal_sensors_widget_pulsateWarning ? 4 : 0;
+				pulsateDuration = thermal_sensors_widget_pulsateWarning ? 900 : 0;
+			} else { // thermalSensorValue > thermal_sensors_widget_coreCriticalTempThreshold
+				barBgColor = criticalColor;
+				barBgColorShadowTop = criticalColor;
+				barBgColorShadowBottom = criticalColorShadowBottom;
+				pulsateTimes = thermal_sensors_widget_pulsateCritical ? 7 : 0;
+				pulsateDuration = thermal_sensors_widget_pulsateCritical ? 900 : 0;
+			}
+		} else { //assuming sensor is for a zone, check Zone Threshold config settings
+			
+			warningTempThresholdPosition = thermal_sensors_widget_zoneWarningTempThreshold;
+			criticalTempThresholdPosition = thermal_sensors_widget_zoneCriticalTempThreshold;
+
+			if (thermalSensorValue < thermal_sensors_widget_zoneWarningTempThreshold) {
+			
+				barBgColor = normalColor;
+				barBgColorShadowTop = normalColorShadowTop;
+				barBgColorShadowBottom = normalColorShadowBottom;
+				pulsateTimes = 0;
+				pulsateDuration = 0;
+
+			} else if (thermalSensorValue >= thermal_sensors_widget_zoneWarningTempThreshold 
+						&& thermalSensorValue < thermal_sensors_widget_zoneCriticalTempThreshold) {
+						
+				barBgColor = warningColor;
+				barBgColorShadowTop = warningColor;
+				barBgColorShadowBottom = warningColorShadowBottom;
+				pulsateTimes = thermal_sensors_widget_pulsateWarning ? 4 : 0;
+				pulsateDuration = thermal_sensors_widget_pulsateWarning ? 900 : 0;
+
+			} else { // thermalSensorValue > thermal_sensors_widget_zoneCriticalTempThreshold
+			
+				barBgColor = criticalColor;
+				barBgColorShadowTop = criticalColor;
+				barBgColorShadowBottom = criticalColorShadowBottom;
+				pulsateTimes = thermal_sensors_widget_pulsateCritical ? 7 : 0;
+				pulsateDuration = thermal_sensors_widget_pulsateCritical ? 900 : 0;
+			}
+		}
+
+		//NOTE: variable thermal_sensors_widget_showFullSensorName is declared/set in "thermal_sensors.widget.php"
+		if (!thermal_sensors_widget_showFullSensorName) {
+			sensorName = getSensorFriendlyName(sensorName);
+		}
+
+		//build temperature item/row for a sensor
+		//NOTE: additional styles are set in 'thermal_sensors.widget.php'
+		var thermalSensorRow = 	"<div class='thermalSensorRow' id='thermalSensorRow" + i + "' >" + 
+							//sensor name and temperature value
+							"	<div class='thermalSensorTextShell'><div class='thermalSensorText' id='thermalSensorText" + i + "'>" + sensorName + ": </div><div class='thermalSensorValue' id='thermalSensorValue" + i + "'>" + thermalSensorValue + " &deg;C</div></div>" + 
+							//temperature bar
+							"	<div class='thermalSensorBarShell' id='thermalSensorBarShell" + i + "' >" + 
+							"		<div class='thermalSensorBar' id='thermalSensorBar" + i + "' style='background-color: " + barBgColor + "; border-top-color: " + barBgColorShadowTop + "; border-bottom-color: " + barBgColorShadowBottom + "; width:" + thermalSensorValue + "%;' ></div>" + 
+							//threshold targets (warning and critical)
+							"		<div class='thermalSensorWarnThresh' id='thermalSensorWarnThresh" + i + "' style='left:" + warningTempThresholdPosition  + "%;' ></div>" + 
+							"		<div class='thermalSensorCritThresh' id='thermalSensorCritThresh" + i + "' style='left:" + criticalTempThresholdPosition + "%;' ></div>" + 
+							//temperature scale (max 100 C)
+							"		<div class='thermal_sensors_widget_scale000'></div>" + 
+							"		<div class='thermal_sensors_widget_scale010'></div>" + 
+							"		<div class='thermal_sensors_widget_scale020'></div>" + 
+							"		<div class='thermal_sensors_widget_scale030'></div>" + 
+							"		<div class='thermal_sensors_widget_scale040'></div>" + 
+							"		<div class='thermal_sensors_widget_scale050'></div>" + 
+							"		<div class='thermal_sensors_widget_scale060'></div>" + 
+							"		<div class='thermal_sensors_widget_scale070'></div>" + 
+							"		<div class='thermal_sensors_widget_scale080'></div>" + 
+							"		<div class='thermal_sensors_widget_scale090'></div>" + 
+							"		<div class='thermal_sensors_widget_scale100'></div>" + 
+							"		<div class='thermal_sensors_widget_mark100'>100&deg;</div>" + 
+							"	</div>" + 
+							"</div>";
+						
+		//collect parameters for warning/critical items we need to pulsate
+		if (pulsateTimes > 0) {
+			var params = i + "|" + barBgColor + "|" + pulsateTimes + "|" + pulsateDuration;
+			itemsToPulsate.push(params);
+		}
+		
+		//append HTML item
+		thermalSensorsHTMLContent = thermalSensorsHTMLContent + thermalSensorRow;
+	}
+	
+	//load generated graph into thermalSensorsContainer (DIV defined in "thermal_sensors.widget.php")
+	loadThermalSensorsContainer(thermalSensorsHTMLContent);
+	
+	if (itemsToPulsate.length > 0) {
+		//pulsate/flash warning/critical items we collected
+		pulsateThermalSensorsItems(itemsToPulsate);
+	}
+}
+
+function pulsateThermalSensorsItems(itemsToPulsate) {
+	
+	//pulsate/flash warning/critical items we collected
+	for (var i = 0; i < itemsToPulsate.length; i++) {
+	
+		var pulsateParams = itemsToPulsate[i].split("|");
+		var rowNum = parseInt(pulsateParams[0]);
+		//var textColor = pulsateParams[1];
+		var pulsateTimes = parseInt(pulsateParams[2]);
+		var pulsateDuration = parseInt(pulsateParams[3]);
+
+		//pulsate temp Value
+		var divThermalSensorValue = jQuery("#thermalSensorValue" + rowNum); //get temp value by id
+		divThermalSensorValue.effect("pulsate", { 
+				 times: pulsateTimes
+				,easing: 'linear' //'easeInExpo' 
+		}, pulsateDuration);
+		////set Temp Value color
+		//divThermalSensorValue.css( { color: textColor } );		
+		
+		//pulsate temp Bar
+		var divThermalSensorBar = jQuery("#thermalSensorBar" + rowNum); //get temp bar by id
+		divThermalSensorBar.effect("pulsate", { 
+				 times: pulsateTimes
+				,easing: 'linear' //'easeInExpo' 
+		}, pulsateDuration);
+		
+	}
+}
+
+function getSensorFriendlyName(sensorFullName){
+
+	var friendlyName = "";
+	
+	switch (sensorFullName) {
+		case "hw.acpi.thermal.tz0.temperature":
+			friendlyName = "Zone 0";
+			break;
+		case "hw.acpi.thermal.tz1.temperature":
+			friendlyName = "Zone 1";
+			break;
+		case "dev.cpu.0.temperature":
+			friendlyName = "Core 0";
+			break;
+		case "dev.cpu.1.temperature":
+			friendlyName = "Core 1";
+			break;
+		case "dev.cpu.2.temperature":
+			friendlyName = "Core 2";
+			break;
+		case "dev.cpu.3.temperature":
+			friendlyName = "Core 3";
+			break;
+		default:
+			friendlyName = sensorFullName;
+	}
+
+	return friendlyName;
+}
+
+function getThermalSensorValue(stringValue){
+	return (+parseFloat(stringValue) || 0).toFixed(1);
+}

--- a/usr/local/www/widgets/widgets/thermal_sensors.widget.php
+++ b/usr/local/www/widgets/widgets/thermal_sensors.widget.php
@@ -1,0 +1,316 @@
+<?php
+/*
+	$Id: thermal_sensors.widget.php
+	Description: Thermal Sensors Widget.
+		NOTE: depends on proper cofing in System >> Advanced >> Miscellaneous tab >> Thermal Sensors section.
+
+	File location: 
+		\usr\local\www\widgets\widgets\
+	Depends on:
+		\usr\local\www\widgets\javascript\thermal_sensors.js
+		\usr\local\www\widgets\include\thermal_sensors.inc
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+ */
+
+$nocsrf = true;
+
+require_once("guiconfig.inc");
+require_once("/usr/local/www/widgets/include/thermal_sensors.inc");
+
+//=========================================================================
+//called by showThermalSensorsData() (jQuery Ajax call) in thermal_sensors.js
+if (isset($_GET["getThermalSensorsData"])) {
+    //get Thermal Sensors data and return
+    echo getThermalSensorsData();
+    return;
+}
+//=========================================================================
+
+
+const WIDGETS_CONFIG_SECTION_KEY = "widgets";
+const THERMAL_SENSORS_WIDGET_SUBSECTION_KEY = "thermal_sensors_widget";
+
+//default constants
+const DEFAULT_WARNING_THRESHOLD = 60; //60 C
+const DEFAULT_CRITICAL_THRESHOLD = 70; //70 C
+const MIN_THRESHOLD_VALUE = 1; //deg C
+const MAX_THRESHOLD_VALUE = 100; //deg C
+
+//NOTE: keys used in $_POST and $config should match text and checkbox inputs' IDs/names in HTML code section
+//=========================================================================
+//save widget config settings on POST
+if ($_POST) {
+	saveThresholdSettings($config, $_POST, "thermal_sensors_widget_zone_warning_threshold", "thermal_sensors_widget_zone_critical_threshold");
+	saveThresholdSettings($config, $_POST, "thermal_sensors_widget_core_warning_threshold", "thermal_sensors_widget_core_critical_threshold");
+
+	//handle checkboxes separately
+	saveGraphDisplaySettings($config, $_POST, "thermal_sensors_widget_show_raw_output");
+	saveGraphDisplaySettings($config, $_POST, "thermal_sensors_widget_show_full_sensor_name");
+	saveGraphDisplaySettings($config, $_POST, "thermal_sensors_widget_pulsate_warning");
+	saveGraphDisplaySettings($config, $_POST, "thermal_sensors_widget_pulsate_critical");
+
+	//write settings to config file
+	write_config("Saved thermal_sensors_widget settings via Dashboard.");
+	header("Location: ../../index.php");
+}
+
+function saveThresholdSettings(&$configArray, &$postArray, $warningValueKey, $criticalValueKey) {
+	$warningValue = 0;
+	$criticalValue = 0;
+
+	if (isset($postArray[$warningValueKey])) {
+		$warningValue = (int) $postArray[$warningValueKey];
+	}
+
+	if (isset($postArray[$criticalValueKey])) {
+		$criticalValue = (int) $postArray[$criticalValueKey];
+	}
+
+	if (
+		($warningValue >= MIN_THRESHOLD_VALUE && $warningValue <= MAX_THRESHOLD_VALUE) &&
+		($criticalValue >= MIN_THRESHOLD_VALUE && $criticalValue <= MAX_THRESHOLD_VALUE) &&
+		($warningValue < $criticalValue)
+	) {
+		//all validated ok, save to config array
+		$configArray[WIDGETS_CONFIG_SECTION_KEY][THERMAL_SENSORS_WIDGET_SUBSECTION_KEY][$warningValueKey] = $warningValue;
+		$configArray[WIDGETS_CONFIG_SECTION_KEY][THERMAL_SENSORS_WIDGET_SUBSECTION_KEY][$criticalValueKey] = $criticalValue;
+	}
+}
+
+function saveGraphDisplaySettings(&$configArray, &$postArray, $valueKey) {
+    $configArray[WIDGETS_CONFIG_SECTION_KEY][THERMAL_SENSORS_WIDGET_SUBSECTION_KEY][$valueKey] = isset($postArray[$valueKey]) ? 1 : 0;
+}
+
+//=========================================================================
+//get Threshold settings from config (apply defaults if missing)
+$thermal_sensors_widget_zoneWarningTempThreshold = getThresholdValueFromConfig($config, "thermal_sensors_widget_zone_warning_threshold", DEFAULT_WARNING_THRESHOLD);
+$thermal_sensors_widget_zoneCriticalTempThreshold = getThresholdValueFromConfig($config, "thermal_sensors_widget_zone_critical_threshold", DEFAULT_CRITICAL_THRESHOLD);
+$thermal_sensors_widget_coreWarningTempThreshold = getThresholdValueFromConfig($config, "thermal_sensors_widget_core_warning_threshold", DEFAULT_WARNING_THRESHOLD);
+$thermal_sensors_widget_coreCriticalTempThreshold = getThresholdValueFromConfig($config, "thermal_sensors_widget_core_critical_threshold", DEFAULT_CRITICAL_THRESHOLD);
+
+//get display settings from config (apply defaults if missing)
+$thermal_sensors_widget_showRawOutput = getBoolValueFromConfig($config, "thermal_sensors_widget_show_raw_output", false);
+$thermal_sensors_widget_showFullSensorName = getBoolValueFromConfig($config, "thermal_sensors_widget_show_full_sensor_name", false);
+$thermal_sensors_widget_pulsateWarning = getBoolValueFromConfig($config, "thermal_sensors_widget_pulsate_warning", true);
+$thermal_sensors_widget_pulsateCritical = getBoolValueFromConfig($config, "thermal_sensors_widget_pulsate_critical", true);
+
+function getThresholdValueFromConfig(&$configArray, $valueKey, $defaultValue) {
+
+	$thresholdValue = $defaultValue;
+
+	if (isset($configArray[WIDGETS_CONFIG_SECTION_KEY][THERMAL_SENSORS_WIDGET_SUBSECTION_KEY][$valueKey])) {
+		$thresholdValue = (int) $configArray[WIDGETS_CONFIG_SECTION_KEY][THERMAL_SENSORS_WIDGET_SUBSECTION_KEY][$valueKey];
+	}
+
+	if ($thresholdValue < MIN_THRESHOLD_VALUE || $thresholdValue > MAX_THRESHOLD_VALUE) {
+		//set to default if not in allowed range
+		$thresholdValue = $defaultValue;
+	}
+	return $thresholdValue;
+}
+
+function getBoolValueFromConfig(&$configArray, $valueKey, $defaultValue) {
+
+	$boolValue = false;
+
+	if (isset($configArray[WIDGETS_CONFIG_SECTION_KEY][THERMAL_SENSORS_WIDGET_SUBSECTION_KEY][$valueKey])) {
+		$boolValue = (bool) $configArray[WIDGETS_CONFIG_SECTION_KEY][THERMAL_SENSORS_WIDGET_SUBSECTION_KEY][$valueKey];
+	} else {
+		//set to default if not in allowed range
+		$boolValue = $defaultValue;
+	}
+	return $boolValue;
+}
+
+//=========================================================================
+?>
+
+<script language="javascript" type="text/javascript">
+	//set Thresholds, to be used in thermal_sensors.js
+	var thermal_sensors_widget_zoneWarningTempThreshold = <?= $thermal_sensors_widget_zoneWarningTempThreshold; ?>;
+	var thermal_sensors_widget_zoneCriticalTempThreshold = <?= $thermal_sensors_widget_zoneCriticalTempThreshold; ?>;
+	var thermal_sensors_widget_coreWarningTempThreshold = <?= $thermal_sensors_widget_coreWarningTempThreshold; ?>;
+	var thermal_sensors_widget_coreCriticalTempThreshold = <?= $thermal_sensors_widget_coreCriticalTempThreshold; ?>;
+
+	//set Graph display settings, to be used in thermal_sensors.js
+	var thermal_sensors_widget_showRawOutput = <?= $thermal_sensors_widget_showRawOutput ? "true" : "false"; ?>;
+	var thermal_sensors_widget_showFullSensorName = <?= $thermal_sensors_widget_showFullSensorName ? "true" : "false"; ?>;
+	var thermal_sensors_widget_pulsateWarning = <?= $thermal_sensors_widget_pulsateWarning ? "true" : "false"; ?>;
+	var thermal_sensors_widget_pulsateCritical = <?= $thermal_sensors_widget_pulsateCritical ? "true" : "false"; ?>;
+
+	//start showing temp data
+	//NOTE: the refresh interval will be reset to a proper value in showThermalSensorsData() (thermal_sensors.js).
+	jQuery(document).ready(function() {
+		showThermalSensorsData();
+	});
+
+</script>
+
+<style type="text/css">
+	/*thermal_sensors widget styles*/
+
+	.thermalSensorRow		{ width: 100%; border: 0px solid #ddd; padding: 1px; border-radius: 3px; }
+	.thermalSensorBarShell	{ position: relative; width: 100%; height: 5px; border: 1px solid lightgray; border-radius: 3px; }
+	.thermalSensorBar		{ position: absolute; width:   0%; height: 1px; z-index: 1; border-style: solid; border-radius: 3px; 
+							  background-color: LimeGreen; 
+							  border-top-width: 2px; border-top-color: Lime; 
+							  border-left-width: 0px;   
+							  border-right-width: 0px; 
+							  border-bottom-width: 2px; border-bottom-color: Green; 
+	}
+	.thermalSensorTextShell	{ height: 20px; width: 100%; top: 3px; }
+	.thermalSensorText		{ float: left; height: 20px; top: 3px; }
+	.thermalSensorValue		{ float: left; height: 20px; top: 3px; font-weight: bold; margin-left: 10px;}
+
+	.thermalSensorWarnThresh	{ position: absolute; background-color: orange; height: 16px; width: 2px; z-index: 2; margin-top: -8px; }
+	.thermalSensorCritThresh	{ position: absolute; background-color:    red; height: 16px; width: 2px; z-index: 2; margin-top: -8px; }
+
+	.thermal_sensors_widget_scale000 { position: absolute; height: 5px; width: 1px; left: -1px; margin-top: -4px; background-color: lightgray; z-index: 0; font-size: 0; }
+	.thermal_sensors_widget_scale020 { position: absolute; height: 3px; width: 1px; left:  10%; margin-top: -4px; background-color: lightgray; z-index: 0; font-size: 0; }
+	.thermal_sensors_widget_scale010 { position: absolute; height: 3px; width: 1px; left:  20%; margin-top: -4px; background-color: lightgray; z-index: 0; font-size: 0; }
+	.thermal_sensors_widget_scale030 { position: absolute; height: 3px; width: 1px; left:  30%; margin-top: -4px; background-color: lightgray; z-index: 0; font-size: 0; }
+	.thermal_sensors_widget_scale040 { position: absolute; height: 3px; width: 1px; left:  40%; margin-top: -4px; background-color: lightgray; z-index: 0; font-size: 0; }
+	.thermal_sensors_widget_scale050 { position: absolute; height: 3px; width: 1px; left:  50%; margin-top: -4px; background-color: lightgray; z-index: 0; font-size: 0; }
+	.thermal_sensors_widget_scale060 { position: absolute; height: 3px; width: 1px; left:  60%; margin-top: -4px; background-color: lightgray; z-index: 0; font-size: 0; }
+	.thermal_sensors_widget_scale070 { position: absolute; height: 3px; width: 1px; left:  70%; margin-top: -4px; background-color: lightgray; z-index: 0; font-size: 0; }
+	.thermal_sensors_widget_scale080 { position: absolute; height: 3px; width: 1px; left:  80%; margin-top: -4px; background-color: lightgray; z-index: 0; font-size: 0; }
+	.thermal_sensors_widget_scale090 { position: absolute; height: 3px; width: 1px; left:  90%; margin-top: -4px; background-color: lightgray; z-index: 0; font-size: 0; }
+	.thermal_sensors_widget_scale100 { position: absolute; height: 9px; width: 1px; left: 100%; margin-top: -6px; background-color: lightgray; z-index: 0; font-size: 0; }
+
+	.thermal_sensors_widget_mark100 { position: absolute; width: 15px; left: 96%; margin-top: -12px; font: 6pt Arial, sans-serif; text-align: left; color: #575757; }
+
+</style>
+
+
+<input type="hidden" id="thermal_sensors-config" name="thermal_sensors-config" value="">
+<div id="thermal_sensors-settings" name="thermal_sensors-settings" class="widgetconfigdiv" style="display:none;">
+	<form action="/widgets/widgets/thermal_sensors.widget.php" method="post" id="iform_thermal_sensors_settings" name="iform_thermal_sensors_settings">
+	<table width="100%" border="0">
+		<tr>
+		<td align="left" colspan="2">
+			<span style="font-weight: bold" >Thresholds in &deg;C (1 to 100):</span>
+		</td>
+		<td align="right" colspan="1">
+			<span style="font-weight: bold" >Display settings:</span>
+		</td>
+		</tr>
+		<tr>
+		<td align="right">
+			Zone Warning: 
+		</td>
+		<td>
+			<input type="text" maxlength="3" size="3" class="formfld unknown" 
+			   name="thermal_sensors_widget_zone_warning_threshold" 
+			   id="thermal_sensors_widget_zone_warning_threshold" 
+			   value="<?= $thermal_sensors_widget_zoneWarningTempThreshold; ?>" />
+		</td>
+		<td align="right">
+			<label for="thermal_sensors_widget_show_raw_output">Show raw output (no graph): </label>
+			<input type="checkbox" 
+			   id="thermal_sensors_widget_show_raw_output" 
+			   name="thermal_sensors_widget_show_raw_output" 
+			   value="<?= $thermal_sensors_widget_showRawOutput; ?>" <?= ($thermal_sensors_widget_showRawOutput) ? " checked='checked'" : ""; ?> />
+		</td>
+		</tr>
+		<tr>
+		<td align="right">
+			Zone Critical: 
+		</td>
+		<td>
+			<input type="text" maxlength="3" size="3" class="formfld unknown" 
+			   name="thermal_sensors_widget_zone_critical_threshold" 
+			   id="thermal_sensors_widget_zone_critical_threshold" 
+			   value="<?= $thermal_sensors_widget_zoneCriticalTempThreshold; ?>" />
+		</td>
+		<td align="right">
+			<label for="thermal_sensors_widget_show_full_sensor_name">Show full sensor name: </label>
+			<input type="checkbox" 
+			   id="thermal_sensors_widget_show_full_sensor_name" 
+			   name="thermal_sensors_widget_show_full_sensor_name" 
+			   value="<?= $thermal_sensors_widget_showFullSensorName; ?>" <?= ($thermal_sensors_widget_showFullSensorName) ? " checked='checked'" : ""; ?> />
+		</td>
+		</tr>
+		<tr>
+		<td align="right">
+			Core Warning: 
+		</td>
+		<td>
+			<input type="text" maxlength="3" size="3" class="formfld unknown" 
+			   name="thermal_sensors_widget_core_warning_threshold" 
+			   id="thermal_sensors_widget_core_warning_threshold" 
+			   value="<?= $thermal_sensors_widget_coreWarningTempThreshold ?>" />
+		</td>
+		<td align="right">
+			<label for="thermal_sensors_widget_pulsate_warning">Pulsate Warning: </label>
+			<input type="checkbox" 
+			   id="thermal_sensors_widget_pulsate_warning" 
+			   name="thermal_sensors_widget_pulsate_warning" 
+			   value="<?= $thermal_sensors_widget_pulsateWarning; ?>" <?= ($thermal_sensors_widget_pulsateWarning) ? " checked='checked'" : ""; ?> />
+		</td>
+		</tr>
+		<tr>
+		<td align="right">
+			Core Critical: 
+		</td>
+		<td>
+			<input type="text" maxlength="3" size="3" class="formfld unknown" 
+			   name="thermal_sensors_widget_core_critical_threshold" 
+			   id="thermal_sensors_widget_core_critical_threshold" 
+			   value="<?= $thermal_sensors_widget_coreCriticalTempThreshold ?>" />
+		</td>
+		<td align="right">
+			<label for="thermal_sensors_widget_pulsate_critical">Pulsate Critical: </label>
+			<input type="checkbox" 
+			   id="thermal_sensors_widget_pulsate_critical" 
+			   name="thermal_sensors_widget_pulsate_critical" 
+			   value="<?= $thermal_sensors_widget_pulsateCritical; ?>" <?= ($thermal_sensors_widget_pulsateCritical) ? " checked='checked'" : ""; ?> />
+		</td>
+		</tr>
+		<tr>
+		<td align="right" colspan="3">
+			<input type="submit" id="thermal_sensors_widget_submit" name="thermal_sensors_widget_submit" class="formbtn" value="Save" />
+		</td>
+		</tr>
+		<tr>
+		<td align="left" colspan="3">
+			<span>* You can configure a proper Thermal Sensor / Module under <br />
+			&nbsp;&nbsp;&nbsp;<a href="system_advanced_misc.php">System &gt; Advanced &gt; Miscellaneous : Thermal Sensors section</a>.</span>
+		</td>
+		</tr>
+	</table>
+	</form>
+</div>
+
+<div style="padding: 5px">
+	<div id="thermalSensorsContainer" class="listr">
+		(Updating...)<br /><br />
+	</div>
+</div>
+
+<!-- needed to display the widget settings menu -->
+<script language="javascript" type="text/javascript">
+
+	textlink = jQuery("#thermal_sensors-configure");
+	textlink.css({display: "inline"});
+
+</script>


### PR DESCRIPTION
Original post: http://forum.pfsense.org/index.php/topic,59193.0.html
NOTE: I've changed the widget name from "Core Temperatures" to "Thermal Sensors", which I think is more appropriate.

Description:
Thermal Sensors Widget is a stand-alone widget.
No existing/original file changes required.
Displays Thermal Sensors data for anything returned by "sysctl -a | grep temperature" command (in will fall back to "No Thermal Sensors data available" message if no data available).
Configurable thresholds and display appearance.
NOTE: depends on proper cofing in System >> Advanced >> Miscellaneous tab >> Thermal Sensors section.

Designed and tested for:
pfSense 2.1-BETA1 (i386)
Browsers: FF, Chrome and IE9.
Hardware tested on: Intel DH77EB, Core i3 3225
