### PR TITLE
Make sure /usr/local/etc/rc.d exists

### DIFF
--- a/etc/inc/service-utils.inc
+++ b/etc/inc/service-utils.inc
@@ -49,6 +49,7 @@ define("RCFILEPREFIX", "/usr/local/etc/rc.d/");
 function write_rcfile($params) {
 	global $g;
 
+	safe_mkdir(RCFILEPREFIX);
 	$rcfile_fullname = RCFILEPREFIX . $params['file'];
 	if (!file_exists($rcfile_fullname) && !is_link($rcfile_fullname) && !touch($rcfile_fullname))
 		return false;


### PR DESCRIPTION
On 2.2-ALPHA (i386)built on Mon Apr 21 13:01:11 CDT 2014 (for example) there was /usr/local/etc but not /usr/local/etc/rc.d - when I tried to install bandwidthd, that called write_rcfile() which failed because /usr/local/etc/rc.d did not already exist.
Best to check for it and make it if it does not exist.
(I am guessing that the 2.1.n image builds already had /usr/local/etc/rc.d bnefore any packages were installed, otherwise this problem should have already been an issue prior to 2.2)
