### PR TITLE
Update an existing cron entry for pppoe periodic resets

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -1428,8 +1428,8 @@ function handle_pppoe_reset($post_array) {
 	}
 	if (empty($item))
 		return;
-	if (isset($item['ID']))
-		$config['cron']['item'][$item['ID']] = $item;
+	if (isset($itemhash['ID']))
+		$config['cron']['item'][$itemhash['ID']] = $item;
 	else
 		$config['cron']['item'][] = $item;
 }


### PR DESCRIPTION
The array variable name was incorrect in the test, so the existing cron entry was not being matched. Fixes #3192
This proved to be just a plain old bug. You can slip this into 2.1 also if you are about to rebuild it.
