### PR TITLE
Imrpoves the datePicker on the add/edit userManager page 

### DIFF
--- a/usr/local/www/system_usermanager.php
+++ b/usr/local/www/system_usermanager.php
@@ -351,7 +351,7 @@ include("head.inc");
 
 <script>
 	jQuery(function() {
-		jQuery( "#expires" ).datepicker( { dateFormat: 'mm/dd/yy', changeYear: true, yearRange: "+0:2099" } );
+		jQuery( "#expires" ).datepicker( { dateFormat: 'mm/dd/yy', changeYear: true, yearRange: "+0:+100" } );
 	});
 </script>
 


### PR DESCRIPTION
Improves the look of the datePicker and does away with the button opening a datePicker in a new window.

This makes the following file redundant for THIS page. Is it used anywhere else??? If so point me to the pages and I will make the same changes so we can delete this file:

https://github.com/pfsense/pfsense/blob/master/usr/local/www/javascript/datetimepicker.js
