### PR TITLE
Fix to SMART disk matching

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -2080,7 +2080,8 @@ function get_smart_drive_list() {
 	$disk_list = explode(" ", get_single_sysctl("kern.disks"));
 	foreach ($disk_list as $id => $disk) {
 		// We only want certain kinds of disks for S.M.A.R.T.
-		if (preg_match("/^(ad|da|ada).*[0-9]{1,2}$/", $disk) === FALSE) {
+		// 1 is a match, 0 is no match, False is any problem processing the regex
+		if (preg_match("/^(ad|da|ada).*[0-9]{1,2}$/", $disk) !== 1) {
 			unset($disk_list[$id]);
 		}
 	}


### PR DESCRIPTION
preg_match returns 0 when the string does not match the regex.
0 does not "===" FALSE
So this check is not always working.
preg_match returns 1 when the string matches the regex.
IMO it is better to check for !== 1 - then anything that is not success (0 or false or...) will be unset.
