### PR TITLE
Get real interface when dhcrelay uses default GW

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -1377,7 +1377,7 @@ function services_dhcrelay_configure() {
 			if (is_array($config['gateways']['gateway_item'])) {
 				foreach ($config['gateways']['gateway_item'] as $gateway) {
 					if (isset($gateway['defaultgw'])) {
-						$destif = $gateway['interface'];
+						$destif = get_real_interface($gateway['interface']);
 						break;
 					}
 				}


### PR DESCRIPTION
If the DHCP Relay server is not on any local subnet, and not on any subnet that has an internal static route, but is somewhere that no specific route is known, then this code finds the default gateway and uses that in the DHCP relay "-i" parameter. The current code gets just the interface name (like "wan", "opt1"). But DHCP Relay command needs to be fed the actual device name "vr0", "vr1" etc.
To break this I simply enabled DHCP Relay, select "LAN" interface, and put Destination Server 1.2.3.4
Making this changed fixed it.
Forum: https://forum.pfsense.org/index.php?topic=75010.0
