### PR TITLE
remove css from edit.php page

### DIFF
--- a/usr/local/www/edit.php
+++ b/usr/local/www/edit.php
@@ -199,7 +199,7 @@ outputJavaScriptFileInline("javascript/base64.js");
 <!-- file viewer/editor -->
 <table width="100%">
 	<tr>
-		<td valign="top" class="label">
+		<td valign="top">
 			<div style="background:#eeeeee;" id="fileOutput">
 				<textarea id="fileContent" name="fileContent" style="width:100%;" rows="30" wrap="off"></textarea>
 			</div>


### PR DESCRIPTION
I'm working on a new theme and currently this page does not display properly (in the new theme). Removing the label class fixes this and appears to make no difference in all the existing themes
