### PR TITLE
fixes Bug #3569

### DIFF
--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -295,8 +295,10 @@ if ($pkg['custom_php_after_head_command'])
 		//delete current line jQuery function
 		jQuery('#maintable td .delete').live('click', function() {
 			//do not remove first line
-			if (jQuery("#maintable tr").length > 2)
+			if (jQuery("#maintable tr").length > 2){
 				jQuery(this).parent().parent().remove();
+				return false;
+			}
 	    });
 	    
 		//add new line jQuery function
@@ -306,6 +308,7 @@ if ($pkg['custom_php_after_head_command'])
 			var new_row=jQuery("table#maintable tr:last").html().replace(/(name|id)="(\w+)(\d+)"/g,"$1='$2"+c_id+"'");
 			//apply new id to created line rowhelperid
 			jQuery("table#maintable tr:last").after("<tr>"+new_row+"<\/tr>");
+			return false;
 	    });
 		// Call enablechange function
 		enablechange();


### PR DESCRIPTION
On packages that uses row_helper when user clicks on add or delete button, the page scrolls to top.
It seems something with ajax
http://stackoverflow.com/questions/1061580/jquery-click-on-anchor-element-forces-scroll-to-top

A simple return false after jquery action fixes the unwanted scroll.
