### PR TITLE
Correct evaluation for "Acct-Interim-Interval" from RADIUS

### DIFF
--- a/etc/inc/radius.inc
+++ b/etc/inc/radius.inc
@@ -686,7 +686,7 @@ class Auth_RADIUS extends PEAR {
                 break;
 
             case 85: /* Acct-Interim-Interval: RFC 2869 */
-                $this->attributes['interim_interval'] = radius_cvt_int($datav[1]);
+                $this->attributes['interim_interval'] = radius_cvt_int($data);
                 break;
             }
         }


### PR DESCRIPTION
BUG: Setting "Acct-Interim-Interval :=600" in FreeRadius2 evaluates to 'random' number with PfSense 2.1.
Possibly a bug related to:
https://forum.pfsense.org/index.php?topic=60079.0
https://forum.pfsense.org/index.php?topic=60262.0

Solution: correted data variable used for evaluation.
