### PR TITLE
RRD Graph Fixes

### DIFF
--- a/usr/local/www/status_rrd_graph.inc
+++ b/usr/local/www/status_rrd_graph.inc
@@ -1,0 +1,129 @@
+<?php
+/* $Id$ */
+/*
+	status_rrd_graph.inc
+	Part of pfSense
+	Copyright (C) 2009 Seth Mos <seth.mos@dds.nl>
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/*	
+	pfSense_BUILDER_BINARIES:	none
+	pfSense_MODULE:	system
+*/
+
+/* Calculate and return graph start and end date based on period and graph. */
+function get_dates($period, $graph) {
+	$now = time();
+
+	$curyear = date('Y', $now);
+	$curmonth = date('m', $now);
+	$curweek = date('W', $now);
+	$curweekday = date('N', $now) - 1; // We want to start on monday
+	$curday = date('d', $now);
+	$curhour = date('G', $now);
+	$curminute = date('i', $now);
+	$cursecond = date('s', $now);
+
+	if($period == "absolute") {
+		switch($graph) {
+			case "eight_hour":	$start = mktime($curhour - 8,	$curminute, $cursecond + 1, $curmonth,		$curday,		$curyear);		break;
+			case "day":		$start = mktime($curhour,		$curminute, $cursecond + 1, $curmonth,		$curday - 1,	$curyear);		break;
+			case "week":	$start = mktime($curhour,		$curminute, $cursecond + 1, $curmonth,		$curday - 7,	$curyear);		break;
+			case "month":	$start = mktime($curhour,		$curminute, $cursecond + 1, $curmonth - 1,	$curday,		$curyear);		break;
+			case "quarter":	$start = mktime($curhour,		$curminute, $cursecond + 1, $curmonth - 3,	$curday,		$curyear);		break;
+			case "year":	$start = mktime($curhour,		$curminute, $cursecond + 1, $curmonth,		$curday,		$curyear - 1);	break;
+			case "four_year":	$start = mktime($curhour,		$curminute, $cursecond + 1, $curmonth,		$curday,		$curyear - 4);	break;
+		}
+							  $end = mktime($curhour,		$curminute, $cursecond,		$curmonth,		$curday,		$curyear);
+	} else {
+		switch($period) {
+			case "previous":
+				$offset = -1;
+				break;
+			default:
+				$offset = 0;
+		}
+		switch($graph) {
+			case "eight_hour":
+				if($curhour < 24)
+					$starthour = 16;
+				if($curhour < 16)
+					$starthour = 8;
+				if($curhour < 8)
+					$starthour = 0;
+
+				switch($offset) {
+					case 0:
+						$houroffset = $starthour;
+						break;
+					default:
+						$houroffset = $starthour + ($offset * 8);
+						break;
+				}
+				$start = mktime($houroffset, 0, 0, $curmonth, $curday, $curyear);
+				$end = mktime(($houroffset + 7), 59, 59, $curmonth, $curday, $curyear);
+				break;
+			case "day":
+				$start = mktime(0, 0, 0, $curmonth, ($curday + $offset), $curyear);
+				$end = mktime(23, 59, 59, $curmonth, ($curday + $offset), $curyear);
+				break;
+			case "week":
+				switch($offset) {
+					case 0:
+						$weekoffset = 0;
+						break;
+					default:
+						$weekoffset = ($offset * 7);
+						break;
+				}
+				$start = mktime(0, 0, 0, $curmonth, (($curday - $curweekday) + $weekoffset), $curyear);
+				$end = mktime(23, 59, 59, $curmonth, (($curday - $curweekday) + $weekoffset + 6), $curyear);
+				break;
+			case "month":
+				$start = mktime(0, 0, 0, ($curmonth + $offset), 1, $curyear);
+				$end = mktime(23, 59, 59, (($curmonth + $offset) + 1), 0, $curyear);
+				break;
+			case "quarter":
+				$start = mktime(0, 0, 0, (($curmonth - 2) + $offset), 1, $curyear);
+				$end = mktime(23, 59, 59, (($curmonth + $offset) + 1), 0, $curyear);
+				break;
+			case "year":
+				$start = mktime(0, 0, 0, 1, 1, ($curyear + $offset));
+				$end = mktime(23, 59, 59, 1, 0, (($curyear + $offset) +1));
+				break;
+			case "four_year":
+				$start = mktime(0, 0, 0, 1, 1, (($curyear - 3) + $offset));
+				$end = mktime(23, 59, 59, 1, 0, (($curyear + $offset) +1));
+				break;
+		}
+#		if($offset == 0) $end = $now;
+	}
+	// echo "start $start ". date('l jS \of F Y h:i:s A', $start) .", end $end ". date('l jS \of F Y h:i:s A', $end) ."<br>";
+	$dates = array();
+	$dates['start'] = $start;
+	$dates['end'] = $end;
+	return $dates;
+}
+
+?>

--- a/usr/local/www/status_rrd_graph_img.php
+++ b/usr/local/www/status_rrd_graph_img.php
@@ -84,6 +84,10 @@ if($end < $start) {
         $end = $now;
 }
 
+$graphbegintime = date("M j H\\\:i\\\:s Y", $start);
+$graphendtime = date("M j H\\\:i\\\:s Y", $end);
+$graphrange = $graphbegintime . ' - ' . $graphendtime;
+
 $seconds = $end - $start;
 
 $scales = array();
@@ -95,12 +99,6 @@ $scales[2764800] = "DAY:1:WEEK:1:WEEK:1:0:Week %W";
 $scales[16070400] = "WEEK:1:MONTH:1:MONTH:1:0:%b";
 $scales[42854400] = "MONTH:1:MONTH:1:MONTH:1:0:%b";
 
-$archives = array();
-$archives[1] = 1200;
-$archives[5] = 720;
-$archives[60] = 1860;
-$archives[1440] = 2284;
-
 $defOptions = array(
 	'to' => 1,
 	'parts' => 1,
@@ -109,14 +107,33 @@ $defOptions = array(
 	'separator' => ', '
 );
 
-/* always set the average to the highest value as a fallback */
-$average = 1440 * 60;
-foreach($archives as $rra => $value) {
-        $archivestart = $now - ($rra * 60 * $value);
-        if($archivestart <= $start) {
-                $average = $rra * 60;
-                break;
-        }
+/* Set the 'average' granularity to be used for each graph length. */
+switch($curgraph) {
+	case "eight_hour":	$average =    1 * 60;	break;
+	case "day":			$average =    5 * 60;	break;
+	case "week":		$average =   60 * 60;	break;
+	case "month":		$average =   60 * 60;	break;
+	case "quarter":		$average = 1440 * 60;	break;
+	case "year":		$average = 1440 * 60;	break;
+	case "four_year":	$average = 1440 * 60;	break;
+	case "custom": 
+		$archives = array();
+		$archives[1] = 1200;
+		$archives[5] = 720;
+		$archives[60] = 1860;
+		$archives[1440] = 2284;
+
+		/* always set the average to the highest value as a fallback */
+		$average = 1440 * 60;
+		foreach($archives as $rra => $value) {
+			$archivestart = $now - ($rra * 60 * $value);
+			if($archivestart <= $start) {
+				$average = $rra * 60;
+				break;
+			}
+		}
+		break;
+	default:		$average = 1440 * 60;	break;	// always set the average to the highest value as a fallback
 }
 
 foreach($scales as $scalelength => $value) {
@@ -153,11 +170,11 @@ $data = true;
 /* Don't leave it up to RRD Tool to select the RRA and resolution to use. */
 /* Specify the RRA and resolution to use per the graph havg value. */
 switch ($havg) {
-	case "1 minute":	$step = 60;		break;
-	case "5 minutes":	$step = 300;	break;
-	case "1 hour":		$step = 3600;	break;
+	case "1 minute":	$step =    60;	break;
+	case "5 minutes":	$step =   300;	break;
+	case "1 hour":		$step =  3600;	break;
 	case "1 day":		$step = 86400;	break;
-	default:			$step = 0;		break;
+	default:			$step =     0;	break;
 }
 
 $rrddbpath = "/var/db/rrd/";
@@ -477,7 +494,7 @@ if((strstr($curdatabase, "-traffic.rrd")) && (file_exists("$rrddbpath$curdatabas
 	$graphcmd .= "GPRINT:\"$curif-out6_bits_block:LAST:%7.2lf %Sb/s\" ";
 	$graphcmd .= "GPRINT:\"$curif-bytes_out6_t_block:AVERAGE:%7.2lf %sB o\" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif(strstr($curdatabase, "-throughput.rrd")) {
 	/* define graphcmd for throughput stats */
@@ -605,7 +622,7 @@ elseif(strstr($curdatabase, "-throughput.rrd")) {
 	$graphcmd .= "GPRINT:\"tput-out_bits_block:LAST:%7.2lf %Sb/s\" ";
 	$graphcmd .= "GPRINT:\"tput-bytes_out_t_block:AVERAGE:%7.2lf %sB o\" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-packets.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for packets stats */
@@ -731,7 +748,7 @@ elseif((strstr($curdatabase, "-packets.rrd")) && (file_exists("$rrddbpath$curdat
 	$graphcmd .= "GPRINT:\"$curif-out6_pps_block:LAST:%7.2lf %S pps\" ";
 	$graphcmd .= "GPRINT:\"$curif-pps_out6_t_block:AVERAGE:%7.2lf %s pkts\" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-wireless.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for packets stats */
@@ -764,7 +781,7 @@ elseif((strstr($curdatabase, "-wireless.rrd")) && (file_exists("$rrddbpath$curda
 	$graphcmd .= "GPRINT:\"$curif-channel:AVERAGE:%7.2lf      \" ";
 	$graphcmd .= "GPRINT:\"$curif-channel:LAST:%7.2lf\" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-vpnusers.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for vpn users stats */
@@ -783,7 +800,7 @@ elseif((strstr($curdatabase, "-vpnusers.rrd")) && (file_exists("$rrddbpath$curda
 	$graphcmd .= "GPRINT:\"$curif-users:AVERAGE:%7.2lf      \" ";
 	$graphcmd .= "GPRINT:\"$curif-users:LAST:%7.2lf \" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-states.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for states stats */
@@ -837,7 +854,7 @@ elseif((strstr($curdatabase, "-states.rrd")) && (file_exists("$rrddbpath$curdata
 	$graphcmd .= "GPRINT:\"$curif-dstip:MAX:%7.2lf %s    \" ";
 	$graphcmd .= "GPRINT:\"$curif-dstip:LAST:%7.2lf %s    \" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-processor.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for processor stats */
@@ -889,7 +906,7 @@ elseif((strstr($curdatabase, "-processor.rrd")) && (file_exists("$rrddbpath$curd
 	$graphcmd .= "GPRINT:\"processes:MAX:%7.2lf %s    \" ";
 	$graphcmd .= "GPRINT:\"processes:LAST:%7.2lf %s    \" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-memory.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for memory usage stats */
@@ -941,7 +958,7 @@ elseif((strstr($curdatabase, "-memory.rrd")) && (file_exists("$rrddbpath$curdata
 	$graphcmd .= "GPRINT:\"wire:MAX:%7.2lf %s    \" ";
 	$graphcmd .= "GPRINT:\"wire:LAST:%7.2lf %S    \" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-mbuf.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for mbuf usage stats */
@@ -985,7 +1002,7 @@ elseif((strstr($curdatabase, "-mbuf.rrd")) && (file_exists("$rrddbpath$curdataba
 	$graphcmd .= "GPRINT:\"max:MAX:%7.2lf %s    \" ";
 	$graphcmd .= "GPRINT:\"max:LAST:%7.2lf %S    \" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-queues.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for queue stats */
@@ -1014,7 +1031,7 @@ elseif((strstr($curdatabase, "-queues.rrd")) && (file_exists("$rrddbpath$curdata
 		if($t > 7) { $t = 0; }
 	}
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-queuedrops.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for queuedrop stats */
@@ -1044,7 +1061,7 @@ elseif((strstr($curdatabase, "-queuedrops.rrd")) && (file_exists("$rrddbpath$cur
 		if($t > 7) { $t = 0; }
 	}
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-quality.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* make a link quality graphcmd, we only have WAN for now, others too follow */
@@ -1080,7 +1097,7 @@ elseif((strstr($curdatabase, "-quality.rrd")) && (file_exists("$rrddbpath$curdat
 		GPRINT:loss:LAST:\"\tLast\: %3.1lf %%\\n\" \\
 		AREA:loss10#$colorqualityloss:\"Packet loss\\n\" \\
 		LINE1:delay#$colorqualityrtt[5]:\"Delay average\\n\" \\
-		COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\"";
+		COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\"";
 }
 elseif((strstr($curdatabase, "spamd.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* graph a spamd statistics graph */
@@ -1119,7 +1136,7 @@ elseif((strstr($curdatabase, "spamd.rrd")) && (file_exists("$rrddbpath$curdataba
 		GPRINT:consmin:MIN:\"Min\\:%6.2lf\\t\" \\
 		GPRINT:consavg:AVERAGE:\"Avg\\:%6.2lf\\t\" \\
 		GPRINT:consmax:MAX:\"Max\\:%6.2lf\\n\" \\
-		COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+		COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\"";
 }
 elseif((strstr($curdatabase, "-cellular.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	$graphcmd = "$rrdtool graph $rrdtmppath$curdatabase-$curgraph.png ";
@@ -1137,7 +1154,7 @@ elseif((strstr($curdatabase, "-cellular.rrd")) && (file_exists("$rrddbpath$curda
 	$graphcmd .= "GPRINT:\"$curif-rssi:AVERAGE:%7.2lf     \" ";
 	$graphcmd .= "GPRINT:\"$curif-rssi:LAST:%7.2lf \" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-loggedin.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for online Captive Portal users stats */
@@ -1156,7 +1173,7 @@ elseif((strstr($curdatabase, "-loggedin.rrd")) && (file_exists("$rrddbpath$curda
 	$graphcmd .= "AREA:\"$curif-totalusers_d#{$colorcaptiveportalusers[0]}:Total logged in users\" ";
 	$graphcmd .= "GPRINT:\"$curif-totalusers_d:MAX:%8.0lf \\n\" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";	
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "-concurrent.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for online Captive Portal users stats */
@@ -1178,7 +1195,7 @@ elseif((strstr($curdatabase, "-concurrent.rrd")) && (file_exists("$rrddbpath$cur
 	$graphcmd .= "GPRINT:\"$curif-concurrentusers:AVERAGE:%8.0lf      \" ";
 	$graphcmd .= "GPRINT:\"$curif-concurrentusers:MAX:%8.0lf \" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";	
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 elseif((strstr($curdatabase, "ntpd.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for ntpd (was: mbuf) usage stats */
@@ -1222,7 +1239,7 @@ elseif((strstr($curdatabase, "ntpd.rrd")) && (file_exists("$rrddbpath$curdatabas
 	$graphcmd .= "GPRINT:\"wander:MAX:%7.2lf %s    \" ";
 	$graphcmd .= "GPRINT:\"wander:LAST:%7.2lf %S    \" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t`date +\"%b %d %H\:%M\:%S %Y\"`\" ";
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t  {$graphrange}\" ";
 }
 else {
 	$data = false;

--- a/usr/local/www/status_rrd_graph_settings.php
+++ b/usr/local/www/status_rrd_graph_settings.php
@@ -48,6 +48,7 @@ $pconfig['enable'] = isset($config['rrd']['enable']);
 $pconfig['category'] = $config['rrd']['category'];
 $pconfig['style'] = $config['rrd']['style'];
 $pconfig['period'] = $config['rrd']['period'];
+$pconfig['update_interval'] = $config['rrd']['update_interval'];
 
 $curcat = "settings";
 $categories = array('system' => gettext("System"),
@@ -84,6 +85,7 @@ if ($_POST['ResetRRD']) {
                 $config['rrd']['category'] = $_POST['category'];
                 $config['rrd']['style'] = $_POST['style'];
                 $config['rrd']['period'] = $_POST['period'];
+                $config['rrd']['update_interval'] = $_POST['update_interval'];
                 write_config();
 
                 $retval = 0;
@@ -227,6 +229,13 @@ include("head.inc");
 					?>
 					</select>
 					<b><?=gettext("This selects the default period.");?></b>
+				</td>
+			</tr>
+			<tr>
+				<td width="22%" valign="top" class="vtable"><?=gettext("Update interval");?></td>
+				<td width="78%" class="vtable">
+					<input name="update_interval" type="text" id="update_interval" size="10" value="<?php if($pconfig['update_interval']) echo $pconfig['update_interval']; else echo '355' ?>"/>
+					<b><?=gettext("This sets the graph update interval seconds.");?></b>
 				</td>
 			</tr>
 			<tr>

--- a/usr/local/www/status_rrd_graph_update.php
+++ b/usr/local/www/status_rrd_graph_update.php
@@ -1,0 +1,80 @@
+<?php
+/* $Id$ */
+/*
+	status_rrd_graph_update.php
+	Part of pfSense
+	Copyright (C) 2013 NOYB <NOYB at NOYB dot com>
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+/*	
+	pfSense_BUILDER_BINARIES:	none
+	pfSense_MODULE:	system
+*/
+
+require_once("status_rrd_graph.inc");
+
+status_rrd_graph_update_set_start_end();
+
+/* Now update the graph. */
+include("status_rrd_graph_img.php");
+
+/* Update start and end times for graph update based on period and graph. */
+function status_rrd_graph_update_set_start_end() {
+
+	$status_rrd_graph_update_vars = status_rrd_graph_update_get_set_vars();
+	$graph  = $status_rrd_graph_update_vars['graph'];
+	$period = $status_rrd_graph_update_vars['period'];
+
+	$dates = get_dates($period, $graph);
+
+	$_GET['start'] = $dates['start'];
+	$_GET['end'] = $dates['end'];
+}
+
+/* Get and return needed vars from URL query string. */
+function status_rrd_graph_update_get_set_vars() {
+
+	if ($_GET['graph']) {
+		$curgraph = $_GET['graph'];
+	} else {
+		$curgraph = "custom";
+	}
+
+	if ($_GET['period']) {
+		$curperiod = $_GET['period'];
+	} else {
+		if(! empty($config['rrd']['period'])) {
+			$curperiod = $config['rrd']['period'];
+		} else {
+			$curperiod = "absolute";
+		}
+	}
+
+	$result = array();
+	$result['graph'] = $curgraph;
+	$result['period'] = $curperiod;
+	return $result;
+}
+
+?>


### PR DESCRIPTION
Replace the current date on graphs with graph begin and end date range.
Current time is not useful in some views.  Particularly Previous Period views.

Correct graph period ranges (start & end) in get_dates function.

Fix graph updates to use updated start and end times.
Rather than a static start time and "now" for end time.
Which:
# Causes Absolute Timespan, Current Period and Previous Period graph lengths to grow indefinitely .
# Makes Previous Period views turn in to previous period plus current period.
# Prevents the period of both Current and Previous period views from updating to the new period when a period time boundary is crossed. 
Consolidate if not previous period checks into a single check.

Set the 'average' granularity to be used for each graph length.

For 'Current Period' view, leave graph end variable set to period end rather than forcing it to current time (now).

Add Graph Update Interval Setting.