### PR TITLE
Fix typo in filter.inc. Fixes #3028.

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -867,7 +867,7 @@ function filter_generate_optcfg_array() {
 		if(!is_ipaddrv6($oc['ipaddrv6']) && !empty($oc['ipaddrv6']))
 			$oic['type6'] = $oc['ipaddrv6'];
 		if (!empty($oc['track6-interface']))
-			$oc['track6-interface'] = $oc['track6-interface'];
+			$oic['track6-interface'] = $oc['track6-interface'];
 		$oic['sn'] = get_interface_subnet($if);
 		$oic['snv6'] = get_interface_subnetv6($if);
 		$oic['mtu'] = empty($oc['mtu']) ? 1500 : $oc['mtu'];


### PR DESCRIPTION
Due to the typo, FilterIfList never got a 'track6-interface' entry,
which in turn prevented the DHCP6-related pass rules from being
generated for the LAN interface.
