### PR TITLE
Give clients the IPV6 address of the DNS server

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -980,6 +980,7 @@ function services_dhcpdv6_configure() {
 
 				$dhcpdv6cfg[$ifname]['prefixrange']['from'] = Net_IPv6::compress($range['start']);
 				$dhcpdv6cfg[$ifname]['prefixrange']['to'] = Net_IPv6::compress($range['end']);
+				$dhcpdv6cfg[$ifname]['dns6ip'] = get_interface_ipv6($ifname);
 			}
 		}
 	}
@@ -1084,6 +1085,9 @@ EOD;
 
 		if (is_ipaddrv6($dhcpv6ifconf['prefixrange']['from']) && is_ipaddrv6($dhcpv6ifconf['prefixrange']['to'])) {
 			$dhcpdv6conf .= "	prefix6 {$dhcpv6ifconf['prefixrange']['from']} {$dhcpv6ifconf['prefixrange']['to']}/{$dhcpv6ifconf['prefixrange']['prefixlength']};\n";
+		}
+		if (is_ipaddrv6($dhcpv6ifconf['dns6ip'])) {
+			$dhcpdv6conf .= "       option dhcp6.name-servers {$dhcpv6ifconf['dns6ip']};\n";
 		}
     		// default-lease-time
 		if ($dhcpv6ifconf['defaultleasetime'])


### PR DESCRIPTION
For IPV6 WAN tracking interfaces, dhcpdv6 does not provide an IPV6
address for the DNS server... fix that. The IPV6 address should be the
LAN interface IPV6 address, which is served by dnsmask, unbound, or
bind.
