### PR TITLE
Create ntp_status.widget.php

### DIFF
--- a/usr/local/www/widgets/widgets/ntp_status.widget.php
+++ b/usr/local/www/widgets/widgets/ntp_status.widget.php
@@ -41,7 +41,7 @@ require_once("/usr/local/www/widgets/include/ntp_status.inc");
 
 if($_REQUEST['updateme']) {
 //this block displays only on ajax refresh
-	exec("/usr/local/sbin/ntpq -pn | /usr/sbin/tail +3", $ntpq_output);
+	exec("/usr/local/sbin/ntpq -pn | /usr/bin/tail +3", $ntpq_output);
 	$ntpq_counter = 0;
 	foreach ($ntpq_output as $line) {
 		if (substr($line, 0, 1) == "*") {


### PR DESCRIPTION
Dedicated widget which has a javascript clock showing the server time accurately, and based on NTP's running state displays information about sync source, GPS state etc. It refreshes contents every minute, without reloading the entire page.
