### PR TITLE
Add option to specify client management port for OpenVPN client export use

### DIFF
--- a/usr/local/www/vpn_openvpn_server.php
+++ b/usr/local/www/vpn_openvpn_server.php
@@ -187,6 +187,10 @@ if($_GET['act']=="edit"){
 			$pconfig['wins_server2'])
 			$pconfig['wins_server_enable'] = true;
 
+		$pconfig['client_mgmt_port'] = $a_server[$id]['client_mgmt_port'];
+		if ($pconfig['client_mgmt_port'])
+			$pconfig['client_mgmt_port_enable'] = true;
+
 		$pconfig['nbdd_server1'] = $a_server[$id]['nbdd_server1'];
 		if ($pconfig['nbdd_server1'])
 			$pconfig['nbdd_server_enable'] = true;
@@ -298,6 +302,11 @@ if ($_POST) {
 		if ($pconfig['nbdd_server_enable'])
 			if (!empty($pconfig['nbdd_server1']) && !is_ipaddr(trim($pconfig['nbdd_server1'])))
 				$input_errors[] = gettext("The field 'NetBIOS Data Distribution Server #1' must contain a valid IP address");
+	}
+
+	if ($pconfig['client_mgmt_port_enable']) {
+		if ($result = openvpn_validate_port($pconfig['client_mgmt_port'], 'Client management port'))
+			$input_errors[] = $result;
 	}
 
 	if ($pconfig['maxclients'] && !is_numeric($pconfig['maxclients']))
@@ -424,6 +433,9 @@ if ($_POST) {
 			if ($pconfig['dns_server_enable'])
 				$server['nbdd_server1'] = $pconfig['nbdd_server1'];
 		}
+
+		if ($pconfig['client_mgmt_port_enable'])
+			$server['client_mgmt_port'] = $pconfig['client_mgmt_port'];
 
 		if ($_POST['duplicate_cn'] == "yes")
 			$server['duplicate_cn'] = true;
@@ -605,6 +617,14 @@ function wins_server_change() {
 		document.getElementById("wins_server_data").style.display="";
 	else
 		document.getElementById("wins_server_data").style.display="none";
+}
+
+function client_mgmt_port_change() {
+
+	if (document.iform.client_mgmt_port_enable.checked)
+		document.getElementById("client_mgmt_port_data").style.display="";
+	else
+		document.getElementById("client_mgmt_port_data").style.display="none";
 }
 
 function ntp_server_change() {
@@ -1635,6 +1655,31 @@ if ($savemsg)
 							</table>
 						</td>
 					</tr>
+					<tr>
+						<td width="22%" valign="top" class="vncell"><?=gettext("Client Management Port"); ?></td>
+						<td width="78%" class="vtable">
+							<table border="0" cellpadding="2" cellspacing="0">
+								<tr>
+									<td>
+										<?php set_checked($pconfig['client_mgmt_port_enable'],$chk); ?>
+										<input name="client_mgmt_port_enable" type="checkbox" id="client_mgmt_port_enable" value="yes" <?=$chk;?> onClick="client_mgmt_port_change()">
+									</td>
+									<td>
+										<span class="vexpl">
+	                                        <?=gettext("Use a different management port on clients. The default port is 166. Specify a different port if the client machines need to select from multiple OpenVPN links."); ?><br>
+										</span>
+									</td>
+								</tr>
+							</table>
+							<table border="0" cellpadding="2" cellspacing="0" id="client_mgmt_port_data">
+								<tr>
+									<td>
+										<input name="client_mgmt_port" type="text" class="formfld unknown" id="client_mgmt_port" size="30" value="<?=htmlspecialchars($pconfig['client_mgmt_port']);?>">
+									</td>
+								</tr>
+							</table>
+						</td>
+					</tr>
 				</table>
 
 				<table width="100%" border="0" cellpadding="6" cellspacing="0" id="client_opts">
@@ -1751,6 +1796,7 @@ gwredir_change();
 dns_domain_change();
 dns_server_change();
 wins_server_change();
+client_mgmt_port_change();
 ntp_server_change();
 netbios_change();
 tuntap_change();


### PR DESCRIPTION
See forum http://forum.pfsense.org/index.php/topic,63668.0.html and OpenVPN Manager GitHub discussion https://github.com/jochenwierum/openvpn-manager/issues/17
This allows a different client management port to be specified for use by OpenVPN client export when generating a client config for use with OpenVPN manager. Typically a company could have multiple offices with OpenVPN "road-warrior" access. Some users might need to connect to different offices at different times, so they would have multiple OpenVPN client configs installed on their laptop. For this to work with OpenVPN Manager, each client config needs to have a different management channel - only 1 can use the default of "166". The company can chooose a different number in the road-warrior server "client parameters" section at each office. Then the generated client config from each office will have a unique management channel port number.
