### PR TITLE
Some changes in functions involved with radius! 

### DIFF
--- a/etc/inc/captiveportal.inc
+++ b/etc/inc/captiveportal.inc
@@ -203,6 +203,9 @@ function captiveportal_configure_zone($cpcfg) {
 		/* init ipfw rules */
 		captiveportal_init_rules(true);
 
+		/* Clean PIPENO Database */
+		captiveportal_clean_dn_database();
+		
 		/* kill any running minicron */
 		killbypid("{$g['varrun_path']}/cp_prunedb_{$cpzone}.pid");
 
@@ -1367,6 +1370,20 @@ function captiveportal_get_next_dn_ruleno($rulenos_start = 2000, $rulenos_range_
 	return $ruleno;
 }
 
+/* To liberate all PIPENO at the Start*/
+
+function captiveportal_clean_dn_database($rulenos_range_max = 64500) {
+	global $config, $g;
+
+	if (file_exists("{$g['vardb_path']}/captiveportaldn.rules")) {
+		$cpruleslck = lock("captiveportalrulesdn", LOCK_EX);
+		$rules = unserialize(file_get_contents("{$g['vardb_path']}/captiveportaldn.rules"));
+		$rules = array_pad(array(), $rulenos_range_max, false);
+		file_put_contents("{$g['vardb_path']}/captiveportaldn.rules", serialize($rules));
+		unlock($cpruleslck);	
+	}
+}
+
 function captiveportal_free_dn_ruleno($ruleno) {
 	global $config, $g;
 
@@ -1673,12 +1690,14 @@ function portal_mac_radius($clientmac,$clientip) {
 	/* authentication against the radius server */
 	$username = mac_format($clientmac);
 	$auth_list = radius($username,$radmac_secret,$clientip,$clientmac,"MACHINE LOGIN");
-	if (!empty($auth_list['url_redirection'])) 
-	   portal_reply_page($auth_list['url_redirection'], "redir");
+	
 	return FALSE;
 
 	if ($auth_list['auth_val'] == 2)
 		return TRUE;
+	if (!empty($auth_list['url_redirection'])) 
+	   portal_reply_page($auth_list['url_redirection'], "redir");
+	
 }
 
 function captiveportal_reapply_attributes($cpentry, $attributes) {


### PR DESCRIPTION
On line 1204 "if (is_null($pipeno)) {" replaced for "if (empty($pipeno)) {". Pineno takes value 0 if there are no free pipes, is_null would return false instead of true in case it is 0

I guess there is an error in the function portal_mac_radius specifically in the following condition:

if (! empty ($ auth_list ['url_redirection']))
portal_reply_page ($ auth_list ['url_redirection'], "redir");
     return FALSE;

This condition appears at the end of the function so the function never returns TRUE but FALSE always, based on the following:

When using if statements without the curly braces, remember than only one statement will be Executed as part of That condition. If you want to place multiple statements you must use curly braces, and not just put them on the same line.

if (1 == 0) echo "Test 1." echo "Test 2";

If i'm wrong discar the changes.

Thank you!
