### PR TITLE
Log pfsense version to syslog after bootup

### DIFF
--- a/etc/rc
+++ b/etc/rc
@@ -452,7 +452,7 @@ if [ "${GMIRROR_STATUS}" != "" ]; then
 	/usr/local/bin/minicron 60 /var/run/gmirror_status_check.pid /usr/local/sbin/gmirror_status_check.php
 fi
 
-# Log pfSense version to syslog
+# Log product version to syslog
 BUILDTIME=`cat /etc/version.buildtime`
 ARCH=`uname -m`
 echo "$product ($PLATFORM) $version $ARCH $BUILDTIME"


### PR DESCRIPTION
This will log a syslog entry after bootup that has the pfsense version (arch, platform, etc).  This can come in handy for admin purposes to be able to view the logs on a remote server to see what version of pfsense was running at what time.  This can come in handy when you are changing versions a lot and need to know what version you were running a few days ago at a specific time.

The current syslog entries are not very helpful for this.  /var/log/dmesg.boot does have the kernel version logged but it is overwritten on each boot and only resides on the firewall itself which can not serve the purpose of a history.  The kernel version does not get sent to remote syslog servers because networking, etc isn't up soon enough.

Discussion about it:
https://forum.pfsense.org/index.php?topic=77713.0
