### PR TITLE
Fix susbstr-substr typo

### DIFF
--- a/etc/rc.newwanip
+++ b/etc/rc.newwanip
@@ -95,7 +95,7 @@ log_error("rc.newwanip: on (IP address: {$curwanip}) (interface: {$interface_des
  * NOTE: Take care of openvpn and similar if you generate the event to reconfigure an interface.
  *      i.e. OpenVPN might be in tap mode and not have an ip.
  */
-if (($curwanip == "0.0.0.0" || !is_ipaddr($curwanip)) && susbstr($interface_real, 0, 4) != "ovpn") {
+if (($curwanip == "0.0.0.0" || !is_ipaddr($curwanip)) && substr($interface_real, 0, 4) != "ovpn") {
 	log_error("rc.newwanip: Failed to update {$interface} IP, restarting...");
 	send_event("interface reconfigure {$interface}");
 	return;


### PR DESCRIPTION
I just got this error again on 14 Apr 2014 2.2 snapshot. I can see the fix in 2.1 branch. I could have sworn it got fixed in Master also, but I can't see it. So here is the fix for Master.
