### PR TITLE
Adjust DHCP lease local time back to UTC if required

### DIFF
--- a/usr/local/www/status_dhcp_leases.php
+++ b/usr/local/www/status_dhcp_leases.php
@@ -99,22 +99,24 @@ function leasecmp($a, $b) {
 function adjust_gmt($dt) {
 	global $config; 
 	$dhcpd = $config['dhcpd'];
-	foreach ($dhcpd as $dhcpleaseinlocaltime) {
-		$dhcpleaseinlocaltime = $dhcpleaseinlocaltime['dhcpleaseinlocaltime'];
+	foreach ($dhcpd as $dhcpditem) {
+		$dhcpleaseinlocaltime = $dhcpditem['dhcpleaseinlocaltime'];
 		if ($dhcpleaseinlocaltime == "yes") 
 			break;
 	}
 	$timezone = $config['system']['timezone'];
 	$ts = strtotime($dt . " GMT");
 	if ($dhcpleaseinlocaltime == "yes") {
+		/* The lease data comes with time in local by default. So nothing to do here. */
+		return strftime("%Y/%m/%d %H:%M:%S", $ts);
+	} else {
+		/* Adjust the time back to UTC by subtracting the time zone offset. */
 		$this_tz = new DateTimeZone($timezone); 
 		$dhcp_lt = new DateTime(strftime("%I:%M:%S%p", $ts), $this_tz); 
 		$offset = $this_tz->getOffset($dhcp_lt);
-		$ts = $ts + $offset;
+		$ts = $ts - $offset;
 		return strftime("%Y/%m/%d %I:%M:%S%p", $ts);
 	}
-	else
-		return strftime("%Y/%m/%d %H:%M:%S", $ts);
 }
 
 function remove_duplicate($array, $field)


### PR DESCRIPTION
The time in dhcpd.leases file is now actually in local time. So if the user has selected to display the leases in local time, then nothing needs to be done. And if they want to display in UTC, then the time zone offset needs to be subtracted from the time.
Forum post: http://forum.pfsense.org/index.php/topic,70504.0.html
