### PR TITLE
carp, provide a way to 'permanently' set carp to 'maintenance mode' (advskew 254) persisting a reboot

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -1346,6 +1346,25 @@ function interface_bring_down($interface = "wan", $destroy = false, $ifacecfg = 
 	return;
 }
 
+function interfaces_carp_set_maintenancemode($carp_maintenancemode){
+	global $config;
+	if (isset($config["virtualip_carp_maintenancemode"]) && $carp_maintenancemode == false) {
+		unset($config["virtualip_carp_maintenancemode"]);
+		write_config("Leave CARP maintenance mode");
+	} else
+	if (!isset($config["virtualip_carp_maintenancemode"]) && $carp_maintenancemode == true) {
+		$config["virtualip_carp_maintenancemode"] = true;
+		write_config("Enter CARP maintenance mode");
+	}
+
+	$viparr = &$config['virtualip']['vip'];
+	foreach ($viparr as $vip) {
+		if ($vip['mode'] == "carp") {
+			interface_carp_configure($vip);
+		}
+	}
+}
+
 function interfaces_ptpid_used($ptpid) {
 	global $config;
 
@@ -2174,7 +2193,13 @@ function interface_carp_configure(&$vip) {
 	if (!empty($vip['advbase']))
 		$advbase = "advbase " . escapeshellarg($vip['advbase']);
 
-	mwexec("/sbin/ifconfig {$realif} vhid " . escapeshellarg($vip['vhid']) . " advskew " . escapeshellarg($vip['advskew']) . " {$advbase} {$password}");
+	$carp_maintenancemode = isset($config["virtualip_carp_maintenancemode"]);
+	if ($carp_maintenancemode)
+		$advskew = "advskew 254";
+	else
+		$advskew = "advskew " . escapeshellarg($vip['advskew']);
+	
+	mwexec("/sbin/ifconfig {$realif} vhid " . escapeshellarg($vip['vhid']) . " {$advskew} {$advbase} {$password}");
 
 	if (is_ipaddrv4($vip['subnet']))
 		mwexec("/sbin/ifconfig {$realif} " . escapeshellarg($vip['subnet']) . "/" . escapeshellarg($vip['subnet_bits']) . " alias vhid " . escapeshellarg($vip['vhid']));

--- a/usr/local/www/carp_status.php
+++ b/usr/local/www/carp_status.php
@@ -39,6 +39,7 @@
 */
 
 require_once("guiconfig.inc");
+require_once("globals.inc");
 
 function gentitle_pkg($pgname) {
 	global $config;
@@ -50,6 +51,9 @@ unset($carp_interface_count_cache);
 unset($interface_ip_arr_cache);
 
 $status = get_carp_status();
+if($_POST['carp_maintenancemode'] <> "") {
+	interfaces_carp_set_maintenancemode(!isset($config["virtualip_carp_maintenancemode"]));
+}
 if($_POST['disablecarp'] <> "") {
 	if($status == true) {
 		mwexec("/sbin/sysctl net.inet.carp.allow=0");
@@ -116,7 +120,12 @@ include("head.inc");
 					echo "<input type=\"submit\" name=\"disablecarp\" id=\"disablecarp\" value=\"" . gettext("Enable Carp") . "\">";
 				} else {
 					$carp_enabled = true;
-					echo "<input type=\"submit\" name=\"disablecarp\" id=\"disablecarp\" value=\"" . gettext("Disable Carp") . "\">";
+					echo "<input type=\"submit\" name=\"disablecarp\" id=\"disablecarp\" value=\"" . gettext("Disable Carptemporarily") . "\">";
+				}
+				if(isset($config["virtualip_carp_maintenancemode"])) {
+					echo "<input type=\"submit\" name=\"carp_maintenancemode\" id=\"carp_maintenancemode\" value=\"" . gettext("Leave Carp maintenance mode now and on reboot") . "\">";
+				} else {
+					echo "<input type=\"submit\" name=\"carp_maintenancemode\" id=\"carp_maintenancemode\" value=\"" . gettext("Enter Carp maintenance mode now and on reboot") . "\">";
 				}
 			}
 ?>


### PR DESCRIPTION
carp, provide a way to 'permanently' set carp to 'maintenance mode' (advskew 254) persisting a reboot

Option to set CARP interfaces to 'maintenance mode', persisting through a reboot so the primary machines stays as backup/inactive.
This is required when there are some problems (possibly with the hardware) and the primary machine needs to be booted and checked again before becoming 'master'. Currently it will take back the master state during reboot even though there might still be problems or some re-configuring to do.

p.s. it is for some reason not possible to reset advskew back to '0'.. should that number be removed as an option, and use 1 as a minimal value ? or should a 'workaround' be made?
