### PR TITLE
Tidy up "firewall_schedule_edit.php"

### DIFF
--- a/usr/local/www/firewall_schedule_edit.php
+++ b/usr/local/www/firewall_schedule_edit.php
@@ -808,7 +808,7 @@ EOD;
                     	$monthlimit = $monthcounter + 12;
                     	$yearcounter = date("Y");
                     	for ($k=0; $k<12; $k++){?>	             
-                    		<option value="<?php echo $monthcounter;?>"><?php echo date("F y", mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter)));?></option>
+                    		<option value="<?php echo $monthcounter;?>"><?php echo date("F_y", mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter)));?></option>
                           <?php        	
                           if ($monthcounter == 12)
 							{
@@ -837,9 +837,9 @@ EOD;
 						$lasttr = FALSE;
 						$positioncounter = 1;//7 for Sun, 1 for Mon, 2 for Tues, etc						
 						?>	
-	                        <div id="<?php echo date("F y",mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter)));?>" style=" position:relative; display:<?php if($firstmonth)echo "block";else echo "none";?>">    	
-		                   	<table border="1" cellspacing="1" cellpadding="1" id="calTable" class="tabcont" summary="month">
-								<tr><td colspan="7" align="center" class="listbg"><b><?php echo date("F Y", mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter)));?></b></td>
+	                        <div id="<?php echo date("F_y",mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter)));?>" style=" position:relative; display:<?php if($firstmonth)echo "block";else echo "none";?>">    	
+		                   	<table border="1" cellspacing="1" cellpadding="1" id="calTable<?=$monthcounter . $yearcounter;?>" class="tabcont" summary="month">
+								<tr><td colspan="7" align="center" class="listbg"><b><?php echo date("F_Y", mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter)));?></b></td>
 								</tr>
 								<tr>	
 									<td align="center" class="listhdrr" style="cursor: pointer;" onclick="daytoggle('w1p1');"><u><b><?=gettext("Mon");?></b></u></td>
@@ -877,7 +877,7 @@ EOD;
 										echo "<td align=\"center\" class=\"listr\"></td>";
 									}
 									
-									if ($positioncounter ==7){
+									if ($positioncounter == 7 || $daycounter > $numberofdays){
 										$positioncounter = 1;
 										echo "</tr>";
 									}


### PR DESCRIPTION
ID statements (DIV tags) cannot take a space separated list of words, so use the underscore character between the month and year.

Make the ID statement in the TABLE tags unique by adding the month and year PHP variables to the ID.

At the end of the month, the TR tag is not being closed correctly, so add a check to see if the day count is greater than the number of days.
