### PR TITLE
Handle firewall log filter regex input better bug #3689

### DIFF
--- a/etc/inc/filter_log.inc
+++ b/etc/inc/filter_log.inc
@@ -81,11 +81,17 @@ function conv_log_filter($logfile, $nentries, $tail = 50, $filtertext = "", $fil
 	return isset($config['syslog']['reverse']) ? $filterlog : array_reverse($filterlog);
 }
 
+function escape_filter_regex($filtertext) {
+	/* If the caller (user) has not already put a backslash before a slash, to escape it in the regex, */
+	/* then this will do it. Take out any "\/" already there, then turn all ordinary "/" into "\/".  */
+	return str_replace('/', '\/', str_replace('\/', '/', $filtertext));
+}
+
 function match_filter_line($flent, $filtertext = "") {
 	if (!$filtertext)
 		return true;
-	$filtertext = str_replace(' ', '\s+', $filtertext);
-	return preg_match("/{$filtertext}/i", implode(" ", array_values($flent)));
+	$filtertext = escape_filter_regex(str_replace(' ', '\s+', $filtertext));
+	return @preg_match("/{$filtertext}/i", implode(" ", array_values($flent)));
 }
 
 function match_filter_field($flent, $fields) {
@@ -95,12 +101,20 @@ function match_filter_field($flent, $fields) {
 			$fields[$field] = substr($fields[$field], 1);
 			if (preg_match("/act/i", $field)) {
 				if ( (in_arrayi($flent[$field], explode(",", str_replace(" ", ",", $fields[$field]))) ) ) return false;
-			} else if ( (preg_match("/{$fields[$field]}/i", $flent[$field])) ) return false;
+			} else {
+				$field_regex = escape_filter_regex($fields[$field]);
+				if ( (@preg_match("/{$field_regex}/i", $flent[$field])) )
+					return false;
+			}
 		}
 		else {
 			if (preg_match("/act/i", $field)) {
 				if ( !(in_arrayi($flent[$field], explode(",", str_replace(" ", ",", $fields[$field]))) ) ) return false;
-			} else if ( !(preg_match("/{$fields[$field]}/i", $flent[$field])) ) return false;
+			} else {
+				$field_regex = escape_filter_regex($fields[$field]);
+				if ( !(@preg_match("/{$field_regex}/i", $flent[$field])) )
+					return false;
+			}
 		}
 	}	
 	return true;


### PR DESCRIPTION
If the user inputs an invalid regex in any of the filter fields, then a page full of "warning" messages appear in the GUI, about whatever is invalid. 
If for some reason the user wants to match a forward slash somewhere, then they have to realize to escape it, doing "\/" instead of just "/". Be nice to this special case, because the user does not necessarily know that "/" is being used as the delimiter in the preg_match call. Turn "/" into "\/" (when the "\" is not already put in by the user).
For other regex issues, suppress the warning output, using "@". When the user inputs some invalid garbage in a filter field, an empty filtered firewall log table will be displayed, rather than screens full of PHP warning output.
