### PR TITLE
filter_generate_port error log function name

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -1956,7 +1956,7 @@ function filter_generate_port(& $rule, $target = "source", $isnat = false) {
 			$srcport = explode("-", $rule[$target]['port']);
 			$srcporta = alias_expand($srcport[0]);
 			if(!$srcporta)
-				log_error(sprintf(gettext("filter_generate_address: %s is not a valid {$target} port."), $srcport[0]));
+				log_error(sprintf(gettext("filter_generate_port: %s is not a valid {$target} port."), $srcport[0]));
 			else if((!$srcport[1]) || ($srcport[0] == $srcport[1])) {
 				$src .= " port {$srcporta} ";
 			} else if(($srcport[0] == 1) && ($srcport[1] == 65535)) {


### PR DESCRIPTION
Absolutely minor adjustment to make the error log message refer to the new function name. Almost not worth the bother, but what the heck.
