### PR TITLE
Update "pkg_edit.,php"

### DIFF
--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -258,10 +258,15 @@ else
 	$title = gettext("Package Editor");
 
 $pgtitle = $title;
-include("head.inc");
 
-if ($pkg['custom_php_after_head_command'])
+if ($pkg['custom_php_after_head_command']) {
+	$closehead = false;
+	include("head.inc");
 	eval($pkg['custom_php_after_head_command']);
+	echo "</head>\n";
+}
+else
+	include("head.inc");
 
 ?>
 


### PR DESCRIPTION
When evaluating "custom_php_after_head_command", if the PHP code also contains JavaScript ("squid_auth.xml" for example) then this will cause HTML errors, as you are not supposed to have anything between the closing HEAD tag and the opening BODY tag.

Add the CLOSEHEAD PHP variable, move the include HEAD.INC into the PHP IF statement and manually close the HEAD tab, else just include HEAD.INC
