### PR TITLE
Fixes for bug #3607 (Problems with apinger being incorrectly configured when using a PPoE interface)

### DIFF
--- a/etc/inc/gwlb.inc
+++ b/etc/inc/gwlb.inc
@@ -185,14 +185,30 @@ EOD;
 					" " . escapeshellarg($gateway['gateway']), true);
 			}
 		} else if ($gateway['ipprotocol'] == "inet6") { // This is an IPv6 gateway...
-			/* link locals really need a different src ip */
-			if(is_linklocal($gateway['gateway'])) {
-				$gwifip = find_interface_ipv6_ll($gateway['interface'], true);
+			if ($gateway['monitor'] == $gateway['gateway']) {
+				/* link locals really need a different src ip */
+				if (is_linklocal($gateway['gateway'])) {
+					$gwifip = find_interface_ipv6_ll($gateway['interface'], true);
+				} else {
+					$gwifip = find_interface_ipv6($gateway['interface'], true);
+				}
 			} else {
+				/* 'monitor' has been set, so makes sure it has precedence over
+				 * 'gateway' in defining the source IP. Otherwise if 'gateway'
+				 * is a local link and 'monitor' is global routable then the
+				 * ICMP6 response would not find its way back home...
+				 */
 				$gwifip = find_interface_ipv6($gateway['interface'], true);
+				if (is_linklocal($gateway['monitor'])) {
+					if (!strstr($gateway['monitor'], '%')) {
+						$gateway['monitor'] .= "%{$gateway['interface']}";
+					}
+				} else {
+					// Monitor is a routable address, so use a routable address for the "src" part
+					$gwifip = find_interface_ipv6($gateway['interface'], true);
+				}
 			}
-			if (is_linklocal($gateway['monitor']) && !strstr($gateway['monitor'], '%'))
-				$gateway['monitor'] .= "%{$gateway['interface']}";
+							
 			if (!is_ipaddrv6($gwifip))
 				continue; //Skip this target
 


### PR DESCRIPTION
This fixes two issues related to bug https://redmine.pfsense.org/issues/3607.

When using PPoE, apinger will typically be misconfigured and will fail to start.

The first issue is an incorrect mechanism used to detect the type (IPv4/IPv6) of the interface as in the PPoE case the IP is often set to "dynamic".

The second issue is a problem whereby apinger won't receive the ICMP6 replies because the source address can sometimes be incorrectly set when specifying a routable 'monitor' IPv6 address (which is often something you have to do in the UK when using PPoE as it seems most ADSL backends won't reply to an ICMP6 sent to the local link address).
