### PR TITLE
Alix 2D6 crashes during 2.1 upgrade process with an out of diskspace error

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -2787,7 +2787,9 @@ function upgrade_080_to_081() {
 		file_put_contents("{$g['tmp_path']}/{$xmldumpnew}", $xml);
 		mwexec("$rrdtool restore -f {$g['tmp_path']}/{$xmldumpnew} {$rrddbpath}/{$database} 2>&1");
 		unset($xml);
-
+		# Default /tmp tmpfs is ~40mb, do not leave temp files around
+		unlink("{$g['tmp_path']}/{$xmldump}");
+		unlink("{$g['tmp_path']}/{$xmldumpnew}");
 	}
 	enable_rrd_graphing();
 	/* Let's save the RRD graphs after we run enable RRD graphing */


### PR DESCRIPTION
Updating the the RRD graphs causes two copies of each RRD's XML file to be stored in /tmp.

On Nanobsd, the default /tmp size is 40mb. It doesn't require very many RRD XML dumps before this is exhausted.
