### PR TITLE
Only include a scheduled rule if it is strictly before the end time

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -3418,7 +3418,7 @@ function filter_tdr_hour($schedule) {
 	$now = strtotime("now");
 	if($g['debug'])
 		log_error("[TDR DEBUG] S: $starting_time E: $ending_time N: $now");
-	if($now >= $starting_time and $now <= $ending_time)
+	if($now >= $starting_time and $now < $ending_time)
 		return true;
 	return false;
 }


### PR DESCRIPTION
The exact moment of the end time is the end of the schedule. We do not want to include a rule when filter_configure_sync wakes up at 00:15:00 etc and is on a not-slow system that processes this code during the interval 00:15:00 to 00:15:01. This should help intermittent issues with schedules not finishing at the appropriate 15-minute boundary. Might help or fix #3558
