### PR TITLE
fix up loader.js for theme pfsense_ng_fs - Fixes traffic shaper graphs not loader as reported in the forum

### DIFF
--- a/usr/local/www/themes/pfsense_ng_fs/loader.js
+++ b/usr/local/www/themes/pfsense_ng_fs/loader.js
@@ -213,7 +213,7 @@ function finishedResizing()
 		resizeRmColumns(); // Check if we can delete any columns
 	else if( colWidth > specifiedColWidth ) // Columns width COULD display more columns properly    
 		resizeAddColumns(); // Check if we can add any columns
-};
+}
 
 ///////////////// end widget code part 1 /////////////////////////
 


### PR DESCRIPTION
Currently loader.js is performing various jQuery code related to the multiple columns (full screen dashboard) on document load, this is obviously only required for the dashboard page. It caused an issue on the traffic shaper, where the progress bars didn't load. Therefore...

commit d285ffd adds an if statement on line 235 and moves some existing code inside of it. This checks if element 'columnModifier' exists, it should only exist in themes ending in '_fs' and on the dashboard ie index.php page. So only widget code is executed when on the dashboard page.

@rbgara
