### PR TITLE
Fix #3174 Handling of gateway groups in openvpn_restart()

### DIFF
--- a/etc/inc/openvpn.inc
+++ b/etc/inc/openvpn.inc
@@ -789,6 +789,14 @@ function openvpn_restart($mode, $settings) {
 	/* Do not start a client if we are a CARP backup on this vip! */
 	if (($mode == "client") && strstr($settings['interface'], "_vip") && (get_carp_interface_status($settings['interface']) == "BACKUP"))
 		return;
+		
+	/* Check if client is bound to a gateway group */    
+	$a_groups = return_gateway_groups_array();
+	if (is_array($a_groups[$settings['interface']])) {
+	/* the interface is a gateway group. If a vip is defined and its a CARP backup then do not start */
+		if (($a_groups[$settings['interface']][0]['vip'] <> "") && (get_carp_interface_status($a_groups[$settings['interface']][0]['vip']) == "BACKUP"))
+			return;
+	}
 
 	/* start the new process */
 	$fpath = $g['varetc_path']."/openvpn/{$mode_id}.conf";


### PR DESCRIPTION
If the underlying vip of a gateway group that an openvpn client is bound to is in backup mode then the client should not start.
