### PR TITLE
Added curl_setopt options for Custom DNS

### DIFF
--- a/etc/inc/dyndns.class
+++ b/etc/inc/dyndns.class
@@ -558,6 +558,8 @@
 						log_error("Custom DDNS ({$this->_dnsHost}): DNS update() starting.");
 					if (strstr($this->dnsUpdateURL, "%IP%")) {$needsIP = TRUE;} else {$needsIP = FALSE;}
 					if ($this->_dnsUser != '') {
+						curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4 );
+						curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
 						curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY); 
 						curl_setopt($ch, CURLOPT_USERPWD, "{$this->_dnsUser}:{$this->_dnsPass}");
 					}


### PR DESCRIPTION
Added curl_setopt options for Custom DNS to bind to IPv4 (CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4) and to not ssl-verify peer (CURLOPT_SSL_VERIFYPEER, FALSE) to work with more custom providers
