### PR TITLE
Relax advanced options firewall rules tests

### DIFF
--- a/usr/local/www/firewall_rules_edit.php
+++ b/usr/local/www/firewall_rules_edit.php
@@ -481,15 +481,6 @@ if ($_POST) {
 			$input_errors[] = gettext("You can only specify the state timeout (advanced option) for TCP protocol.");
 	}
 
-	if (!in_array($_POST['proto'], array("icmp","udp","tcp","tcp/udp"))) {
-		if (!empty($_POST['max']))
-			$input_errors[] = gettext("You can only specify the maximum state entries (advanced option) for ICMP/TCP/UDP protocols.");
-		if (!empty($_POST['max-src-nodes']))
-			$input_errors[] = gettext("You can only specify the maximum number of unique source hosts (advanced option) for ICMP/TCP/UDP protocols.");
-		if (!empty($_POST['max-src-states']))
-			$input_errors[] = gettext("You can only specify the maximum state entries per host (advanced option) for ICMP/TCP/UDP protocols.");
-	}
-
 	if ($_POST['type'] <> "pass") {
 		if (!empty($_POST['max']))
 			$input_errors[] = gettext("You can only specify the maximum state entries (advanced option) for Pass type rules.");
@@ -1255,10 +1246,10 @@ $i--): ?>
 				<input name="tagged" id="tagged" value="<?=htmlspecialchars($pconfig['tagged']);?>" />
 				<br /><span class="vexpl"><?=gettext("You can match packet on a mark placed before on another rule.")?>
 				</span></p><p>
-				<input name="max" id="max" value="<?php echo htmlspecialchars($pconfig['max']) ?>" /><br/><?=gettext(" Maximum state entries this rule can create (TCP/UDP/ICMP)");?></p><p>
-				<input name="max-src-nodes" id="max-src-nodes" value="<?php echo htmlspecialchars($pconfig['max-src-nodes']) ?>" /><br/><?=gettext(" Maximum number of unique source hosts (TCP/UDP/ICMP)");?></p><p>
+				<input name="max" id="max" value="<?php echo htmlspecialchars($pconfig['max']) ?>" /><br/><?=gettext(" Maximum state entries this rule can create");?></p><p>
+				<input name="max-src-nodes" id="max-src-nodes" value="<?php echo htmlspecialchars($pconfig['max-src-nodes']) ?>" /><br/><?=gettext(" Maximum number of unique source hosts");?></p><p>
 				<input name="max-src-conn" id="max-src-conn" value="<?php echo htmlspecialchars($pconfig['max-src-conn']) ?>" /><br/><?=gettext(" Maximum number of established connections per host (TCP only)");?></p><p>
-				<input name="max-src-states" id="max-src-states" value="<?php echo htmlspecialchars($pconfig['max-src-states']) ?>" /><br/><?=gettext(" Maximum state entries per host (TCP/UDP/ICMP)");?></p><p>
+				<input name="max-src-states" id="max-src-states" value="<?php echo htmlspecialchars($pconfig['max-src-states']) ?>" /><br/><?=gettext(" Maximum state entries per host");?></p><p>
 				<input name="max-src-conn-rate" id="max-src-conn-rate" value="<?php echo htmlspecialchars($pconfig['max-src-conn-rate']) ?>" /> /
 				<select name="max-src-conn-rates" id="max-src-conn-rates">
 					<option value=""<?php if(intval($pconfig['max-src-conn-rates']) < 1) echo " selected=\"selected\""; ?>></option>


### PR DESCRIPTION
Various advanced options are now possible for any protocol since https://github.com/pfsense/pfsense/commit/653bde345e8f960de5bc745fe74e64d8ef3fd2d3
So allow these through the front-end GUI validation also.
