### PR TITLE
Ticket #3860 Correctly display SMTP SSL TLS boxes

### DIFF
--- a/usr/local/www/system_advanced_notifications.php
+++ b/usr/local/www/system_advanced_notifications.php
@@ -84,6 +84,8 @@ if ($_POST) {
 
 	unset($input_errors);
 	$pconfig = $_POST;
+	$pconfig['smtpssl'] = isset($_POST['smtpssl']) ? 'checked' : 'unchecked';
+	$pconfig['smtptls'] = isset($_POST['smtptls']) ? (isset($_POST['smtpssl']) ? 'unchecked' : 'checked') : 'unchecked';
 
 	/* if this is an AJAX caller then handle via JSON */
 	if (isAjax() && is_array($input_errors)) {
@@ -114,8 +116,8 @@ if ($_POST) {
 		// SMTP
 		$config['notifications']['smtp']['ipaddress'] = $_POST['smtpipaddress'];
 		$config['notifications']['smtp']['port'] = $_POST['smtpport'];
-		$config['notifications']['smtp']['ssl'] = isset($_POST['smtpssl']) ? 'checked' : 'unchecked';
-		$config['notifications']['smtp']['tls'] = isset($_POST['smtptls']) ? (isset($_POST['smtpssl']) ? 'unchecked' : 'checked') : 'unchecked';
+		$config['notifications']['smtp']['ssl'] = $pconfig['smtpssl'];
+		$config['notifications']['smtp']['tls'] = $pconfig['smtptls'];
 		$config['notifications']['smtp']['notifyemailaddress'] = $_POST['smtpnotifyemailaddress'];
 		$config['notifications']['smtp']['username'] = $_POST['smtpusername'];
 		$config['notifications']['smtp']['password'] = $_POST['smtppassword'];


### PR DESCRIPTION
After using the "Test" button, $_POST['smtpssl'] and $_POST['smtptls'] was 'on' or null - this got blindly copied back into $pconfig[] and resulted in the state of the SSL/TLS/STARTTLS checkboxes not being redisplayed.
Fixed by setting $pconfig['smtpssl'] and $pconfig['smtptls'] using the code that was previously done only to set these in $config
This pull request fixes it in 2.1 branch.
I will make another pull request for master 2.2
