### PR TITLE
Add pfSense version to syslog (remote syslog more importantly) on bootup

### DIFF
--- a/etc/rc
+++ b/etc/rc
@@ -452,6 +452,11 @@ if [ "${GMIRROR_STATUS}" != "" ]; then
 	/usr/local/bin/minicron 60 /var/run/gmirror_status_check.pid /usr/local/sbin/gmirror_status_check.php
 fi
 
+# Log pfSense version to syslog
+PFSENSE_BUILDTIME=`cat /etc/version.buildtime`
+PFSENSE_ARCH=`uname -m`
+echo "pfSense ($PLATFORM) $version $PFSENSE_ARCH $PFSENSE_BUILDTIME"
+
 echo "Bootup complete"
 
 /usr/local/bin/beep.sh start 2>&1 >/dev/null


### PR DESCRIPTION
Feature request on redmine at https://redmine.pfsense.org/issues/3699
Discussion on the forum at https://forum.pfsense.org/index.php?topic=77713.0

This allows a remote syslog server to get log entries to have a history of what pfSense versions were running over time.  dmesg.boot does at least log the kernel build time but that is overwritten on every boot.  System.log does log the kernel version on the local system but system.log is too small to contain a history.  The kernel version is not sent to remote syslog servers because it is logged locally before network is up, etc.

This change allows remote syslog servers to log the current version, arch, platform (cdrom, nanobsd, pfSense, etc) of the firewalls on bootup.
