### PR TITLE
Re-enabling static lease updates

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -849,6 +849,7 @@ EOD;
 
 	if ($need_ddns_updates) {
 		$dhcpdconf .= "ddns-update-style interim;\n";
+		$dhcpdconf .= "update-static-leases on;\n";
 
 		$dhcpdconf .= dhcpdkey($dhcpifconf);
 		$dhcpdconf .= dhcpdzones($ddns_zones, $dhcpifconf);


### PR DESCRIPTION
"update-static-leases on;" should be kept. Adding it back.
