### PR TITLE
Validate firewall rule advanced options requirements (2.1 branch)

### DIFF
--- a/usr/local/www/firewall_rules_edit.php
+++ b/usr/local/www/firewall_rules_edit.php
@@ -472,6 +472,51 @@ if ($_POST) {
 			$input_errors[] = gettext("You can only select a layer7 container for Pass type rules.");
 	}
 
+	if ($_POST['proto'] <> "tcp") {
+		if (!empty($_POST['max']))
+			$input_errors[] = gettext("You can only specify the maximum state entries (advanced option) for TCP protocol.");
+		if (!empty($_POST['max-src-nodes']))
+			$input_errors[] = gettext("You can only specify the maximum number of unique source hosts (advanced option) for TCP protocol.");
+		if (!empty($_POST['max-src-conn']))
+			$input_errors[] = gettext("You can only specify the maximum number of established connections per host (advanced option) for TCP protocol.");
+		if (!empty($_POST['max-src-states']))
+			$input_errors[] = gettext("You can only specify the maximum state entries per host (advanced option) for TCP protocol.");
+		if (!empty($_POST['max-src-conn-rate']) || !empty($_POST['max-src-conn-rates']))
+			$input_errors[] = gettext("You can only specify the maximum new connections / per second(s) (advanced option) for TCP protocol.");
+		if (!empty($_POST['statetimeout']))
+			$input_errors[] = gettext("You can only specify the state timeout (advanced option) for TCP protocol.");
+	}
+
+	if ($_POST['type'] <> "pass") {
+		if (!empty($_POST['max']))
+			$input_errors[] = gettext("You can only specify the maximum state entries (advanced option) for Pass type rules.");
+		if (!empty($_POST['max-src-nodes']))
+			$input_errors[] = gettext("You can only specify the maximum number of unique source hosts (advanced option) for Pass type rules.");
+		if (!empty($_POST['max-src-conn']))
+			$input_errors[] = gettext("You can only specify the maximum number of established connections per host (advanced option) for Pass type rules.");
+		if (!empty($_POST['max-src-states']))
+			$input_errors[] = gettext("You can only specify the maximum state entries per host (advanced option) for Pass type rules.");
+		if (!empty($_POST['max-src-conn-rate']) || !empty($_POST['max-src-conn-rates']))
+			$input_errors[] = gettext("You can only specify the maximum new connections / per second(s) (advanced option) for Pass type rules.");
+		if (!empty($_POST['statetimeout']))
+			$input_errors[] = gettext("You can only specify the state timeout (advanced option) for Pass type rules.");
+	}
+
+	if (($_POST['statetype'] == "none") && (empty($_POST['l7container']))) {
+		if (!empty($_POST['max']))
+			$input_errors[] = gettext("You cannot specify the maximum state entries (advanced option) if statetype is none and no L7 container is selected.");
+		if (!empty($_POST['max-src-nodes']))
+			$input_errors[] = gettext("You cannot specify the maximum number of unique source hosts (advanced option) if statetype is none and no L7 container is selected.");
+		if (!empty($_POST['max-src-conn']))
+			$input_errors[] = gettext("You cannot specify the maximum number of established connections per host (advanced option) if statetype is none and no L7 container is selected.");
+		if (!empty($_POST['max-src-states']))
+			$input_errors[] = gettext("You cannot specify the maximum state entries per host (advanced option) if statetype is none and no L7 container is selected.");
+		if (!empty($_POST['max-src-conn-rate']) || !empty($_POST['max-src-conn-rates']))
+			$input_errors[] = gettext("You cannot specify the maximum new connections / per second(s) (advanced option) if statetype is none and no L7 container is selected.");
+		if (!empty($_POST['statetimeout']))
+			$input_errors[] = gettext("You cannot specify the state timeout (advanced option) if statetype is none and no L7 container is selected.");
+	}
+
 	if (!$_POST['tcpflags_any']) {
 		$settcpflags = array();
 		$outoftcpflags = array();


### PR DESCRIPTION
Checks that the user has selected a TCP Pass rule etc when using the state-related advanced options. Validates as per the checks that are applied in filter.inc when generating the actual pf rules.
Forum discussion: http://forum.pfsense.org/index.php/topic,64653.15.html
Bug report #3098
This is the version for the 2.1 branch, which is the code I have tested on a real system.
