### PR TITLE
Fix error in 2.1 branch dhcp6prefixonly implementation

### DIFF
--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -876,8 +876,6 @@ if ($_POST['apply']) {
 				if ($_POST['gatewayv6'] != "none") {
 					$wancfg['gatewayv6'] = $_POST['gatewayv6'];
 				}
-				if($_POST['dhcp6prefixonly'] == "yes")
-					$wancfg['dhcp6prefixonly'] = true;
 				break;
 			case "slaac":
 				$wancfg['ipaddrv6'] = "slaac";
@@ -886,6 +884,8 @@ if ($_POST['apply']) {
 				$wancfg['ipaddrv6'] = "dhcp6";
 				$wancfg['dhcp6-duid'] = $_POST['dhcp6-duid'];
 				$wancfg['dhcp6-ia-pd-len'] = $_POST['dhcp6-ia-pd-len'];
+				if($_POST['dhcp6prefixonly'] == "yes")
+					$wancfg['dhcp6prefixonly'] = true;
 				if($gateway_item) {
 					$a_gateways[] = $gateway_item;
 				}


### PR DESCRIPTION
The Main branch code was in the correct place, but the version applied to 2.1 branch had this code in the wrong place. Arghhh - tearing my hair out trying to see what was wrong! 
There are still significant numbers of changes on 2.1 branch and a reasonable amount of diverging code on Main, so there are going to be more "little" errors like this between branches. We will all have to look carefully at code applied to both branches :)
