### PR TITLE
bugfix #3347: Certificate Authority SAN names not working in 2.

### DIFF
--- a/etc/inc/certs.inc
+++ b/etc/inc/certs.inc
@@ -293,6 +293,14 @@ function cert_create(& $cert, $caref, $keylen, $lifetime, $dn, $type="user", $di
 			break;
 	}
 
+	// in case of using Subject Alternative Names use other sections (with postfix '_san')
+	// pass subjectAltName over environment variable 'SAN'
+	if ($dn['subjectAltName']) {
+		putenv("SAN={$dn['subjectAltName']}"); // subjectAltName can be set _only_ via configuration file
+		$cert_type .= '_san';
+		unset($dn['subjectAltName']);
+	}
+
 	$args = array(
 		"x509_extensions" => $cert_type,
 		"digest_alg" => $digest_alg,

--- a/etc/ssl/openssl.cnf
+++ b/etc/ssl/openssl.cnf
@@ -9,6 +9,10 @@
 HOME                    = .
 RANDFILE                = $ENV::HOME/.rnd
 
+# default SAN value if $ENV::SAN is not defined
+#
+SAN                     =
+
 # Extra OBJECT IDENTIFIER info:
 #oid_file               = $ENV::HOME/.oid
 oid_section             = new_oids
@@ -212,6 +216,15 @@ authorityKeyIdentifier=keyid,issuer:always
 #nsCaPolicyUrl
 #nsSslServerName
 
+[ usr_cert_san ]
+
+# copy of [ usr_cert ] plus nonempty Subject Alternative Names
+basicConstraints=CA:FALSE
+nsComment                       = "OpenSSL Generated User Certificate"
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer:always
+subjectAltName=$ENV::SAN
+
 [ server ]
 
 # Make a cert with nsCertType=server
@@ -222,6 +235,18 @@ subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid,issuer:always
 extendedKeyUsage=serverAuth
 keyUsage = digitalSignature, keyEncipherment
+
+[ server_san ]
+
+# copy of [ server ] plus nonempty Subject Alternative Names
+basicConstraints=CA:FALSE
+nsCertType			= server
+nsComment			= "OpenSSL Generated Server Certificate"
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer:always
+extendedKeyUsage=serverAuth
+keyUsage = digitalSignature, keyEncipherment
+subjectAltName=$ENV::SAN
 
 [ v3_req ]
 
@@ -266,6 +291,14 @@ basicConstraints = CA:true
 # Where 'obj' is a standard or added object
 # You can even override a supported extension:
 # basicConstraints= critical, DER:30:03:01:01:FF
+
+[ v3_ca_san ]
+
+# copy of [ v3_ca ] plus nonempty Subject Alternative Names
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer:always
+basicConstraints = CA:true
+subjectAltName=$ENV::SAN
 
 [ crl_ext ]
 


### PR DESCRIPTION
1

subjectAltName can be set _only_ via configuration file - created three extra sections in openssl.cnf to use in case of existing subjectAltName.

Unfortunately it is not possible to assign empty value to subjectAltName in openssl.cnf

on branches hotfix/3347-Certificate_Authority_SAN_names_not_working, master
branches hotfix/3347-Certificate_Authority_SAN_names_not_working
