### PR TITLE
Added check if $config['ipsec']["ipsec_{$lkey}"] is set.

### DIFF
--- a/usr/local/www/system_advanced_misc.php
+++ b/usr/local/www/system_advanced_misc.php
@@ -172,6 +172,7 @@ if ($_POST) {
 
 		foreach ($ipsec_loglevels as $lkey => $ldescr) {
 			if (empty($_POST["ipsec_{$lkey}"]))
+				if(isset($config['ipsec']["ipsec_{$lkey}"]))
 				unset($config['ipsec']["ipsec_{$lkey}"]);
 			else
 				$config['ipsec']["ipsec_{$lkey}"] = $_POST["ipsec_{$lkey}"];


### PR DESCRIPTION
Line 175; Error from unset when $_POST["ipsec_{$lkey}"] is empty with $config['ipsec']["ipsec_{$lkey}"] is also not set, added check to see if $config['ipsec']["ipsec_{$lkey}"] is set.
