### PR TITLE
Dynamic DNS - List GWGs in Interface to send update from

### DIFF
--- a/usr/local/www/services_dyndns_edit.php
+++ b/usr/local/www/services_dyndns_edit.php
@@ -248,6 +248,7 @@ function _onTypeChange(type){
 							echo "selected";
 						echo ">{$ifdesc}</option>\n";
 					}
+					unset($iflist);
 					$grouplist = return_gateway_groups_array();
 				   	foreach ($grouplist as $name => $group) {
 						echo "<option value=\"{$name}\"";
@@ -255,19 +256,34 @@ function _onTypeChange(type){
 							echo "selected";
 						echo ">GW Group {$name}</option>\n";
 					}
+					unset($grouplist);
 				?>
 					</select>
 					</td>
 					</td>
 				</tr>	
 				<tr id="_requestiftr">
-				   <td width="22%" valign="top" class="vncellreq"><?=gettext("Interface to send update from");?></td>  
-				   <td width="78%" class="vtable">
-				   <select name="requestif" class="formselect" id="requestif">
-				   <?php $iflist = get_configured_interface_with_descr();
-				   		foreach ($iflist as $if => $ifdesc):?>
-							<option value="<?=$if;?>" <?php if ($pconfig['requestif'] == $if) echo "selected";?>><?=$ifdesc;?></option>
-					<?php endforeach; ?>
+					<td width="22%" valign="top" class="vncellreq"><?=gettext("Interface to send update from");?></td>  
+					<td width="78%" class="vtable">
+					<select name="requestif" class="formselect" id="requestif">
+				<?php
+					$iflist = get_configured_interface_with_descr();					
+					foreach ($iflist as $if => $ifdesc) {
+						echo "<option value=\"{$if}\"";
+						if ($pconfig['requestif'] == $if)
+							echo "selected";
+						echo ">{$ifdesc}</option>\n";
+					}
+					unset($iflist);
+					$grouplist = return_gateway_groups_array();
+					foreach ($grouplist as $name => $group) {
+						echo "<option value=\"{$name}\"";
+						if ($pconfig['requestif'] == $name)
+							echo "selected";
+						echo ">GW Group {$name}</option>\n";
+					}
+					unset($grouplist);
+				?>
 					</select>
 					<br/><?= gettext("Note: This is almost always the same as the Interface to Monitor.");?>
 					</td>


### PR DESCRIPTION
Back-port of this fix done in master https://github.com/pfsense/pfsense/commit/31300a95f71b14dcb98c139388205223a36e8c8b and https://github.com/pfsense/pfsense/commit/8f56dd279432c4fd5a027310622e2650822e4651
Unfortunately this never got back-merged to 2.1 branch. A user on the forum noticed the issue again on 2.1.1 - https://forum.pfsense.org/index.php?topic=74922.0
I am submitting this so that when the next security issue happens, and there is 2.1.n+1 then this little fix will also happen automagically. I see that it will pay to back-port any fix because you just never know when a new release of an "old" branch will be forced by some out-of-band issue.
(I wonder what other fixes are in master that missed being back-ported to 2.1 branch.)
