### PR TITLE
Workarounds for making the bootup safer on low mem systems

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -239,10 +239,6 @@ function filter_configure_sync($delete_states_if_needed = true) {
 		return;
 	}
 
-	// Copy rules.debug to rules.debug.old
-	if(file_exists("{$g['tmp_path']}/rules.debug"))
-		@copy("{$g['tmp_path']}/rules.debug", "{$g['tmp_path']}/rules.debug.old");
-
 	$limitrules = "";
 	/* Define the maximum number of tables the system can handle (should be at least aliases*2+some spare) */
 	$maxtables = is_numeric($config['system']['maximumtables']) ? $config['system']['maximumtables'] : "3000";
@@ -295,8 +291,13 @@ function filter_configure_sync($delete_states_if_needed = true) {
 	$rules .= "{$altq_queues}\n";
 	$rules .= "{$natrules}\n";
 	$rules .= "{$pfrules}\n";
-
 	$rules .= discover_pkg_rules("filter");
+
+	unset($aliases, $gateways, $altq_queues, $natrules, $pfrules);
+
+	// Copy rules.debug to rules.debug.old
+	if(file_exists("{$g['tmp_path']}/rules.debug"))
+		@copy("{$g['tmp_path']}/rules.debug", "{$g['tmp_path']}/rules.debug.old");
 
 	if (!@file_put_contents("{$g['tmp_path']}/rules.debug", $rules, LOCK_EX)) {
 		log_error("WARNING: Could not write new rules!");
@@ -374,9 +375,12 @@ function filter_configure_sync($delete_states_if_needed = true) {
 	/* run items scheduled for after filter configure run */
 	$fda = fopen("{$g['tmp_path']}/commands.txt", "w");
 	if($fda) {
-		if($after_filter_configure_run)
+		if($after_filter_configure_run) {
 			foreach($after_filter_configure_run as $afcr)
 				fwrite($fda, $afcr . "\n");
+			unset($after_filter_configure_run);
+		}
+
 		/*
 		 *      we need a way to let a user run a shell cmd after each
 		 *      filter_configure() call.  run this xml command after
@@ -392,6 +396,7 @@ function filter_configure_sync($delete_states_if_needed = true) {
 		mwexec("sh {$g['tmp_path']}/commands.txt &");
 		unlink("{$g['tmp_path']}/commands.txt");
 	}
+
 	/* if time based rules are enabled then swap in the set */
 	if($time_based_rules == true)
 		filter_tdr_install_cron(true);
@@ -669,6 +674,7 @@ function filter_generate_aliases() {
 	}
 	$result = "{$alias} \n";
 	$result .= "{$aliases}";
+
 	return $result;
 }
 
@@ -1956,7 +1962,7 @@ function filter_generate_port(& $rule, $target = "source", $isnat = false) {
 			$srcport = explode("-", $rule[$target]['port']);
 			$srcporta = alias_expand($srcport[0]);
 			if(!$srcporta)
-				log_error(sprintf(gettext("filter_generate_address: %s is not a valid {$target} port."), $srcport[0]));
+				log_error(sprintf(gettext("filter_generate_port: %s is not a valid {$target} port."), $srcport[0]));
 			else if((!$srcport[1]) || ($srcport[0] == $srcport[1])) {
 				$src .= " port {$srcporta} ";
 			} else if(($srcport[0] == 1) && ($srcport[1] == 65535)) {
@@ -2490,6 +2496,7 @@ function filter_generate_user_rule($rule) {
 		$aline['divert'] . $aline['icmp-type'] . $aline['icmp6-type'] . $aline['tag'] . $aline['tagged'] . $aline['dscp'] .
 		$aline['vlanprio'] . $aline['vlanprioset'] . $aline['allowopts'] . $aline['flags'] . $aline['queue'] . $aline['dnpipe'] . $aline['schedlabel'];
 
+	unset($aline);
 
 	return $line;
 }
@@ -2561,15 +2568,9 @@ block quick inet proto { tcp, udp } from any to any port = 0
 block quick inet6 proto { tcp, udp } from any port = 0 to any
 block quick inet6 proto { tcp, udp } from any to any port = 0
 
-
-EOD;
-
-	$ipfrules .= <<<EOD
-
 # Snort package
 block quick from <snort2c> to any label "Block snort2c hosts"
 block quick from any to <snort2c> label "Block snort2c hosts"
-
 
 EOD;
 
@@ -2826,8 +2827,8 @@ EOD;
 	}
 	/*
 	 * NB: The loopback rules are needed here since the antispoof would take precedence then.
-	 *		If you ever add the 'quick' keyword to the antispoof rules above move the looback
-	 *		rules before them.
+	 *	If you ever add the 'quick' keyword to the antispoof rules above move the looback
+	 *	rules before them.
 	 */
 	$ipfrules .= <<<EOD
 
@@ -2845,6 +2846,7 @@ pass out inet all keep state allow-opts label "let out anything IPv4 from firewa
 pass out inet6 all keep state allow-opts label "let out anything IPv6 from firewall host itself"
 
 EOD;
+
 	foreach ($FilterIflist as $ifdescr => $ifcfg) {
 		if(isset($ifcfg['virtual']))
 			continue;
@@ -2873,12 +2875,9 @@ EOD;
 
 	/* add ipsec interfaces */
 	if(isset($config['ipsec']['enable']) || isset($config['ipsec']['client']['enable']))
-		$ipfrules .= <<<EOD
-pass out on \$IPsec all keep state label "IPsec internal host to host"
+		$ipfrules .= "pass out on \$IPsec all keep state label \"IPsec internal host to host\"\n";
 
-EOD;
-
-	if(!isset($config['system']['webgui']['noantilockout'])) {
+	if(is_array($config['system']['webgui']) && !isset($config['system']['webgui']['noantilockout'])) {
 		$alports = filter_get_antilockout_ports();
 
 		if(count($config['interfaces']) > 1 && !empty($FilterIflist['lan']['if'])) {
@@ -2900,7 +2899,9 @@ pass in quick on {$wanif} proto tcp from any to ({$wanif}) port { {$alports} } k
 
 EOD;
 		}
+		unset($alports);
 	}
+
 	/* PPTPd enabled? */
 	if($pptpdcfg['mode'] && ($pptpdcfg['mode'] != "off") && !isset($config['system']['disablevpnrules'])) {
 		if($pptpdcfg['mode'] == "server")
@@ -3054,10 +3055,7 @@ EOD;
 	update_filter_reload_status(gettext("Creating IPsec rules..."));
 	$ipfrules .= filter_generate_ipsec_rules();
 
-	$ipfrules .= <<<EOD
-anchor "tftp-proxy/*"
-
-EOD;
+	$ipfrules .= "\nanchor \"tftp-proxy/*\"\n";
 
 	update_filter_reload_status("Creating uPNP rules...");
 	if (is_array($config['installedpackages']['miniupnpd']) && is_array($config['installedpackages']['miniupnpd']['config'][0])) {

--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -949,7 +949,7 @@ function interface_gif_configure(&$gif, $gifkey = "") {
 	/* Do not change the order here for more see gif(4) NOTES section. */
 	mwexec("/sbin/ifconfig {$gifif} tunnel {$realifip} {$gif['remote-addr']}");
 	if((is_ipaddrv6($gif['tunnel-local-addr'])) || (is_ipaddrv6($gif['tunnel-remote-addr']))) {
-		mwexec("/sbin/ifconfig {$gifif} inet6 {$gif['tunnel-local-addr']} {$gif['tunnel-remote-addr']} prefixlen /{$gif['tunnel-remote-net']} ");
+		mwexec("/sbin/ifconfig {$gifif} inet6 {$gif['tunnel-local-addr']} {$gif['tunnel-remote-addr']} prefixlen {$gif['tunnel-remote-net']} ");
 	} else {
 		mwexec("/sbin/ifconfig {$gifif} {$gif['tunnel-local-addr']} {$gif['tunnel-remote-addr']} netmask " . gen_subnet_mask($gif['tunnel-remote-net']));
 	}

--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -132,12 +132,45 @@ function lock($lock, $op = LOCK_SH) {
 	}
 }
 
+function try_lock($lock, $timeout = 5) {
+	global $g, $cfglckkeyconsumers;
+	if (!$lock)
+		die(gettext("WARNING: You must give a name as parameter to try_lock() function."));
+	if (!file_exists("{$g['tmp_path']}/{$lock}.lock")) {
+		@touch("{$g['tmp_path']}/{$lock}.lock");
+		@chmod("{$g['tmp_path']}/{$lock}.lock", 0666);
+	}
+	$cfglckkeyconsumers++;
+	if ($fp = fopen("{$g['tmp_path']}/{$lock}.lock", "w")) {
+		$trycounter = 0;
+		while(!flock($fp, LOCK_EX | LOCK_NB)) {
+			if ($trycounter >= $timeout) {
+				fclose($fp);
+				return NULL;
+			}
+			sleep(1);
+			$trycounter++;
+		}
+
+		return $fp;
+	}
+
+	return NULL;
+}
+
 /* unlock configuration file */
 function unlock($cfglckkey = 0) {
 	global $g, $cfglckkeyconsumers;
 	flock($cfglckkey, LOCK_UN);
 	fclose($cfglckkey);
 	return;
+}
+
+/* unlock forcefully configuration file */
+function unlock_force($lock) {
+	global $g;
+
+	@unlink("{$g['tmp_path']}/{$lock}.lock");
 }
 
 function send_event($cmd) {

--- a/etc/rc.newwanip
+++ b/etc/rc.newwanip
@@ -132,6 +132,10 @@ switch($config['interfaces'][$interface]['ipaddrv6']) {
 	case "6rd":
 		interface_6rd_configure($interface, $config['interfaces'][$interface]);
 		break;
+	case "dhcp6":
+		if (isset($config['interfaces'][$interface]['dhcp6usev4iface']))
+			interface_dhcpv6_configure($interface, $config['interfaces'][$interface]);
+		break;
 }
 
 /* Check Gif tunnels */

--- a/etc/rc.openvpn
+++ b/etc/rc.openvpn
@@ -41,19 +41,22 @@ require_once("openvpn.inc");
 function openvpn_resync_if_needed ($mode, $ovpn_settings, $interface) {
 	global $g, $config;
 
-	$resync_needed = false;
-	if (empty($interface)) {
-		$resync_needed = true;
-	} else {
+	$resync_needed = true;
+	if (!empty($interface)) {
 		$mode_id = $mode . $ovpn_settings['vpnid'];
 		$fpath = "{$g['varetc_path']}/openvpn/{$mode_id}.interface";
-		$current_device = file_get_contents($fpath);
-		$new_device = get_failover_interface($ovpn_settings['interface']);
-		$this_device = $config['interfaces'][$interface]['if'];
-		if (($current_device != $new_device) || ($current_device == $this_device) || ($new_device == $this_device))
-			$resync_needed = true;
+		if (file_exists($fpath)) {
+			$current_device = file_get_contents($fpath);
+			$current_device = trim($current_device, " \t\n");
+			$new_device = get_failover_interface($ovpn_settings['interface']);
+			if (isset($config['interfaces'][$interface])) {
+				$this_device = $config['interfaces'][$interface]['if'];
+				if (($current_device == $new_device) || ($current_device != $this_device) || ($new_device != $this_device))
+					$resync_needed = false;
+			}
+		}
 	}
-	if ($resync_needed) {
+	if ($resync_needed == true) {
 		log_error("OpenVPN: Resync " . $mode_id . " " . $ovpn_settings['description']);
 		openvpn_resync($mode, $ovpn_settings);
 	}
@@ -77,7 +80,13 @@ if(is_array($config['openvpn']['openvpn-server']) || is_array($config['openvpn']
 } else
 	return;
 
-$openvpnlck = lock('openvpn', LOCK_EX);
+$openvpnlck = try_lock('openvpn', 10);
+if (!$openvpnlck) {
+	log_error(gettext("Could not obtain openvpn lock for executing rc.openvpn for more than 10 seconds continuing..."));
+	unlock_force('openvpn');
+	$openvpnlck = lock('openvpn', LOCK_EX);
+}
+
 $arg_array = explode(",",$argument);
 foreach ($arg_array as $arg_element) {
 	$gwgroups = array();

--- a/usr/local/sbin/ntpdate_sync_once.sh
+++ b/usr/local/sbin/ntpdate_sync_once.sh
@@ -3,14 +3,25 @@
 NOTSYNCED="true"
 MAX_ATTEMPTS=3
 SERVER=`/bin/cat /cf/conf/config.xml | /usr/bin/grep timeservers | /usr/bin/cut -d">" -f2 | /usr/bin/cut -d"<" -f1`
+if [ "${SERVER}" = "" ]; then
+	exit
+fi
+
 /bin/pkill -f ntpdate_sync_once.sh
 
 ATTEMPT=1
 # Loop until we're synchronized, but for a set number of attempts so we don't get stuck here forever.
 while [ "$NOTSYNCED" = "true" ] && [ ${ATTEMPT} -le ${MAX_ATTEMPTS} ]; do
 	# Ensure that ntpd and ntpdate are not running so that the socket we want will be free.
-	/usr/bin/killall ntpd 2>/dev/null
-	/usr/bin/killall ntpdate 2>/dev/null
+	while [ true ]; do
+		/usr/bin/killall ntpdate 2>/dev/null
+		/bin/pgrep ntpd
+		if [ $? -eq 0 ]; then
+			/usr/bin/killall ntpd 2>/dev/null
+		else
+			break
+		fi
+	done
 	sleep 1
 	/usr/local/bin/ntpdate -s -t 5 ${SERVER}
 	if [ "$?" = "0" ]; then


### PR DESCRIPTION
On low mem systems. E.g. our Alix board with 256 MB RAM the bootup crashes often because random processes get killed (out_of_swap_space). In some cases even the routing or the firewall does not start.
So with this packaged the admin can delays the bootup. Often the software seems to grab a lot of RAM and then release it again. So if we start several OpenVPN servers at once it crashes but if we start them one by one and wait in between it works.
