### PR TITLE
Set LDAP option to dereference aliases when searching

### DIFF
--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -739,6 +739,7 @@ function ldap_test_bind($authcfg) {
         }
 
 	ldap_set_option($ldap, LDAP_OPT_REFERRALS, 0);
+	ldap_set_option($ldap, LDAP_OPT_DEREF, LDAP_DEREF_SEARCHING);
 	ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, (int)$ldapver);
  
 	if ($ldapanon == true) {
@@ -809,6 +810,7 @@ function ldap_get_user_ous($show_complete_ou=true, $authcfg) {
 	$ldapfilter = "(|(ou=*)(cn=Users))";
 
 	ldap_set_option($ldap, LDAP_OPT_REFERRALS, 0);
+	ldap_set_option($ldap, LDAP_OPT_DEREF, LDAP_DEREF_SEARCHING);
 	ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, (int)$ldapver);
 
 	if ($ldapanon == true) {
@@ -919,6 +921,7 @@ function ldap_get_groups($username, $authcfg) {
         }
     
 	ldap_set_option($ldap, LDAP_OPT_REFERRALS, 0);
+	ldap_set_option($ldap, LDAP_OPT_DEREF, LDAP_DEREF_SEARCHING);
 	ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, (int)$ldapver);
 
 	/* bind as user that has rights to read group attributes */
@@ -1042,6 +1045,7 @@ function ldap_backed($username, $passwd, $authcfg) {
         ldap_setup_caenv($authcfg);
 
 	ldap_set_option($ldap, LDAP_OPT_REFERRALS, 0);
+	ldap_set_option($ldap, LDAP_OPT_DEREF, LDAP_DEREF_SEARCHING);
 	ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, (int)$ldapver);
 
 	/* Make sure we can connect to LDAP */


### PR DESCRIPTION
Adding this setting allows users to set up aliases in their LDAP directory, and then have them dereferenced properly by pfSense.

For example, I have a bunch of people under `ou=people,dc=example,dc=com`.  I then created a second ou `ou=vpnusers,dc=example,dc=com` and created aliases similar to the following under it:

```
dn: uid=user.name,ou=vpnusers,dc=example,dc=com
objectClass: alias
objectClass: extensibleObject
objectClass: top
aliasedObjectName: uid=user.name,ou=people,dc=example,dc=com
uid: user.name
```

In the pfSense User Manager I can then create an LDAP server entry that has an authentication container of `ou=vpnusers,dc=example,dc=com` with user naming attribute `uid`, giving me an LDAP connection that only authenticates a subset of the possible users.

This provides an alternative way of restricting the access of subsets of users and allows things like setting up an OpenVPN server to which only some users have access.

I have tested this on a pfSense 2.0.2 release install using both the authentication diagnostics page and an OpenVPN server configured for user authentication only (no client certificates).
