### PR TITLE
Tidy up and improve log.widget.php

### DIFF
--- a/usr/local/www/widgets/widgets/log.widget.php
+++ b/usr/local/www/widgets/widgets/log.widget.php
@@ -148,6 +148,7 @@ function format_log_line(row) {
 		<br/>
 		Interfaces:
 		<select id="filterlogentriesinterfaces" name="filterlogentriesinterfaces" class="formselect">
+			<option value="All">ALL</option>
                       <?php
 						$interfaces = get_configured_interface_with_descr();
 					  	foreach ($interfaces as $iface => $ifacename): ?>


### PR DESCRIPTION
Since commit 4cfcbd3 the first entry in the drop down menu of "number of lines to show" = " ".

I assume this was an error???? Reverted the if statement which does this @N0YB

removed white spaces

Fixed interface drop down menu to use the selected tag so when the settings are reopened they show the currently selected interface
