### PR TITLE
Tidy up the "Helper Icons"

### DIFF
--- a/etc/inc/service-utils.inc
+++ b/etc/inc/service-utils.inc
@@ -442,23 +442,19 @@ function get_service_status_icon($service, $withtext = true, $smallicon = false)
 	$output = "";
 	if(get_service_status($service)) {
 		$statustext = gettext("Running");
-		$output .= '<td class="listr" align="center">' . "\n";
 		$output .= "<img style=\"vertical-align:middle\" title=\"" . sprintf(gettext("%s Service is"),$service["name"]) . " {$statustext}\" src=\"/themes/" . $g["theme"] . "/images/icons/";
 		$output .= ($smallicon) ? "icon_pass.gif" : "icon_service_running.gif";
-		$output .= "\" alt=\"status\" />";
+		$output .= "\" alt=\"status\" />&nbsp;";
 		if ($withtext)
-			$output .= "&nbsp;&nbsp;" . $statustext;
-		$output .= "</td>\n";
+			$output .= "&nbsp;" . $statustext;
 	} else {
 		$service_enabled = is_service_enabled($service['name']);
 		$statustext = ($service_enabled) ? gettext("Stopped") : gettext("Disabled");
-		$output .= '<td class="listbg" align="center">' . "\n";
 		$output .= "<img style=\"vertical-align:middle\" title=\"" . sprintf(gettext("%s Service is"),$service["name"]) . " {$statustext}\" src=\"/themes/" . $g["theme"] . "/images/icons/";
 		$output .= ($smallicon) ? "icon_block.gif" : "icon_service_stopped.gif";
-		$output .= "\" alt=\"status\" />";
+		$output .= "\" alt=\"status\" />&nbsp;";
 		if ($withtext)
-			$output .= "&nbsp;&nbsp;" . "<font color=\"white\">{$statustext}</font>";
-		$output .= "</td>\n";
+			$output .= "&nbsp;<font color=\"white\">{$statustext}</font>";
 	}
 	return $output;
 }

--- a/usr/local/www/status_services.php
+++ b/usr/local/www/status_services.php
@@ -93,11 +93,16 @@ if (count($services) > 0) {
 			continue;
 		if (empty($service['description']))
 			$service['description'] = get_pkg_descr($service['name']);
-		echo '<tr><td class="listlr" width="20%">' . $service['name'] . '</td>' . "\n";
-		echo '<td class="listr" width="55%">' . $service['description'] . '</td>' . "\n";
-		echo get_service_status_icon($service, true, true);
-		echo '<td valign="middle" class="list nowrap">';
-		echo get_service_control_links($service);
+		echo "<tr><td class=\"listlr\" width=\"20%\">" . $service['name'] . "</td>\n";
+		echo "<td class=\"listr\" width=\"55%\">" . $service['description'] . "</td>\n";
+		// if service is running then listr else listbg
+		$bgclass = null;
+		if (get_service_status($service))
+			$bgclass = "listr";
+		else
+			$bgclass = "listbg";
+		echo "<td class=\"" . $bgclass . "\" align=\"center\">" . get_service_status_icon($service, true, true) . "</td>\n";
+		echo "<td valign=\"middle\" class=\"list nowrap\">" . get_service_control_links($service);
 		$scut = get_shortcut_by_service_name($service['name']);
 		if (!empty($scut)) {
 			echo get_shortcut_main_link($scut, true, $service);
@@ -107,7 +112,7 @@ if (count($services) > 0) {
 		echo "</td></tr>\n";
 	}
 } else {
-	echo "<tr><td colspan=\"3\" align=\"center\">" . gettext("No services found") . ".</td></tr>\n";
+	echo "<tr><td colspan=\"3\" align=\"center\">" . gettext("No services found") . " . </td></tr>\n";
 }
 
 ?>

--- a/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/usr/local/www/widgets/widgets/services_status.widget.php
@@ -73,15 +73,19 @@ if (count($services) > 0) {
 		if (empty($service['description']))
 			$service['description'] = get_pkg_descr($service['name']);
 		$service_desc = explode(".",$service['description']);
-		echo '<tr><td class="listlr">' . $service['name'] . '</td>' . "\n";
-		echo '<td class="listr">' . $service_desc[0] . '</td>' . "\n";
-		echo get_service_status_icon($service, false, true);
-		echo '<td valign="middle" class="list nowrap">';
-		echo get_service_control_links($service);
-		echo "</td></tr>\n";
+		echo "<tr><td class=\"listlr\">" . $service['name'] . "</td>\n";
+		echo "<td class=\"listr\">" . $service_desc[0] . "</td>\n";
+		// if service is running then listr else listbg
+		$bgclass = null;
+		if (get_service_status($service))
+			$bgclass = "listr";
+		else
+			$bgclass = "listbg";
+		echo "<td class=\"" . $bgclass . "\" align=\"center\">" . get_service_status_icon($service, true, true) . "</td>\n";
+		echo "<td valign=\"middle\" class=\"list nowrap\">" . get_service_control_links($service) . "</td></tr>\n";
 	}
 } else {
-	echo "<tr><td colspan=\"3\" align=\"center\">" . gettext("No services found") . ".</td></tr>\n";
+	echo "<tr><td colspan=\"3\" align=\"center\">" . gettext("No services found") . " . </td></tr>\n";
 }
 ?>
 </table>


### PR DESCRIPTION
The "Helper Icons" at the top right of some service pages at present
produces 30+ HTML errors/warnings, this is due to the table cell being
wrapped in a span statement then in a div statement, table cells can
only be part of a table row then within a table statement.
- remove the table cell definitions from /etc/inc/service-utils.inc
- add the table cell definition from /etc/inc/service-utils.inc to
  /usr/local/www/status_services.php and add some logic to determine if
  the service is running which will then determine which class statement
  to use and pad the icon with a space
- apply the same table cell definition and logic as above to
  /usr/local/www/widgets/widgets/services_status.widget.php
