### PR TITLE
Reintroduce graphcounter var to traffic_graphs.widget.php

### DIFF
--- a/usr/local/www/widgets/widgets/traffic_graphs.widget.php
+++ b/usr/local/www/widgets/widgets/traffic_graphs.widget.php
@@ -141,6 +141,7 @@ if (isset($a_config["scale_type"])) {
 </script>
 
 <?php
+$graphcounter = 0;
 foreach ($ifdescrs as $ifname => $ifdescr) {
 	$ifinfo = get_interface_info($ifname);
 	if ($shown[$ifname]) {
@@ -148,6 +149,7 @@ foreach ($ifdescrs as $ifname => $ifdescr) {
 		$showgraphbutton = "none";
 		$graphdisplay = "inline";
 		$interfacevalue = "show";
+		$graphcounter++;
 	} else {
 		$mingraphbutton = "none";
 		$showgraphbutton = "inline";
@@ -169,7 +171,7 @@ foreach ($ifdescrs as $ifname => $ifdescr) {
 				<div style="clear:both;"></div>
 			</div>
 			<div id="<?=$ifname;?>graphdiv" style="display:<?php echo $graphdisplay;?>">
-				<object data="graph.php?ifnum=<?=$ifname;?>&amp;ifname=<?=rawurlencode($ifdescr);?>&amp;timeint=<?=$refreshinterval;?>&amp;initdelay=<?=($graphcounter+1) * 2;?>" height="100%" width="100%">
+				<object data="graph.php?ifnum=<?=$ifname;?>&amp;ifname=<?=rawurlencode($ifdescr);?>&amp;timeint=<?=$refreshinterval;?>&amp;initdelay=<?=$graphcounter * 2;?>" height="100%" width="100%">
 					<param name="id" value="graph" />
 					<param name="type" value="image/svg+xml" />
 					<param name="pluginspage" value="http://www.adobe.com/svg/viewer/install/auto" />


### PR DESCRIPTION
This counter got lost in commit https://github.com/pfsense/pfsense/commit/ee965a5c7bf37b852795e1201688e3b20bf3d8d1
But the code at line 174 was still using it to offset the start time of each shown graph by 2 seconds, which I guess helps the graph data collection requests back to the pfSense to be staggered, not all having to be serviced at almost exactly the same time.
I noticed this while having a quick look at all the traffic graph widget code to see if there was an obvious place where the 2x bandwidth graphing problem happens. The "\* 2" here in line 174 has nothing to do with that!
