### PR TITLE
Return full issuer for DN with multiple attribute values

### DIFF
--- a/etc/inc/certs.inc
+++ b/etc/inc/certs.inc
@@ -449,10 +449,16 @@ function cert_get_issuer($str_crt, $decode = true) {
 
 	ksort($components);
 	foreach ($components as $a => $v) {
-		if (!strlen($issuer))
-			$issuer = "{$a}={$v}";
-		else
-			$issuer = "{$a}={$v}, {$issuer}";
+		if (is_array($v)) {
+			ksort($v);
+			foreach ($v as $w) {
+				$aissuer = "{$a}={$w}";
+				$issuer = (strlen($issuer)) ? "{$aissuer}, {$issuer}" : $aissuer;
+			}
+		} else {
+			$aissuer = "{$a}={$v}";
+			$issuer = (strlen($issuer)) ? "{$aissuer}, {$issuer}" : $aissuer;
+		}
 	}
 
 	return $issuer;


### PR DESCRIPTION
https://redmine.pfsense.org/issues/3542

cert_get_issuer() doesn't always work properly.

e.g. "CN=Some Root CA,OU=Certificates Department,OU=(c) Copyright SomeCorp,O=SomeCorp,C=US"

$v would be array, so $issuer would end up as "CN=Some Root CA,OU=Array,O=SomeCorp,C=US".

cert_get_subject() has the correct logic, so copy that into get_issuer.
