### PR TITLE
Captive Portal modification to allow SIP2 authentication

### DIFF
--- a/etc/inc/captiveportal.inc
+++ b/etc/inc/captiveportal.inc
@@ -47,6 +47,7 @@ require_once("config.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("radius.inc");
+require_once("sip2.inc");
 require_once("voucher.inc");
 
 function get_default_captive_portal_html() {

--- a/etc/inc/sip2.inc
+++ b/etc/inc/sip2.inc
@@ -1,0 +1,269 @@
+<?php
+/*
+    Copyright (c) 2009, Niles Ingalls <niles@atheos.net>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. The names of the authors may not be used to endorse or promote products
+       derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+    IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+    OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+    EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+	This is based on the SIP2 protocol described here:
+	http://solutions.3m.com/wps/portal/3M/en_US/library/home/resources/protocols/
+
+	This script has only been tested with Evergreen 1.2.3 using Open NSIP.
+	If I followed the standard properly, it might work with your ILS too!
+
+*/
+
+/*
+SIP2 AUTHENTICATION
+---------------------
+*/
+
+
+class sip2
+{
+	var $seqno = -1;
+	var $language = '001';
+	var $retry = '5';
+	var $timeout = '5';
+	var $skipcrc = '1';
+	var $userid;
+	var $password;
+	var $login;
+
+	function login()
+	{ 
+
+		global $config;	
+		$this->skipcrc = $config['captiveportal']['sip2skipcrc'];
+		$command = sprintf("9300CN%s|CO%s|CP%s|AY%sAZ", $config['captiveportal']['sip2login'], $config['captiveportal']['sip2password'], $config['captiveportal']['sip2location'], $this->seqno = $this->seqno());
+		$command = $command . $this->crc($command) . "\r";
+
+		fwrite($this->connection, $command);
+
+			// we don't need the data back from our Login, but if we don't go through the motion, the next fread() gets this info instead :/
+
+			while ($term != "\x0D") { 
+
+		 		$term = fread($this->connection, 1);
+
+			}
+
+		$this->login = true;
+	}
+	
+	function authenticate()
+	{
+
+		global $config;
+
+		if ($this->login == true) {
+
+			$patron_array = $this->return_patron_array($this->patron_information());
+
+			if ((isset($patron_array['BL']) && $patron_array['BL'] == 'Y') && (isset($patron_array['CQ']) && $patron_array['CQ'] == 'Y' )) return true;
+
+		} else { // authenticate() was called before login
+
+			$this->login();		
+			return $this->authenticate();
+
+		}
+
+	}
+
+	function fines()
+	{
+
+		global $config;
+
+		if ($this->login == true) {
+
+			$patron_array = $this->return_patron_array($this->patron_information());
+			
+			if (!($config['captiveportal']['sip2threshold'] > 0 && $patron_array['BV'] < $config['captiveportal']['sip2threshold'])) return $patron_array['BV'];
+
+		} else { // fines() was called before login
+
+		        $this->login();
+				$this->authenticate();
+				return $this->fines();
+
+		}
+
+	}	
+
+	function item_information($item)
+	{
+
+		global $config;
+		$command = sprintf("17%sAO%s|AB%s|AC", date('Ymd    His'), $config['captiveportal']['sip2institution'],$item);
+
+                $command = $command . $this->crc($command) . "\r";
+
+                fwrite($this->connection, $command);
+
+                                while ($term != "\x0D") {
+
+                                        $term = fread($this->connection, 1);
+                                        $result .= $term;
+
+                                }
+// probably want to break this down to title, owning library, permanent location, current location
+		return trim($result);
+
+        }
+		
+	function patron_information()
+	{
+
+		global $config;	
+		$command = sprintf("63001%s   Y      AO%s|AA%s|AD%s|BP1|BQ5|AY%sAZ", date('Ymd    His'), $config['captiveportal']['sip2institution'], $this->userid, $this->password, $this->seqno = $this->seqno());
+		$command = $command . $this->crc($command) . "\r";
+
+		fwrite($this->connection, $command);	
+		stream_set_timeout($this->connection, $this->timeout);
+
+				while ($term != "\x0D") {
+
+					$info = stream_get_meta_data($this->connection);
+					if ($info['timed_out']) die("Connection timed out!\n");
+					
+					$term = fread($this->connection, 1);
+					$result .= $term;
+
+				}
+
+				if ($this->skipcrc || $this->crc_validate(trim($result))) {
+
+					return trim($result);
+
+				} else {
+
+					// CRC error, request resend.
+					return $this->acs_resend(); 
+
+				}
+
+	}
+
+	function return_patron_array($message) {
+
+		$result = explode("|", $message);
+		array_shift($result);
+
+			foreach($result AS $value) {
+
+				$response[substr($value,0,2)] = substr($value, 2);
+
+			}
+
+		return $response;
+
+	}
+
+	function acs_resend()
+	{
+
+		if ($this->retry-- > 0) {
+
+			$command = sprintf("97|AY%sAZ", $this->seqno = $this->seqno());
+			$command = $command . $this->crc($command) . "\r";
+
+			fwrite($this->connection, $command);
+
+			while ($term != "\x0D") {
+
+				$term = fread($this->connection, 1);
+				$result .= $term;
+
+			}
+
+			$result = trim($result);
+			
+			if ($this->skipcrc || $this->crc_validate(trim($result))) {
+
+				return trim($result);
+
+			} else {
+
+					// CRC error, request resend.
+				return $this->acs_resend();
+
+			}
+			
+		} else {
+
+			echo "exceeded all CRC retries, giving up\n";  //Log this somewhere.
+
+		}
+
+	}
+
+	function connect()
+	{
+
+                global $config;
+		if (!$this->connection = fsockopen($config['captiveportal']['sip2server'], $config['captiveportal']['sip2port'])) die("Cannot Connect\n");
+
+	}
+
+	function disconnect()
+	{
+
+		fclose($this->connection);
+
+	}
+
+	function crc($msg) {
+
+		for($i = 0; $i < strlen($msg); $i++) {
+
+			$total = $total + ord($msg[$i]);
+
+		}
+
+		return substr(sprintf("%X", ($total) * -1), -4, 4);
+
+	}
+
+	function crc_validate($message)
+	{
+
+		if ($this->crc(substr($message, 0, -4)) == substr($message, -4)) return true;
+
+	}
+
+	function seqno() 
+    {
+
+        $this->seqno++;
+
+        if ($this->seqno > 9 ) $this->seqno = 0;
+ 
+        return ($this->seqno);
+ 
+   }
+
+}
+?>

--- a/usr/local/captiveportal/index.php
+++ b/usr/local/captiveportal/index.php
@@ -153,6 +153,36 @@ EOD;
 	captiveportal_logportalauth("unauthenticated",$clientmac,$clientip,"ACCEPT");
 	portal_allow($clientip, $clientmac, "unauthenticated");
 
+} else if ($_POST['accept'] && $cpcfg['auth_method'] == "SIP2") {
+                
+        $sip2 = new sip2;
+        $sip2->userid = $_POST['auth_user'];
+        $sip2->password = $_POST['auth_pass'];
+        $sip2->connect();
+        $sip2->login();
+
+        if ($sip2->fines()) {
+
+                captiveportal_logportalauth($_POST['auth_user'],$clientmac,$clientip,"FAILURE - Bill due: $" . $sip2->fines());
+                portal_reply_page($redirurl, "error", "You have an outstanding bill in the amount of $" . $sip2->fines());
+                exit;
+ 
+        } else {
+
+                $loginok = $sip2->authenticate();
+
+        }
+
+        $sip2->disconnect();
+        
+     if ($loginok){
+         captiveportal_logportalauth($_POST['auth_user'],$clientmac,$clientip,"LOGIN");
+         portal_allow($clientip, $clientmac,$_POST['auth_user']);
+     } else {
+         captiveportal_logportalauth($_POST['auth_user'],$clientmac,$clientip,"FAILURE");
+         portal_reply_page($redirurl, "error");
+     }
+
 } else if (isset($config['voucher'][$cpzone]['enable']) && $_POST['accept'] && $_POST['auth_voucher']) {
 	$voucher = trim($_POST['auth_voucher']);
 	$timecredit = voucher_auth($voucher);

--- a/usr/local/www/services_captiveportal.php
+++ b/usr/local/www/services_captiveportal.php
@@ -184,6 +184,14 @@ if ($a_cp[$cpzone]) {
 	$pconfig['radiusvendor'] = $a_cp[$cpzone]['radiusvendor'];
 	$pconfig['radiussession_timeout'] = isset($a_cp[$cpzone]['radiussession_timeout']);
 	$pconfig['radiussrcip_attribute'] = $a_cp[$cpzone]['radiussrcip_attribute'];
+        $pconfig['sip2server'] = $a_cp[$cpzone]['sip2server'];
+        $pconfig['sip2port'] = $a_cp[$cpzone]['sip2port'];
+        $pconfig['sip2login'] = $a_cp[$cpzone]['sip2login'];
+        $pconfig['sip2password'] = $a_cp[$cpzone]['sip2password'];
+        $pconfig['sip2institution'] = $a_cp[$cpzone]['sip2institution'];
+        $pconfig['sip2location'] = $a_cp[$cpzone]['sip2location'];
+        $pconfig['sip2threshold'] = $a_cp[$cpzone]['sip2threshold'];
+        $pconfig['sip2skipcrc'] = $a_cp[$cpzone]['sip2skipcrc'];
 	$pconfig['passthrumacadd'] = isset($a_cp[$cpzone]['passthrumacadd']);
 	$pconfig['passthrumacaddusername'] = isset($a_cp[$cpzone]['passthrumacaddusername']);
 	$pconfig['radmac_format'] = $a_cp[$cpzone]['radmac_format'];
@@ -290,6 +298,16 @@ if ($_POST) {
 	if (($_POST['radiusacctport'] && !is_port($_POST['radiusacctport']))) {
 		$input_errors[] = sprintf(gettext("A valid port number must be specified. [%s]"), $_POST['radiusacctport']);
 	}
+        if (($_POST['sip2server'] && !is_ipaddr($_POST['sip2server']))) {
+                $input_errors[] = sprintf(gettext("A valid IP address must be specified. [%s]"), $_POST['sip2server']);
+        }
+        if (($_POST['sip2port'] && !is_numeric($_POST['sip2port']))) {
+                $input_errors[] = sprintf(gettext("A valid port number must be specified. [%s]"), $_POST['sip2port']);
+        }
+        if (($_POST['sip2threshold'] && !is_port($_POST['sip2threshold']))) {
+                $input_errors[] = sprintf(gettext("A valid numeric amount must be specified. (no decimals or $) [%s]"), $_POST['sip2threshold']
+);
+        }
 	if ($_POST['maxproc'] && (!is_numeric($_POST['maxproc']) || ($_POST['maxproc'] < 4) || ($_POST['maxproc'] > 100))) {
 		$input_errors[] = gettext("The maximum number of concurrent connections per client IP address may not be larger than the global maximum.");
 	}
@@ -375,6 +393,14 @@ if ($_POST) {
 		$newcp['radiusvendor'] = $_POST['radiusvendor'] ? $_POST['radiusvendor'] : false;
 		$newcp['radiussession_timeout'] = $_POST['radiussession_timeout'] ? true : false;
 		$newcp['radiussrcip_attribute'] = $_POST['radiussrcip_attribute'];
+                $newcp['sip2server'] = $_POST['sip2server'];
+                $newcp['sip2port'] = $_POST['sip2port'];
+                $newcp['sip2login'] = $_POST['sip2login'];
+                $newcp['sip2password'] = $_POST['sip2password'];
+                $newcp['sip2threshold'] = $_POST['sip2threshold'];
+                $newcp['sip2institution'] = $_POST['sip2institution'];
+                $newcp['sip2location'] = $_POST['sip2location'];
+                $newcp['sip2skipcrc'] = $_POST['sip2skipcrc'];
 		$newcp['passthrumacadd'] = $_POST['passthrumacadd'] ? true : false;
 		$newcp['passthrumacaddusername'] = $_POST['passthrumacaddusername'] ? true : false;
 		$newcp['radmac_format'] = $_POST['radmac_format'] ? $_POST['radmac_format'] : false;
@@ -417,11 +443,12 @@ include("head.inc");
 <script language="JavaScript">
 <!--
 function enable_change(enable_change) {
-	var endis, radius_endis;
+	var endis, radius_endis, sip2_endis;
 	endis = !(document.iform.enable.checked || enable_change);
 	localauth_endis = !((!endis && document.iform.auth_method[1].checked) || enable_change);
 	radius_endis = !((!endis && document.iform.auth_method[2].checked) || enable_change);
 	https_endis = !((!endis && document.iform.httpslogin_enable.checked) || enable_change);
+        sip2_endis = !((!endis && document.iform.auth_method[3].checked) || enable_change);
 
 	document.iform.cinterface.disabled = endis;
 	//document.iform.maxproc.disabled = endis;
@@ -448,6 +475,15 @@ function enable_change(enable_change) {
 	document.iform.radiuskey3.disabled = radius_endis;
 	document.iform.radiuskey4.disabled = radius_endis;
 	document.iform.radacct_enable.disabled = radius_endis;
+        document.iform.sip2server.disabled = sip2_endis;
+        document.iform.sip2port.disabled = sip2_endis;
+        document.iform.sip2login.disabled = sip2_endis;
+        document.iform.sip2password.disabled = sip2_endis;
+        document.iform.sip2port.disabled = sip2_endis;
+        document.iform.sip2threshold.disabled = sip2_endis;
+        document.iform.sip2institution.disabled = sip2_endis;
+        document.iform.sip2location.disabled = sip2_endis;
+        document.iform.sip2skipcrc.disabled = sip2_endis;
 	document.iform.peruserbw.disabled = endis;
 	document.iform.bwdefaultdn.disabled = endis;
 	document.iform.bwdefaultup.disabled = endis;
@@ -936,6 +972,55 @@ function enable_change(enable_change) {
 					<?=gettext("unformatted:"); ?> 001122334455
 				</td>
 			</tr>
+                        <tr>
+                                <td colspan="2" class="list" height="12"></td>
+                        </tr>
+                        <tr>
+                                <td colspan="2" valign="top" class="optsect_t2">SIP2 Connectivity</td>
+                        </tr>
+                                
+                        <tr>
+                                <td class="vncell" valign="top">SIP2 Server</td>
+                                <td class="vtable"><input name="sip2server" type="text" class="formfld unknown" id="sip2server" size="30" value
+="<?=htmlspecialchars($pconfig['sip2server']);?>"></td>
+                        </tr>
+                        <tr>                                     
+                                <td class="vncell" valign="top">SIP2 Port</td>
+                                <td class="vtable"><input name="sip2port" type="text" class="formfld unknown" id="sip2port" size="6" value="<?=
+htmlspecialchars($pconfig['sip2port']);?>"><br>
+                                Leave this field blank to use the defaualt port (6002).</td>
+                        </tr>
+                        <tr>
+                                <td class="vncell" valign="top">SIP2 Login</td>
+                                <td class="vtable"><input name="sip2login" type="text" class="formfld unknown" id="sip2login" size="30" value="
+<?=htmlspecialchars($pconfig['sip2login']);?>"></td>
+                        </tr>
+                        <tr>
+                                <td class="vncell" valign="top">SIP2 Password</td>
+                                <td class="vtable"><input name="sip2password" type="text" class="formfld unknown" id="sip2password" size="30" v
+alue="<?=htmlspecialchars($pconfig['sip2password']);?>"></td>
+                        </tr>
+                        <tr>
+                                <td class="vncell" valign="top">SIP2 Institution</td>
+                                <td class="vtable"><input name="sip2institution" type="text" class="formfld unknown" id="sip2institution" size=
+"30" value="<?=htmlspecialchars($pconfig['sip2institution']);?>"></td>
+                        </tr>
+                        <tr>
+                                <td class="vncell" valign="top">SIP2 Location</td>
+                                <td class="vtable"><input name="sip2location" type="text" class="formfld unknown" id="sip2location" size="30" v
+alue="<?=htmlspecialchars($pconfig['sip2location']);?>"><br>
+                                optional</td>
+                        <tr>
+                                <td class="vncell" valign="top">SIP2 Fine Threshold</td>
+                                <td class="vtable"><input name="sip2threshold" type="text" class="formfld unknown" id="sip2threshold" size="6"
+value="<?=htmlspecialchars($pconfig['sip2threshold']);?>"><br>
+                                Patrons account must be below this amount to authenticate. Leave blank to disable.</td>
+                        </tr>
+                        <tr>
+                                <td class="vncell" valign="top">CRC Check</td>
+                                <td class="vtable"><input name="sip2skipcrc" type="checkbox" id="sip2skipcrc" value="no" onClick="enable_change
+(false)" <?php if ($pconfig['sip2skipcrc']) echo "checked"; ?>><strong><?=gettext("Disable CRC Check"); ?></strong><br></td>
+                        </tr>
 		</table>
 	</tr>
 	<tr>


### PR DESCRIPTION
This contribution will allow public libraries to authenticate patrons against their ILS software.
It can be configured to prevent patrons with excessive fines from authenticating, and should work with
any SIP2 compliant ISL. (most of them)
Tested and known to work with Evergreen and Sirsi. 
http://en.wikipedia.org/wiki/Standard_Interchange_Protocol
