### PR TITLE
Highlight online+active in results

### DIFF
--- a/usr/local/www/status_dhcp_leases.php
+++ b/usr/local/www/status_dhcp_leases.php
@@ -343,9 +343,17 @@ foreach ($leases as $data) {
 		if ($data['act'] != "active" && $data['act'] != "static") {
 			$fspans = "<span class=\"gray\">";
 			$fspane = "</span>";
-		} else {
+		} else
 			$fspans = $fspane = "";
-		}
+		if ($data['online'] == "online")
+			$fspans2 = 'style="background-color:#00ff00"';
+		else
+			$fspans2 = "";
+		if ($data['act'] == "active")
+			$fspans3 = 'style="background-color:#00ff00"';
+		else
+			$fspans3 = "";
+
                 $lip = ip2ulong($data['ip']);
 		if ($data['act'] == "static") {
 			foreach ($config['dhcpd'] as $dhcpif => $dhcpifconf) {
@@ -396,8 +404,8 @@ foreach ($leases as $data) {
 					echo "<td class=\"listr\">{$fspans} n/a {$fspane}&nbsp;</td>\n";
 					echo "<td class=\"listr\">{$fspans} n/a {$fspane}&nbsp;</td>\n";
 				}
-                echo "<td class=\"listr\">{$fspans}{$data['online']}{$fspane}&nbsp;</td>\n";
-                echo "<td class=\"listr\">{$fspans}{$data['act']}{$fspane}&nbsp;</td>\n";
+                echo "<td class=\"listr\" {$fspans2}>{$data['online']}&nbsp;</td>\n";
+                echo "<td class=\"listr\" {$fspans3}>{$data['act']}&nbsp;</td>\n";
 		
 		if ($data['type'] == "dynamic") {
 			echo "<td valign=\"middle\"><a href=\"services_dhcp_edit.php?if={$data['if']}&mac={$data['mac']}&hostname={$data['hostname']}\">";


### PR DESCRIPTION
"class=grey" isn't really useful with a significant number of temporary leases, because you can't quickly pick out by eye, the few current or active leases from a long list of inactive or past leases.

This highlights the "online" and "active" leases that currently exist, so it's much easier to see the active or online devices in the leases table