### PR TITLE
Fix not rules for OPTn network case

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -2091,13 +2091,13 @@ function filter_generate_port(& $rule, $target = "source", $isnat = false) {
 function filter_address_add_vips_subnets(&$subnets, $if, $not) {
 	global $FilterIflist;
 
-	if (!isset($FilterIflist[$if]['vips']) || !is_array($FilterIflist[$if]['vips']))
-		return;
-
 	$if_subnets = array($subnets);
 
 	if ($not == true)
 		$subnets = "!{$subnets}";
+
+	if (!isset($FilterIflist[$if]['vips']) || !is_array($FilterIflist[$if]['vips']))
+		return;
 
 	foreach ($FilterIflist[$if]['vips'] as $vip) {
 		foreach ($if_subnets as $subnet)
@@ -2141,8 +2141,7 @@ function filter_generate_address(& $rule, $target = "source", $isnat = false) {
 					$opt_ip = $FilterIflist["opt{$optmatch[1]}"]['ipv6'];
 					if(!is_ipaddrv6($opt_ip))
 						return "";
-					$src = $opt_ip . "/" .
-					$FilterIflist["opt{$optmatch[1]}"]['snv6'];
+					$src = $opt_ip . "/" . $FilterIflist["opt{$optmatch[1]}"]['snv6'];
 				/* check for opt$NUMip here */
 				} else if(preg_match("/opt([0-9]*)ip/", $rule[$target]['network'], $matches)) {
 					$src = $FilterIflist["opt{$matches[1]}"]['ipv6'];
@@ -2156,8 +2155,7 @@ function filter_generate_address(& $rule, $target = "source", $isnat = false) {
 					$opt_ip = $FilterIflist["opt{$optmatch[1]}"]['ip'];
 					if(!is_ipaddrv4($opt_ip))
 						return "";
-					$src = $opt_ip . "/" .
-					$FilterIflist["opt{$optmatch[1]}"]['sn'];
+					$src = $opt_ip . "/" . $FilterIflist["opt{$optmatch[1]}"]['sn'];
 				/* check for opt$NUMip here */
 				} else if(preg_match("/opt([0-9]*)ip/", $rule[$target]['network'], $matches)) {
 					$src = $FilterIflist["opt{$matches[1]}"]['ip'];
@@ -2262,10 +2260,9 @@ function filter_generate_address(& $rule, $target = "source", $isnat = false) {
 				    (strpos($src, '{') === false))
 					$src = " !{$src}";
 			}
-			if (is_subnet($src))
-				filter_address_add_vips_subnets($src, $rule[$target]['network'],
-					isset($rule[$target]['not']));
 		}
+		if (is_subnet($src))
+			filter_address_add_vips_subnets($src, $rule[$target]['network'], isset($rule[$target]['not']));
 	} else if($rule[$target]['address']) {
 		$expsrc = alias_expand($rule[$target]['address']);
 		if(isset($rule[$target]['not']))


### PR DESCRIPTION
Reported in forum https://forum.pfsense.org/index.php?topic=82319.0
The "if (is_subnet($src)) ... filter_address_add_vips_subnets" code needs to go outside all of the if that checks for opt interfaces (not just in the else part). That makes filter_address_add_vips_subnets get called in all cases, including when optn network is specified. (line 2264, 2265)
Then filter_address_add_vips_subnets needs to process the "not" code early, before checking if there are any VIPs (which was causing the routine to exit early in simple cases) - lines 2093-2100 chunk. This should also fix cases of using "LANnet", "WANnet" and "not" in rules on an interface that has just a plain address (no VIPs).
Lines 2144 and 2158 are no functional change. The formatting of the multi-line statement was odd, so I put it back all on 1 line.
