### PR TITLE
Make Firewall Rules Advanced Options open if used

### DIFF
--- a/usr/local/www/firewall_rules_edit.php
+++ b/usr/local/www/firewall_rules_edit.php
@@ -46,17 +46,18 @@ require_once("filter.inc");
 require("shaper.inc");
 
 function is_aoadv_used($rule_config) {
-	if (($rule_config['allowopts']) ||
-	    ($rule_config['disablereplyto']) ||
+	// Note that the user could set "tag" or "tagged" to the string "0", which is valid but empty().
+	if ((isset($rule_config['allowopts'])) ||
+	    (isset($rule_config['disablereplyto'])) ||
 	    ($rule_config['tag'] != "") ||
 	    ($rule_config['tagged'] != "") ||
-	    ($rule_config['max'] != "") ||
-	    ($rule_config['max-src-nodes'] != "") ||
-	    ($rule_config['max-src-conn'] != "") ||
-	    ($rule_config['max-src-states'] != "") ||
-	    ($rule_config['max-src-conn-rate'] != "") ||
-	    ($rule_config['max-src-conn-rates'] != "") ||
-	    ($rule_config['statetimeout'] != ""))
+	    (!empty($rule_config['max'])) ||
+	    (!empty($rule_config['max-src-nodes'])) ||
+	    (!empty($rule_config['max-src-conn'])) ||
+	    (!empty($rule_config['max-src-states'])) ||
+	    (!empty($rule_config['max-src-conn-rate'])) ||
+	    (!empty($rule_config['max-src-conn-rates'])) ||
+	    (!empty($rule_config['statetimeout'])))
 		return true;
 	return false;
 }


### PR DESCRIPTION
Currently, if there are some settings defined in Firewall Rules Edit, Advanced Features, Advanced Options, the Advanced Options section is left minimized when the Firewall Edit screen is displayed. This makes it easy for a user to not notice that there are some Advanced Options settings.
This change makes the Advanced Options section be displayed if any of the settings are defined, in the same way it is done for all the other Advanced Features sections.
