### PR TITLE
fixing typo for GIF tunnels to work over IPv6

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -945,7 +945,7 @@ function interface_gif_configure(&$gif, $gifkey = "") {
 			$realifip = $ipaddr;
 		else
 			$realifip = get_interface_ipv6($gif['if']);
-		$realifgw = get_interface_gatewayv6($gif['if']);
+		$realifgw = get_interface_gateway_v6($gif['if']);
 	}
 	/* make sure the parent interface is up */
 	if($realif)


### PR DESCRIPTION
the call of get_interface_gatewayv6() in the creation of a GIF tunnel over IPv6 leads to a "Fatal error: Call to undefined function get_interface_gatewayv6() in /etc/inc/interfaces.inc on line 934". changeing the function call to get_interface_gateway_v6() fixed it for me on my local system.
