### PR TITLE
Correct month, quarter (3 months), and 4 year RRD graphs length.

### DIFF
--- a/usr/local/www/status_rrd_graph.php
+++ b/usr/local/www/status_rrd_graph.php
@@ -240,10 +240,10 @@ $graph_length = array(
 	"8hour" => 28800,
 	"day" => 86400,
 	"week" => 604800,
-	"month" => 2764800,
-	"quarter" => 8035200,
+	"month" => 2678400,
+	"quarter" => 7948800,
 	"year" => 31622400,
-	"4year" => 126489600);
+	"4year" => 126230400);
 
 $pgtitle = array(gettext("Status"),gettext("RRD Graphs"));
 


### PR DESCRIPTION
Correct month, quarter (3 months), and 4 year RRD graphs length.
Longest possible month is 31 days, not 32.
Longest possible quarter (3 months) is 92 days (30+31+31), not 93 (31+31+31).
4 Years is 1461 days (365 x 4 + 1), not 1464 (366 x 4).  Except about once every century or so when leap year is skipped 4 years is then 1460 days.  But that is not going to happen again for a very long time.  Unfortunately pfSense, nor anyone alive today will probably still be alive by then.
