### PR TITLE
change tooltip type 'velcro' to 'greasy'. It fixes issue #2625

### DIFF
--- a/usr/local/www/guiconfig.inc
+++ b/usr/local/www/guiconfig.inc
@@ -1139,7 +1139,7 @@ function rule_popup($src,$srcport,$dst,$dstport){
 				$width="350";
 				break;
 			}
-			$span_begin = "<span style=\"cursor: help;\" onmouseover=\"var response_html=domTT_activate(this, event, 'id','ttalias_{$alias_id}','content','{$loading_image}', 'trail', true, 'delay', 300, 'fade', 'both', 'fadeMax', 93, 'styleClass', 'niceTitle','type','velcro','width',{$width});alias_popup('{$alias_id}','{$g['theme']}','".gettext('loading...')."');\" onmouseout=\"this.style.color = ''; domTT_mouseout(this, event);\"><u>";
+			$span_begin = "<span style=\"cursor: help;\" onmouseover=\"var response_html=domTT_activate(this, event, 'id','ttalias_{$alias_id}','content','{$loading_image}', 'trail', true, 'delay', 300, 'fade', 'both', 'fadeMax', 93, 'styleClass', 'niceTitle','type','greasy','width',{$width});alias_popup('{$alias_id}','{$g['theme']}','".gettext('loading...')."');\" onmouseout=\"this.style.color = ''; domTT_mouseout(this, event);\"><u>";
 			$span_end = "</u></span>";
 			if ($alias_name['name'] == $src) {
 				$descriptions['src'] = $span_begin;


### PR DESCRIPTION
Was changed tooltip type 'velcro' to 'greasy'. A greasy tip disappears when a mouse out occurs on owner.
