### PR TITLE
Remove if statement

### DIFF
--- a/usr/local/www/index.php
+++ b/usr/local/www/index.php
@@ -700,7 +700,7 @@ pfSense_handle_custom_code("/usr/local/pkg/dashboard/pre_dashboard");
 				<br />
 					<img src="./themes/<?= $g['theme']; ?>/images/misc/widget_loader.gif" width="25" height="25" alt="<?=gettext("Loading selected widget"); ?>..." />
 				<br />
-			</div> <?php } if ($divdisplay != "block") $display = none; ?>
+			</div> <?php $display = "none"; } ?>
 			<div id="<?php echo $widgetname;?>" style="display:<?php echo $display; ?>;">				
 				<?php 
 					if ($divdisplay == "block")


### PR DESCRIPTION
Can someone run their eyes over this before merging!

If i'm reading the code right there are 2 if statements checking if $divdisplay != "block"

Which would look like this:

```
if ($divdisplay != "block") {
    <div id="<?php echo $widgetname;?>-loader" style="display:<?php echo $display; ?>;" align="center"><br />
    <img src="./themes/<?= $g['theme']; ?>/images/misc/widget_loader.gif" width="25" height="25" alt="<?=gettext("Loading selected widget"); ?>..." />
    <br /></div> 
} 

if ($divdisplay != "block") 
    $display = none;

<div id="<?php echo $widgetname;?>" style="display:<?php echo $display; ?>;">               


if ($divdisplay == "block")
{
    include($directory . $widget);
} 
```

If this is correct, I have moved the $display = none; to the first loop and removed the redundant loop.
Also placed the none within quotes.
