### PR TITLE
Tighten is_linklocal() [now rebased: see #1786]

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -369,9 +369,11 @@ function long2ip32($ip) {
 	return long2ip($ip & 0xFFFFFFFF);
 }
 
-/* Convert IP address to long int, truncated to 32-bits to avoid sign extension on 64-bit platforms. */
+/* Convert IP address to long int, truncated to 32-bits to avoid sign extension on 64-bit platforms. 
+   Returns '' if not valid IPv4. */
 function ip2long32($ip) {
-	return ( ip2long($ip) & 0xFFFFFFFF );
+	$a = ip2long($ip);
+	return ($a === False ? '' : $a & 0xFFFFFFFF);
 }
 
 /* Convert IP address to unsigned long int. */
@@ -531,9 +533,27 @@ function is_ipaddrv4($ipaddr) {
 		return false;
 }
 
-/* returns true if $ipaddr is a valid linklocal address */
+/* returns true if $ipaddr is a valid linklocal address 
+   TODO: does not validate %interface (if any) other than to check [a-z0-9]+  */
+   
 function is_linklocal($ipaddr) {
-	return (strtolower(substr($ipaddr, 0, 5)) == "fe80:");
+	if (!is_string($ipaddr))
+		return '';
+	if (($ip4 = ip2long32($ipaddr)) !== false) {
+		// IPv4 ?
+		list($local4lo, $local4hi) = array(ip2long32('169.254.1.0'), ip2long32('169.254.254.255'));
+		if ($ip4 >= $local4lo && $ip4 <= $local4hi)
+			return 4;
+	} elseif (preg_match('/^(?:[0-9a-f:]{2,39})(?:%[0-9a-z]+)?$/i', $ipaddr, $ip6)) {
+		// IPv6 ?
+		// not attempting to validate interface part $ip6[2] (if any) at present, as long as it's plausible (%[0-9a-z]+)
+
+		// linklocal requires '1111111010' and 54 zero bits (fe80::), see rfc4291 2.5.6
+		$iptest = substr(Net_IPv6::_Ip2Bin($ip6[1]),0,64);
+		if ($iptest == '1111111010' . str_repeat('0',54))
+			return 6;
+	}
+	return '';
 }
 
 /* returns scope of a linklocal address */

--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -544,9 +544,9 @@ function is_linklocal($ipaddr) {
 		list($local4lo, $local4hi) = array(ip2long32('169.254.1.0'), ip2long32('169.254.254.255'));
 		if ($ip4 >= $local4lo && $ip4 <= $local4hi)
 			return 4;
-	} elseif (preg_match('/^(?:[0-9a-f:]{2,39})(?:%[0-9a-z]+)?$/i', $ipaddr, $ip6)) {
+	} elseif (preg_match('/^([0-9a-f:]{2,39})(%([0-9a-z]+))?$/i', $ipaddr, $ip6)) {
 		// IPv6 ?
-		// not attempting to validate interface part $ip6[2] (if any) at present, as long as it's plausible (%[0-9a-z]+)
+		// not attempting to validate interface part $ip6[3] (if any) at present, as long as it's plausible (%[0-9a-z]+)
 
 		// linklocal requires '1111111010' and 54 zero bits (fe80::), see rfc4291 2.5.6
 		$iptest = substr(Net_IPv6::_Ip2Bin($ip6[1]),0,64);


### PR DESCRIPTION
is_linklocal has a few issues, including validating as linklocal, addresses that aren't linklocal according to RFC 4291, and doing no validation of reasonableness on any %(interface) part that may exist, allowing this to contain arbitrary text.

Changes made:

1) Tests for IPv4 linklocal addresses - while not much needed, they should probably be recognised as code handling linklocal may reasonably expect is_linklocal() to be IPv4/IPv6 agnostic.

2) For IPv6, it tests at least, that the purported interface is [0-9a-z]+ otherwise user input or other text such as "fe80::%\n;ARBIRARYTEXT;" would be validated as a linklocal address and inserted into pf and perhaps other places without further detection, leading to possible vulnerabilities. But it doesn't test more than this (and probably should test for valid interface name).

3) Follows RFC 4291 exactly: IPv6 linklocal isn't just "fe80::", it requires the rest of the first 64 bits to be zero too. The RFC defines it as '1111111010' + 54 zeros (Ref: https://tools.ietf.org/html/rfc4291#section-2.5.6 )

4) Returns 4 or 6 to give a more exact response to the calling function as to whether the match was an IPv4 linklocal or IPv6 linklocal address (both evaluate to True for Boolean test purposes such as "if (is_linklocal(...))")