### PR TITLE
Remove useless check for alias description matching an interface descrip...

### DIFF
--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -107,12 +107,6 @@ if (isset($id) && $a_aliases[$id]) {
 	$pconfig['type'] = $a_aliases[$id]['type'];
 	$pconfig['descr'] = html_entity_decode($a_aliases[$id]['descr']);
 
-	/* interface list */
-	$iflist = get_configured_interface_with_descr(false, true);
-	foreach ($iflist as $if => $ifdesc)
-		if($ifdesc == $pconfig['descr'])
-			$input_errors[] = sprintf(gettext("Sorry, an interface is already named %s."), $pconfig['descr']);
-
 	if(preg_match("/urltable/i", $a_aliases[$id]['type'])) {
 		$pconfig['address'] = $a_aliases[$id]['url'];
 		$pconfig['updatefreq'] = $a_aliases[$id]['updatefreq'];


### PR DESCRIPTION
...tion

While looking at other checks in the code I noticed this check. It was not effective anyway, because the first line inside "if ($_POST)" below does
unset($input_errors);
which undoes this check anyway.

In any case the check is not relevant. For example I might have interface WAN with description (which is really the alternate/display name for an interface) as MYISP.

I cannot also have an Alias with name MYISP - that is checked for already later in the code.
But I can have an Alias with description MYISP - in the case of an Alias the description really is just helpful text for the user, it is the name that really counts for use in the pf configuration.
So the code is not needed.
