### PR TITLE
Correctly decide if dhcrelay (v4) is enabled

### DIFF
--- a/etc/inc/service-utils.inc
+++ b/etc/inc/service-utils.inc
@@ -282,13 +282,8 @@ function get_services() {
 		if ($oc['if'] && (!link_interface_to_bridge($if)))
 			$iflist[$if] = $if;
 	}
-	$show_dhcprelay = false;
-	foreach($iflist as $if) {
-		if(isset($config['dhcrelay'][$if]['enable']))
-			$show_dhcprelay = true;
-	}
 
-	if($show_dhcprelay == true) {
+	if(isset($config['dhcrelay']['enable'])) {
 		$pconfig = array();
 		$pconfig['name'] = "dhcrelay";
 		$pconfig['description'] = gettext("DHCP Relay");


### PR DESCRIPTION
The previous code had some complex and incorrect way of looking to see if dhcrelay (v4) was enabled in the config. This prevented dhcrelay from being shown in the services list, and thus it could not be stopped, started, restarted.
Now it shows in the services-status list. The code to stop, start and restart was already there, and now it is visible on the GUI it works.
