### PR TITLE
DynDNS status widget async update

### DIFF
--- a/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
@@ -65,7 +65,7 @@ if($_REQUEST['getdyndnsstatus']) {
 			echo htmlspecialchars($cached_ip);
 			echo "</font>";
 		} else {
-			echo "N/A";
+			echo "N/A " . date("H:i:s");
 		}
 	}
 	exit;
@@ -146,6 +146,8 @@ if($_REQUEST['getdyndnsstatus']) {
 				data: pars,
 				complete: dyndnscallback
 			});
+		// Refresh the status every 5 minutes
+		setTimeout('dyndns_getstatus()', 5*60*1000);
 	}
 	function dyndnscallback(transport) {
 		// The server returns a string of statuses separated by vertical bars
@@ -156,6 +158,7 @@ if($_REQUEST['getdyndnsstatus']) {
 			jQuery(divlabel).prop('innerHTML',responseStrings[count]);
 		}
 	}
+	// Do the first status check 2 seconds after the dashboard opens
 	setTimeout('dyndns_getstatus()', 2000);
 //]]>
 </script>


### PR DESCRIPTION
The Dynamic DNS status widget performs remote operations to the www to check the cached dynamic DNS IP against the actual current public-facing IP. When an external link is slow, or particularly when the cable is plugged in (it seems up) but actually the internet is down, it takes a long time for a response from http://checkip.dyndns.com/ to time out. The dashboard page hangs in a half-drawn state (up to drawing the DynDNS status table) for up to 30 seconds.
This change puts the code that does these external operations into some ajax/Java script that runs after the dashboard has drawn up. Code concept unashamedly stolen from the system information widget.
