### PR TITLE
When adding Port or URL alias default the alias type

### DIFF
--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -3,7 +3,7 @@
 /*
 	firewall_aliases_edit.php
 	Copyright (C) 2004 Scott Ullrich
-	Copyright (C) 2009 Ermal Luçi
+	Copyright (C) 2009 Ermal LuÃ§i
 	Copyright (C) 2010 Jim Pingle
 	All rights reserved.
 
@@ -674,9 +674,9 @@ if (empty($tab)) {
 			<select name="type" class="formselect" id="type" onchange="update_box_type(); typesel_change();">
 				<option value="host" <?php if ($pconfig['type'] == "host") echo "selected=\"selected\""; ?>><?=gettext("Host(s)"); ?></option>
 				<option value="network" <?php if ($pconfig['type'] == "network") echo "selected=\"selected\""; ?>><?=gettext("Network(s)"); ?></option>
-				<option value="port" <?php if ($pconfig['type'] == "port") echo "selected=\"selected\""; ?>><?=gettext("Port(s)"); ?></option>
+				<option value="port" <?php if (($pconfig['type'] == "port") || (empty($pconfig['type']) && ($tab == "port"))) echo "selected=\"selected\""; ?>><?=gettext("Port(s)"); ?></option>
 				<!--<option value="openvpn" <?php if ($pconfig['type'] == "openvpn") echo "selected=\"selected\""; ?>><?=gettext("OpenVPN Users"); ?></option> -->
-				<option value="url" <?php if ($pconfig['type'] == "url") echo "selected=\"selected\""; ?>><?=gettext("URL (IPs)");?></option>
+				<option value="url" <?php if (($pconfig['type'] == "url") || (empty($pconfig['type']) && ($tab == "url"))) echo "selected=\"selected\""; ?>><?=gettext("URL (IPs)");?></option>
 				<option value="url_ports" <?php if ($pconfig['type'] == "url_ports") echo "selected=\"selected\""; ?>><?=gettext("URL (Ports)");?></option>
 				<option value="urltable" <?php if ($pconfig['type'] == "urltable") echo "selected=\"selected\""; ?>><?=gettext("URL Table (IPs)"); ?></option>
 				<option value="urltable_ports" <?php if ($pconfig['type'] == "urltable_ports") echo "selected=\"selected\""; ?>><?=gettext("URL Table (Ports)"); ?></option>


### PR DESCRIPTION
When viewing the Port or URL aliases tab, and pressing "+" (add), make the default alias type match the Port or URL tab from which the user pressed "+".
It was annoying that when I was in the Aliases, Ports tab and pressed "+", the aliases edit screen would default the new alias type to "Host".
This backports easily to 2.1 branch (which is what I used to test).
