### PR TITLE
Handle no dhcpd settings when upgrading

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -3150,6 +3150,10 @@ function upgrade_097_to_098() {
 
 function upgrade_098_to_099() {
 	global $config;
+
+	if (empty($config['dhcpd']) || !is_array($config['dhcpd']))
+		return;
+
 	foreach ($config['dhcpd'] as & $dhcpifconf) {
 		if (isset($dhcpifconf['next-server'])) {
 			$dhcpifconf['nextserver'] = $dhcpifconf['next-server'];


### PR DESCRIPTION
This minor fix was in master but not 2.1 branch. I noticed the warning message when doing a fresh install/test of 2.1.4-release. It prevents the warning message:
Warning: Invalid argument supplied for foreach() in /etc/inc/upgrade_config.inc on line 3153
Might as well fix it it 2.1-branch also, in case there is another 2.1.n release.
