### PR TITLE
Fix display of CIDR/Update Freq in Alias Edit

### DIFF
--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -427,9 +427,9 @@ function typesel_change() {
 			break;
 	}
 
-	jQuery("select[id^='address_subnet']").prop("disabled", field_disabled);
+	jQuery("select[id='address_subnet']").prop("disabled", field_disabled);
 	if (set_value == true);
-		jQuery("select[id^='address_subnet']").prop("value", field_value);
+		jQuery("select[id='address_subnet']").prop("value", field_value);
 }
 
 function add_alias_control() {


### PR DESCRIPTION
Fixes #3376. I have no idea what the "^" characters were meant to do, but removing them makes the CIDR/Update Freq value be displayed correctly when editing. Will there be some other side-effect from removing the "^"?
This needs to be fixed in 2.1 branch as well as master.
