### PR TITLE
Merge commit to correct debugging issue

### DIFF
--- a/etc/rc
+++ b/etc/rc
@@ -70,7 +70,7 @@ if [ "$PLATFORM" = "pfSense" ]; then
 	if [ -f /usr/bin/grep ]; then
 		ZFSROOT=`/sbin/zfs mount | /usr/bin/grep ' /$' | /usr/bin/cut -d ' ' -f 1`
 		if [ "$ZFSROOT" != "" ]; then
-			echo /sbin/zfs set readonly=off $ZFSROOT
+			/sbin/zfs set readonly=off $ZFSROOT
 		fi
 	fi
 fi


### PR DESCRIPTION
Accidentally changed this from executing the zfs command to echoing the
expected command in previous commits.
This had been set while debugging a better command to set ZFSROOT
variable.
