### PR TITLE
improve gateway widget dimensions

### DIFF
--- a/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/usr/local/www/widgets/widgets/gateways.widget.php
@@ -42,7 +42,7 @@ $counter = 1;
 
 ?>
 
-<table bgcolor="#990000" width="100%" border="0" cellspacing="0" cellpadding="0" style="table-layout: fixed;" summary="gateway status">
+<table bgcolor="#990000" width="100%" border="0" cellspacing="0" cellpadding="0" summary="gateway status">
 	<tr>
 	<td class="vncellt" width="30%" id="gatewayname">
 			Name
@@ -140,4 +140,5 @@ $counter = 1;
 	</tr>
 	<?php } // foreach ?>
 </table>
+
 


### PR DESCRIPTION
Here are some minor changes which stops the table inside the Gateway widget spilling out of the widget as new columns are created in the pfsense_ng_fs theme. Here is an extreme example:

![error7](https://f.cloud.github.com/assets/4223752/866826/2358740a-f6b7-11e2-9188-0ae2fea0ea1c.png)

I think it is fine to merge the PR in its current state, its not perfect. 

On my 1080p screen 5 columns is the perfect number of viable columns and the original problem is only noticeable at >=6 columns @ 1080p. If someone has a 2k+ screen then in theory 10 columns (the max we allow in pfsense) should look fine with or without this fix.

Screenshot with changes applied, widget does not spill out of widget, text fields are clipped. 

5columns:
![5cols](https://f.cloud.github.com/assets/4223752/867017/f36d0ae2-f6cc-11e2-8e98-6bfdc44cd017.png)

6columns:
![6cols](https://f.cloud.github.com/assets/4223752/867021/06570fae-f6cd-11e2-87bc-fc2903aabdd7.png)

7columns:
![7cols](https://f.cloud.github.com/assets/4223752/867020/fff21a00-f6cc-11e2-9c5f-9382df99d51b.png)

commit 10a1f2d reverts a change I made in commit 9b03bd4. 10a1f2d stops the title (gateway name) spilling out of its cell. I couldnt use the ellipsis class on the gateway names as it made the fields shortened eg "DH..." on all the other themes.

This also lines up the table cells properly. If you compare the screenshots the first ones the cells don't line up.

If your not happy I will close the PR.
