### PR TITLE
Dodgy-looking stuff in graph calculations

### DIFF
--- a/usr/local/www/status_rrd_graph_img.php
+++ b/usr/local/www/status_rrd_graph_img.php
@@ -201,7 +201,7 @@ if ($altq_list_queues[$curif]) {
 
 $speedlimit = ($upstream + $downstream);
 
-/* Set default colors explicity, the theme can then override them below.
+/* Set default colors explicitly, the theme can then override them below.
    This prevents missing colors in themes from crashing the graphs. */
 /* Traffic Outbound		Out-P-4,  Out-B-4,  Out-P-6,  Out-B-6 */
 $colortrafficup		= array('666666', 'CCCCCC', '2217AA', '625AE7');
@@ -397,11 +397,11 @@ if((strstr($curdatabase, "-traffic.rrd")) && (file_exists("$rrddbpath$curdatabas
 
 	$graphcmd .= "CDEF:\"$curif-bytes_t_pass=$curif-bytes_in_t_pass,$curif-bytes_out_t_pass,+\" ";
 	$graphcmd .= "CDEF:\"$curif-bytes_t_block=$curif-bytes_in_t_block,$curif-bytes_out_t_block,+\" ";
-	$graphcmd .= "CDEF:\"$curif-bytes_t=$curif-bytes_in_t_pass,$curif-bytes_out_t_block,+\" ";
+	$graphcmd .= "CDEF:\"$curif-bytes_t=$curif-bytes_t_pass,$curif-bytes_t_block,+\" ";
 
 	$graphcmd .= "CDEF:\"$curif-bytes_t_pass6=$curif-bytes_in6_t_pass,$curif-bytes_out6_t_pass,+\" ";
 	$graphcmd .= "CDEF:\"$curif-bytes_t_block6=$curif-bytes_in6_t_block,$curif-bytes_out6_t_block,+\" ";
-	$graphcmd .= "CDEF:\"$curif-bytes_t6=$curif-bytes_in6_t_pass,$curif-bytes_out6_t_block,+\" ";
+	$graphcmd .= "CDEF:\"$curif-bytes_t6=$curif-bytes_t_pass6,$curif-bytes_t_block6,+\" ";
 	$graphcmd .= "VDEF:\"$curif-in_bits_95=$curif-in_bits,95,PERCENT\" ";
 	$graphcmd .= "CDEF:\"$curif-out_bits_mul=$curif-out_bits,$multiplier,*\" ";
 	$perc = $multiplier > 0 ? "95" : "5";
@@ -516,8 +516,8 @@ elseif(strstr($curdatabase, "-throughput.rrd")) {
 		$graphcmd .= "CDEF:\"{$ifname}-out_bits_pass={$ifname}-out_bytes_pass,8,*\" ";
 		$graphcmd .= "CDEF:\"{$ifname}-bits_io_pass={$ifname}-in_bits_pass,{$ifname}-out_bits_pass,+\" ";
 
-		$graphcmd .= "CDEF:\"{$ifname}-in_bits_block={$ifname}-in_bytes,8,*\" ";
-		$graphcmd .= "CDEF:\"{$ifname}-out_bits_block={$ifname}-out_bytes,8,*\" ";
+		$graphcmd .= "CDEF:\"{$ifname}-in_bits_block={$ifname}-in_bytes_block,8,*\" ";
+		$graphcmd .= "CDEF:\"{$ifname}-out_bits_block={$ifname}-out_bytes_block,8,*\" ";
 		$graphcmd .= "CDEF:\"{$ifname}-bits_io_block={$ifname}-in_bits_block,{$ifname}-out_bits_block,+\" ";
 
 		$graphcmd .= "CDEF:\"{$ifname}-bytes_in_pass={$ifname}-in_bytes_pass,0,$speedlimit,LIMIT,UN,0,{$ifname}-in_bytes_pass,IF,$average,*\" ";


### PR DESCRIPTION
I noticed that the graphs in this post - https://forum.pfsense.org/index.php/topic,72794.0.html - had numbers for in-block and out-block that had similar numbers to in-pass and out-pass. See image http://postimg.org/image/nouktm12p/
That seemed hard to believe. Found these calculations that look wrong.
