### PR TITLE
local_sync_accounts: provides empty STDIN to pw userdel command

### DIFF
--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -329,7 +329,7 @@ function local_sync_accounts() {
 			$line = explode(":",fgets($fd));
 			if (((!strncmp($line[0], "_", 1)) || ($line[2] < 2000) || ($line[2] > 65000)) && ($line[0] != "admin"))
 				continue;
-			$cmd = "/usr/sbin/pw userdel -n '{$line[0]}'";
+			$cmd = "/bin/echo | /usr/sbin/pw userdel -n '{$line[0]}'";
 			if($debug)
 				log_error(sprintf(gettext("Running: %s"), $cmd));
 			mwexec($cmd);


### PR DESCRIPTION
The /usr/sbin/pw command may wait for user input. For example,
if there is a manual crontab settings for :foobar account, then
when this account is requested to be deleted, the command will
ask if user wants to delete crontab settings for the account.

Because the command waits for user input, the boot process will
hang at the "Synchronizing user settings..." step, unless user
presses any key.

To avoid this problem, we use the /bin/echo command to give
empty input for /usr/bin/pw command. This is an alternative of
typing "no" or "n".

This is a not the best way. Maybe closing STDIN is good. Or
force users to change account settings from webUI.

See also #852 (pull request). Renato Botelho points out that
"pw userdel" will call "crontab -u %user -r" that is interative.
"pw groupdel" will never be interative, though.
