### PR TITLE
Fix #3935 Properly allow WAN without LAN

### DIFF
--- a/etc/inc/config.console.inc
+++ b/etc/inc/config.console.inc
@@ -224,8 +224,8 @@ EOD;
 			}
 			
 			if($lanif == "") {
-				fclose($fp);
-				return;
+				/* It is OK to have just a WAN, without a LAN so break if the user does not want LAN. */
+				break;
 			}
 	
 			if ($lanif === "a")


### PR DESCRIPTION
Was broken by https://github.com/pfsense/pfsense/commit/bd0b5d2dc7a279d3473a65a11d67efb5e39392be
