### PR TITLE
Really fix #3376 Alias Edit does not display correctly

### DIFF
--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -461,9 +461,9 @@ function typesel_change() {
 			break;
 	}
 
-	jQuery("select[id='address_subnet']").prop("disabled", field_disabled);
-	if (set_value == true);
-		jQuery("select[id='address_subnet']").prop("value", field_value);
+	jQuery("select[id^='address_subnet']").prop("disabled", field_disabled);
+	if (set_value == true)
+		jQuery("select[id^='address_subnet']").prop("value", field_value);
 }
 
 function add_alias_control() {


### PR DESCRIPTION
Thanks to Grischa Zengel for spotting the semi-colon at the end of the "if" line that was the real cause. Please also back merge this to 2.1 branch.
