### PR TITLE
Add nohttpsforwards option to captive portal

### DIFF
--- a/etc/inc/captiveportal.inc
+++ b/etc/inc/captiveportal.inc
@@ -553,7 +553,9 @@ EOD;
 			$listenporthttps = $config['captiveportal'][$cpzone]['listenporthttps'];
 		else
 			$listenporthttps = 8001 + $$config['captiveportal'][$cpzone]['zoneid'];
-		$cprules .= "add 65531 fwd 127.0.0.1,{$listenporthttps} tcp from any to any dst-port 443 in\n";
+			if (!isset($config['captiveportal'][$cpzone]['nohttpsforwards'])) {
+				$cprules .= "add 65531 fwd 127.0.0.1,{$listenporthttps} tcp from any to any dst-port 443 in\n";
+			}
 	}
 	
 	$cprules .= <<<EOD

--- a/usr/local/www/services_captiveportal.php
+++ b/usr/local/www/services_captiveportal.php
@@ -160,6 +160,7 @@ if ($a_cp[$cpzone]) {
 	$pconfig['preauthurl'] = strtolower($a_cp[$cpzone]['preauthurl']);
 	$pconfig['blockedmacsurl'] = strtolower($a_cp[$cpzone]['blockedmacsurl']);
 	$pconfig['certref'] = $a_cp[$cpzone]['certref'];
+	$pconfig['nohttpsforwards'] = isset($a_cp[$cpzone]['nohttpsforwards']);
 	$pconfig['logoutwin_enable'] = isset($a_cp[$cpzone]['logoutwin_enable']);
 	$pconfig['peruserbw'] = isset($a_cp[$cpzone]['peruserbw']);
 	$pconfig['bwdefaultdn'] = $a_cp[$cpzone]['bwdefaultdn'];
@@ -340,6 +341,7 @@ if ($_POST) {
 		$newcp['bwdefaultdn'] = $_POST['bwdefaultdn'];
 		$newcp['bwdefaultup'] = $_POST['bwdefaultup'];
 		$newcp['certref'] = $_POST['certref'];
+		$newcp['nohttpsforwards'] = $_POST['nohttpsforwards'] ? true : false;
 		$newcp['logoutwin_enable'] = $_POST['logoutwin_enable'] ? true : false;
 		$newcp['nomacfilter'] = $_POST['nomacfilter'] ? true : false;
 		$newcp['noconcurrentlogins'] = $_POST['noconcurrentlogins'] ? true : false;
@@ -465,6 +467,7 @@ function enable_change(enable_change) {
 	document.iform.radmac_format.disabled = radius_endis;
 	document.iform.httpsname.disabled = https_endis;
 	document.iform.certref.disabled = https_endis;
+	document.iform.nohttpsforwards.disabled = https_endis;
 	document.iform.logoutwin_enable.disabled = endis;
 	document.iform.nomacfilter.disabled = endis;
 	document.iform.noconcurrentlogins.disabled = endis;
@@ -974,6 +977,13 @@ function enable_change(enable_change) {
 				<b><?=gettext("No Certificates defined."); ?></b> <br />Create one under <a href="system_certmanager.php">System &gt; Cert Manager</a>.
 			<?php endif; ?>
 		</td>
+	</tr>
+	<tr>
+		<td valign="top" class="vncell"><?=gettext("Disable HTTPS forwards"); ?></td>
+		<td class="vtable">
+			<input name="nohttpsforwards" type="checkbox" class="formfld" id="nohttpsforwards" value="yes" <?php if ($pconfig['nohttpsforwards']) echo "checked"; ?>>
+			<strong><?=gettext("Disable HTTPS forwards"); ?></strong><br>
+			<?=gettext("If this option is set, attempts to connect to SSL/HTTPS (Port 443) sites will not be forwarded to the captive portal.  This prevents certificate errors from being presented to the user even if HTTPS logins are enabled.  Users must attempt a connecton to an HTTP (Port 80) site to get forwarded to the captive portal. If HTTPS logins are enabled, the user will be redirected to the HTTPS login page."); ?></td>
 	</tr>
 	<tr>
 		<td width="22%" valign="top" class="vncell"><?=gettext("Portal page contents"); ?></td>


### PR DESCRIPTION
If the nohttpsforwards option is set, attempts to connect to SSL/HTTPS (Port 443) sites will not be forwarded to the captive portal.  This prevents certificate errors from being presented to the user even if HTTPS logins are enabled.  Users must attempt a connecton to an HTTP (Port 80) site to get forwarded to the captive portal. If HTTPS logins are enabled, the user will be redirected to the HTTPS login page.
