### PR TITLE
Archive start is “now” minus archive length

### DIFF
--- a/usr/local/www/status_rrd_graph_img.php
+++ b/usr/local/www/status_rrd_graph_img.php
@@ -96,10 +96,10 @@ $scales[16070400] = "WEEK:1:MONTH:1:MONTH:1:0:%b";
 $scales[42854400] = "MONTH:1:MONTH:1:MONTH:1:0:%b";
 
 $archives = array();
-$archives[1] = 1000;
-$archives[5] = 1000;
-$archives[60] = 1000;
-$archives[720] = 3000;
+$archives[1] = 1200;
+$archives[5] = 720;
+$archives[60] = 1860;
+$archives[1440] = 3652;
 
 $defOptions = array(
 	'to' => 1,
@@ -110,7 +110,7 @@ $defOptions = array(
 );
 
 /* always set the average to the highest value as a fallback */
-$average = 720 * 60;
+$average = 1440 * 60;
 foreach($archives as $rra => $value) {
         $archivestart = $now - ($rra * 60 * $value);
         if($archivestart <= $start) {


### PR DESCRIPTION
Archive start is “now” minus archive length.  Not “end” minus archive length. Sometimes "end" is not "now".

Adjust archives array values to match sizes for average variable calculation.
