### PR TITLE
Handle no dhcpd settings when upgrading

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -3150,6 +3150,10 @@ function upgrade_097_to_098() {
 
 function upgrade_098_to_099() {
 	global $config;
+
+	if (!is_array($config['dhcpd']))
+		return;
+
 	foreach ($config['dhcpd'] as & $dhcpifconf) {
 		if (isset($dhcpifconf['next-server'])) {
 			$dhcpifconf['nextserver'] = $dhcpifconf['next-server'];


### PR DESCRIPTION
I was testing 2.1.4-release on a new full install in a VM with only WAN defined. During the first boot after install this warning is emitted:
Warning: Invalid argument supplied for foreach() in /etc/inc/upgrade_config.inc on line 3153
It does not cause any issue, but might as well properly handle the case when there are no dhcpd settings.
