### PR TITLE
Fix Bug #3627 Diagnostics: Tables - Remove button dont work after update...

### DIFF
--- a/usr/local/www/diag_tables.php
+++ b/usr/local/www/diag_tables.php
@@ -106,7 +106,7 @@ if ($savemsg) print_info_box($savemsg);
 		window.location='diag_tables.php?type=' + entrytype;
 	}
 	function del_entry(entry) {
-		jQuery.ajax("diag_tables.php?type=<?php echo htmlspecialchars($tablename);?>&amp;delete=" + entry, {
+		jQuery.ajax("diag_tables.php?type=<?php echo htmlspecialchars($tablename);?>&delete=" + entry, {
 		complete: function(response) {
 			if (200 == response.status) {
 				// Escape all dots to not confuse jQuery selectors
@@ -154,7 +154,7 @@ if ($savemsg) print_info_box($savemsg);
 	</tr>
 <?php $count = 0; foreach($entries as $entryA): ?>
 	<?php $entry = trim($entryA); ?>
-	<tr id='table_row_<?=$count?>'>
+	<tr id='<?=$entry?>'>
 		<td>
 			<?php echo $entry; ?>
 		</td>


### PR DESCRIPTION
... to PfSense 2.1.2

This annoyed me also, so I thought it worth finding what changes exactly broke this.
del_entry was broken on 2.1 branch by https://github.com/pfsense/pfsense/commit/fe3088b965a99772e76622d17ceae87288471edc
These 2 small changes make it work again without needing to reverse the other bits of stuff in that commit.
Note that Master does not have that commit at all. There are lots of these "XHTML Compliance" and similar commits in 2.1 branch that are not done in master. I don't understand why that is. Why don't those code cleanups also need to be applied to master?
