### PR TITLE
make miniupnpd listen on interface instead of IP

### DIFF
--- a/usr/local/pkg/miniupnpd.inc
+++ b/usr/local/pkg/miniupnpd.inc
@@ -156,10 +156,9 @@
 				/* above function returns iface if fail */
 				if($if!=$iface) {
 					$addr = find_interface_ip($if);
-					$bits = find_interface_subnet($if);
 					/* check that the interface has an ip address before adding parameters */
 					if (is_ipaddr($addr)) {
-						$config_text .= "listening_ip={$addr}/{$bits}\n";
+						$config_text .= "listening_ip={$if}\n";
 						if(!$ifaces_active) {
 							$webgui_ip = $addr;
 							$ifaces_active = $iface;


### PR DESCRIPTION
The 'listening_ip' option in miniupnpd.conf can accept an interface name
directly instead of having to translate it to an IPv4 address first. (This is
actually required if IPv6 support is enabled.)
