### PR TITLE
Proposed fix for bug #3057

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -128,9 +128,8 @@ function services_radvd_configure() {
 		}
 		switch($dhcpv6ifconf['ramode']) {
 			case "managed":
-				$radvdconf .= "\tAdvManagedFlag on;\n";
-				break;
 			case "assist":
+				$radvdconf .= "\tAdvManagedFlag on;\n";
 				$radvdconf .= "\tAdvOtherConfigFlag on;\n";
 				break;
 		}


### PR DESCRIPTION
Turn on AdvManagedFlag and AdvOtherConfigFlag for both 'managed' and 'assist' ramodes.
