### PR TITLE
etc/group: admin group causes pw(1) error

### DIFF
--- a/etc/group
+++ b/etc/group
@@ -26,7 +26,6 @@ network:*:69:
 www:*:80:
 nogroup:*:65533:
 nobody:*:65534:
-admin:*:0:
 audit:*:77:
 _ntp:*:123:
 _relayd:*:913:


### PR DESCRIPTION
I'm not entirely sure if deletion or reverting to id 101 is the better option. Feel free to discuss.

The issue was introduced in commit 128f6a3e in 2005: the admin
user was mapped to wheel and group admin was set to gid 0,
which clashes with the wheel group:

```
php: rc.bootup: The command '/usr/sbin/pw userdel -n 'admin''
returned exit code '1', the output was 'pw: entry inconsistent
pw: gr_copy(): Invalid argument'
```

Delete the admin group since it is no longer used.
