### PR TITLE
CaptivePortal check for getNasIP already exists

### DIFF
--- a/etc/inc/captiveportal.inc
+++ b/etc/inc/captiveportal.inc
@@ -1584,6 +1584,7 @@ function getVolume($ip) {
  *
  */
 
+if (!function_exists('getNasIP')) {
 function getNasIP()
 {
 	global $config, $cpzone;
@@ -1601,6 +1602,7 @@ function getNasIP()
 		$nasIp = "0.0.0.0";
 
 	return $nasIp;
+}
 }
 
 function portal_ip_from_client_ip($cliip) {


### PR DESCRIPTION
http://forum.pfsense.org/index.php/topic,66764.0.html
Do not committ this pull request - I think it should have a better solution that eliminates the code duplication of getNasIP in 2 places. A dev who knows how they want the include file hierarchy to work can sort that out. This pull request is just to highlight the issue reported in the forum.
