### PR TITLE
Add more services and reorder

### DIFF
--- a/etc/inc/wizardapp.inc
+++ b/etc/inc/wizardapp.inc
@@ -31,16 +31,90 @@
 
 $gamesplist = array();
 
-$gamesplist['arma2'] = array();
-	/* ARMA 2 */
-	$gamesplist['arma2'][] = array('arma2', 'udp', '2302', '2310', 'both');
-	
+/* Game Consoles and Game Clients */
+
+$gamesplist['playstationconsoles'] = array();
+	/* Playstation 3, Playstation 4 and PS Vita */
+	$gamesplist['playstationconsoles'][] = array('PS-Network-TCP', 'tcp', '10040', '10060', 'both');
+	$gamesplist['playstationconsoles'][] = array('PS-Network-UDP', 'udp', '50000', '60000', 'both');
+	$gamesplist['playstationconsoles'][] = array('PS-Home-TCP-1', 'tcp', '3478', '3480', 'both');
+	$gamesplist['playstationconsoles'][] = array('PS-Home-TCP-2', 'tcp', '8080', '8080', 'both');
+	$gamesplist['playstationconsoles'][] = array('PS-TCP-1', 'tcp', '5223', '5223', 'both');
+	$gamesplist['playstationconsoles'][] = array('PS-TCP-2', 'tcp', '10070', '10080', 'both');
+	$gamesplist['playstationconsoles'][] = array('PS-UDP-1', 'udp', '3478', '3479', 'both');
+	$gamesplist['playstationconsoles'][] = array('PS-UDP-2', 'udp', '3658', '3658', 'both');
+	$gamesplist['playstationconsoles'][] = array('PS-UDP-3', 'udp', '10070', '10070', 'both');
+	$gamesplist['playstationconsoles'][] = array('PS-RemotePlay', 'tcp', '9293', '9293', 'both');
+
+$gamesplist['wiiconsoles'] = array();
+	/* XBox Consoles */
+	$gamesplist['wiiconsoles'][] = array('Wii-Consoles-TCP-1', 'tcp', '6667', '6667', 'both');
+	$gamesplist['wiiconsoles'][] = array('Wii-Consoles-TCP-2', 'tcp', '12400', '12400', 'both');
+	$gamesplist['wiiconsoles'][] = array('Wii-Consoles-TCP-3', 'tcp', '28910', '28910', 'both');
+	$gamesplist['wiiconsoles'][] = array('Wii-Consoles-TCP-4', 'tcp', '29900', '29901', 'both');
+	$gamesplist['wiiconsoles'][] = array('Wii-Consoles-TCP-5', 'tcp', '29920', '29920', 'both');
+
+$gamesplist['xboxconsoles'] = array();
+	/* XBox Consoles */
+	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-UDP-1', 'udp', '88', '88', 'both');
+	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-UDP-2', 'udp', '3074', '3074', 'both');
+	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-TCP-1', 'tcp', '3074', '3074', 'both');
+	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-TCP-2', 'tcp', '3659', '3659', 'both');
+	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-TCP-3', 'tcp', '500', '500', 'both');
+	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-TCP-4', 'tcp', '3544', '3544', 'both');
+	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-TCP-5', 'tcp', '4500', '4500', 'both');
+
 $gamesplist['battlenet'] = array();
 	/* Blizzard Publishing games */
 	$gamesplist['battlenet'][] = array('Battle.NET-game1-tcp', 'tcp', '6112', '6119', 'both'); //diablo, diablo2, starcraft, warcraft 2, warcraft 3
 	$gamesplist['battlenet'][] = array('Battle.NET-game1-udp', 'udp', '6112', '6119', 'both'); //diablo, diablo2, starcraft, warcraft 2
 	$gamesplist['battlenet'][] = array('Battle.NET-diablo2', 'tcp', '4000', '4000', 'both'); //diablo2
 	$gamesplist['battlenet'][] = array('Battle.NET-game2', 'tcp', '1119', '1119', 'both');  //diablo3, starcraft 2
+	$gamesplist['battlenet'][] = array('Battle.NET-game3', 'tcp', '3724', '3724', 'both');  //starcraft2
+
+$gamesplist['eaorigin'] = array();
+	/* EA Origin Client */
+	$gamesplist['eaorigin'][] = array('EA-Origin-TCP-1', 'tcp', '1024', '1124', 'both');
+	$gamesplist['eaorigin'][] = array('EA-Origin-TCP-2', 'tcp', '9960', '9969', 'both');
+	$gamesplist['eaorigin'][] = array('EA-Origin-TCP-3', 'tcp', '18000', '18000', 'both');
+	$gamesplist['eaorigin'][] = array('EA-Origin-TCP-4', 'tcp', '18120', '18120', 'both');
+	$gamesplist['eaorigin'][] = array('EA-Origin-TCP-5', 'tcp', '18060', '18060', 'both');
+	$gamesplist['eaorigin'][] = array('EA-Origin-TCP-6', 'tcp', '27900', '27900', 'both');
+	$gamesplist['eaorigin'][] = array('EA-Origin-TCP-7', 'tcp', '28910', '28910', 'both');
+	$gamesplist['eaorigin'][] = array('EA-Origin-TCP-8', 'tcp', '29900', '29900', 'both');
+	$gamesplist['eaorigin'][] = array('EA-Origin-UDP-1', 'udp', '1024', '1124', 'both');
+	$gamesplist['eaorigin'][] = array('EA-Origin-UDP-2', 'udp', '18000', '18000', 'both');
+	$gamesplist['eaorigin'][] = array('EA-Origin-UDP-3', 'udp', '29900', '29900', 'both');
+
+$gamesplist['steam'] = array();
+	/* Steam Games */
+	$gamesplist['steam'][] = array('Steam-game-udp', 'udp', '27000', '27030', 'both');  //america's army 3, cs:s, cs:go, HL2, COD: Black Ops, COD: Black Ops 2, Natural Selection 2
+	$gamesplist['steam'][] = array('Steam-game-tcp', 'tcp', '27000', '27030', 'both');  //america's army 3, cs:s, cs:go, HL2, COD: Black Ops, COD: Black Ops 2, Natural Selection 2
+	$gamesplist['steam'][] = array('Steam-hltv', 'udp', '27015', '27030', 'both');
+	$gamesplist['steam'][] = array('Steam-1', 'udp', '4380', '4380', 'both');
+	$gamesplist['steam'][] = array('Steam-2', 'udp', '1200', '1200', 'both');
+	$gamesplist['steam'][] = array('Steam-voice', 'udp', '3478', '3480', 'both');
+
+$gamesplist['gamesforwindowslive'] = array();
+	/* Games for Windows Live */
+	$gamesplist['gamesforwindowslive'][] = array('Games4WinLive-1', 'udp', '88', '88', 'both');
+	$gamesplist['gamesforwindowslive'][] = array('Games4WinLive-2', 'udp', '3074', '3074', 'both');
+	$gamesplist['gamesforwindowslive'][] = array('Games4WinLive-3', 'tcp', '3074', '3074', 'both');
+
+/* Games */
+
+$gamesplist['arma2'] = array();
+	/* ARMA 2 */
+	$gamesplist['arma2'][] = array('arma2', 'udp', '2302', '2310', 'both');
+	
+$gamesplist['arma3'] = array();
+	/* ARMA 3 */
+	$gamesplist['arma3'][] = array('arma3-game-traffic', 'udp', '2302', '2302', 'both');
+	$gamesplist['arma3'][] = array('arma3-steam-query', 'udp', '2303', '2303', 'both');
+	$gamesplist['arma3'][] = array('arma3-steam-port', 'udp', '2304', '2304', 'both');
+	$gamesplist['arma3'][] = array('arma3-BattleEye-1', 'tcp', '2345', '2345', 'both');
+	$gamesplist['arma3'][] = array('arma3-BattleEye-2', 'tcp', '2344', '2344', 'both');
+	$gamesplist['arma3'][] = array('arma3-BattleEye-2', 'udp', '2344', '2344', 'both');
 
 $gamesplist['battlefield2'] = array();
 	/* Battlefield 2 */
@@ -55,7 +129,7 @@ $gamesplist['battlefield2'] = array();
 	$gamesplist['battlefield2'][] = array('BF2-55123-55125', 'udp', '55123', '55125', 'both');
 	
 $gamesplist['battlefield3'] = array();
-	/* Battlefield 3 */
+	/* Battlefield 3 and Battlefield 4 */
 	$gamesplist['battlefield3'][] = array('BF3-1', 'tcp', '9988', '9988', 'both');
 	$gamesplist['battlefield3'][] = array('BF3-2', 'tcp', '20000', '20100', 'both');
 	$gamesplist['battlefield3'][] = array('BF3-3', 'tcp', '22990', '22990', 'both');
@@ -65,6 +139,9 @@ $gamesplist['battlefield3'] = array();
 	$gamesplist['battlefield3'][] = array('BF3-7', 'udp', '14000', '14016', 'both');
 	$gamesplist['battlefield3'][] = array('BF3-8', 'udp', '22990', '23006', 'both');
 	$gamesplist['battlefield3'][] = array('BF3-9', 'udp', '25200', '25300', 'both');
+	$gamesplist['battlefield3'][] = array('BF3-PS-1', 'tcp', '10000', '10100', 'both');
+	$gamesplist['battlefield3'][] = array('BF3-PS-2', 'tcp', '1935', '1935', 'both');
+
 
 $gamesplist['battlefieldbc2'] = array();
 	/* Battlefield Bad Company 2 */
@@ -99,6 +176,38 @@ $gamesplist['crysis2'] = array();
 	/* Crysis 2 */
 	$gamesplist['crysis2'][] = array('Crysis2', 'udp', '64100', '64100', 'both');
 
+$gamesplist['crysis3'] = array();
+	/* Crysis 3 */
+	$gamesplist['crysis3'][] = array('Crysis3-TCP-1', 'tcp', '9988', '9988', 'both');
+	$gamesplist['crysis3'][] = array('Crysis3-TCP-2', 'tcp', '17502', '17502', 'both');
+	$gamesplist['crysis3'][] = array('Crysis3-TCP-3', 'tcp', '25650', '25780', 'both');
+	$gamesplist['crysis3'][] = array('Crysis3-TCP-4', 'tcp', '42127', '42127', 'both');
+	$gamesplist['crysis3'][] = array('Crysis3-TCP-5', 'tcp', '64100', '64110', 'both');
+	$gamesplist['crysis3'][] = array('Crysis3-UDP-1', 'udp', '3659', '3659', 'both');
+	$gamesplist['crysis3'][] = array('Crysis3-UDP-2', 'udp', '10000', '10100', 'both');
+	$gamesplist['crysis3'][] = array('Crysis3-UDP-3', 'udp', '25650', '25780', 'both');
+	$gamesplist['crysis3'][] = array('Crysis3-UDP-4', 'udp', '64100', '64110', 'both');
+
+$gamesplist['deadspace2'] = array();
+	/* Dead Space 2 */
+	$gamesplist['deadspace2'][] = array('DeadSpace2-TCP-1', 'tcp', '28910', '28910', 'both');
+	$gamesplist['deadspace2'][] = array('DeadSpace2-TCP-2', 'tcp', '29900', '29901', 'both');
+	$gamesplist['deadspace2'][] = array('DeadSpace2-UDP-1', 'udp', '8088', '28088', 'both');
+
+$gamesplist['deadspace3'] = array();
+	/* Dead Space 3 */
+	$gamesplist['deadspace3'][] = array('DeadSpace3-TCP-1', 'tcp', '1024', '1124', 'both');
+	$gamesplist['deadspace3'][] = array('DeadSpace3-TCP-2', 'tcp', '9960', '9969', 'both');
+	$gamesplist['deadspace3'][] = array('DeadSpace3-TCP-3', 'tcp', '18000', '18000', 'both');
+	$gamesplist['deadspace3'][] = array('DeadSpace3-TCP-4', 'tcp', '18120', '18120', 'both');
+	$gamesplist['deadspace3'][] = array('DeadSpace3-TCP-5', 'tcp', '18060', '18060', 'both');
+	$gamesplist['deadspace3'][] = array('DeadSpace3-TCP-6', 'tcp', '27900', '27900', 'both');
+	$gamesplist['deadspace3'][] = array('DeadSpace3-TCP-7', 'tcp', '28910', '28910', 'both');
+	$gamesplist['deadspace3'][] = array('DeadSpace3-TCP-8', 'tcp', '29900', '29900', 'both');
+	$gamesplist['deadspace3'][] = array('DeadSpace3-UDP-1', 'udp', '1024', '1124', 'both');
+	$gamesplist['deadspace3'][] = array('DeadSpace3-UDP-2', 'udp', '18000', '18000', 'both');
+	$gamesplist['deadspace3'][] = array('DeadSpace3-UDP-3', 'udp', '29900', '29900', 'both');
+
 $gamesplist['deltaforce'] = array();
 	/* delta force */
 	$gamesplist['deltaforce'][] = array('Delta1', 'udp', '17478', '17488', 'both');
@@ -115,17 +224,28 @@ $gamesplist['doom3'] = array();
 	$gamesplist['doom3'][] = array('DOOM3-1', 'udp', '27650', '27650', 'both');
 	$gamesplist['doom3'][] = array('DOOM3-2', 'udp', '27666', '27666', 'both');
 
+$gamesplist['dragonage2'] = array();
+	/* Dragon Age 2 */
+	$gamesplist['dragonage2'][] = array('DragonAge2-TCP-1', 'tcp', '8000', '8000', 'both');
+	$gamesplist['dragonage2'][] = array('DragonAge2-TCP-2', 'tcp', '12025', '12025', 'both');
+	$gamesplist['dragonage2'][] = array('DragonAge2-TCP-3', 'tcp', '15101', '15325', 'both');
+	$gamesplist['dragonage2'][] = array('DragonAge2-TCP-4', 'tcp', '18081', '18081', 'both');
+	$gamesplist['dragonage2'][] = array('DragonAge2-TCP-5', 'tcp', '42127', '42127', 'both');
+	$gamesplist['dragonage2'][] = array('DragonAge2-UDP-1', 'udp', '1900', '1900', 'both');
+	$gamesplist['dragonage2'][] = array('DragonAge2-UDP-2', 'udp', '5355', '5355', 'both');
+	$gamesplist['dragonage2'][] = array('DragonAge2-UDP-3', 'udp', '8001', '8001', 'both');
+
+$gamesplist['empireearth'] = array();
+	/* empire earth */
+	$gamesplist['empireearth'][] = array('EmpireEarth-1', 'tcp', '33335', '33336', 'both');
+	$gamesplist['empireearth'][] = array('EmpireEarth-2', 'udp', '33334', '33334', 'both');
+
 $gamesplist['eveonline'] = array();
 	/* EVE Online */
 	$gamesplist['eveonline'][] = array('EVEOnline-tcp', 'tcp', '26000', '26000', 'both');
 	$gamesplist['eveonline'][] = array('EVEOnline-udp', 'udp', '26000', '26000', 'both');
 	$gamesplist['eveonline'][] = array('EVEOnline-alternate-tcp', 'tcp', '3724', '3724', 'both');
 	$gamesplist['eveonline'][] = array('EVEOnline-alternate-udp', 'udp', '3724', '3724', 'both');
-
-$gamesplist['empireearth'] = array();
-	/* empire earth */
-	$gamesplist['empireearth'][] = array('EmpireEarth-1', 'tcp', '33335', '33336', 'both');
-	$gamesplist['empireearth'][] = array('EmpireEarth-2', 'udp', '33334', '33334', 'both');
 
 $gamesplist['everquest'] = array();
 	/* everquest */
@@ -167,12 +287,6 @@ $gamesplist['halflife'] = array();
 	$gamesplist['halflife'][] = array('HL-2', 'udp', '27650', '27650', 'both');
 	$gamesplist['halflife'][] = array('HL-3', 'udp', '27666', '27666', 'both');
 
-$gamesplist['halo2'] = array();
-	/* Halo2 + XBOX Live */
-	$gamesplist['halo2'][] = array('Halo2-1', 'udp', '88', '88', 'both');
-	$gamesplist['halo2'][] = array('Halo2-2', 'udp', '3074', '3074', 'both');
-	$gamesplist['halo2'][] = array('Halo2-3', 'tcp', '3074', '3074', 'both');
-
 $gamesplist['leagueoflegends'] = array();
 	/* League of Legends */
 	$gamesplist['leagueoflegends'][] = array('LeagueofLegends-1', 'udp', '5000', '5500', 'both');
@@ -184,6 +298,11 @@ $gamesplist['lineage2'] = array();
 	$gamesplist['lineage2'][] = array('Lineage2-2009', 'tcp', '2009', '2009', 'both');
 	$gamesplist['lineage2'][] = array('Lineage2-2106', 'tcp', '2106', '2106', 'both');
 	$gamesplist['lineage2'][] = array('Lineage2-7777', 'tcp', '7777', '7777', 'both');
+
+$gamesplist['masseffect3'] = array();
+	/* MassEffect 3 */
+	$gamesplist['masseffect3'][] = array('MassEffect3-UDP-1', 'udp', '5659', '5659', 'both');
+	$gamesplist['masseffect3'][] = array('MassEffect3-UDP-1', 'udp', '6000', '6000', 'both');
 
 $gamesplist['mechwarrioronline'] = array();
 	/* MechWarrior: Online */
@@ -198,7 +317,7 @@ $gamesplist['minecraft'] = array();
 
 $gamesplist['operationflashpoint-dr'] = array();
 	/* Operation Flashpoint: Dragon Rising */
-	$gamesplist['operationflashpoint-dr'][] = array('operationflashpoint-dr-game', 'udp', '9105', '9105', 'both');
+	$gamesplist['operationflashpoint-dr'][] = array('OperationFlashpoint-DR', 'udp', '9105', '9105', 'both');
 
 $gamesplist['planetside'] = array();
 	/* PlanetSide */
@@ -212,45 +331,24 @@ $gamesplist['planetside2'] = array();
 	/* PlanetSide 2 */
 	$gamesplist['planetside2'][] = array('PlanetSide2-game', 'udp', '20040', '20199', 'both');
 	$gamesplist['planetside2'][] = array('PlanetSide2-voice', 'udp', '5062', '5062', 'both');
-	
-$gamesplist['playstation3'] = array();
-	/* PlayStation 2 */
-	$gamesplist['playstation3'][] = array('PS3-pshome1', 'tcp', '3478', '3480', 'both');
-	$gamesplist['playstation3'][] = array('PS3-pshome2', 'tcp', '8080', '8080', 'both');
-	$gamesplist['playstation3'][] = array('PS3-tcp1', 'tcp', '5223', '5223', 'both');
-	$gamesplist['playstation3'][] = array('PS3-tcp2', 'tcp', '10070', '10080', 'both');
-	$gamesplist['playstation3'][] = array('PS3-udp1', 'udp', '3478', '3479', 'both');
-	$gamesplist['playstation3'][] = array('PS3-udp2', 'udp', '3658', '3658', 'both');
-	$gamesplist['playstation3'][] = array('PS3-udp3', 'udp', '10070', '10070', 'both');
-	$gamesplist['playstation3'][] = array('PS3-remoteplay', 'tcp', '9293', '9293', 'both');
-	
+
+
 $gamesplist['quakeiii'] = array();
 	/* quake3 */
-	$gamesplist['quakeiii'][] = array('quakeiii', 'udp', '27910', '27919', 'both');
+	$gamesplist['quakeiii'][] = array('Quake3', 'udp', '27910', '27919', 'both');
 	
 $gamesplist['quakeiv'] = array();
 	/* quake4 */
-	$gamesplist['quakeiv'][] = array('quakeiv-server-udp', 'udp', '27650', '27650', 'both');
-	$gamesplist['quakeiv'][] = array('quakeiv-server-tcp', 'tcp', '27650', '27650', 'both');
-	$gamesplist['quakeiv'][] = array('quakeiv-client-udp', 'udp', '28004', '28004', 'both');
-	$gamesplist['quakeiv'][] = array('quakeiv-client-tcp', 'tcp', '28004', '28004', 'both');
+	$gamesplist['quakeiv'][] = array('QuakeIV-server-udp', 'udp', '27650', '27650', 'both');
+	$gamesplist['quakeiv'][] = array('QuakeIV-server-tcp', 'tcp', '27650', '27650', 'both');
+	$gamesplist['quakeiv'][] = array('QuakeIV-client-udp', 'udp', '28004', '28004', 'both');
+	$gamesplist['quakeiv'][] = array('QuakeIV-client-tcp', 'tcp', '28004', '28004', 'both');
 
 $gamesplist['starwarstor'] = array();
 	/* quake3 */
 	$gamesplist['starwarstor'][] = array('StarWarsTOR-1', 'tcp', '8995', '8995', 'both');
 	$gamesplist['starwarstor'][] = array('StarWarsTOR-2', 'tcp', '12000', '12999', 'both');
 	$gamesplist['starwarstor'][] = array('StarWarsTOR-2', 'tcp', '20000', '30000', 'both');
-
-$gamesplist['steam'] = array();
-	/* Steam Games */
-	$gamesplist['steam'][] = array('steam-game-udp', 'udp', '27000', '27030', 'both');  //america's army 3, cs:s, cs:go, HL2, COD: Black Ops, COD: Black Ops 2, Natural Selection 2
-	$gamesplist['steam'][] = array('steam-game-tcp', 'tcp', '27000', '27030', 'both');  //america's army 3, cs:s, cs:go, HL2, COD: Black Ops, COD: Black Ops 2, Natural Selection 2
-	$gamesplist['steam'][] = array('steam-hltv', 'udp', '27015', '27030', 'both');
-	$gamesplist['steam'][] = array('steam-1', 'udp', '4380', '4380', 'both');
-	$gamesplist['steam'][] = array('steam-2', 'udp', '1200', '1200', 'both');
-	$gamesplist['steam'][] = array('steam-voice', 'udp', '3478', '3480', 'both');
-	//NOTE: steam downloads, probably don't want this in the game que
-	//$gamesplist['steam'][] = array('steam-downloads', 'tcp', '27014', '27050', 'both');
 
 $gamesplist['tigerwoods2004ps2'] = array();
 	/* tiger woods 2004 ps2 */
@@ -260,8 +358,8 @@ $gamesplist['tigerwoods2004ps2'] = array();
 
 $gamesplist['tribesascend'] = array();
 	/* Tribes Ascend */
-	$gamesplist['tribesascend'][] = array('tribesascend-tcp', 'tcp', '9000', '9001', 'both');
-	$gamesplist['tribesascend'][] = array('tribesascend-udp', 'udp', '9002', '9999', 'both');
+	$gamesplist['tribesascend'][] = array('TribesAscend-tcp', 'tcp', '9000', '9001', 'both');
+	$gamesplist['tribesascend'][] = array('TribesAscend-udp', 'udp', '9002', '9999', 'both');
 
 $gamesplist['unrealtournament'] = array();
 	/* Unreal Tournament */
@@ -278,13 +376,6 @@ $gamesplist['wow'] = array();
 	$gamesplist['wow'][] = array('WoW', 'tcp', '3724', '3724', 'both');
 	$gamesplist['wow'][] = array('WoW-voice', 'udp', '1119', '1119', 'both');
 	$gamesplist['wow'][] = array('WoW-voice', 'udp', '3724', '3724', 'both');
-
-$gamesplist['xbox360'] = array();
-	/* XBox360 and Games for Windows Live*/
-	$gamesplist['xbox360'][] = array('xbox360-1', 'udp', '88', '88', 'both');
-	$gamesplist['xbox360'][] = array('xbox360-2', 'udp', '3074', '3074', 'both');
-	$gamesplist['xbox360'][] = array('xbox360-3', 'tcp', '3074', '3074', 'both');
-
 
 $voiplist = array();
 
@@ -357,111 +448,216 @@ $p2plist = array();
 $othersplist = array();
 	/* Unlike other areas we are posting the queue H or L or BLANK */
 
-	$othersplist['msrdp'] = array();
-		/* MSRDP */
-		$othersplist['msrdp'][] = array('MSRDP', 'tcp', '3389', '3389', 'both');
-	$othersplist['pptp'] = array();
-		/* PPTP */
-		$othersplist['pptp'][] = array('PPTP', 'tcp', '1723', '1723', 'both');
-		$othersplist['pptp'][] = array('PPTPGRE', 'gre', '', '', 'both');
-	$othersplist['ipsec'] = array();
-		/* IPSEC */
-		$othersplist['ipsec'][] = array('IPSEC', 'udp', '500', '500', 'both');
-		$othersplist['ipsec'][] = array('IPSEC', 'ah', '', '', 'both');
-		$othersplist['ipsec'][] = array('IPSEC', 'esp', '', '', 'both');
-	$othersplist['streamingmp3'] = array();
-		/* streaming mp3 media aka shoutcast */
-		$othersplist['streamingmp3'][] = array('STREAMINGMP3', 'tcp', '8000', '8100', 'both');
-	$othersplist['irc'] = array();
-		/* internet relay chat */
-		$othersplist['irc'][] = array('IRC', 'tcp', '6667', '6670', 'both');
-	$othersplist['jabber'] = array();
-		/* jabber */
-		$othersplist['jabber'][] = array('IRC', 'tcp', '5222', '5222', 'both');
-		$othersplist['jabber'][] = array('IRC', 'tcp', '5223', '5223', 'both');
-		$othersplist['jabber'][] = array('IRC', 'tcp', '5269', '5269', 'both');
-	$othersplist['dns'] = array();
-		/* domain name system */
-		$othersplist['dns'][] = array('DNS1', 'tcp', '53', '53', 'both');
-		$othersplist['dns'][] = array('DNS2', 'udp', '53', '53', 'both');
-	$othersplist['http'] = array();
-		/* HTTP aka Web Traffic */
-		$othersplist['http'][] = array('HTTP', 'tcp', '80', '80', 'both');
-		$othersplist['http'][] = array('HTTPS', 'tcp', '443', '443', 'both');
-	$othersplist['smtp'] = array();
-		/* Secure shell traffic */
-		$othersplist['smtp'][] = array('SMTP', 'tcp', '25', '25', 'both');
-	$othersplist['pop3'] = array();
-		/* Post Office Protocol - POP3 */
-		$othersplist['pop3'][] = array('POP3', 'tcp', '110', '110', 'both');
-	$othersplist['icmp'] = array();
-		/* ICMP */
-		$othersplist['icmp'][] = array('ICMP', 'icmp', '', '', 'both');
-	$othersplist['imap'] = array();
-		/* IMAP */
-		$othersplist['imap'][] = array('IMAP', 'tcp', '143', '143', 'both');
-	$othersplist['smb'] = array();
-		/* Microsoft SMB and friends */
-		$othersplist['smb'][] = array('SMB1', 'tcp', '445', '445', 'both');
-		$othersplist['smb'][] = array('SMB2', 'tcp', '137-139', '137-139', 'both');
-	$othersplist['rtsp'] = array();
-		/* realtime streaming protocol */
-		$othersplist['rtsp'][] = array('RTSP1', 'tcp', '554', '554', 'both');
-	$othersplist['snmp'] = array();
-		/* Simple network management protocol */
-		$othersplist['snmp'][] = array('SNMP', 'tcp', '161', '161', 'both');
-		$othersplist['snmp'][] = array('SNMP2', 'udp', '161', '161', 'both');
-	$othersplist['vnc'] = array();
-		/* virtual network control */
-		$othersplist['vnc'][] = array('VNC', 'tcp', '5900', '5930', 'both');
+	/* Remote Service / Terminal emulation */
+
 	$othersplist['appleremotedesktop'] = array();
 		/* apple remote desktop */
 		$othersplist['appleremotedesktop'][] = array('AppleRemoteDesktop1', 'tcp', '3283', '3283', 'both');
 		$othersplist['appleremotedesktop'][] = array('AppleRemoteDesktop2', 'tcp', '5900', '5900', 'both');
 		$othersplist['appleremotedesktop'][] = array('AppleRemoteDesktop3', 'udp', '3283', '3283', 'both');
 		$othersplist['appleremotedesktop'][] = array('AppleRemoteDesktop4', 'udp', '5900', '5900', 'both');
+
+	$othersplist['msrdp'] = array();
+		/* MSRDP */
+		$othersplist['msrdp'][] = array('MSRDP', 'tcp', '3389', '3389', 'both');
+
+	$othersplist['pcanywhere'] = array();
+		/* symantec pc anywhere */
+		$othersplist['pcanywhere'][] = array('PCAnywhere-1', 'tcp', '5631', '5631', 'both');
+		$othersplist['pcanywhere'][] = array('PCAnywhere-2', 'udp', '5632', '5632', 'both');
+
+	$othersplist['vnc'] = array();
+		/* virtual network control */
+		$othersplist['vnc'][] = array('VNC', 'tcp', '5900', '5930', 'both');
+
+	/* Messanger Clients */
+
+	$othersplist['aolinstantmessenger'] = array();
+		/* AIM */
+		$othersplist['aolinstantmessenger'][] = array('AIM', 'tcp', '5190', '5190', 'both');
+
+	$othersplist['facetime'] = array();
+		/* Facetime */
+		$othersplist['facetime'][] = array('Facetime-UDP-1', 'udp', '3478', '3479', 'both');
+		$othersplist['facetime'][] = array('Facetime-UDP-2', 'tcp', '16384', '16387', 'both');
+		$othersplist['facetime'][] = array('Facetime-UDP-3', 'tcp', '16393', '16402', 'both');
+
+	$othersplist['googlehangouts'] = array();
+		/* Google Hangouts */
+		$othersplist['googlehangouts'][] = array('GoogleHangouts-UDP', 'udp', '19302', '19309', 'both');
+		$othersplist['googlehangouts'][] = array('GoogleHangouts-TCP', 'tcp', '19305', '9309', 'both');
+
 	$othersplist['icq'] = array();
 		/* icq */
 		$othersplist['icq'][] = array('ICQ1', 'tcp', '5190', '5190', 'both');
 		$othersplist['icq'][] = array('ICQ2', 'udp', '5190', '5190', 'both');
-	$othersplist['lotusnotes'] = array();
-		/* lotus notes */
-		$othersplist['lotusnotes'][] = array('LotusNotes1', 'tcp', '1352', '1352', 'both');
-		$othersplist['lotusnotes'][] = array('LotusNotes2', 'udp', '1352', '1352', 'both');
-	$othersplist['aolinstantmessenger'] = array();
-		/* AIM */
-		$othersplist['aolinstantmessenger'][] = array('AIM', 'tcp', '5190', '5190', 'both');
+
+	$othersplist['irc'] = array();
+		/* internet relay chat */
+		$othersplist['irc'][] = array('IRC', 'tcp', '6667', '6670', 'both');
+
+	$othersplist['jabber'] = array();
+		/* jabber */
+		$othersplist['jabber'][] = array('IRC', 'tcp', '5222', '5222', 'both');
+		$othersplist['jabber'][] = array('IRC', 'tcp', '5223', '5223', 'both');
+		$othersplist['jabber'][] = array('IRC', 'tcp', '5269', '5269', 'both');
+
 	$othersplist['msnmessenger'] = array();
 		/* msn messenger */
 		$othersplist['msnmessenger'][] = array('MSN1', 'tcp', '1863', '1863', 'both');
 		$othersplist['msnmessenger'][] = array('MSN2', 'tcp', '6891', '6900', 'both');
 		$othersplist['msnmessenger'][] = array('MSN3', 'tcp', '6901', '6901', 'both');
 		$othersplist['msnmessenger'][] = array('MSN4', 'udp', '6901', '6901', 'both');
+		
+	$othersplist['teamspeak'] = array();
+		/* teamspeak  */
+		$othersplist['teamspeak'][] = array('TeamSpeak-1', 'tcp', '14534', '14534', 'both');
+		$othersplist['teamspeak'][] = array('TeamSpeak-2', 'tcp', '51234', '51234', 'both');
+		$othersplist['teamspeak'][] = array('TeamSpeak-3', 'udp', '8767', '8768', 'both');
+
+	$othersplist['teamspeak3'] = array();
+		/* teamspeak 3 */
+		$othersplist['teamspeak3'][] = array('TeamSpeak3-FileTransfer', 'tcp', '30033', '30033', 'both');
+		$othersplist['teamspeak3'][] = array('TeamSpeak3-ServerQuery', 'tcp', '10011', '10011', 'both');
+		$othersplist['teamspeak3'][] = array('TeamSpeak3-Voice', 'udp', '9987', '9987', 'both');
+		$othersplist['teamspeak3'][] = array('TeamSpeak3-TSDNS', 'tcp', '41144', '41144', 'both');
+
+	$othersplist['ventrilo'] = array();
+		/* ventrilo */
+		$othersplist['ventrilo'][] = array('Ventrilo-TCP', 'tcp', '3784', '3784', 'both');
+		$othersplist['ventrilo'][] = array('Ventrilo-UDP', 'udp', '3784', '3784', 'both');
+		$othersplist['ventrilo'][] = array('Ventrilo-Voice', 'udp', '6100', '6100', 'both');
+
+	/* VPN */
+
+	$othersplist['pptp'] = array();
+		/* PPTP */
+		$othersplist['pptp'][] = array('PPTP', 'tcp', '1723', '1723', 'both');
+		$othersplist['pptp'][] = array('PPTPGRE', 'gre', '', '', 'both');
+
+	$othersplist['ipsec'] = array();
+		/* IPSEC */
+		$othersplist['ipsec'][] = array('IPSEC', 'udp', '500', '500', 'both');
+		$othersplist['ipsec'][] = array('IPSEC', 'ah', '', '', 'both');
+		$othersplist['ipsec'][] = array('IPSEC', 'esp', '', '', 'both');
+
+	/* Multimedia/Streaming */
+
+	$othersplist['itunesradio'] = array();
+		/* Apple iTunes Radio Stream */
+		$othersplist['itunesradio'][] = array('iTunesRadio', 'tcp', '42000', '42999', 'both');
+
+	$othersplist['streamingmp3'] = array();
+		/* streaming mp3 media aka shoutcast */
+		$othersplist['streamingmp3'][] = array('STREAMINGMP3', 'tcp', '8000', '8100', 'both');
+
+	$othersplist['rtsp'] = array();
+		/* realtime streaming protocol */
+		$othersplist['rtsp'][] = array('RTSP1', 'tcp', '554', '554', 'both');
+
+	/* Web */
+
+	$othersplist['http'] = array();
+		/* HTTP aka Web Traffic */
+		$othersplist['http'][] = array('HTTP', 'tcp', '80', '80', 'both');
+		$othersplist['http'][] = array('HTTPS', 'tcp', '443', '443', 'both');
+
+	/* Mail */
+
+	$othersplist['imap'] = array();
+		/* IMAP */
+		$othersplist['imap'][] = array('IMAP', 'tcp', '143', '143', 'both');
+		$othersplist['imap'][] = array('IMAP-Secure', 'tcp', '993', '993', 'both');
+
+	$othersplist['lotusnotes'] = array();
+		/* lotus notes */
+		$othersplist['lotusnotes'][] = array('LotusNotes1', 'tcp', '1352', '1352', 'both');
+		$othersplist['lotusnotes'][] = array('LotusNotes2', 'udp', '1352', '1352', 'both');
+
+	$othersplist['pop3'] = array();
+		/* Post Office Protocol - POP3 */
+		$othersplist['pop3'][] = array('POP3', 'tcp', '110', '110', 'both');
+		$othersplist['pop3'][] = array('POP3-Secure', 'tcp', '995', '995', 'both');
+
+	$othersplist['smtp'] = array();
+		/* SMTP */
+		$othersplist['smtp'][] = array('SMTP', 'tcp', '25', '25', 'both');
+		$othersplist['smtp'][] = array('SMTP-Secure-1', 'tcp', '465', '465', 'both');
+		$othersplist['smtp'][] = array('SMTP-Secure-2', 'tcp', '587', '587', 'both');
+
+	/* Game Downloader */
+
+	//NOTE: Battle.net-Downloader runs on this port range.  Don't want that up with the game que.
+	$othersplist['battlenetdownloader'] = array();
+		$othersplist['battlenetdownloader'][] = array('Battle.NET-Downloader', 'tcp', '6881', '6999', 'both');
+
+	//NOTE: steam downloads, probably don't want this in the game que
+	$othersplist['steamdownloader'] = array();
+		$othersplist['steamdownloader'][] = array('Steam-Downloader', 'tcp', '27014', '27050', 'both');
+
+	/* Miscellaneous */
+
+	$othersplist['apns'] = array();
+		/* Apple Push Notification Service */
+		$othersplist['apns'][] = array('APNS', 'tcp', '5223', '5223', 'both');
+		$othersplist['apns'][] = array('APNS', 'tcp', '2195', '2196', 'both');
+
+	$othersplist['applemobilesync'] = array();
+		/* Apple Mobile Sync */
+		$othersplist['applemobilesync'][] = array('AppleMobileSync', 'tcp', '2336', '2336', 'both');
+
+	$othersplist['crashplan'] = array();
+		/* crashplan  */
+		$othersplist['crashplan'][] = array('CrashPlan-1', 'tcp', '4282', '4282', 'both');
+		$othersplist['crashplan'][] = array('CrashPlan-2', 'tcp', '4285', '4285', 'both');
+
+	$othersplist['cvsup'] = array();
+		/* cvs  */
+		$othersplist['cvsup'][] = array('cvsup', 'tcp', '5999', '5999', 'both');
+
+	$othersplist['dns'] = array();
+		/* domain name system */
+		$othersplist['dns'][] = array('DNS1', 'tcp', '53', '53', 'both');
+		$othersplist['dns'][] = array('DNS2', 'udp', '53', '53', 'both');
+
+	$othersplist['git'] = array();
+		/* GIT  */
+		$othersplist['git'][] = array('git', 'tcp', '9418', '9418', 'both');
+	
+	$othersplist['hbci'] = array();
+		/* HBCI  */
+		$othersplist['hbci'][] = array('HBCI', 'tcp', '3000', '3000', 'both');
+
+	$othersplist['icmp'] = array();
+		/* ICMP */
+		$othersplist['icmp'][] = array('ICMP', 'icmp', '', '', 'both');
+
 	$othersplist['mysqlserver'] = array();
 		/* mysql server */
 		$othersplist['mysqlserver'][] = array('MySQL1', 'tcp', '3306', '3306', 'both');
+
 	$othersplist['nntp'] = array();
 		/* nntp */
 		$othersplist['nntp'][] = array('NNTP1', 'tcp', '119', '119', 'both');
 		$othersplist['nntp'][] = array('NNTP2', 'udp', '119', '119', 'both');
-	$othersplist['pcanywhere'] = array();
-		/* symantec pc anywhere */
-		$othersplist['pcanywhere'][] = array('pcany1', 'tcp', '5631', '5631', 'both');
-		$othersplist['pcanywhere'][] = array('pcany2', 'udp', '5632', '5632', 'both');
-	$othersplist['teamspeak'] = array();
-		/* teamspeak  */
-		$othersplist['teamspeak'][] = array('teamspeak1', 'tcp', '14534', '14534', 'both');
-		$othersplist['teamspeak'][] = array('teamspeak2', 'tcp', '51234', '51234', 'both');
-		$othersplist['teamspeak'][] = array('teamspeak3', 'udp', '8767', '8768', 'both');
-	$othersplist['cvsup'] = array();
-		/* cvs  */
-		$othersplist['cvsup'][] = array('cvsup', 'tcp', '5999', '5999', 'both');
-	$othersplist['hbci'] = array();
-		/* HBCI  */
-		$othersplist['hbci'][] = array('HBCI', 'tcp', '3000', '3000', 'both');
+		
 	$othersplist['slingbox'] = array();
+		/* slingbox */
 		$othersplist['slingbox'][] = array('Slingbox1', 'tcp', '5001', '5001', 'both');
 		$othersplist['slingbox'][] = array('Slingbox2', 'udp', '5001', '5001', 'both');
 
+	$othersplist['smb'] = array();
+		/* Microsoft SMB and friends */
+		$othersplist['smb'][] = array('SMB1', 'tcp', '445', '445', 'both');
+		$othersplist['smb'][] = array('SMB2', 'tcp', '137-139', '137-139', 'both');
+
+	$othersplist['snmp'] = array();
+		/* Simple network management protocol */
+		$othersplist['snmp'][] = array('SNMP', 'tcp', '161', '161', 'both');
+		$othersplist['snmp'][] = array('SNMP2', 'udp', '161', '161', 'both');
+
+	$othersplist['subversion'] = array();
+		/* subversion  */
+		$othersplist['subversion'][] = array('subversion', 'tcp', '3690', '3690', 'both');
 
 ?>

--- a/usr/local/www/wizards/traffic_shaper_wizard_dedicated.xml
+++ b/usr/local/www/wizards/traffic_shaper_wizard_dedicated.xml
@@ -439,13 +439,59 @@
 				<type>checkbox</type>
 				<typehint>Prioritize network gaming traffic</typehint>
 				<description>This will raise the priority of gaming traffic to higher than most traffic.</description>
-				<enablefields>ARMA2,BattleNET,Battlefield2,Battlefield3,BattlefieldBC2,Borderlands,CallOfDuty,Counterstrike,Crysis2,DeltaForce,Dirt3,DOOM3,EmpireEarth,EveOnline,Everquest,Everquest2,FarCry,FarCry2,FarCry3,GunZOnline,HalfLife,Halo2,LeagueofLegends,Lineage2,MechwarriorOnline,Minecraft,OperationFlashpointDR,PlanetSide,PlanetSide2,PlayStation3,QuakeIII,QuakeIV,Steam,StarWarsTOR,TigerWoods2004PS2,TribesAscend,UnrealTournament,WolfensteinEnemyTerritory,WorldOfWarcraft,XBox360</enablefields>
+				<enablefields>BattleNET,EAOrigin,GameForWindowsLive,PlayStationConsoles,Steam,WiiConsoles,XboxConsoles,ARMA2,ARMA3,Battlefield2,Battlefield3,BattlefieldBC2,Borderlands,CallOfDuty,Counterstrike,Crysis2,Crysis3,DeltaForce,DeadSpace2,DeadSpace3,Dirt3,DOOM3,DragonAge2,EmpireEarth,EveOnline,Everquest,Everquest2,FarCry,FarCry2,FarCry3,GunZOnline,HalfLife,LeagueofLegends,Lineage2,MassEffect3,MechwarriorOnline,Minecraft,OperationFlashpointDR,PlanetSide,PlanetSide2,QuakeIII,QuakeIV,StarWarsTOR,TigerWoods2004PS2,TribesAscend,UnrealTournament,WolfensteinEnemyTerritory,WorldOfWarcraft</enablefields>
 				<donotdisable>true</donotdisable>
 				<bindstofield>ezshaper-&gt;step6-&gt;enable</bindstofield>
 			</field>
 			<field>
 				<name>Next</name>
 				<type>submit</type>
+			</field>
+			<field>
+				<name>Enable/Disable specific game consoles and services</name>
+				<type>listtopic</type>
+			</field>
+			<field>
+				<name>BattleNET</name>
+				<type>checkbox</type>
+				<typehint>Battle.net - Virtually every game from Blizzard publishing should match this.  This includes the following game series: Starcraft, Diablo, Warcraft.  Guild Wars also uses this port.</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;battlenet</bindstofield>
+			</field>
+			<field>
+				<name>EAOrigin</name>
+				<type>checkbox</type>
+				<typehint>EA Origin Client - Some PC games by EA use this.</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;eaorigin</bindstofield>
+			</field>
+				<field>
+				<name>GameForWindowsLive</name>
+				<type>checkbox</type>
+				<typehint>Games for Windows Live</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;gamesforwindowslive</bindstofield>
+			</field>
+			<field>
+				<name>PlayStationConsoles</name>
+				<type>checkbox</type>
+				<typehint>PlayStation Consoles - This should cover all ports required for the Playstation 4, Playstation, PS Vita</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;playstationconsoles</bindstofield>
+			</field>
+			<field>
+				<name>Steam</name>
+				<type>checkbox</type>
+				<typehint>Steam Game Client (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Half-Life 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2 and many other games on the Steam)</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;steam</bindstofield>
+			</field>
+			<field>
+				<name>WiiConsoles</name>
+				<type>checkbox</type>
+				<typehint>Wii Consoles - Wii, Wii U, DS and 3DS</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;wiiconsoles</bindstofield>
+			</field>
+			<field>
+				<name>XboxConsoles</name>
+				<type>checkbox</type>
+				<typehint>Xbox Consoles - Xbox 360 and Xbox One</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;xboxconsoles</bindstofield>
 			</field>
 			<field>
 				<name>Enable/Disable specific games</name>
@@ -458,10 +504,10 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;arma2</bindstofield>
 			</field>
 			<field>
-				<name>BattleNET</name>
+				<name>ARMA3</name>
 				<type>checkbox</type>
-				<typehint>Battle.net - Virtually every game from Blizzard publishing should match this.  This includes the following game series: Starcraft, Diablo, Warcraft.  Guild Wars also uses this port.</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;battlenet</bindstofield>
+				<typehint>ARMA 3</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;arma3</bindstofield>
 			</field>
 			<field>
 				<name>Battlefield2</name>
@@ -472,7 +518,7 @@
 			<field>
 				<name>Battlefield3</name>
 				<type>checkbox</type>
-				<typehint>Battlefield 3 - this game uses a LARGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
+				<typehint>Battlefield 3 and 4 - this game uses a LARGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;battlefield3</bindstofield>
 			</field>
 			<field>
@@ -506,6 +552,24 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;crysis2</bindstofield>
 			</field>
 			<field>
+				<name>Crysis3</name>
+				<type>checkbox</type>
+				<typehint>Crysis 3</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;crysis3</bindstofield>
+			</field>
+			<field>
+				<name>DeadSpace2</name>
+				<type>checkbox</type>
+				<typehint>Dead Space2 - this game uses a HUGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;deadspace2</bindstofield>
+			</field>
+			<field>
+				<name>DeadSpace3</name>
+				<type>checkbox</type>
+				<typehint>Dead Space 3</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;deadspace3</bindstofield>
+			</field>
+			<field>
 				<name>DeltaForce</name>
 				<type>checkbox</type>
 				<typehint>Delta Force</typehint>
@@ -522,6 +586,12 @@
 				<type>checkbox</type>
 				<typehint>DOOM3</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;doom3</bindstofield>
+			</field>
+			<field>
+				<name>DragonAge2</name>
+				<type>checkbox</type>
+				<typehint>Dragon Age 2</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;dragonage2</bindstofield>
 			</field>
 			<field>
 				<name>EmpireEarth</name>
@@ -578,12 +648,6 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;halflife</bindstofield>
 			</field>
 			<field>
-				<name>Halo2</name>
-				<type>checkbox</type>
-				<typehint>Halo2 via Xbox live</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;halo2xbox</bindstofield>
-			</field>
-			<field>
 				<name>LeagueofLegends</name>
 				<type>checkbox</type>
 				<typehint>League of Legends - this game uses a LARGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
@@ -594,6 +658,12 @@
 				<type>checkbox</type>
 				<typehint>Lineage II</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;lineage2</bindstofield>
+			</field>
+			<field>
+				<name>MassEffect3</name>
+				<type>checkbox</type>
+				<typehint>Mass Effect 3</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;masseffect3</bindstofield>
 			</field>
 			<field>
 				<name>MechwarriorOnline</name>
@@ -620,12 +690,6 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;planetside2</bindstofield>
 			</field>
 			<field>
-				<name>PlayStation3</name>
-				<type>checkbox</type>
-				<typehint>PlayStation 3</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;playstation3</bindstofield>
-			</field>
-			<field>
 				<name>OperationFlashpointDR</name>
 				<type>checkbox</type>
 				<typehint>Operation Flashpoint: Dragon Rising</typehint>
@@ -648,12 +712,6 @@
 				<type>checkbox</type>
 				<typehint>StarWars: The Old Republic - this game uses a LARGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;starwarstor</bindstofield>
-			</field>
-			<field>
-				<name>Steam</name>
-				<type>checkbox</type>
-				<typehint>Steam (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Half-Life 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2)</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;steam</bindstofield>
 			</field>
 			<field>
 				<name>TigerWoods2004PS2</name>
@@ -686,12 +744,6 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;wow</bindstofield>
 			</field>
 			<field>
-				<name>Xbox360</name>
-				<type>checkbox</type>
-				<typehint>XBox 360 and Games for Windows Live</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;xbox360</bindstofield>
-			</field>
-      <field>
 				<name>Next</name>
 				<type>submit</type>
 			</field>
@@ -709,7 +761,7 @@
 				<type>checkbox</type>
 				<typehint>Other networking protocols</typehint>
 				<description>This will help raise or lower the priority of other protocols higher than most traffic.</description>
-				<enablefields>AIM,AppleRemoteDesktop,DNS,HTTP,ICMP,ICQ,IMAP,IPSEC,IRC,Jabber,LotusNotes,MSN,MSRDP,MySqlServer,PCAnywhere,POP3,PPTP,RTSP,SMB,SMTP,SNMP,StreamingMP3,TeamSpeak,VNC,NNTP,CVSUP,Slingbox,HBCI</enablefields>
+				<enablefields>AppleRemoteDesktop,MSRDP,PCAnywhere,VNC,AIM,Facetime,GoogleHangouts,ICQ,IRC,Jabber,MSN,TeamSpeak,TeamSpeak3,Ventrilo,PPTP,IPSEC,iTunesRadio,StreamingMP3,RTSP,HTTP,IMAP,LotusNotes,POP3,SMTP,BattleNETDownloader,SteamDownloader,APNS,AppleMobileSync,CrashPlan,CVSUP,DNS,GIT,HBCI,ICMP,MySqlServer,NNTP,Slingbox,SMB,SNMP,Subversion</enablefields>
 				<donotdisable>true</donotdisable>
 				<bindstofield>ezshaper-&gt;step7-&gt;enable</bindstofield>
 			</field>
@@ -720,46 +772,6 @@
 			<field>
 				<name>Remote Service / Terminal emulation</name>
 				<type>listtopic</type>
-			</field>
-			<field>
-				<name>MSRDP</name>
-				<type>select</type>
-				<bindstofield>ezshaper-&gt;step7-&gt;msrdp</bindstofield>
-				<options>
-					<option>
-						<name>Default priority</name>
-						<value>D</value>
-					</option>
-					<option>
-						<name>Higher priority</name>
-						<value>H</value>
-					</option>
-					<option>
-						<name>Lower priority</name>
-						<value>L</value>
-					</option>
-				</options>
-				<typehint>Microsoft Remote Desktop Protocol</typehint>
-			</field>
-			<field>
-				<name>VNC</name>
-				<bindstofield>ezshaper-&gt;step7-&gt;vnc</bindstofield>
-				<type>select</type>
-				<options>
-					<option>
-						<name>Default priority</name>
-						<value>D</value>
-					</option>
-					<option>
-						<name>Higher priority</name>
-						<value>H</value>
-					</option>
-					<option>
-						<name>Lower priority</name>
-						<value>L</value>
-					</option>
-				</options>
-				<typehint>Virtual Network Computing</typehint>
 			</field>
 			<field>
 				<name>AppleRemoteDesktop</name>
@@ -782,6 +794,26 @@
 				<typehint>Apple Remote Desktop</typehint>
 			</field>
 			<field>
+				<name>MSRDP</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;msrdp</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Microsoft Remote Desktop Protocol</typehint>
+			</field>
+			<field>
 				<name>PCAnywhere</name>
 				<bindstofield>ezshaper-&gt;step7-&gt;pcanywhere</bindstofield>
 				<type>select</type>
@@ -802,8 +834,88 @@
 				<typehint>Symantec PC Anywhere</typehint>
 			</field>
 			<field>
+				<name>VNC</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;vnc</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Virtual Network Computing</typehint>
+			</field>
+			<field>
 				<name>Messengers</name>
 				<type>listtopic</type>
+			</field>
+			<field>
+				<name>AIM</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;aolinstantmessenger</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>AOL Instant Messenger</typehint>
+			</field>
+			<field>
+				<name>Facetime</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;facetime</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Facetime</typehint>
+			</field>
+			<field>
+				<name>ICQ</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;icq</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>ICQ</typehint>
 			</field>
 			<field>
 				<name>IRC</name>
@@ -846,8 +958,8 @@
 				<typehint>Jabber instant messanger</typehint>
 			</field>
 			<field>
-				<name>ICQ</name>
-				<bindstofield>ezshaper-&gt;step7-&gt;icq</bindstofield>
+				<name>GoogleHangouts</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;googlehangouts</bindstofield>
 				<type>select</type>
 				<options>
 					<option>
@@ -863,27 +975,7 @@
 						<value>L</value>
 					</option>
 				</options>
-				<typehint>ICQ</typehint>
-			</field>
-			<field>
-				<name>AIM</name>
-				<bindstofield>ezshaper-&gt;step7-&gt;aolinstantmessenger</bindstofield>
-				<type>select</type>
-				<options>
-					<option>
-						<name>Default priority</name>
-						<value>D</value>
-					</option>
-					<option>
-						<name>Higher priority</name>
-						<value>H</value>
-					</option>
-					<option>
-						<name>Lower priority</name>
-						<value>L</value>
-					</option>
-				</options>
-				<typehint>AOL Instant Messenger</typehint>
+				<typehint>Google Hangouts</typehint>
 			</field>
 			<field>
 				<name>MSN</name>
@@ -924,6 +1016,46 @@
 					</option>
 				</options>
 				<typehint>TeamSpeak</typehint>
+			</field>
+			<field>
+				<name>Teamspeak3</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;teamspeak3</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>TeamSpeak 3</typehint>
+			</field>
+			<field>
+				<name>Ventrilo</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;ventrilo</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Ventrilo</typehint>
 			</field>
 			<field>
 				<name>VPN</name>
@@ -972,6 +1104,26 @@
 			<field>
 				<name>Multimedia/Streaming</name>
 				<type>listtopic</type>
+			</field>
+			<field>
+				<name>iTunesRadio</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;itunesradio</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>iTunes Radio - this rule uses a LARGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
 			</field>
 			<field>
 				<name>StreamingMP3</name>
@@ -1122,8 +1274,132 @@
 				<typehint>Lotus Notes</typehint>
 			</field>
 			<field>
+				<name>Game Downloader</name>
+				<type>listtopic</type>
+			</field>
+			<field>
+				<name>BattleNetDownloader</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;battlenetdownloader</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Battle.NET Downloader</typehint>
+			</field>
+			<field>
+				<name>SteamDownloader</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;steamdownloader</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Steam Downloader</typehint>
+			</field>
+			<field>
 				<name>Miscellaneous</name>
 				<type>listtopic</type>
+			</field>
+			<field>
+				<name>APNS</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;apns</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Apple Push Notification Service</typehint>
+			</field>
+			<field>
+				<name>AppleMobileSync</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;applemobilesync</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Apple Mobile Sync</typehint>
+			</field>
+			<field>
+				<name>CrashPlan</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;crashplan</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>CrashPlan</typehint>
+			</field>
+			<field>
+				<name>CVSUP</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;cvsup</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>CVSUP</typehint>
 			</field>
 			<field>
 				<name>DNS</name>
@@ -1144,6 +1420,46 @@
 					</option>
 				</options>
 				<typehint>Domain Name Services</typehint>
+			</field>
+			<field>
+				<name>Git</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;git</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Git Server</typehint>
+			</field>
+			<field>
+				<name>HBCI</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;hbci</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>HBCI</typehint>
 			</field>
 			<field>
 				<name>ICMP</name>
@@ -1246,8 +1562,8 @@
 				<typehint>Internet News</typehint>
 			</field>
 			<field>
-				<name>CVSUP</name>
-				<bindstofield>ezshaper-&gt;step7-&gt;cvsup</bindstofield>
+				<name>Slingbox</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;slingbox</bindstofield>
 				<type>select</type>
 				<options>
 					<option>
@@ -1263,48 +1579,28 @@
 						<value>L</value>
 					</option>
 				</options>
-				<typehint>CVSUP</typehint>
+				<typehint>Slingbox</typehint>
 			</field>
 			<field>
-        <name>Slingbox</name>
-        <bindstofield>ezshaper-&gt;step7-&gt;slingbox</bindstofield>
-        <type>select</type>
-        <options>
-          <option>
-            <name>Default priority</name>
-            <value>D</value>
-          </option>
-          <option>
-            <name>Higher priority</name>
-            <value>H</value>
-          </option>
-          <option>
-            <name>Lower priority</name>
-            <value>L</value>
-          </option>
-          </options>
-       <typehint>Slingbox</typehint>
-      </field>
-			<field>
-        <name>HBCI</name>
-        <bindstofield>ezshaper-&gt;step7-&gt;hbci</bindstofield>
-        <type>select</type>
-        <options>
-          <option>
-            <name>Default priority</name>
-            <value>D</value>
-          </option>
-          <option>
-            <name>Higher priority</name>
-            <value>H</value>
-          </option>
-          <option>
-            <name>Lower priority</name>
-            <value>L</value>
-          </option>
-          </options>
-       <typehint>HBCI</typehint>
-      </field>	
+				<name>Subversion</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;subversion</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Subversion Server</typehint>
+			</field>
 			<field>
 				<name>Next</name>
 				<type>submit</type>

--- a/usr/local/www/wizards/traffic_shaper_wizard_multi_all.xml
+++ b/usr/local/www/wizards/traffic_shaper_wizard_multi_all.xml
@@ -447,13 +447,59 @@
 				<type>checkbox</type>
 				<typehint>Prioritize network gaming traffic</typehint>
 				<description>This will raise the priority of gaming traffic to higher than most traffic.</description>
-				<enablefields>ARMA2,BattleNET,Battlefield2,Battlefield3,BattlefieldBC2,Borderlands,CallOfDuty,Counterstrike,Crysis2,DeltaForce,Dirt3,DOOM3,EmpireEarth,EveOnline,Everquest,Everquest2,FarCry,FarCry2,FarCry3,GunZOnline,HalfLife,Halo2,LeagueofLegends,Lineage2,MechwarriorOnline,Minecraft,OperationFlashpointDR,PlanetSide,PlanetSide2,PlayStation3,QuakeIII,QuakeIV,Steam,StarWarsTOR,TigerWoods2004PS2,TribesAscend,UnrealTournament,WolfensteinEnemyTerritory,WorldOfWarcraft,XBox360</enablefields>
+				<enablefields>BattleNET,EAOrigin,GameForWindowsLive,PlayStationConsoles,Steam,WiiConsoles,XboxConsoles,ARMA2,ARMA3,Battlefield2,Battlefield3,BattlefieldBC2,Borderlands,CallOfDuty,Counterstrike,Crysis2,Crysis3,DeltaForce,DeadSpace2,DeadSpace3,Dirt3,DOOM3,DragonAge2,EmpireEarth,EveOnline,Everquest,Everquest2,FarCry,FarCry2,FarCry3,GunZOnline,HalfLife,LeagueofLegends,Lineage2,MassEffect3,MechwarriorOnline,Minecraft,OperationFlashpointDR,PlanetSide,PlanetSide2,QuakeIII,QuakeIV,StarWarsTOR,TigerWoods2004PS2,TribesAscend,UnrealTournament,WolfensteinEnemyTerritory,WorldOfWarcraft</enablefields>
 				<donotdisable>true</donotdisable>
 				<bindstofield>ezshaper-&gt;step6-&gt;enable</bindstofield>
 			</field>
 			<field>
 				<name>Next</name>
 				<type>submit</type>
+			</field>
+			<field>
+				<name>Enable/Disable specific game consoles and services</name>
+				<type>listtopic</type>
+			</field>
+			<field>
+				<name>BattleNET</name>
+				<type>checkbox</type>
+				<typehint>Battle.net - Virtually every game from Blizzard publishing should match this.  This includes the following game series: Starcraft, Diablo, Warcraft.  Guild Wars also uses this port.</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;battlenet</bindstofield>
+			</field>
+			<field>
+				<name>EAOrigin</name>
+				<type>checkbox</type>
+				<typehint>EA Origin Client - Some PC games by EA use this.</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;eaorigin</bindstofield>
+			</field>
+				<field>
+				<name>GameForWindowsLive</name>
+				<type>checkbox</type>
+				<typehint>Games for Windows Live</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;gamesforwindowslive</bindstofield>
+			</field>
+			<field>
+				<name>PlayStationConsoles</name>
+				<type>checkbox</type>
+				<typehint>PlayStation Consoles - This should cover all ports required for the Playstation 4, Playstation, PS Vita</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;playstationconsoles</bindstofield>
+			</field>
+			<field>
+				<name>Steam</name>
+				<type>checkbox</type>
+				<typehint>Steam Game Client (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Half-Life 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2 and many other games on the Steam)</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;steam</bindstofield>
+			</field>
+			<field>
+				<name>WiiConsoles</name>
+				<type>checkbox</type>
+				<typehint>Wii Consoles - Wii, Wii U, DS and 3DS</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;wiiconsoles</bindstofield>
+			</field>
+			<field>
+				<name>XboxConsoles</name>
+				<type>checkbox</type>
+				<typehint>Xbox Consoles - Xbox 360 and Xbox One</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;xboxconsoles</bindstofield>
 			</field>
 			<field>
 				<name>Enable/Disable specific games</name>
@@ -466,10 +512,10 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;arma2</bindstofield>
 			</field>
 			<field>
-				<name>BattleNET</name>
+				<name>ARMA3</name>
 				<type>checkbox</type>
-				<typehint>Battle.net - Virtually every game from Blizzard publishing should match this.  This includes the following game series: Starcraft, Diablo, Warcraft.  Guild Wars also uses this port.</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;battlenet</bindstofield>
+				<typehint>ARMA 3</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;arma3</bindstofield>
 			</field>
 			<field>
 				<name>Battlefield2</name>
@@ -480,7 +526,7 @@
 			<field>
 				<name>Battlefield3</name>
 				<type>checkbox</type>
-				<typehint>Battlefield 3 - this game uses a LARGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
+				<typehint>Battlefield 3 and 4 - this game uses a LARGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;battlefield3</bindstofield>
 			</field>
 			<field>
@@ -514,6 +560,24 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;crysis2</bindstofield>
 			</field>
 			<field>
+				<name>Crysis3</name>
+				<type>checkbox</type>
+				<typehint>Crysis 3</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;crysis3</bindstofield>
+			</field>
+			<field>
+				<name>DeadSpace2</name>
+				<type>checkbox</type>
+				<typehint>Dead Space2 - this game uses a HUGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;deadspace2</bindstofield>
+			</field>
+			<field>
+				<name>DeadSpace3</name>
+				<type>checkbox</type>
+				<typehint>Dead Space 3</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;deadspace3</bindstofield>
+			</field>
+			<field>
 				<name>DeltaForce</name>
 				<type>checkbox</type>
 				<typehint>Delta Force</typehint>
@@ -530,6 +594,12 @@
 				<type>checkbox</type>
 				<typehint>DOOM3</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;doom3</bindstofield>
+			</field>
+			<field>
+				<name>DragonAge2</name>
+				<type>checkbox</type>
+				<typehint>Dragon Age 2</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;dragonage2</bindstofield>
 			</field>
 			<field>
 				<name>EmpireEarth</name>
@@ -586,12 +656,6 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;halflife</bindstofield>
 			</field>
 			<field>
-				<name>Halo2</name>
-				<type>checkbox</type>
-				<typehint>Halo2 via Xbox live</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;halo2xbox</bindstofield>
-			</field>
-			<field>
 				<name>LeagueofLegends</name>
 				<type>checkbox</type>
 				<typehint>League of Legends - this game uses a LARGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
@@ -602,6 +666,12 @@
 				<type>checkbox</type>
 				<typehint>Lineage II</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;lineage2</bindstofield>
+			</field>
+			<field>
+				<name>MassEffect3</name>
+				<type>checkbox</type>
+				<typehint>Mass Effect 3</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;masseffect3</bindstofield>
 			</field>
 			<field>
 				<name>MechwarriorOnline</name>
@@ -628,12 +698,6 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;planetside2</bindstofield>
 			</field>
 			<field>
-				<name>PlayStation3</name>
-				<type>checkbox</type>
-				<typehint>PlayStation 3</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;playstation3</bindstofield>
-			</field>
-			<field>
 				<name>OperationFlashpointDR</name>
 				<type>checkbox</type>
 				<typehint>Operation Flashpoint: Dragon Rising</typehint>
@@ -656,12 +720,6 @@
 				<type>checkbox</type>
 				<typehint>StarWars: The Old Republic - this game uses a LARGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;starwarstor</bindstofield>
-			</field>
-			<field>
-				<name>Steam</name>
-				<type>checkbox</type>
-				<typehint>Steam (Includes: America's Army 3, Counter-Strike: Source, Counter-Strike: Global Offensive, Half-Life 2, COD: Black Ops Series, Borderlands 2, Natural Selection 2, Left 4 Dead Series, Portal 2)</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;steam</bindstofield>
 			</field>
 			<field>
 				<name>TigerWoods2004PS2</name>
@@ -694,12 +752,6 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;wow</bindstofield>
 			</field>
 			<field>
-				<name>Xbox360</name>
-				<type>checkbox</type>
-				<typehint>XBox 360 and Games for Windows Live</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;xbox360</bindstofield>
-			</field>
-			<field>
 				<name>Next</name>
 				<type>submit</type>
 			</field>
@@ -717,7 +769,7 @@
 				<type>checkbox</type>
 				<typehint>Other networking protocols</typehint>
 				<description>This will help raise or lower the priority of other protocols higher than most traffic.</description>
-				<enablefields>AIM,AppleRemoteDesktop,DNS,HTTP,ICMP,ICQ,IMAP,IPSEC,IRC,Jabber,LotusNotes,MSN,MSRDP,MySqlServer,PCAnywhere,POP3,PPTP,RTSP,SMB,SMTP,SNMP,StreamingMP3,TeamSpeak,VNC,NNTP,CVSUP,Slingbox,HBCI</enablefields>
+				<enablefields>AppleRemoteDesktop,MSRDP,PCAnywhere,VNC,AIM,Facetime,GoogleHangouts,ICQ,IRC,Jabber,MSN,TeamSpeak,TeamSpeak3,Ventrilo,PPTP,IPSEC,iTunesRadio,StreamingMP3,RTSP,HTTP,IMAP,LotusNotes,POP3,SMTP,BattleNETDownloader,SteamDownloader,APNS,AppleMobileSync,CrashPlan,CVSUP,DNS,GIT,HBCI,ICMP,MySqlServer,NNTP,Slingbox,SMB,SNMP,Subversion</enablefields>
 				<donotdisable>true</donotdisable>
 				<bindstofield>ezshaper-&gt;step7-&gt;enable</bindstofield>
 			</field>
@@ -728,46 +780,6 @@
 			<field>
 				<name>Remote Service / Terminal emulation</name>
 				<type>listtopic</type>
-			</field>
-			<field>
-				<name>MSRDP</name>
-				<type>select</type>
-				<bindstofield>ezshaper-&gt;step7-&gt;msrdp</bindstofield>
-				<options>
-					<option>
-						<name>Default priority</name>
-						<value>D</value>
-					</option>
-					<option>
-						<name>Higher priority</name>
-						<value>H</value>
-					</option>
-					<option>
-						<name>Lower priority</name>
-						<value>L</value>
-					</option>
-				</options>
-				<typehint>Microsoft Remote Desktop Protocol</typehint>
-			</field>
-			<field>
-				<name>VNC</name>
-				<bindstofield>ezshaper-&gt;step7-&gt;vnc</bindstofield>
-				<type>select</type>
-				<options>
-					<option>
-						<name>Default priority</name>
-						<value>D</value>
-					</option>
-					<option>
-						<name>Higher priority</name>
-						<value>H</value>
-					</option>
-					<option>
-						<name>Lower priority</name>
-						<value>L</value>
-					</option>
-				</options>
-				<typehint>Virtual Network Computing</typehint>
 			</field>
 			<field>
 				<name>AppleRemoteDesktop</name>
@@ -790,6 +802,26 @@
 				<typehint>Apple Remote Desktop</typehint>
 			</field>
 			<field>
+				<name>MSRDP</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;msrdp</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Microsoft Remote Desktop Protocol</typehint>
+			</field>
+			<field>
 				<name>PCAnywhere</name>
 				<bindstofield>ezshaper-&gt;step7-&gt;pcanywhere</bindstofield>
 				<type>select</type>
@@ -810,8 +842,88 @@
 				<typehint>Symantec PC Anywhere</typehint>
 			</field>
 			<field>
+				<name>VNC</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;vnc</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Virtual Network Computing</typehint>
+			</field>
+			<field>
 				<name>Messengers</name>
 				<type>listtopic</type>
+			</field>
+			<field>
+				<name>AIM</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;aolinstantmessenger</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>AOL Instant Messenger</typehint>
+			</field>
+			<field>
+				<name>Facetime</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;facetime</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Facetime</typehint>
+			</field>
+			<field>
+				<name>ICQ</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;icq</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>ICQ</typehint>
 			</field>
 			<field>
 				<name>IRC</name>
@@ -854,8 +966,8 @@
 				<typehint>Jabber instant messanger</typehint>
 			</field>
 			<field>
-				<name>ICQ</name>
-				<bindstofield>ezshaper-&gt;step7-&gt;icq</bindstofield>
+				<name>GoogleHangouts</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;googlehangouts</bindstofield>
 				<type>select</type>
 				<options>
 					<option>
@@ -871,27 +983,7 @@
 						<value>L</value>
 					</option>
 				</options>
-				<typehint>ICQ</typehint>
-			</field>
-			<field>
-				<name>AIM</name>
-				<bindstofield>ezshaper-&gt;step7-&gt;aolinstantmessenger</bindstofield>
-				<type>select</type>
-				<options>
-					<option>
-						<name>Default priority</name>
-						<value>D</value>
-					</option>
-					<option>
-						<name>Higher priority</name>
-						<value>H</value>
-					</option>
-					<option>
-						<name>Lower priority</name>
-						<value>L</value>
-					</option>
-				</options>
-				<typehint>AOL Instant Messenger</typehint>
+				<typehint>Google Hangouts</typehint>
 			</field>
 			<field>
 				<name>MSN</name>
@@ -932,6 +1024,46 @@
 					</option>
 				</options>
 				<typehint>TeamSpeak</typehint>
+			</field>
+			<field>
+				<name>Teamspeak3</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;teamspeak3</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>TeamSpeak 3</typehint>
+			</field>
+			<field>
+				<name>Ventrilo</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;ventrilo</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Ventrilo</typehint>
 			</field>
 			<field>
 				<name>VPN</name>
@@ -980,6 +1112,26 @@
 			<field>
 				<name>Multimedia/Streaming</name>
 				<type>listtopic</type>
+			</field>
+			<field>
+				<name>iTunesRadio</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;itunesradio</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>iTunes Radio - this rule uses a LARGE port range, be aware that you may need to manually rearrange the resulting rules to correctly prioritize other traffic.</typehint>
 			</field>
 			<field>
 				<name>StreamingMP3</name>
@@ -1130,8 +1282,132 @@
 				<typehint>Lotus Notes</typehint>
 			</field>
 			<field>
+				<name>Game Downloader</name>
+				<type>listtopic</type>
+			</field>
+			<field>
+				<name>BattleNetDownloader</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;battlenetdownloader</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Battle.NET Downloader</typehint>
+			</field>
+			<field>
+				<name>SteamDownloader</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;steamdownloader</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Steam Downloader</typehint>
+			</field>
+			<field>
 				<name>Miscellaneous</name>
 				<type>listtopic</type>
+			</field>
+			<field>
+				<name>APNS</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;apns</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Apple Push Notification Service</typehint>
+			</field>
+			<field>
+				<name>AppleMobileSync</name>
+				<type>select</type>
+				<bindstofield>ezshaper-&gt;step7-&gt;applemobilesync</bindstofield>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Apple Mobile Sync</typehint>
+			</field>
+			<field>
+				<name>CrashPlan</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;crashplan</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>CrashPlan</typehint>
+			</field>
+			<field>
+				<name>CVSUP</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;cvsup</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>CVSUP</typehint>
 			</field>
 			<field>
 				<name>DNS</name>
@@ -1152,6 +1428,46 @@
 					</option>
 				</options>
 				<typehint>Domain Name Services</typehint>
+			</field>
+			<field>
+				<name>Git</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;git</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>Git Server</typehint>
+			</field>
+			<field>
+				<name>HBCI</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;hbci</bindstofield>
+				<type>select</type>
+				<options>
+					<option>
+						<name>Default priority</name>
+						<value>D</value>
+					</option>
+					<option>
+						<name>Higher priority</name>
+						<value>H</value>
+					</option>
+					<option>
+						<name>Lower priority</name>
+						<value>L</value>
+					</option>
+				</options>
+				<typehint>HBCI</typehint>
 			</field>
 			<field>
 				<name>ICMP</name>
@@ -1254,8 +1570,8 @@
 				<typehint>Internet News</typehint>
 			</field>
 			<field>
-				<name>CVSUP</name>
-				<bindstofield>ezshaper-&gt;step7-&gt;cvsup</bindstofield>
+				<name>Slingbox</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;slingbox</bindstofield>
 				<type>select</type>
 				<options>
 					<option>
@@ -1271,31 +1587,11 @@
 						<value>L</value>
 					</option>
 				</options>
-				<typehint>CVSUP</typehint>
+				<typehint>Slingbox</typehint>
 			</field>
 			<field>
-        <name>Slingbox</name>
-        <bindstofield>ezshaper-&gt;step7-&gt;slingbox</bindstofield>
-        <type>select</type>
-        <options>
-          <option>
-            <name>Default priority</name>
-            <value>D</value>
-          </option>
-          <option>
-            <name>Higher priority</name>
-            <value>H</value>
-          </option>
-          <option>
-            <name>Lower priority</name>
-            <value>L</value>
-          </option>
-          </options>
-       <typehint>Slingbox</typehint>
-      </field>
-			<field>
-				<name>HBCI</name>
-				<bindstofield>ezshaper-&gt;step7-&gt;hbci</bindstofield>
+				<name>Subversion</name>
+				<bindstofield>ezshaper-&gt;step7-&gt;subversion</bindstofield>
 				<type>select</type>
 				<options>
 					<option>
@@ -1311,7 +1607,7 @@
 						<value>L</value>
 					</option>
 				</options>
-				<typehint>HBCI</typehint>
+				<typehint>Subversion Server</typehint>
 			</field>
 			<field>
 				<name>Next</name>


### PR DESCRIPTION
Add following shaping rules:
ARMA 3
WII
EA Origin
Games For Windows Live
Crysis 3
DeadSpace 2
DeadSpace 3
DragonAge2
MassEffect3
Facetime
Google Hangouts
TeamSpeak 3
Ventrilo
iTunes Rado
IMAP/S
POP3/S
SMTP/S
Apple Mobile Sync
Apple Push Network Service
Crashplan
Git
Subversion
BattleNet Downloader
Steam Downloader

Changed:
Playstation
Xbox to include XBOX one
Battlefield 3 to include 4
OperationFlashpoint rename
Quake 3 rename
Quake 4 rename
Tribes Ascend rename

Removed:
Halo2 because its covered under XBOX

Add Game console and Client section with Wii, PlayStation, XBOX,
BattleNet, EA Origin and Steam.  Reordered file contents by section and
alphabetically for user friendliness.  Added Game Downloader section in
step 7 which includes ports for Battle.NET and Steam.
