### PR TITLE
outgoing interface ip address incorrectly set in unbound.conf

### DIFF
--- a/etc/inc/unbound.inc
+++ b/etc/inc/unbound.inc
@@ -146,7 +146,7 @@ EOF;
         foreach($outgoing_interfaces as $outif) {
             $outip = get_interface_ip($outif);
             if (!is_null($outip))
-                $outgoingints .= "outgoing-interface: $intip\n";
+                $outgoingints .= "outgoing-interface: $outip\n";
         }
     }
 


### PR DESCRIPTION
DNS resolver outgoing interface IP address is incorrectly set to the
last inbound interface IP address... fix it.
