### PR TITLE
Add powerd normal mode flag (-n)

### DIFF
--- a/conf.default/config.xml
+++ b/conf.default/config.xml
@@ -200,6 +200,7 @@
 		<ipv6allow/>
 		<powerd_ac_mode>hadp</powerd_ac_mode>
 		<powerd_battery_mode>hadp</powerd_battery_mode>
+		<powerd_normal_mode>hadp</powerd_normal_mode>
 		<bogons>
 			<interval>monthly</interval>
 		</bogons>

--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -57,7 +57,11 @@ function activate_powerd() {
 		if (!empty($config['system']['powerd_battery_mode']))
 			$battery_mode = $config['system']['powerd_battery_mode'];
 
-		mwexec("/usr/sbin/powerd -b $battery_mode -a $ac_mode");
+		$normal_mode = "hadp";
+		if (!empty($config['system']['powerd_normal_mode']))
+			$normal_mode = $config['system']['powerd_normal_mode'];
+
+		mwexec("/usr/sbin/powerd -b $battery_mode -a $ac_mode -n $normal_mode");
 	}
 }
 

--- a/usr/local/www/system_advanced_misc.php
+++ b/usr/local/www/system_advanced_misc.php
@@ -78,6 +78,10 @@ $pconfig['powerd_battery_mode'] = "hadp";
 if (!empty($config['system']['powerd_battery_mode']))
 	$pconfig['powerd_battery_mode'] = $config['system']['powerd_battery_mode'];
 
+$pconfig['powerd_normal_mode'] = "hadp";
+if (!empty($config['system']['powerd_normal_mode']))
+	$pconfig['powerd_normal_mode'] = $config['system']['powerd_normal_mode'];
+
 $crypto_modules = array('glxsb' => gettext("AMD Geode LX Security Block"),
 			'aesni' => gettext("AES-NI CPU-based Acceleration"));
 
@@ -163,6 +167,7 @@ if ($_POST) {
 
 		$config['system']['powerd_ac_mode'] = $_POST['powerd_ac_mode'];
 		$config['system']['powerd_battery_mode'] = $_POST['powerd_battery_mode'];
+		$config['system']['powerd_normal_mode'] = $_POST['powerd_normal_mode'];
 
 		if($_POST['crypto_hardware'])
 			$config['system']['crypto_hardware'] = $_POST['crypto_hardware'];
@@ -395,6 +400,14 @@ function tmpvar_checked(obj) {
 										<option value="adp"<?php if($pconfig['powerd_battery_mode']=="adp") echo " selected=\"selected\""; ?>><?=gettext("Adaptive");?></option>
 										<option value="min"<?php if($pconfig['powerd_battery_mode']=="min") echo " selected=\"selected\""; ?>><?=gettext("Minimum");?></option>
 										<option value="max"<?php if($pconfig['powerd_battery_mode']=="max") echo " selected=\"selected\""; ?>><?=gettext("Maximum");?></option>
+									</select>
+									<br />
+									<?=gettext("On Unknown Power Mode"); ?>&nbsp;:&nbsp;
+									<select name="powerd_normal_mode" id="powerd_normal_mode">
+										<option value="hadp"<?php if($pconfig['powerd_normal_mode']=="hadp") echo " selected=\"selected\""; ?>><?=gettext("Hiadaptive");?></option>
+										<option value="adp"<?php if($pconfig['powerd_normal_mode']=="adp") echo " selected=\"selected\""; ?>><?=gettext("Adaptive");?></option>
+										<option value="min"<?php if($pconfig['powerd_normal_mode']=="min") echo " selected=\"selected\""; ?>><?=gettext("Minimum");?></option>
+										<option value="max"<?php if($pconfig['powerd_normal_mode']=="max") echo " selected=\"selected\""; ?>><?=gettext("Maximum");?></option>
 									</select>
 									<br /><br />
 									<?=gettext("The powerd utility monitors the system state and sets various power control " .


### PR DESCRIPTION
When the AC line state is unknown powerd looks to the -n flag. Added the ability to set this flag.
![screen shot 2014-10-05 at 6 49 11 pm](https://cloud.githubusercontent.com/assets/8129878/4520220/e0ca17ce-4ce1-11e4-86bf-ce058fe41cf9.png)
