### PR TITLE
Do not include disabled OpenVPN in vpn_networks and negate_networks

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -777,10 +777,12 @@ function filter_get_vpns_list() {
 		if(is_array($config['openvpn']["openvpn-$type"])) {
 			foreach ($config['openvpn']["openvpn-$type"] as $settings) {
 				if(is_array($settings)) {
-					if (is_subnet($settings['remote_network']) && $settings['remote_network'] <> "0.0.0.0/0")
-						$vpns_arr[] = $settings['remote_network'];
-					if (is_subnet($settings['tunnel_network']) && $settings['tunnel_network'] <> "0.0.0.0/0")
-						$vpns_arr[] = $settings['tunnel_network'];
+					if (!isset($settings['disable'])) {
+						if (is_subnet($settings['remote_network']) && $settings['remote_network'] <> "0.0.0.0/0")
+							$vpns_arr[] = $settings['remote_network'];
+						if (is_subnet($settings['tunnel_network']) && $settings['tunnel_network'] <> "0.0.0.0/0")
+							$vpns_arr[] = $settings['tunnel_network'];
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Not a big thing, I just noticed this when testing some OpenVPN configs and enabling/disabling various OpenVPN instances. Can just stay in master for eventual release, or be applied wherever you think.
