### PR TITLE
carp, provide a way to 'permanently' set carp to 'maintenance mode' (advskew 254) persisting a reboot

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -1322,6 +1322,32 @@ function interface_bring_down($interface = "wan", $destroy = false, $ifacecfg = 
 	return;
 }
 
+function interfaces_carp_set_maintenancemode($carp_maintenancemode){
+	global $config;
+	if (isset($config["virtualip_carp_maintenancemode"]) && $carp_maintenancemode == false) {
+		unset($config["virtualip_carp_maintenancemode"]);
+		write_config("Leave CARP maintenance mode");
+	} else
+	if (!isset($config["virtualip_carp_maintenancemode"]) && $carp_maintenancemode == true) {
+		$config["virtualip_carp_maintenancemode"] = true;
+		write_config("Enter CARP maintenance mode");
+	}
+
+	$viparr = &$config['virtualip']['vip'];
+	foreach ($viparr as $vip) {
+		switch ($vip['mode']) {
+			case "carp":
+				$vipif = "{$vip['interface']}_vip{$vip['vhid']}";
+				if ($carp_maintenancemode == true){
+					`ifconfig {$vipif} advskew 254`;
+				} else {
+					`ifconfig {$vipif} advskew {$vip['advskew']}`;
+				}
+			break;
+		}
+	}
+}
+
 function interfaces_ptpid_used($ptpid) {
 	global $config;
 
@@ -1939,9 +1965,9 @@ function interfaces_carp_setup() {
 		mwexec("/sbin/ifconfig pfsync0 -syncdev -syncpeer down", false);
 	}
 
-	if($config['virtualip']['vip'] && !isset($config["virtualip_carp_disabled"])) {
+	if($config['virtualip']['vip'])
 		mwexec("/sbin/sysctl net.inet.carp.allow=1", true);
-	} else
+	else
 		mwexec("/sbin/sysctl net.inet.carp.allow=0", true);
 
 	if ($g['booting']) {
@@ -2176,13 +2202,19 @@ function interface_carp_configure(&$vip) {
 	if (!empty($vip['advbase']))
 		$advbase = "advbase {$vip['advbase']}";
 
+	$carp_maintenancemode = isset($config["virtualip_carp_maintenancemode"]);
+	if ($carp_maintenancemode)
+		$advskew = "advskew 254";
+	else
+		$advskew = "advskew {$vip['advskew']}";
+	
 	if(is_ipaddrv4($vip['subnet'])) {
 		$broadcast_address = gen_subnet_max($vip['subnet'], $vip['subnet_bits']);
-		mwexec("/sbin/ifconfig {$vipif} {$vip['subnet']}/{$vip['subnet_bits']} vhid {$vip['vhid']} advskew {$vip['advskew']} {$advbase} {$password}");
+		mwexec("/sbin/ifconfig {$vipif} {$vip['subnet']}/{$vip['subnet_bits']} vhid {$vip['vhid']} {$advskew} {$advbase} {$password}");
 	}
 	if(is_ipaddrv6($vip['subnet'])) {
 		$broadcast_address = gen_subnet_max($vip['subnet'], $vip['subnet_bits']);
-		mwexec("/sbin/ifconfig {$vipif} inet6 {$vip['subnet']} prefixlen {$vip['subnet_bits']} vhid {$vip['vhid']} advskew {$vip['advskew']} {$advbase} {$password}");
+		mwexec("/sbin/ifconfig {$vipif} inet6 {$vip['subnet']} prefixlen {$vip['subnet_bits']} vhid {$vip['vhid']} {$advskew} {$advbase} {$password}");
 	}
 
 	interfaces_bring_up($vipif);

--- a/usr/local/www/carp_status.php
+++ b/usr/local/www/carp_status.php
@@ -53,21 +53,8 @@ unset($interface_ip_arr_cache);
 $status = get_carp_status();
 
 
-if($_POST['disablecarppermanently'] <> "") {
-	if (isset($config["virtualip_carp_disabled"])) {
-		unset($config["virtualip_carp_disabled"]);
-		$desc = "CARP enabled";
-	} else {
-		$config["virtualip_carp_disabled"] = true;
-		$desc = "CARP disabled";
-	}
-	write_config($desc);
-	
-	if(isset($config["virtualip_carp_disabled"])) {
-		mwexec("/sbin/sysctl net.inet.carp.allow=0");
-	} else {
-		mwexec("/sbin/sysctl net.inet.carp.allow=1");
-	}
+if($_POST['carp_maintenancemode'] <> "") {
+	interfaces_carp_set_maintenancemode(!isset($config["virtualip_carp_maintenancemode"]));
 }
 if($_POST['disablecarp'] <> "") {
 	if($status == true) {
@@ -134,16 +121,17 @@ include("head.inc");
 				}
 			}
 			if($carpcount > 0) {
-				$carp_enabled = $status;
-				if(isset($config["virtualip_carp_disabled"])) {
-					echo "<input type=\"submit\" name=\"disablecarppermanently\" id=\"disablecarppermanently\" value=\"" . gettext("Enable Carp now and on reboot") . "\">";
+				if($status == false) {
+					$carp_enabled = false;
+					echo "<input type=\"submit\" name=\"disablecarp\" id=\"disablecarp\" value=\"" . gettext("Enable Carp") . "\">";
 				} else {
-					echo "<input type=\"submit\" name=\"disablecarppermanently\" id=\"disablecarppermanently\" value=\"" . gettext("Disable Carp now and on reboot") . "\">";
-					if($status == false) {
-						echo "<input type=\"submit\" name=\"disablecarp\" id=\"disablecarp\" value=\"" . gettext("Enable Carp") . "\">";
-					} else {
-						echo "<input type=\"submit\" name=\"disablecarp\" id=\"disablecarp\" value=\"" . gettext("Disable Carp temporarily") . "\">";
-					}
+					$carp_enabled = true;
+					echo "<input type=\"submit\" name=\"disablecarp\" id=\"disablecarp\" value=\"" . gettext("Disable Carptemporarily") . "\">";
+				}
+				if(isset($config["virtualip_carp_maintenancemode"])) {
+					echo "<input type=\"submit\" name=\"carp_maintenancemode\" id=\"carp_maintenancemode\" value=\"" . gettext("Leave Carp maintenance mode now and on reboot") . "\">";
+				} else {
+					echo "<input type=\"submit\" name=\"carp_maintenancemode\" id=\"carp_maintenancemode\" value=\"" . gettext("Enter Carp maintenance mode now and on reboot") . "\">";
 				}
 			}
 ?>


### PR DESCRIPTION
--OLD-carp, provide a way to 'permanently' disable carp persisting a reboot to provide a way to cleanly reboot/update a master machine without the issue that not all services are available.-OLD--

Ok revised the code to not disable carp completely, but now set the advskew to 254 when clicking "maintenance mode". This effectively makes it so other backup machines will take and keep the VIP's unless they fail completely. In which case the current machine will become master as a partially working box is probably better then nothing..
