### PR TITLE
Handle comma-separated list of remote networks when making vpn_networks table

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -798,8 +798,11 @@ function filter_get_vpns_list() {
 			foreach ($config['openvpn']["openvpn-$type"] as $settings) {
 				if(is_array($settings)) {
 					if (!isset($settings['disable'])) {
-						if (is_subnet($settings['remote_network']) && $settings['remote_network'] <> "0.0.0.0/0")
-							$vpns_arr[] = $settings['remote_network'];
+						$remote_networks = explode(',', $settings['remote_network']);
+						foreach ($remote_networks as $remote_network) {
+							if (is_subnet($remote_network) && ($remote_network <> "0.0.0.0/0"))
+								$vpns_arr[] = $remote_network;
+						}
 						if (is_subnet($settings['tunnel_network']) && $settings['tunnel_network'] <> "0.0.0.0/0")
 							$vpns_arr[] = $settings['tunnel_network'];
 					}


### PR DESCRIPTION
If remote_networks for an OpenVPN instance is a list of more than 1 network then none of the networks gets added to the vpn_networks table. The code simply did not address this new comma-separated list feature. Now it does, and the vpn_networks table contains all the remote networks listed.
Related to forum thread: http://forum.pfsense.org/index.php/topic,66776.msg377169.html#msg377169
and bug report #3309 - but from the bug report, there might be some other issue to be addressed also.
