### PR TITLE
Fix logic in detecting if OpenVPN resync needed

### DIFF
--- a/etc/rc.openvpn
+++ b/etc/rc.openvpn
@@ -54,7 +54,7 @@ function openvpn_resync_if_needed ($mode, $ovpn_settings, $interface) {
 				$new_device = get_failover_interface($ovpn_settings['interface']);
 				if (isset($config['interfaces'][$interface])) {
 					$this_device = $config['interfaces'][$interface]['if'];
-					if (($current_device == $new_device) && ($current_device != $this_device) && ($new_device != $this_device))
+					if (($current_device == $new_device) && ($current_device != $this_device))
 						$resync_needed = false;
 				}
 			}


### PR DESCRIPTION
Commit https://github.com/pfsense/pfsense/commit/f33dcc5c79c54af7daf91a81cfdd7f489e8cb67c reversed the logic sequence when testing if $resync_needed - the individual tests were changed from "==" to "!=" and so on, but the conjunction also need to be changed - "or" needs to be "and". I had noticed that VPNs on some gateway groups of mine didn't failover recently, but hadn't gone looking for the problem until now.
This might help bug #3243 - it will probably now make the OpenVPN resync on every interface/gateway change for the cases of CARP VIPs and VLANs mentioned in that bug report. At least that will be better than not resyncing at all. The tests can probably be made even better by getting a better version of $this_device that has the VIP or VLAN device name.
