### PR TITLE
Convert XML parser die to an Exception and catch it

### DIFF
--- a/etc/inc/xmlparse.inc
+++ b/etc/inc/xmlparse.inc
@@ -90,7 +90,7 @@ function startElement($parser, $name, $attrs) {
 
 	} else if (isset($ptr)) {
 		/* multiple entries not allowed for this element, bail out */
-		die(sprintf(gettext('XML error: %1$s at line %2$d cannot occur more than once') . "\n",
+		throw new Exception(sprintf(gettext('XML error: %1$s at line %2$d cannot occur more than once') . "\n",
 				$name,
 				xml_get_current_line_number($parser)));
 	}
@@ -186,7 +186,13 @@ function parse_xml_config_raw($cffile, $rootobj, $isstring = "false") {
 	}
 
 	while ($data = fread($fp, 4096)) {
-		if (!xml_parse($xml_parser, $data, feof($fp))) {
+		try {
+			$ok = xml_parse($xml_parser, $data, feof($fp));
+		} catch (Exception $e) {
+			log_error($e->getMessage());
+			return -1;
+		}
+		if (!$ok) {
 			log_error(sprintf(gettext('XML error: %1$s at line %2$d in %3$s') . "\n",
 						xml_error_string(xml_get_error_code($xml_parser)),
 						xml_get_current_line_number($xml_parser),

--- a/etc/inc/xmlparse_attr.inc
+++ b/etc/inc/xmlparse_attr.inc
@@ -75,7 +75,7 @@ function startElement_attr($parser, $name, $attrs) {
 
 	} else if (isset($ptr)) {
 		/* multiple entries not allowed for this element, bail out */
-		die(sprintf(gettext('XML error: %1$s at line %2$d cannot occur more than once') . "\n",
+		throw new Exception(sprintf(gettext('XML error: %1$s at line %2$d cannot occur more than once') . "\n",
 				$name,
 				xml_get_current_line_number($parser)));
 	} else if (isset($writeattrs)) {
@@ -193,7 +193,13 @@ function parse_xml_config_raw_attr($cffile, $rootobj, &$parsed_attributes, $isst
 	}
 
 	while ($data = fread($fp, 4096)) {
-		if (!xml_parse($xml_parser, $data, feof($fp))) {
+		try {
+			$ok = xml_parse($xml_parser, $data, feof($fp));
+		} catch (Exception $e) {
+			log_error($e->getMessage());
+			return -1;
+		}
+		if (!$ok) {
 			log_error(sprintf(gettext('XML error: %1$s at line %2$d') . "\n",
 						xml_error_string(xml_get_error_code($xml_parser)),
 						xml_get_current_line_number($xml_parser)));


### PR DESCRIPTION
Other XML issues seem to be handled, logged and return -1 except the case when there are duplicate entries in a config which causes the script to die.
