### PR TITLE
NTP Service GPS page always reverts to 'Custom' GPS type

### DIFF
--- a/usr/local/www/services_ntpd_gps.php
+++ b/usr/local/www/services_ntpd_gps.php
@@ -70,7 +70,7 @@ if ($_POST) {
 	else unset($config['ntpd']['gps']);
 
 	if (!empty($_POST['gpstype']))
-		$config['ntpd']['gps']['type'] = 'Custom';
+		$config['ntpd']['gps']['type'] = $_POST['gpstype'];
 	elseif (isset($config['ntpd']['gps']['type']))
 		unset($config['ntpd']['gps']['type']);
 


### PR DESCRIPTION
Remember and correctly display GPS type setting
