### PR TITLE
Do not allow upgrade_101_to_102 to exit early

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -3182,32 +3182,30 @@ function upgrade_100_to_101() {
 function upgrade_101_to_102() {
 	global $config, $g;
 
-	if (!is_array($config['captiveportal']))
-		return;
+	if (is_array($config['captiveportal'])) {
+		foreach ($config['captiveportal'] as $cpzone => $cp) {
+			if (!is_array($cp['passthrumac']))
+				continue;
 
-	foreach ($config['captiveportal'] as $cpzone => $cp) {
-		if (!is_array($cp['passthrumac']))
-			continue;
-
-		foreach ($cp['passthrumac'] as $idx => $passthrumac)
-			$config['captiveportal'][$cpzone]['passthrumac'][$idx]['action'] = 'pass';
+			foreach ($cp['passthrumac'] as $idx => $passthrumac)
+				$config['captiveportal'][$cpzone]['passthrumac'][$idx]['action'] = 'pass';
+		}
 	}
 
 	/* Convert OpenVPN Compression option to the new style */
 	// Nothing to do if there is no OpenVPN tag
-	if (!isset($config['openvpn']) || !is_array($config['openvpn']))
-		return;
-
-	if (is_array($config['openvpn']['openvpn-server'])) {
-		foreach ($config['openvpn']['openvpn-server'] as &$vpn) {
-			if (!empty($vpn['compression']))
-				$vpn['compression'] = "adaptive";
+	if (isset($config['openvpn']) && is_array($config['openvpn'])) {
+		if (is_array($config['openvpn']['openvpn-server'])) {
+			foreach ($config['openvpn']['openvpn-server'] as &$vpn) {
+				if (!empty($vpn['compression']))
+					$vpn['compression'] = "adaptive";
+			}
 		}
-	}
-	if (is_array($config['openvpn']['openvpn-client'])) {
-		foreach ($config['openvpn']['openvpn-client'] as &$vpn) {
-			if (!empty($vpn['compression']))
-				$vpn['compression'] = "adaptive";
+		if (is_array($config['openvpn']['openvpn-client'])) {
+			foreach ($config['openvpn']['openvpn-client'] as &$vpn) {
+				if (!empty($vpn['compression']))
+					$vpn['compression'] = "adaptive";
+			}
 		}
 	}
 }


### PR DESCRIPTION
This upgrade step does both Captive Portal stuff and OpenVPN stuff. So do not return early just because there is no Captive Portal config.
Both Captive Portal and OpenVPN tests changed to be positive tests, to make sure that everything is checked/tested and there is no chance to return early.
