### PR TITLE
Manage dhcpleaseinlocaltime consistently

### DIFF
--- a/usr/local/www/services_dhcp.php
+++ b/usr/local/www/services_dhcp.php
@@ -161,7 +161,17 @@ if (is_array($dhcpdconf)) {
 		// No reason to specify this per-pool, per the dhcpd.conf man page it needs to be in every
 		//   pool and should be specified in every pool both nodes share, so we'll treat it as global
 		$pconfig['failover_peerip'] = $dhcpdconf['failover_peerip'];
-		$pconfig['dhcpleaseinlocaltime'] = $dhcpdconf['dhcpleaseinlocaltime'];
+
+		// dhcpleaseinlocaltime is global to all interfaces. So if it is selected on any interface,
+		// then show it true/checked.
+		foreach ($config['dhcpd'] as $dhcpdifitem) {
+			$dhcpleaseinlocaltime = $dhcpdifitem['dhcpleaseinlocaltime'];
+			if ($dhcpleaseinlocaltime)
+				break;
+		}
+
+		$pconfig['dhcpleaseinlocaltime'] = $dhcpleaseinlocaltime;
+
 		if (!is_array($dhcpdconf['staticmap']))
 			$dhcpdconf['staticmap'] = array();
 		$a_maps = &$dhcpdconf['staticmap'];
@@ -232,7 +242,7 @@ if (isset($_POST['submit'])) {
 			$numberoptions['item'][] = $numbervalue;
 		}
 	}
-	// Reload the new pconfig variable that the forum uses.
+	// Reload the new pconfig variable that the form uses.
 	$pconfig['numberoptions'] = $numberoptions;
 
 	/* input validation */
@@ -451,7 +461,10 @@ if (isset($_POST['submit'])) {
 			if($previous <> $_POST['failover_peerip'])
 				mwexec("/bin/rm -rf /var/dhcpd/var/db/*");
 			$dhcpdconf['failover_peerip'] = $_POST['failover_peerip'];
-			$dhcpdconf['dhcpleaseinlocaltime'] = $_POST['dhcpleaseinlocaltime'];
+			// dhcpleaseinlocaltime is global to all interfaces. So update the setting on all interfaces.
+			foreach ($config['dhcpd'] as &$dhcpdifitem) {
+				$dhcpdifitem['dhcpleaseinlocaltime'] = $_POST['dhcpleaseinlocaltime'];
+			}
 		} else {
 			// Options that exist only in pools
 			$dhcpdconf['descr'] = $_POST['descr'];


### PR DESCRIPTION
dhcpleaseinlocaltime is actually a global setting, but the setting is stored per-DHCP-enabled-interface.
The display code in status_dhcp_leases already sorts this out - if any interface has the setting enabled then the displayed lease times are adjusted to local time.
This fixes up the input of the setting. If dhcpleaseinlocaltime is checked on any interface, then it will now be shown checked whichever interface tab the user happens to have open.
Whatever the user does to the checkbox, the setting is saved to all interfaces in the config - this is particularly neccesary when unchecking the box. The setting must be cleared in the config for all interfaces.
The way this change works, there is no need to convert existing configs. The code correctly works with both old and new configs.
This came up again in forum: https://forum.pfsense.org/index.php?topic=82881.msg0
It is an annoying "feature" so I think it is worth clearing it up on the UI.
