### PR TITLE
Cut paste bug fix in Remote Syslog DHCP events

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -708,7 +708,7 @@ function system_syslogd_start() {
 		$syslogconf .= "!dhcpd,dhcrelay,dhclient\n";
 		if (!isset($syslogcfg['disablelocallogging']))
 			$syslogconf .= "*.*								{$log_directive}{$g['varlog_path']}/dhcpd.log\n";
-		if (isset($syslogcfg['apinger']))
+		if (isset($syslogcfg['dhcp']))
 			$syslogconf .= system_syslogd_get_remote_servers($syslogcfg, "*.*");
 
 		$syslogconf .= "!relayd\n";


### PR DESCRIPTION
apinger is repeated here from the code above, but it should be dhcp.
Forum https://forum.pfsense.org/index.php?topic=73734.0
Selecting to remote syslog "Gateway Monitor events" would also switch on "DHCP service events" unintentionally.
