### PR TITLE
process_alias_urltable: Added data validation

### DIFF
--- a/etc/inc/pfsense-utils.inc
+++ b/etc/inc/pfsense-utils.inc
@@ -2137,6 +2137,7 @@ function process_alias_urltable($name, $url, $freq, $forceupdate=false) {
 				$ports = explode("\n", file_get_contents($urltable_filename . ".tmp2"));
 				$ports = group_ports($ports);
 				file_put_contents($urltable_filename, implode("\n", $ports));
+				unlink_if_exists($urltable_filename . ".tmp2");
 				unset($ports);
 			} else {
 				@rename("{$urltable_filename}.tmp2", $urltable_filename);


### PR DESCRIPTION
I had noticed that if the downloaded file had unexpected data(In my case a simple <.br/> tag) that pf would stop functioning properly. I have added data validation and tested various entries. Skipped entries are logged to the system log. 

Test results: http://pastebin.com/CVeZ88NT
