### PR TITLE
Added function captiveportal_init_dn_rules to release all pipesno at start and a minor change.

### DIFF
--- a/etc/inc/captiveportal.inc
+++ b/etc/inc/captiveportal.inc
@@ -1686,13 +1686,13 @@ function portal_mac_radius($clientmac,$clientip) {
 	$username = mac_format($clientmac);
 	$auth_list = radius($username,$radmac_secret,$clientip,$clientmac,"MACHINE LOGIN");
 	
-	return FALSE; /* moved here to avoid the function always return false */
-	
 	if ($auth_list['auth_val'] == 2)
 		return TRUE;
 
 	if (!empty($auth_list['url_redirection']))
 		portal_reply_page($auth_list['url_redirection'], "redir");
+
+	return FALSE;
 
 }
 


### PR DESCRIPTION
This solution solves the problem of release the pipes numbers at the beginning of captive portal described in issue # 3062. please check this, thanks. And a minor fix.
