### PR TITLE
IPv6 OpenVPN TAP mode typo

### DIFF
--- a/etc/inc/openvpn.inc
+++ b/etc/inc/openvpn.inc
@@ -514,7 +514,7 @@ function openvpn_reconfigure($mode, $settings) {
 					if ($settings['dev_mode'] == 'tun')
 						$conf .= "ifconfig-ipv6 {$ipv6_1} {$ipv6_2}\n";
 					else
-						$conf .= "ifconfig {$ipv6_1} {$prefix}\n";
+						$conf .= "ifconfig-ipv6 {$ipv6_1} {$prefix}\n";
 				}
 				break;
 			case 'server_tls':
@@ -665,7 +665,7 @@ function openvpn_reconfigure($mode, $settings) {
 			if ($settings['dev_mode'] == 'tun')
 				$conf .= "ifconfig-ipv6 {$ipv6_2} {$ipv6_1}\n";
 			else
-				$conf .= "ifconfig {$ipv6_2} {$prefix}\n";
+				$conf .= "ifconfig-ipv6 {$ipv6_2} {$prefix}\n";
 		}
 
 		if ($settings['proxy_addr']) {


### PR DESCRIPTION
While I was looking at the OpenVPN IPv6 conf file generation code, these stood out - they look like IPv6 TAP mode would not work. I don't use that, and not sure who does, so it is not tested to see if it was broken and now works. But it does look like a simple cut-and-paste problem.
