### PR TITLE
Standardise size of Duplicate Slice button

### DIFF
--- a/usr/local/www/diag_nanobsd.php
+++ b/usr/local/www/diag_nanobsd.php
@@ -217,10 +217,9 @@ if ($savemsg)
 								</select>
 								<br/>
 								<?=gettext("This will duplicate the bootup slice to the alternate slice.  Use this if you would like to duplicate the known good working boot partition to the alternate.");?>
+								<br/><input type='submit' name='duplicateslice' value='<?php echo gettext("Duplicate slice") ?>'>
+							</form>
 						</td>
-					</tr>
-					<tr>
-						<td valign="top" class="">&nbsp;</td><td><br/><input type='submit' value='Duplicate slice'></form></td>
 					</tr>
 					<tr>
 						<td colspan="2" valign="top" class="">&nbsp;</td>


### PR DESCRIPTION
The Duplicate Slice button currently is displayed in smaller text and in a row of its own, separate from the row above that has the rest of the "Duplicate bootup slice" text and slice selection.
This change puts the button in the same row as the slice selection and text, and makes the button text be the same size as the text in other buttons on this page.
Did this first on a 2.1.5 system, so have submitted this against 2.1 branch. I will make another pull request against master also, because a later xhtml compliance change in master will conflict.
