### PR TITLE
Simplify is_ipaddrwithport & is_hostnamewithport [now rebased: see #1788]

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -554,26 +554,25 @@ function is_literalipaddrv6($ipaddr) {
 	return is_ipaddrv6($ipaddr);
 }
 
+/* returns true if $ipport is a valid IPv4:port or [Literal IPv6]:port
+   	false - if not a valid IP+port
+   	true (numeric 4 or 6) - if valid, gives type of IP */
 function is_ipaddrwithport($ipport) {
-	$parts = explode(":", $ipport);
-	$port = array_pop($parts);
-	if (count($parts) == 1) {
-		return is_ipaddrv4($parts[0]) && is_port($port);
-	} elseif (count($parts) > 1) {
-		return is_literalipaddrv6(implode(":", $parts)) && is_port($port);
-	} else {
-		return false;
-	}
+	if (is_string($ipport) && preg_match('/^(?:([^:]+)|\[(.*:.*)\]):([^:])+$/', $ipport, $parts))
+		if (is_port($parts[3])) {
+			if (is_ipaddrv4($parts[1]))
+				return 4;
+			if (is_ipaddrv6($parts[2]))
+				return 6; // shortcut test of IPv6 literal IP by pre-checking '[]' within regex
+		}
+	return false;
 }
 
+/* returns true if $hostport is a valid hostname:port */
 function is_hostnamewithport($hostport) {
-	$parts = explode(":", $hostport);
-	$port = array_pop($parts);
-	if (count($parts) == 1) {
-		return is_hostname($parts[0]) && is_port($port);
-	} else {
-		return false;
-	}
+	if (is_string($hostport) && preg_match('/^(.+):([^:])+$/', $hostport, $parts))
+		return (is_port($parts[2]) && is_hostname($parts[1]));
+	return false;
 }
 
 /* returns true if $ipaddr is a valid dotted IPv4 address or an alias thereof */


### PR DESCRIPTION
Simplify the code for these two functions.

The changed code is extremely similar to the method already used by is_literalipaddrv6(). 

is_ipaddrwithport() uses explode, impode, pushed parts, and generally makes checking and validating more complex than needed. Using a single regex, one can distinguish IPv4:port candidates from [IPv6]:port candidates in one line, avoid separate testing for [] in literal IPv6, and split the parts reliably, more easily than explode-and-array-manipulate.

Similar logic allows is_hostnamewithport() to avoid all explodes, array pop/push, etc, and use a single regex too.

NOTE: it's useful to let a calling function know whether the IP found by is_ipaddrwithport() is an IPv4 or IPv6 IP, as this can shortcut further checks and simplify code. is_ipaddrwithport() returns a True/false value. 

As any positive number Boolean-evaluates to True, I have taken advantage of this to have "success" usefully return 4 or 6 (not just "true") to say the type of IP:port matched. It's no extra effort or cost, transparent to any Boolean test, and allows a lot of efficiency and code simplification elsewhere, since calling code that needs to validate an IP:port *and* test if it's IPv4 or IPv6, a common situation, can now do this from the results of the single is_ipaddrwithport() call.