### PR TITLE
Actually use ldap_attr_group

### DIFF
--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -953,9 +953,10 @@ function ldap_get_groups($username, $authcfg) {
 	if(is_array($info[0][$ldapmemberattribute])) {
 		/* Iterate through the groups and throw them into an array */
 		foreach ($info[0][$ldapmemberattribute] as $member) {
-			if (stristr($member, "CN=") !== false) {
-				$membersplit = explode(",", $member);
-				$memberof[] = preg_replace("/CN=/i", "", $membersplit[0]);
+			$membersplit = explode(",", $member);
+			$membersplit = explode("=", $membersplit[0]);
+			if (strtolower($membersplit[0]) == "cn") {
+				$memberof[] = $membersplit[1];
 			}
 		}
 	}

--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -888,7 +888,7 @@ function ldap_get_groups($username, $authcfg) {
                 $ldapauthcont       = $authcfg['ldap_authcn'];
                 /* Convert attributes to lowercase.  php ldap arrays put everything in lowercase */
                 $ldapnameattribute  = strtolower($authcfg['ldap_attr_user']);
-                $ldapgroupattribute = strtolower($authcfg['ldap_attr_member']);
+                $ldapmemberattribute= strtolower($authcfg['ldap_attr_member']);
                 $ldapfilter         = "({$ldapnameattribute}={$username})";
                 $ldaptype           = "";
                 $ldapver            = $authcfg['ldap_protver'];
@@ -939,20 +939,20 @@ function ldap_get_groups($username, $authcfg) {
 	/* get groups from DN found */
 	/* use ldap_read instead of search so we don't have to do a bunch of extra work */
 	/* since we know the DN is in $_SESSION['ldapdn'] */
-	//$search    = ldap_read($ldap, $ldapdn, "(objectclass=*)", array($ldapgroupattribute));
+	//$search    = ldap_read($ldap, $ldapdn, "(objectclass=*)", array($ldapmemberattribute));
 	if ($ldapscope == "one")
                 $ldapfunc = "ldap_list";
         else
                 $ldapfunc = "ldap_search";
 
-	$search    = @$ldapfunc($ldap, $ldapdn, $ldapfilter, array($ldapgroupattribute));
+	$search    = @$ldapfunc($ldap, $ldapdn, $ldapfilter, array($ldapmemberattribute));
 	$info      = @ldap_get_entries($ldap, $search);
 
 	$countem = $info["count"];	
 	
-	if(is_array($info[0][$ldapgroupattribute])) {
+	if(is_array($info[0][$ldapmemberattribute])) {
 		/* Iterate through the groups and throw them into an array */
-		foreach ($info[0][$ldapgroupattribute] as $member) {
+		foreach ($info[0][$ldapmemberattribute] as $member) {
 			if (stristr($member, "CN=") !== false) {
 				$membersplit = explode(",", $member);
 				$memberof[] = preg_replace("/CN=/i", "", $membersplit[0]);

--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -888,6 +888,7 @@ function ldap_get_groups($username, $authcfg) {
                 $ldapauthcont       = $authcfg['ldap_authcn'];
                 /* Convert attributes to lowercase.  php ldap arrays put everything in lowercase */
                 $ldapnameattribute  = strtolower($authcfg['ldap_attr_user']);
+                $ldapgroupattribute = strtolower($authcfg['ldap_attr_group']);
                 $ldapmemberattribute= strtolower($authcfg['ldap_attr_member']);
                 $ldapfilter         = "({$ldapnameattribute}={$username})";
                 $ldaptype           = "";
@@ -955,7 +956,7 @@ function ldap_get_groups($username, $authcfg) {
 		foreach ($info[0][$ldapmemberattribute] as $member) {
 			$membersplit = explode(",", $member);
 			$membersplit = explode("=", $membersplit[0]);
-			if (strtolower($membersplit[0]) == "cn") {
+			if (strtolower($membersplit[0]) == $ldapgroupattribute) {
 				$memberof[] = $membersplit[1];
 			}
 		}

--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -886,8 +886,9 @@ function ldap_get_groups($username, $authcfg) {
                 $ldapbindun         = $authcfg['ldap_binddn'];
                 $ldapbindpw         = $authcfg['ldap_bindpw'];
                 $ldapauthcont       = $authcfg['ldap_authcn'];
+                /* Convert attributes to lowercase.  php ldap arrays put everything in lowercase */
                 $ldapnameattribute  = strtolower($authcfg['ldap_attr_user']);
-                $ldapgroupattribute  = strtolower($authcfg['ldap_attr_member']);
+                $ldapgroupattribute = strtolower($authcfg['ldap_attr_member']);
                 $ldapfilter         = "({$ldapnameattribute}={$username})";
                 $ldaptype           = "";
                 $ldapver            = $authcfg['ldap_protver'];
@@ -903,8 +904,6 @@ function ldap_get_groups($username, $authcfg) {
 
 	$ldapdn             = $_SESSION['ldapdn'];
 
-	/*Convert attribute to lowercase.  php ldap arrays put everything in lowercase */
-	$ldapgroupattribute = strtolower($ldapgroupattribute);
 	$memberof = array();
 
         /* Setup CA environment if needed. */


### PR DESCRIPTION
There is a config variable ldap_attr_group which isn't used anywhere:

    stretz@slpn-nb-mss:/tmp/pfsense$ grep -R ldap_attr_group *
    usr/local/www/wizards/openvpn_wizard.inc:                       $auth['ldap_attr_group'] = $pconfig['step1']['groupattr'];
    usr/local/www/system_authservers.php:                   $pconfig['ldap_attr_group'] = $a_server[$id]['ldap_attr_group'];
    usr/local/www/system_authservers.php:                                           "ldap_attr_user ldap_attr_group ldap_attr_member ldapauthcontainers");
    usr/local/www/system_authservers.php:                   $server['ldap_attr_group'] = $pconfig['ldap_attr_group'];
    usr/local/www/system_authservers.php:                   document.getElementById("ldap_attr_group").value = "<?=$tmpldata['attr_group'];?>";
    usr/local/www/system_authservers.php:                                                           <input name="ldap_attr_group" type="text" class="formfld unknown" id="ldap_attr_group" size="20" value="<?=htmlspecialchars($pconfig['ldap_attr_group']);?>"/>

I guess it should be used in auth.inc where currently "cn" is hardcoded.

Next: Implement RFE #2869.