### PR TITLE
rc.carpmaster/rc.carpbackup notification method for packages.

### DIFF
--- a/etc/inc/pfsense-utils.inc
+++ b/etc/inc/pfsense-utils.inc
@@ -2860,9 +2860,22 @@ function get_pppoes_child_interfaces($ifpattern) {
 
 }
 
-function call_plugins($plugin_type, $plugin_params) {
+/****f* pfsense-utils/pkg_call_plugins
+ * NAME
+ *   pkg_call_plugins
+ * INPUTS
+ *   $plugin_type value used to search in package configuration if the plugin is used, also used to create the function name
+ *   $plugin_params parameters to pass to the plugin function for passing multiple parameters a array can be used.
+ * RESULT
+ *   returns associative array results from the plugin calls for each package
+ * NOTES
+ *   This generic function can be used to notify or retrieve results from functions that are defined in packages.
+ ******/
+function pkg_call_plugins($plugin_type, $plugin_params) {
 	global $g, $config;
 	$results = array();
+	if (!is_array($config['installedpackages']['package']))
+		return $results;
 	foreach ($config['installedpackages']['package'] as $package) {
 		if(!file_exists("/usr/local/pkg/" . $package['configurationfile']))
 			continue;
@@ -2870,7 +2883,7 @@ function call_plugins($plugin_type, $plugin_params) {
 		$pkgname = substr(reverse_strrchr($package['configurationfile'], "."),0,-1);
 		if (is_array($pkg_config['plugins']))
 			foreach ($pkg_config['plugins'] as $plugin) {
-				if ($plugin['type'] == 'plugin_carp') {
+				if ($plugin['type'] == $plugin_type) {
 					if (file_exists($pkg_config['include_file']))
 						require_once($pkg_config['include_file']);
 					else

--- a/etc/rc.carpbackup
+++ b/etc/rc.carpbackup
@@ -68,7 +68,6 @@ $pluginparams = array();
 $pluginparams['type'] = 'carp';
 $pluginparams['event'] = 'rc.carpbackup';
 $pluginparams['interface'] = $argv[1];
-call_plugins('plugin_carp', $pluginparams);
-
+pkg_call_plugins('plugin_carp', $pluginparams);
 
 ?>

--- a/etc/rc.carpmaster
+++ b/etc/rc.carpmaster
@@ -76,6 +76,6 @@ $pluginparams = array();
 $pluginparams['type'] = 'carp';
 $pluginparams['event'] = 'rc.carpmaster';
 $pluginparams['interface'] = $argv[1];
-call_plugins('plugin_carp', $pluginparams);
+pkg_call_plugins('plugin_carp', $pluginparams);
 
 ?>


### PR DESCRIPTION
rc.carpmaster/rc.carpbackup notification method for packages.

Adds a 'plugin' method for packages to be notified when carp up/down state changes. (To be used by for example haproxy.)

The plugin method itself could be used for other event types when the need arises.
