### PR TITLE
firewall_aliases_edit UI text changes

### DIFF
--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -7,7 +7,7 @@
 	Copyright (C) 2010 Jim Pingle
 	All rights reserved.
 
-	originially part of m0n0wall (http://m0n0.ch/wall)
+	originally part of m0n0wall (http://m0n0.ch/wall)
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 
@@ -476,12 +476,12 @@ function add_alias_control() {
 }
 EOD;
 
-$network_str = gettext("Network");
+$network_str = gettext("Network or FQDN");
 $networks_str = gettext("Network(s)");
 $cidr_str = gettext("CIDR");
 $description_str = gettext("Description");
 $hosts_str = gettext("Host(s)");
-$ip_str = gettext("IP");
+$ip_str = gettext("IP or FQDN");
 $ports_str = gettext("Port(s)");
 $port_str = gettext("Port");
 $url_str = gettext("URL (IPs)");
@@ -513,6 +513,7 @@ function update_box_type() {
 		document.getElementById ("onecolumn").firstChild.data = "{$network_str}";
 		document.getElementById ("twocolumn").firstChild.data = "{$cidr_str}";
 		document.getElementById ("threecolumn").firstChild.data = "{$description_str}";
+		document.getElementById ("threecolumn").style.display = 'block';
 		document.getElementById ("itemhelp").firstChild.data = "{$networks_help}";
 		document.getElementById ("addrowbutton").style.display = 'block';
 	} else if(selected == '{$hosts_str}') {
@@ -520,6 +521,7 @@ function update_box_type() {
 		document.getElementById ("onecolumn").firstChild.data = "{$ip_str}";
 		document.getElementById ("twocolumn").firstChild.data = "";
 		document.getElementById ("threecolumn").firstChild.data = "{$description_str}";
+		document.getElementById ("threecolumn").style.display = 'block';
 		document.getElementById ("itemhelp").firstChild.data = "{$hosts_help}";
 		document.getElementById ("addrowbutton").style.display = 'block';
 	} else if(selected == '{$ports_str}') {
@@ -527,6 +529,7 @@ function update_box_type() {
 		document.getElementById ("onecolumn").firstChild.data = "{$port_str}";
 		document.getElementById ("twocolumn").firstChild.data = "";
 		document.getElementById ("threecolumn").firstChild.data = "{$description_str}";
+		document.getElementById ("threecolumn").style.display = 'block';
 		document.getElementById ("itemhelp").firstChild.data = "{$ports_help}";
 		document.getElementById ("addrowbutton").style.display = 'block';
 	} else if(selected == '{$url_str}') {
@@ -534,6 +537,7 @@ function update_box_type() {
 		document.getElementById ("onecolumn").firstChild.data = "{$url_str}";
 		document.getElementById ("twocolumn").firstChild.data = "";
 		document.getElementById ("threecolumn").firstChild.data = "{$description_str}";
+		document.getElementById ("threecolumn").style.display = 'block';
 		document.getElementById ("itemhelp").firstChild.data = "{$url_help}";
 		document.getElementById ("addrowbutton").style.display = 'block';
 	} else if(selected == '{$url_ports_str}') {
@@ -541,6 +545,7 @@ function update_box_type() {
 		document.getElementById ("onecolumn").firstChild.data = "{$url_ports_str}";
 		document.getElementById ("twocolumn").firstChild.data = "";
 		document.getElementById ("threecolumn").firstChild.data = "{$description_str}";
+		document.getElementById ("threecolumn").style.display = 'block';
 		document.getElementById ("itemhelp").firstChild.data = "{$url_ports_help}";
 		document.getElementById ("addrowbutton").style.display = 'block';
 	} else if(selected == '{$openvpn_user_str}') {
@@ -548,6 +553,7 @@ function update_box_type() {
 		document.getElementById ("onecolumn").firstChild.data = "{$openvpn_str}";
 		document.getElementById ("twocolumn").firstChild.data = "{$openvpn_freq}";
 		document.getElementById ("threecolumn").firstChild.data = "{$description_str}";
+		document.getElementById ("threecolumn").style.display = 'block';
 		document.getElementById ("itemhelp").firstChild.data = "{$openvpn_help}";
 		document.getElementById ("addrowbutton").style.display = 'block';
 	} else if(selected == '{$urltable_str}') {


### PR DESCRIPTION
If type URL Table is selected then the heading "Description" on the 3rd column gets suppressed (I am not really sure why that is, since the description data entry box still appears - I guess someone intended that the data entry box itself also be suppressed, since URL Table takes just a single line entry, the overall description of the alias should be enough - no need for a per-line description. I am not messing with that.)
In any case, if the user then selects some other Alias Type, the "Description" heading on the 3rd column is not re-enabled.
This change fixes that.
I also implemented what is suggested in Redmine #3893 - making the 1st column heading say "IP or FQDN", "Network or FQDN". IMHO that looks fine on the UI and cannot do any harm. (and yes, the longer explanatory text  already tells the user that an FQDN is allowed in these cases.)
