### PR TITLE
Set interface address from console - tidy output

### DIFF
--- a/etc/rc.initial.setlanip
+++ b/etc/rc.initial.setlanip
@@ -463,15 +463,14 @@ if (!$dry_run) {
 	echo "\nPlease wait while the changes are saved to {$upperifname}...";
 	write_config(sprintf(gettext("%s IP configuration from console menu"), $interface));
 	interface_reconfigure(strtolower($upperifname));
-	echo " Reloading filter...";
+	echo "\n Reloading filter...";
 	filter_configure_sync();
-	echo "\n";
 	if($restart_dhcpd) {
-		echo " DHCPD..."; 
+		echo "\n DHCPD..."; 
 		services_dhcpd_configure();
 	}
 	if($restart_webgui) {
-		echo " restarting webConfigurator... ";
+		echo "\n Restarting webConfigurator... ";
 		mwexec("/etc/rc.restart_webgui");
 	}
 }
@@ -496,7 +495,7 @@ if ($intip6 != '') {
 }
 
 if ($intip != '' || $intip6 != '') {
-	if (count($ifdescrs) == "1" or $interface = "lan") {
+	if (count($ifdescrs) == "1" or $interface == "lan") {
 		if ($debug) {
 			echo "ifdescrs count is " . count($ifdescrs) . "\n";
 			echo "interface is {$interface} \n";


### PR DESCRIPTION
While trying to see why this is not working for me (forum https://forum.pfsense.org/index.php?topic=83651.0 ) I have fixed some little things:
1) Get the new-lines right so the output of the restarting looks neat
2) Fix a comparison that had just a single equal sign - it did not break anything real because the subsequent code was just text output to the console. Now that text output does take notice of the correctly-evaluated condition, and $interface is not overwritten.

The issue in the forum post, about the interface IP address config not actually changing, is still the case, at least for me.

IMO these little tidy ups might as well be committed. They make this code better!
