### PR TITLE
fix display of traffic graph

### DIFF
--- a/usr/local/www/widgets/widgets/traffic_graphs.widget.php
+++ b/usr/local/www/widgets/widgets/traffic_graphs.widget.php
@@ -98,12 +98,6 @@ if (isset($a_config["scale_type"])) {
 ?>
 <input type="hidden" id="traffic_graphs-config" name="traffic_graphs-config" value="" />
 
-<?php
-	//set variables for traffic graph
-	$width = "100%";
-	$height = "150";
-?>
-
 <div id="traffic_graphs-settings" class="widgetconfigdiv" style="display:none;">
 <form action="/widgets/widgets/traffic_graphs.widget.php" method="post" name="iform" id="iform">
 	<?php foreach ($ifdescrs as $ifname => $ifdescr) { ?>
@@ -173,11 +167,9 @@ foreach ($ifdescrs as $ifname => $ifdescr) {
 				<div style="clear:both;"></div>
 			</div>
 			<div id="<?=$ifname;?>graphdiv" style="display:<?php echo $graphdisplay;?>">
-				<object data="graph.php?ifnum=<?=$ifname;?>&amp;ifname=<?=rawurlencode($ifdescr);?>&amp;timeint=<?=$refreshinterval;?>&amp;initdelay=<?=($graphcounter+1) * 2;?>">
+				<object data="graph.php?ifnum=<?=$ifname;?>&amp;ifname=<?=rawurlencode($ifdescr);?>&amp;timeint=<?=$refreshinterval;?>&amp;initdelay=<?=($graphcounter+1) * 2;?>" height="100%" width="100%">
 					<param name="id" value="graph" />
 					<param name="type" value="image/svg+xml" />
-					<param name="width" value="<? echo $width; ?>" />
-					<param name="height" value="<? echo $height; ?>" />
 					<param name="pluginspage" value="http://www.adobe.com/svg/viewer/install/auto" />
 				</object>
 			</div>


### PR DESCRIPTION
Since commit 286996b4b1d47aa073c88e1733ff4d9c3efe2020 the traffic graph has spilled out

Think I found the issue. 

Before 
![screenshot from 2014-08-25 14 21 54](https://cloud.githubusercontent.com/assets/4223752/4030334/d25af20e-2c5b-11e4-8cd9-892c78e525eb.png)

![screenshot from 2014-08-25 14 22 21](https://cloud.githubusercontent.com/assets/4223752/4030351/088efc12-2c5c-11e4-8917-654f0d9b5a93.png)
