### PR TITLE
Reset states that are using the wan-ip, when it changes.

### DIFF
--- a/etc/rc.newwanip
+++ b/etc/rc.newwanip
@@ -222,4 +222,10 @@ if (!is_ipaddr($oldip) || $curwanip != $oldip || !is_ipaddrv4($config['interface
 /* signal filter reload */
 filter_configure();
 
+if (is_ipaddr($oldip) && $curwanip != $oldip) {
+	/*  Reset states that are using the wan-ip, for example outbound natted
+		udp traffic would otherwise stay natted using the old wan-ip */
+	mwexec_bg("/sbin/pfctl -k $oldip");
+}
+
 ?>


### PR DESCRIPTION
Reset states that are using the wan-ip, for example outbound natted udp traffic would otherwise stay natted using the old wan-ip
