### PR TITLE
Update services_dyndns_edit.php

### DIFF
--- a/usr/local/www/services_dyndns_edit.php
+++ b/usr/local/www/services_dyndns_edit.php
@@ -71,7 +71,7 @@ if (isset($id) && isset($a_dyndns[$id])) {
 	$pconfig['wildcard'] = isset($a_dyndns[$id]['wildcard']);
 	$pconfig['verboselog'] = isset($a_dyndns[$id]['verboselog']);
 	$pconfig['zoneid'] = $a_dyndns[$id]['zoneid'];
-	$pconfig['ttl'] = isset($a_dyndns[$id]['ttl']);
+	$pconfig['ttl'] = $a_dyndns[$id]['ttl'];
 	$pconfig['updateurl'] = $a_dyndns[$id]['updateurl'];
 	$pconfig['resultmatch'] = $a_dyndns[$id]['resultmatch'];
 	$pconfig['requestif'] = $a_dyndns[$id]['requestif'];


### PR DESCRIPTION
Setting $pconfig['ttl'] to isset result causes the ttl value to be set to 1 (true) upon subsequent saves.
