### PR TITLE
Fix console set interface IP address

### DIFF
--- a/etc/rc.initial.setlanip
+++ b/etc/rc.initial.setlanip
@@ -401,7 +401,7 @@ function console_configure_dhcpd($version = 4) {
 		   number - Nov 2014 - is it really? */
 		if($config[$dhcpd][$interface]) {
 			unset($config[$dhcpd][$interface]['enable']);
-			echo sprintf("Disabling %s DHCPD...", $label_IPvX);
+			printf(gettext("Disabling %s DHCPD..."), $label_IPvX);
 			$restart_dhcpd = true;
 		}
 	}


### PR DESCRIPTION
Problem as per forum https://forum.pfsense.org/index.php?topic=83651.0
The problem comes whenever services_dhcpd_configure is called - the global $config gets reset from the actual current config, and any pending changes in the current process are lost.
It was introduced by commit https://github.com/pfsense/pfsense/commit/86ce2df7fdb04aa15f9fbeda91202c153e9d0cbd
in which services_dhcpdv4_configure() does:

require_once('pkg-utils.inc')

and pkg-utils.inc does various stuff like:

if(file_exists("/cf/conf/use_xmlreader"))
require_once("xmlreader.inc");
else
require_once("xmlparse.inc");

which seems to cause a reset of the $config variable, thus losing the pending changes the user has entered at the console.

The top-level code in rc.initial.setlanip really does not need to (and should not) implement any changes along the way - it should collect all the answers from the user, then write_config and then make all the necessary calls to routines to implement the changes on the running system. This fixes it - defer any calls to services_dhcpd_configure() until after all questions are answered and write_config has happened.
