### PR TITLE
Make select option XHTML compliant for "Number of lines to display".

### DIFF
--- a/usr/local/www/widgets/widgets/log.widget.php
+++ b/usr/local/www/widgets/widgets/log.widget.php
@@ -134,7 +134,7 @@ function format_log_line(row) {
 		Number of lines to display: 
 		<select name="filterlogentries" class="formfld unknown" id="filterlogentries">
 		<?php for ($i = 1; $i <= 20; $i++) { ?>
-			<option value="<?php echo $i;?>" <?php if ($nentries == $i) echo "SELECTED";?>><?php echo $i;?></option>
+			<option value="<?php echo $i;?>" <?php if ($nentries == $i) echo "selected=\"selected\"";?>><?php echo $i;?></option>
 		<?php } ?>
 		</select>
 


### PR DESCRIPTION
http://validator.w3.org/check
"SELECTED" is not a member of a group specified for any attribute 
<option value="7" SELECTED >7</option>

The name and VI delimiter can be omitted from an attribute specification only if SHORTTAG YES is specified 
<option value="7" selected >7</option>

"VI delimiter" is a technical term for the equal sign. This error message means that the name of an attribute and the equal sign cannot be omitted when specifying an attribute. A common cause for this error message is the use of "Attribute Minimization" in document types where it is not allowed, in XHTML for instance.

How to fix: For attributes such as compact, checked or selected, do not write e.g <option selected ... but rather <option selected="selected" ...
