### PR TITLE
use correct domain names when registering static DHCP entries in DNS

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -276,14 +276,22 @@ function system_hosts_generate() {
 			foreach ($config['dhcpd'] as $dhcpif => $dhcpifconf)
 				if(is_array($dhcpifconf['staticmap']) && isset($dhcpifconf['enable']))
 						foreach ($dhcpifconf['staticmap'] as $host)
-							if ($host['ipaddr'] && $host['hostname'])
+							if ($host['ipaddr'] && $host['hostname'] && $host['domain'])
+								$dhosts .= "{$host['ipaddr']}	{$host['hostname']}.{$host['domain']} {$host['hostname']}\n";
+							else if ($host['ipaddr'] && $host['hostname'] && $dhcpifconf['domain'])
+								$dhosts .= "{$host['ipaddr']}	{$host['hostname']}.{$dhcpifconf['domain']} {$host['hostname']}\n";
+							else if ($host['ipaddr'] && $host['hostname'])
 								$dhosts .= "{$host['ipaddr']}	{$host['hostname']}.{$syscfg['domain']} {$host['hostname']}\n";
 		}
 		if (isset($dnsmasqcfg['regdhcpstatic']) && is_array($config['dhcpdv6'])) {
 			foreach ($config['dhcpdv6'] as $dhcpif => $dhcpifconf)
 				if(is_array($dhcpifconf['staticmap']) && isset($dhcpifconf['enable']))
 						foreach ($dhcpifconf['staticmap'] as $host)
-							if ($host['ipaddrv6'] && $host['hostname'])
+							if ($host['ipaddrv6'] && $host['hostname'] && $host['domain'])
+								$dhosts .= "{$host['ipaddrv6']}	{$host['hostname']}.{$host['domain']} {$host['hostname']}\n";
+							else if ($host['ipaddrv6'] && $host['hostname'] && $dhcpifconf['domain'])
+								$dhosts .= "{$host['ipaddrv6']}	{$host['hostname']}.{$dhcpifconf['domain']} {$host['hostname']}\n";
+							else if ($host['ipaddrv6'] && $host['hostname'])
 								$dhosts .= "{$host['ipaddrv6']}	{$host['hostname']}.{$syscfg['domain']} {$host['hostname']}\n";
 		}
 


### PR DESCRIPTION
When registering static DHCP entries in DNS, we first try to use the domain name configured for the static entry (if any), then the domain name configured in the DHCP server settings for the corresponding interface (if any), and as a last resort the system domain name.

This change was proposed by user TechSmurf on the pfSense boards; see http://forum.pfsense.org/index.php/topic,64934.msg352331.html#msg352331.
