### PR TITLE
Add support for protocol 41 in rules. Fixes #3007.

### DIFF
--- a/usr/local/www/firewall_nat_out_edit.php
+++ b/usr/local/www/firewall_nat_out_edit.php
@@ -485,7 +485,7 @@ function poolopts_change() {
 			<td width="22%" valign="top" class="vncellreq"><?=gettext("Protocol");?></td>
 			<td width="78%" class="vtable">
 				<select name="protocol" class="formselect" onchange="proto_change();">
-				<?php $protocols = explode(" ", "any TCP UDP TCP/UDP ICMP ESP AH GRE IGMP carp pfsync");
+				<?php $protocols = explode(" ", "any TCP UDP TCP/UDP ICMP ESP AH GRE IPV6 IGMP carp pfsync");
                                 foreach ($protocols as $proto): ?>
                                         <option value="<?=strtolower($proto);?>" <?php if (strtolower($proto) == $pconfig['protocol']) echo "selected=\"selected\""; ?>><?=htmlspecialchars($proto);?></option>
 				<?php endforeach; ?>

--- a/usr/local/www/firewall_rules_edit.php
+++ b/usr/local/www/firewall_rules_edit.php
@@ -858,7 +858,7 @@ include("head.inc");
 			<td width="78%" class="vtable">
 				<select <?=$edit_disabled;?> name="proto" class="formselect" onchange="proto_change()">
 <?php
-				$protocols = explode(" ", "TCP UDP TCP/UDP ICMP ESP AH GRE IGMP OSPF any carp pfsync");
+				$protocols = explode(" ", "TCP UDP TCP/UDP ICMP ESP AH GRE IPV6 IGMP OSPF any carp pfsync");
 				foreach ($protocols as $proto): ?>
 					<option value="<?=strtolower($proto);?>" <?php if (strtolower($proto) == $pconfig['proto']) echo "selected=\"selected\""; ?>><?=htmlspecialchars($proto);?></option>
 <?php 			endforeach; ?>


### PR DESCRIPTION
This patch adds protocol 41 (as used by GIF tunnels; e.g. HE.net tunnelbroker) to the list of selectable IP protocols for rules. The official name for this protocol is "IPV6" according to /etc/protocols.
