### PR TITLE
Allow "From" field in RFC822 format

### DIFF
--- a/etc/inc/notices.inc
+++ b/etc/inc/notices.inc
@@ -316,8 +316,12 @@ function send_smtp_message($message, $subject = "(no subject)") {
 	$smtp->localhost=$config['system']['hostname'].".".$config['system']['domain'];
 	
 	if($config['notifications']['smtp']['fromaddress'])
-		$from = $config['notifications']['smtp']['fromaddress'];
-	
+		$fromaddress = $config['notifications']['smtp']['fromaddress'];
+		preg_match("#\"([\w\s\-\_\|\.]+)\"#",$fromaddress,$matches_1);
+		$from_display = $matches_1[1];
+		preg_match("/[^0-9<][A-z0-9_]+([.][A-z0-9_]+)*[@][A-z0-9_]+([.][A-z0-9_]+)*[.][A-z]{2,4}/i",$fromaddress,$matches_2);
+		$from = $matches_2[0];
+
 	// Use SMTP Auth if fields are filled out
 	if($config['notifications']['smtp']['username'] && 
 	   $config['notifications']['smtp']['password']) {
@@ -327,7 +331,7 @@ function send_smtp_message($message, $subject = "(no subject)") {
 	}
 
 	$headers = array(
-		"From: {$from}",
+		"From: {$from_display} {$from}",
 		"To: {$to}",
 		"Subject: {$subject}",
 		"Date: ".date("r")


### PR DESCRIPTION
This allow notification email "From" field with a custom format rather the default e-mail address.