### PR TITLE
Reorder reverse lookup overrides so user-specified ones are effective 2.1

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -1660,16 +1660,9 @@ function services_dnsmasq_configure() {
 			}
 		}
 
-		/* Setup forwarded domains */
-		if (isset($config['dnsmasq']['domainoverrides']) && is_array($config['dnsmasq']['domainoverrides'])) {
-			foreach($config['dnsmasq']['domainoverrides'] as $override) {
-				if ($override['ip'] == "!")
-					$override[ip] = "";
-				$args .= ' --server=/' . $override['domain'] . '/' . $override['ip'];
-			}
-		}
-
-		/* If selected, then forward reverse lookups for private IPv4 addresses to nowhere. */
+		/* If selected, then first forward reverse lookups for private IPv4 addresses to nowhere. */
+		/* If any of these are duplicated by a user-specified domain override (e.g. 10.in-addr.arpa) then */
+		/* the user-specified entry made later on the command line below will be the one that is effective. */
 		if (isset($config['dnsmasq']['no_private_reverse'])) {
 			/* Note: Carrier Grade NAT (CGN) addresses 100.64.0.0/10 are intentionally not here. */
 			/* End-users should not be aware of CGN addresses, so reverse lookups for these should not happen. */
@@ -1679,6 +1672,15 @@ function services_dnsmasq_configure() {
 			/* Unfortunately the 172.16.0.0/12 range does not map nicely to the in-addr.arpa scheme. */
 			for ($subnet_num = 16; $subnet_num < 32; $subnet_num++) { 
 				$args .= " --server=/" . $subnet_num . ".172.in-addr.arpa/ ";
+			}
+		}
+
+		/* Setup forwarded domains */
+		if (isset($config['dnsmasq']['domainoverrides']) && is_array($config['dnsmasq']['domainoverrides'])) {
+			foreach($config['dnsmasq']['domainoverrides'] as $override) {
+				if ($override['ip'] == "!")
+					$override[ip] = "";
+				$args .= ' --server=/' . $override['domain'] . '/' . $override['ip'];
 			}
 		}
 


### PR DESCRIPTION
If the user specifies a domain override for 10.in-addr.arpa and also specifies "Do not forward private reverse lookups" then the user-specified entry is not effective. But the code was supposed to allow users to specify individual reverse lookup domain overrides that took precedence.
Re-ordering the placement of the --server entries on the dnsmasq command line fixes this.
Forum: http://forum.pfsense.org/index.php/topic,64986.0.html
Version for 2.1 branch
