### PR TITLE
Include static routes in automatic NAT rules display

### DIFF
--- a/usr/local/www/firewall_nat_out.php
+++ b/usr/local/www/firewall_nat_out.php
@@ -523,6 +523,8 @@ if (is_subsystem_dirty('natconf'))
 			if ($mode == "automatic" || $mode == "hybrid"):
 				if(empty($FilterIflist))
 					filter_generate_optcfg_array();
+				if(empty($GatewaysList))
+					filter_generate_gateways();
 				$automatic_rules = filter_nat_rules_outbound_automatic(implode(" ", filter_nat_rules_automatic_tonathosts()));
 ?>
 				<tr><td colspan="5"><b>&nbsp;<?=gettext("Automatic rules:"); ?></b></td></tr>


### PR DESCRIPTION
If I have an internal gateway to other private subnets behind LAN, and add a static route to those private subnets through the internal gateway, then pfSense very nicely generates NAT rules on WAN-style interfaces to NAT those internal subnets on the way out of WAN. That is very good and convenient. This outbound NAT is actually correctly in the ruleset.
However, the new Outbound NAT GUI page shows the Automatic Outbound NAT rules that are in effect (a great new feature in 2.2). But it did not show the rules for the static routes.
This fixes it. (But the code for all of this is a bit ugly, because it all depends on having a global variable $GatewaysList in view - I am not going to attempt to re-engineer that)
