### PR TITLE
NTP server configuration does not highlight selected interfaces

### DIFF
--- a/usr/local/www/services_ntpd.php
+++ b/usr/local/www/services_ntpd.php
@@ -172,6 +172,10 @@ if ($_POST) {
 }
 $closehead = false;
 $pconfig = &$config['ntpd'];
+if (empty($pconfig['interface']))
+	$pconfig['interface'] = array();
+else
+	$pconfig['interface'] = explode(",", $pconfig['interface']);
 $pgtitle = array(gettext("Services"),gettext("NTP"));
 $shortcut_section = "ntp";
 include("head.inc");


### PR DESCRIPTION
Missing explode of selected interface list prevents logic from working.
