### PR TITLE
Teach Net_IPv6:compress to handle a compressed address as input

### DIFF
--- a/etc/inc/IPv6.inc
+++ b/etc/inc/IPv6.inc
@@ -580,6 +580,9 @@ class Net_IPv6 {
             $cip = preg_replace('/((^:)|(:$))/', '' ,$cip);
             $cip = preg_replace('/((^:)|(:$))/', '::' ,$cip);
 
+         } else {
+            // The input IP appears to be compressed already, give it back as-is to the caller.
+            $cip = $ip;
          }
          if ('' != $netmask) {
 


### PR DESCRIPTION
It turned out to be easy to make Net_IPv6:compress return the compressed address when an already-compressed address is passed to it. This will make it behave in a more sensible manner, so future callers do not have to think about whether the address they are passing is already compressed or not.
I checked the following modules which call Net_IPv6:compress, and it was already working in them because the code always calls with a full uncompressed address, or it was doing uncompress first before calling compress:
interfaces.inc
ipsec.inc
openvpn.inc
pfsense-utils.inc
util.inc

services.inc services_dhcpdv6_configure has some calls to compress related to track6-interface. They look like they already work with full IPv6 addresses before calling compress. But I can't easily test that function. Anyway, this change can only improve things if compress is called under some conditions with an already-compressed IPv6 address.
