### PR TITLE
DHCP correct reverse ptr zone issue

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -535,11 +535,9 @@ EOPP;
 			}
 			$revsubnet = explode(".", $subnet);
 			$revsubnet = array_reverse($revsubnet);
-			foreach ($revsubnet as $octet) {
-				if ($octet != "0")
-					break;
-				array_shift($revsubnet);
-			}
+			
+			# Remove the last octet of the subnet by shifting the first array item from revsubnet
+			array_shift($revsubnet);
 			$newzone['ptr-domain'] = implode(".", $revsubnet) . ".in-addr.arpa";
 		}
 


### PR DESCRIPTION
There is a foreach loop that shifts all the "0" octets from the reverse subnet IP. This works if your subnet is 192.168.1.0/24 or similar, but breaks if the subnet is 10.0.0.0/24 or any subnet with 0's in the third octet or both the second and third octet. For me, this output "zone 10.in-addr.arpa" which did not match my zone configuration in BIND.

To fix this, I removed the foreach loop leaving a single array_shift. The last octet should always be dropped, but there is no need to loop over the array for additional 0's.

As a result, I now have the correct output of "zone 0.0.10.in-addr.arpa" in my dhcpd.conf. I also verified that the DHCP logs show successful update of the forward and reverse DNS entries, and that the DNS entries are propagated to my primary and secondary DNS servers.
