### PR TITLE
Add default case when detecting dynamic gateway ip

### DIFF
--- a/etc/inc/gwlb.inc
+++ b/etc/inc/gwlb.inc
@@ -383,6 +383,14 @@ function return_gateways_array($disabled = false, $localhost = false) {
 								$gateway['gateway'] = "dynamic";
 							$gateway['dynamic'] = true;
 							break;
+						default:
+							$gateway['ipprotocol'] = "inet";
+							$gateway['gateway'] = get_interface_gateway($gateway['interface']);
+							/* no IP address found, set to dynamic */
+							if (!is_ipaddrv4($gateway['gateway']))
+								$gateway['gateway'] = "dynamic";
+							$gateway['dynamic'] = true;
+							break;
 					}
 				}
 
@@ -396,6 +404,14 @@ function return_gateways_array($disabled = false, $localhost = false) {
 						case "pppoe":
 						case "pptp":
 						case "ppp":
+							$gateway['ipprotocol'] = "inet6";
+							$gateway['gateway'] = get_interface_gateway_v6($gateway['interface']);
+							/* no IPv6 address found, set to dynamic6 */
+							if (!is_ipaddrv6($gateway['gateway']))
+								$gateway['gateway'] = "dynamic6";
+							$gateway['dynamic'] = true;
+							break;
+						default:
 							$gateway['ipprotocol'] = "inet6";
 							$gateway['gateway'] = get_interface_gateway_v6($gateway['interface']);
 							/* no IPv6 address found, set to dynamic6 */


### PR DESCRIPTION
Add a default to $wancfg['ipaddr'] case in return_gateways_array function for both ipv4 and ipv6 to allow gateway ip to be returned rather then 'dynamic' for an openvpn connection
