### PR TITLE
local_sync_accounts: provides empty STDIN to :pw command

### DIFF
--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -52,7 +52,7 @@ if(!$do_not_include_config_gui_inc)
 // Will be changed to false if security checks fail
 $security_passed = true;
 
-/* If this function doesn't exist, we're being called from Captive Portal or 
+/* If this function doesn't exist, we're being called from Captive Portal or
    another internal subsystem which does not include authgui.inc */
 if (function_exists("display_error_form") && !isset($config['system']['webgui']['nodnsrebindcheck'])) {
 	/* DNS ReBinding attack prevention.  http://redmine.pfsense.org/issues/708 */
@@ -329,7 +329,7 @@ function local_sync_accounts() {
 			$line = explode(":",fgets($fd));
 			if (((!strncmp($line[0], "_", 1)) || ($line[2] < 2000) || ($line[2] > 65000)) && ($line[0] != "admin"))
 				continue;
-			$cmd = "/usr/sbin/pw userdel -n '{$line[0]}'";
+			$cmd = "/bin/echo | /usr/sbin/pw userdel -n '{$line[0]}'";
 			if($debug)
 				log_error(sprintf(gettext("Running: %s"), $cmd));
 			mwexec($cmd);
@@ -349,7 +349,7 @@ function local_sync_accounts() {
 				continue;
 			if ($line[2] > 65000)
 				continue;
-			$cmd = "/usr/sbin/pw groupdel {$line[2]}";
+			$cmd = "/bin/echo | /usr/sbin/pw groupdel {$line[2]}";
 			if($debug)
 				log_error(sprintf(gettext("Running: %s"), $cmd));
 			mwexec($cmd);
@@ -385,7 +385,7 @@ function local_user_set(& $user) {
 
 	conf_mount_rw();
 
-	$home_base = "/home/";	
+	$home_base = "/home/";
 	$user_uid = $user['uid'];
 	$user_name = $user['name'];
 	$user_home = "{$home_base}{$user_name}";
@@ -393,7 +393,7 @@ function local_user_set(& $user) {
 	$user_group = "nobody";
 
 	// Ensure $home_base exists and is writable
-	if (!is_dir($home_base)) 
+	if (!is_dir($home_base))
 		mkdir($home_base, 0755);
 
 	$lock_account = false;
@@ -444,7 +444,7 @@ function local_user_set(& $user) {
 		$user_op = "usermod";
 	}
 
-	$comment = str_replace(array(":", "!", "@"), " ", $user['descr']); 
+	$comment = str_replace(array(":", "!", "@"), " ", $user['descr']);
 	/* add or mod pw db */
 	$cmd = "/usr/sbin/pw {$user_op} -q -u {$user_uid} -n {$user_name}".
 			" -g {$user_group} -s {$user_shell} -d {$user_home}".
@@ -478,7 +478,7 @@ function local_user_set(& $user) {
 
 	$un = $lock_account ? "" : "un";
 	exec("/usr/sbin/pw {$un}lock {$user_name} -q");
-	
+
 	conf_mount_ro();
 }
 
@@ -550,7 +550,7 @@ function local_user_get_groups($user, $all = false) {
 	sort($groups);
 
 	return $groups;
-	
+
 }
 
 function local_user_set_groups($user, $new_groups = NULL ) {
@@ -764,7 +764,7 @@ function ldap_test_bind($authcfg) {
 	ldap_set_option($ldap, LDAP_OPT_REFERRALS, 0);
 	ldap_set_option($ldap, LDAP_OPT_DEREF, LDAP_DEREF_SEARCHING);
 	ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, (int)$ldapver);
- 
+
 	$ldapbindun = isset($authcfg['ldap_utf8']) ? utf8_encode($ldapbindun) : $ldapbindun;
 	$ldapbindpw = isset($authcfg['ldap_utf8']) ? utf8_encode($ldapbindpw) : $ldapbindpw;
 	if ($ldapanon == true) {
@@ -882,23 +882,23 @@ function ldap_get_user_ous($show_complete_ou=true, $authcfg) {
 
 function ldap_get_groups($username, $authcfg) {
 	global $debug, $config;
-	
+
 	if(!function_exists("ldap_connect"))
 		return;
-	
-	if(!$username) 
+
+	if(!$username)
 		return false;
 
 	if(!isset($authcfg['ldap_nostrip_at']) && stristr($username, "@")) {
 		$username_split = explode("@", $username);
-		$username = $username_split[0];		
+		$username = $username_split[0];
 	}
 
 	if(stristr($username, "\\")) {
 		$username_split = explode("\\", $username);
-		$username = $username_split[0];        
-	}    
-	
+		$username = $username_split[0];
+	}
+
 	//log_error("Getting LDAP groups for {$username}.");
         if ($authcfg) {
                 if (strstr($authcfg['ldap_urltype'], "Standard"))
@@ -946,7 +946,7 @@ function ldap_get_groups($username, $authcfg) {
 		log_error(sprintf(gettext("ERROR! ldap_get_groups() Could not connect to server %s."), $ldapname));
                 return memberof;
         }
-    
+
 	ldap_set_option($ldap, LDAP_OPT_REFERRALS, 0);
 	ldap_set_option($ldap, LDAP_OPT_DEREF, LDAP_DEREF_SEARCHING);
 	ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, (int)$ldapver);
@@ -978,8 +978,8 @@ function ldap_get_groups($username, $authcfg) {
 	$search    = @$ldapfunc($ldap, $ldapdn, $ldapfilter, array($ldapgroupattribute));
 	$info      = @ldap_get_entries($ldap, $search);
 
-	$countem = $info["count"];	
-	
+	$countem = $info["count"];
+
 	if(is_array($info[0][$ldapgroupattribute])) {
 		/* Iterate through the groups and throw them into an array */
 		foreach ($info[0][$ldapgroupattribute] as $member) {
@@ -989,14 +989,14 @@ function ldap_get_groups($username, $authcfg) {
 			}
 		}
 	}
-	
+
 	/* Time to close LDAP connection */
 	@ldap_unbind($ldap);
-	
+
 	$groups = print_r($memberof,true);
-	
+
 	//log_error("Returning groups ".$groups." for user $username");
-	
+
 	return $memberof;
 }
 
@@ -1006,8 +1006,8 @@ function ldap_format_host($host) {
 
 function ldap_backed($username, $passwd, $authcfg) {
 	global $debug, $config;
-	
-	if(!$username) 
+
+	if(!$username)
 		return;
 
 	if(!function_exists("ldap_connect"))
@@ -1015,11 +1015,11 @@ function ldap_backed($username, $passwd, $authcfg) {
 
 	if(!isset($authcfg['ldap_nostrip_at']) && stristr($username, "@")) {
 		$username_split = explode("@", $username);
-		$username = $username_split[0];        
+		$username = $username_split[0];
 	}
 	if(stristr($username, "\\")) {
 		$username_split = explode("\\", $username);
-		$username = $username_split[0];        
+		$username = $username_split[0];
 	}
 
 	if ($authcfg) {
@@ -1049,9 +1049,9 @@ function ldap_backed($username, $passwd, $authcfg) {
                 }
                 else
                 {
-                        $ldapfilter = 
+                        $ldapfilter =
 "(&({$ldapnameattribute}={$username})({$ldapextendedquery}))";
-                } 
+                }
                 $ldaptype           = "";
                 $ldapver            = $authcfg['ldap_protver'];
 		$ldapname	    = $authcfg['name'];
@@ -1059,7 +1059,7 @@ function ldap_backed($username, $passwd, $authcfg) {
 	} else
 		return false;
 
-	/* first check if there is even an LDAP server populated */ 
+	/* first check if there is even an LDAP server populated */
 	if(!$ldapserver) {
 		if ($ldapfallback) {
 			log_error(gettext("ERROR! ldap_backed() called with no LDAP authentication server defined.  Defaulting to local user database. Visit System -> User Manager."));
@@ -1069,7 +1069,7 @@ function ldap_backed($username, $passwd, $authcfg) {
 
 		return false;
 	}
-	
+
         /* Setup CA environment if needed. */
         ldap_setup_caenv($authcfg);
 
@@ -1102,10 +1102,10 @@ function ldap_backed($username, $passwd, $authcfg) {
 		log_error(sprintf(gettext("ERROR! Could not bind to server %s."), $ldapname));
 		return false;
 	}
-	
+
 	/* Get LDAP Authcontainers and split em up. */
 	$ldac_splits = explode(";", $ldapauthcont);
-	
+
 	/* setup the usercount so we think we havn't found anyone yet */
 	$usercount  = 0;
 
@@ -1153,7 +1153,7 @@ function ldap_backed($username, $passwd, $authcfg) {
 	if ($usercount != 1){
 		@ldap_unbind($ldap);
 		log_error(gettext("ERROR! Either LDAP search failed, or multiple users were found."));
-		return false;                         
+		return false;
 	}
 
 	/* Now lets bind as the user we found */
@@ -1234,7 +1234,7 @@ function radius_backed($username, $passwd, $authcfg, &$attributes = array()) {
 
 function get_user_expiration_date($username) {
 	$user = getUserEntry($username);
-	if ($user['expires']) 
+	if ($user['expires'])
 		return $user['expires'];
 }
 
@@ -1359,7 +1359,7 @@ function session_auth() {
 	/* Validate incoming login request */
 	if (isset($_POST['login']) && !empty($_POST['usernamefld']) && !empty($_POST['passwordfld'])) {
 		$authcfg = auth_get_authserver($config['system']['webgui']['authmode']);
-		if (authenticate_user($_POST['usernamefld'], $_POST['passwordfld'], $authcfg) || 
+		if (authenticate_user($_POST['usernamefld'], $_POST['passwordfld'], $authcfg) ||
 		    authenticate_user($_POST['usernamefld'], $_POST['passwordfld'])) {
 			$_SESSION['Logged_In'] = "True";
 			$_SESSION['Username'] = $_POST['usernamefld'];
@@ -1398,7 +1398,7 @@ function session_auth() {
 			$_GET['logout'] = true;
 			$_SESSION['Logout'] = true;
 		} else
-			$_SESSION['last_access'] = time();	
+			$_SESSION['last_access'] = time();
 	} else if (intval($config['system']['webgui']['session_timeout']) == 0) {
 		/* only update if it wasn't ajax */
 		if (!isAjax())


### PR DESCRIPTION
The /usr/sbin/pw command may wait for user input. For example,
if there is a manual crontab settings for :foobar account, then
when this account is requested to be deleted, the command will
ask if user wants to delete crontab settings for the account.

Because the command waits for user input, the boot process will
hang at the "Synchronizing user settings..." step, unless user
presses any key.

To avoid this problem, we use the /bin/echo command to print
empty input for /usr/bin/pw command. This is an alternative of
typing "no" or "n".

This is a not the best way. Maybe closing STDIN is good. Or
force users to change account settings from webUI.
