### PR TITLE
Do not bother with bogonsv6 when interface does not have any ipaddrv6 type

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -60,11 +60,11 @@ $aliases = "";
 
 function is_bogonsv6_used() {
 	global $config, $g;
-	# Only use bogonsv6 table if IPv6 Allow is on, and at least 1 enabled interface also has "blockbogons" enabled.
+	# Use bogonsv6 table if IPv6 Allow is on, and at least 1 enabled interface also has "blockbogons" enabled and some IPv6 address type.
 	$usebogonsv6 = false;
 	if (isset($config['system']['ipv6allow'])) {
 		foreach ($config['interfaces'] as $ifacedata) {
-			if(isset($ifacedata['enable']) && isset($ifacedata['blockbogons'])) {
+			if(isset($ifacedata['enable']) && !empty($ifacedata['ipaddrv6']) && isset($ifacedata['blockbogons'])) {
 				$usebogonsv6 = true;
 				break;
 			}
@@ -2635,7 +2635,7 @@ EOD;
 block in $bogonlog quick on \${$oc['descr']} from <bogons> to any label "block bogon IPv4 networks from {$oc['descr']}"
 
 EOD;
-			if(isset($config['system']['ipv6allow'])) {
+			if(isset($config['system']['ipv6allow']) && !empty($config['interfaces'][$on]['ipaddrv6'])) {
 				$ipfrules .= <<<EOD
 block in $bogonlog quick on \${$oc['descr']} from <bogonsv6> to any label "block bogon IPv6 networks from {$oc['descr']}"
 


### PR DESCRIPTION
We can further reduce the use cases when the bogonsv6 table needs to be used in pf.
If an interface has no IPv6 address type specified, then it simply cannot have an IPv6 packet received and passed to pf for processing, so there is no way that the bogonsv6 table would ever be matched. Therefore do not bother loading bogonsv6 in this case. I think this reasoning is correct?
This is the change for 2.1 branch.
