### PR TITLE
Make it optional for miniupnpd to listen on interface instead of IP (master)

### DIFF
--- a/usr/local/pkg/miniupnpd.inc
+++ b/usr/local/pkg/miniupnpd.inc
@@ -156,9 +156,13 @@
 				/* above function returns iface if fail */
 				if($if!=$iface) {
 					$addr = find_interface_ip($if);
+					$bits = find_interface_subnet($if);
 					/* check that the interface has an ip address before adding parameters */
 					if (is_ipaddr($addr)) {
-						$config_text .= "listening_ip={$if}\n";
+						if ($upnp_config['listen_on_iface'])
+							$config_text .= "listening_ip={$if}\n";
+						else
+							$config_text .= "listening_ip={$addr}/{$bits}\n";
 						if(!$ifaces_active) {
 							$webgui_ip = $addr;
 							$ifaces_active = $iface;

--- a/usr/local/pkg/miniupnpd.xml
+++ b/usr/local/pkg/miniupnpd.xml
@@ -35,7 +35,7 @@
 		<field>
 			<name>UPnP &amp; NAT-PMP Settings</name>
 			<type>listtopic</type>
-			<enablefields>enable_upnp,enable_natpmp,iface_array,overridewanip,upnpqueue,logpackets,sysuptime,permdefault,permuser1,permuser2,permuser3,permuser4</enablefields>
+			<enablefields>enable_upnp,enable_natpmp,listen_on_iface,iface_array,overridewanip,upnpqueue,logpackets,sysuptime,permdefault,permuser1,permuser2,permuser3,permuser4</enablefields>
 		</field>
 		<field>
 			<fielddescr>Enable UPnP &amp; NAT-PMP</fielddescr>
@@ -80,6 +80,11 @@
 			<description>You can use the CTRL or COMMAND key to select multiple interfaces.</description>
 			<required/>
 		</field>
+		<field>
+			<fielddescr>Listen on interface instead of interface's IPv4 address</fielddescr>
+			<fieldname>listen_on_iface</fieldname>
+			<type>checkbox</type>
+		</field>			
 		<field>
 			<fielddescr>Maximum Download Speed (Kbits/second)</fielddescr>
 			<fieldname>download</fieldname>


### PR DESCRIPTION
Since some people were having problems with it; see [forum thread here](https://forum.pfsense.org/index.php?topic=76538.0).
