### PR TITLE
seperate date & time on traffic graphs

### DIFF
--- a/usr/local/www/graph.php
+++ b/usr/local/www/graph.php
@@ -116,7 +116,8 @@ print('<?xml version="1.0" ?>' . "\n");?>
     <text id="ifname" x="<?=$width?>" y="8" <?=$attribs['graphname']?> text-anchor="end"><?=htmlspecialchars($ifname)?></text>
     <text id="switch_unit" x="<?=$width*0.55?>" y="5" <?=$attribs['switch_unit']?>><?=gettext("Switch to bytes/s"); ?></text>
     <text id="switch_scale" x="<?=$width*0.55?>" y="11" <?=$attribs['switch_scale']?>><?=gettext("AutoScale"); ?> (<?=$scale_type?>)</text>
-    <text id="datetime" x="<?=$width*0.33?>" y="5" <?=$attribs['legend']?>> </text>
+    <text id="date" x="<?=$width*0.33?>" y="5" <?=$attribs['legend']?>> </text>
+    <text id="time" x="<?=$width*0.33?>" y="11" <?=$attribs['legend']?>> </text>
     <text id="graphlast" x="<?=$width*0.55?>" y="17" <?=$attribs['legend']?>><?=gettext("Graph shows last"); ?> <?=$time_interval*$nb_plot?> <?=gettext("seconds"); ?></text>
     <polygon id="axis_arrow_x" <?=$attribs['axis']?> points="<?=($width) . "," . ($height)?> <?=($width-2) . "," . ($height-2)?> <?=($width-2) . "," . $height?>"/>
     <text id="error" x="<?=$width*0.5?>" y="<?=$height*0.5?>"  visibility="hidden" <?=$attribs['error']?> text-anchor="middle"><?=$error_text?></text>
@@ -209,9 +210,10 @@ function fetch_data() {
 function plot_data(obj) {
   // Show datetimelegend
   var now = new Date();
-  var datetime = (now.getMonth()+1) + "/" + now.getDate() + "/" + now.getFullYear() + ' ' + 
-    LZ(now.getHours()) + ":" + LZ(now.getMinutes()) + ":" + LZ(now.getSeconds());
-  SVGDoc.getElementById('datetime').firstChild.data = datetime;
+  var time = LZ(now.getHours()) + ":" + LZ(now.getMinutes()) + ":" + LZ(now.getSeconds());
+  SVGDoc.getElementById('time').firstChild.data = time;
+  var date = (now.getMonth()+1) + "/" + now.getDate() + "/" + now.getFullYear();
+  SVGDoc.getElementById('date').firstChild.data = date;
 
   if (!obj.success)
     return handle_error();  // getURL failed to get data


### PR DESCRIPTION
Fixes text overflowing and looks nicer ;)

![original](https://f.cloud.github.com/assets/4223752/875147/ae6af6b4-f89a-11e2-8c09-21bbfda1909e.png)
![separate](https://f.cloud.github.com/assets/4223752/875148/b1c9e072-f89a-11e2-915f-99e4a5330139.png)
