### PR TITLE
Fix editing saving dhcp6prefixonly state

### DIFF
--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -2117,7 +2117,7 @@ $types6 = array("none" => gettext("None"), "staticv6" => gettext("Static IPv6"),
 									<tr style='display:none' name="basicdhcp6_show_dhcp6_prefix_only" id="basicdhcp6_show_dhcp6_prefix_only">
 										<td width="22%" valign="top" class="vncell"><?=gettext("Request only a IPv6 prefix"); ?></td>
 										<td width="78%" class="vtable">
-											<input name="dhcp6prefixonly" type="checkbox" value="yes" <?php if ($pconfig['dhcp6prefixonly'] == true) echo "checked=\"checked\""; ?> />
+											<input name="dhcp6prefixonly" type="checkbox" id="dhcp6prefixonly" value="yes" <?php if ($pconfig['dhcp6prefixonly'] == true) echo "checked=\"checked\""; ?> />
 											<?=gettext("Only request a IPv6 prefix, do not request a IPv6 address"); ?>
 										</td>
 									</tr>


### PR DESCRIPTION
Reported in redmine #3097 and forum http://forum.pfsense.org/index.php/topic,64483.msg350255.html#msg350255
Now the config gets the dhcp6prefixonly setting saved. Now that it can be enabled, people who want to use this functionality will need to test it! I don't have a DHCPv6 ISP to test with.
I don't think this little change will help the other issue/s in #3097 when the WAN link is over PPPoE.
