### PR TITLE
ZFSROOT not hardcoded to zpool or dataset 'tank'

### DIFF
--- a/etc/rc
+++ b/etc/rc
@@ -68,7 +68,7 @@ echo "Mounting filesystems..."
 # Handle ZFS read-only case
 if [ "$PLATFORM" = "pfSense" ]; then
 	if [ -f /usr/bin/grep ]; then
-		ZFSROOT=`/sbin/mount | /usr/bin/grep " / " | /usr/bin/awk -F ' on ' '{print $1}'`
+		ZFSROOT=`/sbin/zfs mount | /usr/bin/grep ' /$' | /usr/bin/cut -d ' ' -f 1`
 		if [ "$ZFSROOT" != "" ]; then
 			echo /sbin/zfs set readonly=off $ZFSROOT
 		fi


### PR DESCRIPTION
For ZFS root readonly case, the WHEREISROOT variable was grep-ing for 'tank', expecting a zpool with that name.

A workaround of naming a dataset 'tank', for example, 'sys/ROOT/tank' or 'sys/tank/pfSense' is compatible, however this shouldn't be hardcoded in.

My proposed change replaces WHEREISROOT with ZFSROOT using awk. I noticed awk is used elsewhere in this script. However it is still simple code that is not resilient against unexpected circumstances, let alone failure.
