### PR TITLE
OpenVPN w/ IPv6 fails to set ifconfig-ipv6 value in conf #2991

### DIFF
--- a/etc/inc/openvpn.inc
+++ b/etc/inc/openvpn.inc
@@ -1243,8 +1243,8 @@ function openvpn_get_interface_ipv6($ipv6, $prefix) {
 	// Is there a better way to do this math?
 	$ipv6_arr = explode(':', $basev6);
 	$last = hexdec(array_pop($ipv6_arr));
-	$ipv6_1 = Net_IPv6::compress(implode(':', $ipv6_arr) . ':' . dechex($last + 1));
-	$ipv6_2 = Net_IPv6::compress(implode(':', $ipv6_arr) . ':' . dechex($last + 2));
+	$ipv6_1 = Net_IPv6::compress(Net_IPv6::uncompress(implode(':', $ipv6_arr) . ':' . dechex($last + 1)));
+	$ipv6_2 = Net_IPv6::compress(Net_IPv6::uncompress(implode(':', $ipv6_arr) . ':' . dechex($last + 2)));
 	return array($ipv6_1, $ipv6_2);
 }
 


### PR DESCRIPTION
Net_IPv6::compress returns "" when the IPv6 address is already compressed!!! That is a bug in Net_IPv6, but might be more difficult to correct right now. The way to make sure things are OK is to call uncompress first, to always make sure an uncompressed IPv6 addres is passed to compress. Note: uncompress works fine if the address is already uncompressed - it returns what it was given.
I will search later for other uses of Net_IPv6::compress in pfSense code, as they will all have the potential for this kind of error.

$ipv6 = "fe80::1";
$ipv6_1 = Net_IPv6::compress($ipv6);
var_dump($ipv6_1);
string(0) ""

$ipv6_1 = Net_IPv6::compress(Net_IPv6::uncompress($ipv6));
var_dump($ipv6_1);
string(7) "fe80::1"
