### PR TITLE
Increased needed memory for APC to 512M + code cleanup

### DIFF
--- a/etc/rc.php_ini_setup
+++ b/etc/rc.php_ini_setup
@@ -27,6 +27,7 @@
 
 # Set our operating platform
 PLATFORM=`/bin/cat /etc/platform`
+MIN_REALMEM_FOR_APC=512
 
 if [ -d /usr/local/lib/php/20090626 ]; then
 	EXTENSIONSDIR="/usr/local/lib/php/20090626/"
@@ -46,22 +47,35 @@ if [ -z "$AVAILMEM" ]; then
 	AVAILMEM=`/bin/expr $MEM / 1048576`
 fi
 
-# Calculate APC SHM size according 
-# to detected memory values
-if [ "$AVAILMEM" -gt "135" ]; then
-	APCSHMEMSIZE="10M"
-fi
-if [ "$AVAILMEM" -gt "256" ]; then
-	APCSHMEMSIZE="20M"
-fi
-if [ "$AVAILMEM" -gt "384" ]; then
-	APCSHMEMSIZE="25M"
-fi
-if [ "$AVAILMEM" -gt "512" ]; then
-	APCSHMEMSIZE="30M"
-fi
-if [ "$AVAILMEM" -gt "784" ]; then
-	APCSHMEMSIZE="50M"
+
+# Get amount of ram installed on this system
+REALMEM=`/sbin/sysctl hw.realmem | /usr/bin/awk '{print $2/1048576}' | /usr/bin/awk -F '.' '{print $1}'`
+export REALMEM
+export LOWMEM
+
+if [  "$REALMEM" -lt "$MIN_REALMEM_FOR_APC" ]; then
+	LOWMEM="TRUE"
+	echo ">>> WARNING!  under $MIN_REALMEM_FOR_APC megabytes of ram detected.  Not enabling APC."
+	echo ">>> WARNING!  under $MIN_REALMEM_FOR_APC megabytes of ram detected.  Not enabling APC." | /usr/bin/logger -p daemon.info -i -t rc.php_ini_setup
+else
+
+	# Calculate APC SHM size according 
+	# to detected memory values
+	if [ "$AVAILMEM" -gt "135" ]; then
+		APCSHMEMSIZE="10M"
+	fi
+	if [ "$AVAILMEM" -gt "256" ]; then
+		APCSHMEMSIZE="20M"
+	fi
+	if [ "$AVAILMEM" -gt "384" ]; then
+		APCSHMEMSIZE="25M"
+	fi
+	if [ "$AVAILMEM" -gt "512" ]; then
+		APCSHMEMSIZE="30M"
+	fi
+	if [ "$AVAILMEM" -gt "784" ]; then
+		APCSHMEMSIZE="50M"
+	fi
 fi
 
 # Set upload directory
@@ -74,7 +88,7 @@ fi
 # Define php modules.  Do not add .so, it will  
 # be done automatically by the script below.
 PHPMODULES="standard"
-if [  "$AVAILMEM" -gt 135 ]; then
+if [ "$LOWMEM" != "TRUE" ]; then
 	PHPMODULES="$PHPMODULES apc"
 fi
 # Config read/write
@@ -249,11 +263,8 @@ for EXT in $PHP_ZEND_MODULES_TS; do
 	fi
 done
 
-# Get amount of ram installed on this system
-RAM=`/sbin/sysctl hw.realmem | /usr/bin/awk '{print $2/1000000}' | /usr/bin/awk -F '.' '{print $1}'`
-export RAM
-export LOWMEM
-if [  "$RAM" -gt 135 ]; then
+
+if [ "$LOWMEM" != "TRUE" ]; then
 
 	/bin/cat >>/usr/local/lib/php.ini <<EOF
 
@@ -263,11 +274,6 @@ apc.enable_cli="0"
 apc.shm_size="${APCSHMEMSIZE}"
 
 EOF
-
-else
-	LOWMEM="TRUE"
-	echo ">>> WARNING!  under 128 megabytes of ram detected.  Not enabling APC."
-	echo ">>> WARNING!  under 128 megabytes of ram detected.  Not enabling APC." | /usr/bin/logger -p daemon.info -i -t rc.php_ini_setup
 fi
 
 	/bin/cat >>/usr/local/lib/php.ini <<EOF


### PR DESCRIPTION
- Increased the needed memory for APC to 512M as we often run into memory problems on our 256M box
- fixed the RAM calculation to divide by 1024 and not 1000
- code cleanup (renaming variables and creating new to avoid magic numbers)
