### PR TITLE
support mitigating BEAST attack, see http://forum.pfsense.org/index.php/topic,63001.0.html

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -1118,7 +1118,8 @@ EOD;
 
 		// Harden SSL a bit for PCI conformance testing
 		$lighty_config .= "ssl.use-sslv2 = \"disable\"\n";
-		$lighty_config .= "ssl.cipher-list = \"DHE-RSA-CAMELLIA256-SHA:DHE-DSS-CAMELLIA256-SHA:CAMELLIA256-SHA:DHE-DSS-AES256-SHA:AES256-SHA:DHE-RSA-CAMELLIA128-SHA:DHE-DSS-CAMELLIA128-SHA:CAMELLIA128-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:AES128-SHA:RC4-SHA:RC4-MD5:!aNULL:!eNULL:!3DES:@STRENGTH\"\n";
+		$lighty_config .= "ssl.honor-cipher-order = \"enable\"\n";
+		$lighty_config .= "ssl.cipher-list = \"ECDHE-RSA-AES256-SHA384:AES256-SHA256:RC4-SHA:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM\"\n";
 
 		if(!(empty($ca) || (strlen(trim($ca)) == 0)))
 			$lighty_config .= "ssl.ca-file = \"{$g['varetc_path']}/{$ca_location}\"\n\n";


### PR DESCRIPTION
According to http://redmine.lighttpd.net/projects/lighttpd/wiki/Release-1_4_30

"...by setting
ssl.cipher-list = "ECDHE-RSA-AES256-SHA384:AES256-SHA256:RC4-SHA:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM"
you can mitigate BEAST attacks."

See discussion at http://forum.pfsense.org/index.php/topic,63001.0.html
