### PR TITLE
Update reserved_keywords checks to match firewall_aliases_edit

### DIFF
--- a/usr/local/www/firewall_aliases_import.php
+++ b/usr/local/www/firewall_aliases_import.php
@@ -38,7 +38,8 @@
 ##|-PRIV
 
 
-$reserved_keywords = array("pass", "out", "queue", "max", "min", "pptp", "pppoe", "L2TP", "OpenVPN", "IPsec");
+// Keywords not allowed in names
+$reserved_keywords = array("all", "pass", "block", "out", "queue", "max", "min", "pptp", "pppoe", "L2TP", "OpenVPN", "IPsec");
 
 require("guiconfig.inc");
 require_once("util.inc");
@@ -47,8 +48,13 @@ require("shaper.inc");
 
 $pgtitle = array(gettext("Firewall"),gettext("Aliases"),gettext("Bulk import"));
 
+// Add all Load balance names to reserved_keywords
+if (is_array($config['load_balancer']['lbpool']))
+	foreach ($config['load_balancer']['lbpool'] as $lbpool)
+		$reserved_keywords[] = $lbpool['name'];
+
 $reserved_ifs = get_configured_interface_list(false, true);
-$reserved_keywords = array_merge($reserved_keywords, $reserved_ifs);
+$reserved_keywords = array_merge($reserved_keywords, $reserved_ifs, $reserved_table_names);
 
 if (!is_array($config['aliases']['alias']))
         $config['aliases']['alias'] = array();


### PR DESCRIPTION
firewall_aliases_import should have the same checks for reserved names as firewall_aliases_edit
This code should really be in a function in a common include file, but which one is the appropriate one?
For now I made the checks the same.
