### PR TITLE
Simplify shaper.inc for ipv6

### DIFF
--- a/etc/inc/shaper.inc
+++ b/etc/inc/shaper.inc
@@ -2782,24 +2782,7 @@ class dummynet_class {
         var $mask;
         var $noerror;
         
-        var $ipv6allow;
-        
-        /* constructor */
-                
-        function __construct() {
-                global $config;
-                if (isset($config['system']['ipv6allow']))
-                        $this->ipv6allow = True;
-                else
-                        $this->ipv6allow = False;
-
-        }
-
         /* Accessor functions */
-        function IPV6Enabled() {
-                return $this->ipv6allow;
-        }
-        
         function SetLink($link) {
                 $this->link = $link;
         }
@@ -2883,14 +2866,11 @@ class dummynet_class {
 		$javascript .= "if ((e.options[e.selectedIndex].text == \"none\") || enable_over) {\n";
 		$javascript .= "document.iform.maskbits.disabled = 1;\n";
 		$javascript .= "document.iform.maskbits.value = \"\";\n";
-                if ($this->IPV6Enabled()) {
-                        $javascript .= "document.iform.maskbitsv6.disabled = 1;\n";
-                        $javascript .= "document.iform.maskbitsv6.value = \"\";\n";
-                }
+		$javascript .= "document.iform.maskbitsv6.disabled = 1;\n";
+		$javascript .= "document.iform.maskbitsv6.value = \"\";\n";
 		$javascript .= "} else {\n";
 		$javascript .= "document.iform.maskbits.disabled = 0;\n";
-                if ($this->IPV6Enabled())
-                        $javascript .= "document.iform.maskbitsv6.disabled = 0;\n";
+                $javascript .= "document.iform.maskbitsv6.disabled = 0;\n";
 		$javascript .= "}}\n";
 		$javascript .= "//]]>\n";
 		$javascript .= "</script>\n";
@@ -2922,11 +2902,9 @@ class dummynet_class {
                 if (isset($data['maskbits']) && ($data['maskbits'] <> ""))
 			if ((!is_numeric($data['maskbits'])) || ($data['maskbits'] <= 0) || ($data['maskbits'] > 32))
 				$input_errors[] = gettext("IPV4 bit mask must be blank or numeric value between 1 and 32.");
-                if ($this->IPV6Enabled())
-                        if (isset($data['maskbitsv6']) && ($data['maskbitsv6'] <> "")) {
-				if ((!is_numeric($data['maskbitsv6'])) || ($data['maskbitsv6'] <= 0) || ($data['maskbitsv6'] > 128))
-					$input_errors[] = gettext("IPV6 bit mask must be blank or numeric value between 1 and 128.");
-			}
+		if (isset($data['maskbitsv6']) && ($data['maskbitsv6'] <> ""))
+			if ((!is_numeric($data['maskbitsv6'])) || ($data['maskbitsv6'] <= 0) || ($data['maskbitsv6'] > 128))
+				$input_errors[] = gettext("IPV6 bit mask must be blank or numeric value between 1 and 128.");
 	}
 	
 	function build_mask_rules(&$pfq_rule) {
@@ -2936,24 +2914,20 @@ class dummynet_class {
 				$pfq_rule .= " mask";
 			switch ($mask['type']) {
 			case 'srcaddress':
-                                if ($this->IPV6Enabled()) {
-                                        if (!empty($mask['bitsv6']) && ($mask['bitsv6'] <> ""))
-                                                $pfq_rule .= " src-ip6 /" . $mask['bitsv6'];
-					else
-						$pfq_rule .= " src-ip6 /128";
-                                }
+				if (!empty($mask['bitsv6']) && ($mask['bitsv6'] <> ""))
+					$pfq_rule .= " src-ip6 /" . $mask['bitsv6'];
+				else
+					$pfq_rule .= " src-ip6 /128";
                                 if (!empty($mask['bits']) && ($mask['bits'] <> ""))
                                         $pfq_rule .= sprintf(" src-ip 0x%x", gen_subnet_mask_long($mask['bits']));
                                 else
 					$pfq_rule .= " src-ip 0xffffffff";
 				break;
 			case 'dstaddress':
-                                if ($this->IPV6Enabled()) {
-                                        if (!empty($mask['bitsv6']) && ($mask['bitsv6'] <> ""))
-                                                $pfq_rule .= " dst-ip6 /" . $mask['bitsv6'];
-					else
-						$pfq_rule .= " dst-ip6 /128";
-                                }
+				if (!empty($mask['bitsv6']) && ($mask['bitsv6'] <> ""))
+					$pfq_rule .= " dst-ip6 /" . $mask['bitsv6'];
+				else
+					$pfq_rule .= " dst-ip6 /128";
                                 if (!empty($mask['bits']) && ($mask['bits'] <> ""))
                                         $pfq_rule .= sprintf(" dst-ip 0x%x", gen_subnet_mask_long($mask['bits']));
                                 else
@@ -3388,16 +3362,14 @@ EOD;
 			$form .= " disabled";
 		$form .= " />";
 		$form .= "&nbsp; IPV4 mask bits (1-32)<br/>";
-                if ($this->IPV6Enabled()) {
-                        $form .= "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/&nbsp;<input type=\"text\" class=\"formfld unknown\" size=\"2\" id=\"maskbitsv6\" name=\"maskbitsv6\" value=\"";
-                        if ($mask['type'] <> "none")
-                        $form .= $mask['bitsv6'];
-                        $form .= "\"";
-                        if ($mask['type'] == "none")
-                                $form .= " disabled";
-                        $form .= " />";
-                        $form .= "&nbsp; IPV6 mask bits (1-128)<br/>";
-                }
+		$form .= "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/&nbsp;<input type=\"text\" class=\"formfld unknown\" size=\"2\" id=\"maskbitsv6\" name=\"maskbitsv6\" value=\"";
+		if ($mask['type'] <> "none")
+		$form .= $mask['bitsv6'];
+		$form .= "\"";
+		if ($mask['type'] == "none")
+			$form .= " disabled";
+		$form .= " />";
+		$form .= "&nbsp; IPV6 mask bits (1-128)<br/>";
 		$form .= "<span class=\"vexpl\">" . gettext("If 'source' or 'destination' slots is chosen, \n"
 		      .  "leaving the mask bits blank will create one pipe per host. Otherwise specify \n"
 		      .  "the number of 'one' bits in the subnet mask used to group multiple hosts \n"
@@ -3483,10 +3455,7 @@ EOD;
 		$mask = $this->GetMask();
 		$cflink['mask'] = $mask['type'];
 		$cflink['maskbits'] = $mask['bits'];
-                if ($this->IPV6Enabled())
-                        $cflink['maskbitsv6'] = $mask['bitsv6'];
-                else
-                        $cflink['maskbitsv6'] = "";
+                $cflink['maskbitsv6'] = $mask['bitsv6'];
 		$cflink['delay'] = $this->GetDelay();
 	}
 
@@ -3666,16 +3635,14 @@ class dnqueue_class extends dummynet_class {
 			$form .= " disabled";
 		$form .= " />";
 		$form .= "&nbsp; IPV4 mask bits (1-32)<br/>";
-                if ($this->IPV6Enabled()) {
-                        $form .= "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/&nbsp;<input type=\"text\" class=\"formfld unknown\" size=\"2\" id=\"maskbitsv6\" name=\"maskbitsv6\" value=\"";
-                        if ($mask['type'] <> "none")
-                        $form .= $mask['bitsv6'];
-                        $form .= "\"";
-                        if ($mask['type'] == "none")
-                                $form .= " disabled";
-                        $form .= " />";
-                        $form .= "&nbsp; IPV6 mask bits (1-128)<br/>";
-                }
+		$form .= "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/&nbsp;<input type=\"text\" class=\"formfld unknown\" size=\"2\" id=\"maskbitsv6\" name=\"maskbitsv6\" value=\"";
+		if ($mask['type'] <> "none")
+		$form .= $mask['bitsv6'];
+		$form .= "\"";
+		if ($mask['type'] == "none")
+			$form .= " disabled";
+		$form .= " />";
+		$form .= "&nbsp; IPV6 mask bits (1-128)<br/>";
 		$form .= "<span class=\"vexpl\">" . gettext("If 'source' or 'destination' slots is chosen, \n"
 		      .  "leaving the mask bits blank will create one pipe per host. Otherwise specify \n"
 		      .  "the number of 'one' bits in the subnet mask used to group multiple hosts \n"
@@ -3758,10 +3725,7 @@ class dnqueue_class extends dummynet_class {
 		$mask = $this->GetMask();
 		$cflink['mask'] = $mask['type'];
 		$cflink['maskbits'] = $mask['bits'];
-                if ($this->IPV6Enabled())
-                        $cflink['maskbitsv6'] = $mask['bitsv6'];
-                else
-                        $cflink['maskbitsv6'] = "";
+                $cflink['maskbitsv6'] = $mask['bitsv6'];
 	}
 }
 


### PR DESCRIPTION
The system->advanced->network->allowIpv6 setting does not disable IPV6 it only creates rule to block all IPV6.
- There is therefore no reason to hide or disable IPV6 shaper settings when IPV6 is blocked globally.
