### PR TITLE
Update rc.firmware to support upgrades on USB Flash devices PROPERLY

### DIFF
--- a/etc/rc.firmware
+++ b/etc/rc.firmware
@@ -208,8 +208,9 @@ pfSenseNanoBSDupgrade)
 	SIZE=`/sbin/fdisk ${COMPLETE_PATH} | /usr/bin/grep Meg | /usr/bin/awk '{ print $5 }' | /usr/bin/cut -d"(" -f2`
 	# USB slices are under-reported even more than CF slices when viewed
 	#   directly, instead of when looking at the entire disk. Compensate
-	#   by adding a few MB.
-	SIZE=`expr $SIZE + 4`
+	#   by adding exactly 6MB. 4MB was consistently 2MB too few, and
+	#   was resulting in failing upgrades on USB Flash based installs.
+	SIZE=`expr $SIZE + 6`
 	if [ "$SIZE" -lt "$NEW_IMG_SIZE" ]; then
 		file_notice "UpgradeFailure" "Upgrade failed due to the upgrade image being larger than the partition that is configured on disk.  Halting. Size on disk: $SIZE < Size of new image: $NEW_IMG_SIZE"
 		echo "Upgrade failed.  Please check the system log file for more information" | wall


### PR DESCRIPTION
Previous USB patch to add 4MB to partition size calculation was not only not working, but worse, causing dev's to close all related tickets as duplicates when it clearly still needed fixing.

Also, some dev's cited that "the CF install base is so much larger it's not worth breaking". Well, you've already broken it by adding a 4MB buffer for USB, which doesn't work. Either patch it right at 6MB, or completely take out the buffer all together to "fix" CF upgrades again. Why sit on a double broken patch?

PoC: EVERY USB flash based install in place upgrade was failing by exactly 2MB. Added this patch to my 2.0.2 system after a failed 2.0.3 upgrade and boom, upgraded to 2.0.3 without issue.

You're welcome ;-)
