### PR TITLE
Fixed unexpected T_IF error

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -2110,7 +2110,7 @@ function upgrade_054_to_055() {
 	/* Let's save the RRD graphs after we run enable RRD graphing */
 	/* The function will restore the rrd.tgz so we will save it after */
 	exec("cd /; LANG=C NO_REMOUNT=1 RRDDBPATH='{$rrddbpath}' CF_CONF_PATH='{$g['cf_conf_path']}' /etc/rc.backup_rrd.sh");
-	unlink_if_exists("{$g['vardb_path']}"/rrd/*.xml");
+	unlink_if_exists("{$g['vardb_path']}"."/rrd/*.xml");
 	if ($g['booting'])
 		echo "Updating configuration...";
 }


### PR DESCRIPTION
Fixed a unexpected 'if' error caused by a string interpreted as a block comment. The exact error that is generated is PHP Parse error:  syntax error, unexpected 'if' (T_IF) in upgrade_config.inc on line 2128.
