### PR TITLE
Tidy up "pkg_mgr_install.php/system_firmware_auto.php" XHTML

### DIFF
--- a/usr/local/www/pkg_mgr_install.php
+++ b/usr/local/www/pkg_mgr_install.php
@@ -167,6 +167,7 @@ if ($_POST) {
 						<br />
 						<!-- status box -->
 						<textarea cols="80" rows="1" name="status" id="status" wrap="hard"><?=gettext("Beginning package installation.");?></textarea>
+						<br />
 						<!-- command output box -->
 						<textarea cols="80" rows="35" name="output" id="output" wrap="hard"></textarea>
 					</td>

--- a/usr/local/www/system_firmware_auto.php
+++ b/usr/local/www/system_firmware_auto.php
@@ -119,6 +119,7 @@ include("head.inc");
 									</script>
 									<!-- status box -->
 									<textarea cols="90" rows="1" name="status" id="status"><?=gettext("Beginning firmware upgrade"); ?>.</textarea>
+									<br />
 									<!-- command output box -->
 									<textarea cols="90" rows="25" name="output" id="output"></textarea>
 								</td>


### PR DESCRIPTION
While using the widescreen theme, when you update the firmware or add a
new package the TEXTAREAs are side-by-side which doesn't look neat.
Add BR tag between TEXTAREA
