### PR TITLE
Check for tmp captiveportal dir before making it

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -938,7 +938,8 @@ function system_generate_lighty_config($filename,
 		$captive_portal_mod_evasive = "evasive.max-conns-per-ip = {$maxprocperip}";
 
 		$server_upload_dirs = "server.upload-dirs = ( \"{$g['tmp_path']}/captiveportal/\" )\n";
-		mkdir("{$g['tmp_path']}/captiveportal", 0555);
+		if(!is_dir("{$g['tmp_path']}/captiveportal"))
+			mkdir("{$g['tmp_path']}/captiveportal", 0555);
 		$server_max_request_size = "server.max-request-size    = 384";
 		$cgi_config = "";
 	} else {


### PR DESCRIPTION
In forum: https://forum.pfsense.org/index.php/topic,72483.0.html
Warning: mkdir(): File exists in /etc/inc/system.inc on line 878
Another little change to get rid of a warning message - could also go into 2.1.1. Seems there are never-ending little things to find for 2.1.1.
Not sure if you would rather call safe_mkdir here? and in other places in this file that have the "if(!is_dir) then mkdir" sequence.
