### PR TITLE
Prevent Internal Server Error if range is backwards

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -394,6 +394,13 @@ function ip_range_to_subnet_array($startip, $endip) {
 		return array();
 	}
 
+	if (ip_greater_than($startip, $endip)) {
+		// Swap start and end so we can process sensibly.
+		$temp = $startip;
+		$startip = $endip;
+		$endip = $temp;
+	}
+
 	// Container for subnets within this range.
 	$rangesubnets = array();
 
@@ -433,7 +440,7 @@ function ip_range_to_subnet_array($startip, $endip) {
 		}
 	}
 
-	// Some logic that will recursivly search from $startip to the first IP before the start of the subnet we just found.
+	// Some logic that will recursively search from $startip to the first IP before the start of the subnet we just found.
 	// NOTE: This may never be hit, the way the above algo turned out, but is left for completeness.
 	if ($startip != $targetsub_min) {
 		$rangesubnets = array_merge($rangesubnets, ip_range_to_subnet_array($startip, ip_before($targetsub_min)));


### PR DESCRIPTION
Fixes redmine #3950 - ip_range_to_subnet_array can easily swap the input parameters if the caller has passed/entered them the wrong way around. That is both friendly to the caller and ensures that a hostile caller can't blow up the routine.
This patches 2.1 branch - will submit pull request for master also.
