### PR TITLE
DHCP also update Dynamic DNS for static leases

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -835,7 +835,7 @@ EOD;
 
 	if ($need_ddns_updates) {
 		$dhcpdconf .= "ddns-update-style interim;\n";
-		$dhcpdconf .= "update-static-mappings on;\n";
+		$dhcpdconf .= "update-static-leases on;\n";
 		
 		if (is_array($ddns_zones)) {
 			$added_zones = array();


### PR DESCRIPTION
Previously, Dynamic DNS is only updated for clients that get addresses from the DHCP address pool. Static mappings are ignored.

Adding this line updates Dynamic DNS for both static-mapped and dynamic DHCP clients.
