### PR TITLE
Display pfSense interface name on status interfaces

### DIFF
--- a/usr/local/www/status_interfaces.php
+++ b/usr/local/www/status_interfaces.php
@@ -81,7 +81,7 @@ include("head.inc");
 <?php endif; ?>
 	<tr>
 		<td colspan="2" class="listtopic">
-			<?=htmlspecialchars($ifname);?> <?=gettext("interface"); ?> (<?=htmlspecialchars($ifinfo['hwif']);?>)
+			<?=htmlspecialchars($ifname);?> <?=gettext("interface"); ?> (<?=htmlspecialchars($ifdescr);?>, <?=htmlspecialchars($ifinfo['hwif']);?>)
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
Sometimes it is a bit difficult to work out which interface descriptive name is which pfSense internal interface name (wan, lan, opt1, opt2...), when the descriptive names have been edited. It is useful to know for:
a) hardware that has wan, lan, opt1... pre-printed on the case (some Alix cases for example), making it easier for less-trained remote office staff to work out which cable corresponds to which interface in pfSense. That is helpful for me talking with remote staff when links are down.
b) looking in config.xml or other techo places where the internal pfSense name is stored/referenced - knowing that straight from a status GUI display saves having to first find the descriptive name in the config, then the pfSense internal name.
What do you think? Is this a worthwhile place to display this data?
If it means trouble re-making screenshots for the book, then don't bother about it for 2.1!
