### PR TITLE
Fixes for DHCP range validation when entering from console

### DIFF
--- a/etc/rc.initial.setlanip
+++ b/etc/rc.initial.setlanip
@@ -349,7 +349,7 @@ $config['interfaces'][$interface]['gatewayv6'] = $gwname6;
 $config['interfaces'][$interface]['enable']    = true;
 
 function console_configure_dhcpd($version = 4) {
-	global $g, $config, $restart_dhcpd, $fp, $interface, $dry_run, $intip, $intbits;
+	global $g, $config, $restart_dhcpd, $fp, $interface, $dry_run, $intip, $intbits, $intip6, $intbits6;
 
 	$label_IPvX = ($version === 6) ? "IPv6"    : "IPv4";
 	$dhcpd      = ($version === 6) ? "dhcpdv6" : "dhcpd";
@@ -357,8 +357,8 @@ function console_configure_dhcpd($version = 4) {
 	if($g['services_dhcp_server_enable'])
 		$yn = prompt_for_enable_dhcp_server($version);
 	if ($yn == "y") {
-		$subnet_start = ($version === 6) ? gen_subnetv6($intip, $intbits) : gen_subnet($intip, $intbits);
-		$subnet_end = ($version === 6) ? gen_subnetv6_max($intip, $intbits) : gen_subnet_max($intip, $intbits);
+		$subnet_start = ($version === 6) ? gen_subnetv6($intip6, $intbits6) : gen_subnet($intip, $intbits);
+		$subnet_end = ($version === 6) ? gen_subnetv6_max($intip6, $intbits6) : gen_subnet_max($intip, $intbits);
 		do {
 			do {
 				echo sprintf(gettext("Enter the start address of the %s client address range:"), $label_IPvX) . " ";


### PR DESCRIPTION
subnet_start and subnet_end calculations were using the wrong vars for the IPv6 case. This is fixed.
DHCP end address must be >= start address- this code now checks for that. If the end address is < start address then it loops back to ask for the start address again.
Most of the diff is due to putting the "do-while ($not_inorder)" loop around the 2 prompts for start and end of DHCP range, and the inner code was indented.
This can all drop into 2.1 branch also, IMHO.
