### PR TITLE
Return GWG protocol when no gateway IP

### DIFF
--- a/etc/inc/gwlb.inc
+++ b/etc/inc/gwlb.inc
@@ -791,15 +791,17 @@ function return_gateway_groups_array() {
 						else if (!empty($int))
 							$gatewayip = get_interface_gateway($gateway['friendlyiface']);
 
-						if (!empty($int) && is_ipaddr($gatewayip)) {
-							$groupmember = array();
-							$groupmember['int']  = $int;
-							$groupmember['gwip']  = $gatewayip;
-							$groupmember['weight']  = isset($gateway['weight']) ? $gateway['weight'] : 1;
-							if (is_array($gwvip_arr[$group['name']])&& !empty($gwvip_arr[$group['name']][$member]))
-								$groupmember['vip'] = $gwvip_arr[$group['name']][$member];
+						if (!empty($int)) {
 							$gateway_groups_array[$group['name']]['ipprotocol'] = $gateway['ipprotocol'];
-							$gateway_groups_array[$group['name']][] = $groupmember;
+							if (is_ipaddr($gatewayip)) {
+								$groupmember = array();
+								$groupmember['int']  = $int;
+								$groupmember['gwip']  = $gatewayip;
+								$groupmember['weight']  = isset($gateway['weight']) ? $gateway['weight'] : 1;
+								if (is_array($gwvip_arr[$group['name']])&& !empty($gwvip_arr[$group['name']][$member]))
+									$groupmember['vip'] = $gwvip_arr[$group['name']][$member];
+								$gateway_groups_array[$group['name']][] = $groupmember;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Forum: http://forum.pfsense.org/index.php/topic,71142.0.html
When no gateway in a group has a gateway IP address yet, the bit of code here was not executed and thus the 'ipprotocol' is never set/returned for the gateway group, even though determining the IP protocol is easily done without actually having the gateway IP known.
This fixes that behaviour with minimal code change, to avoid possible impact on other callers of this fairly complex function. This fixes validation of policy-route firewall rules to a GWG that currently has no known gateway IPs (e.g. the forum poster has 2 WAN DHCP with the cables not yet connected).
return_gateway_groups_array() can now return the GWG IP protocol and also have all member gateways down. I think this will be of benefit to other callers, and not have a negative impact. But those more familiar with all the uses of this function should think about any other side-effects this may have before committing:)
This could usefully be back-ported to 2.1 branch also.
