### PR TITLE
Handle reverse-lookup zones for unbound - fixes #4014

### DIFF
--- a/etc/inc/unbound.inc
+++ b/etc/inc/unbound.inc
@@ -470,7 +470,7 @@ function unbound_add_domain_overrides($pvt_rev="") {
 		}
 	}
 
-	if ($pvt_rev == true)
+	if ($pvt_rev != "")
 		return $domain_entries;
 	else
 		file_put_contents("{$g['unbound_chroot_path']}/domainoverrides.conf", $domain_entries);


### PR DESCRIPTION
## By default unbound returns nothing for private reverse lookups. Here is some information about that from https://www.unbound.net/documentation/unbound.conf.html

```
   The  default  zones  are  localhost, reverse 127.0.0.1 and ::1, and the
   AS112 zones. The AS112 zones are reverse DNS zones for private use  and
   reserved IP addresses for which the servers on the internet cannot pro-
   vide correct answers. They are configured by default to  give  nxdomain
   (no  reverse  information)  answers.  The defaults can be turned off by
   specifying your own local-zone of that name, or using  the  'nodefault'
   type. Below is a list of the default zone contents.
```

---
## Just specifying 'nodefault' did not work. I found other threads where people used this in unbound.conf
## local-zone: "49.10.in-addr.arpa" typetransparent

Note that it works if specifying the domain override with or without a final "." So the code here checks for the special cases of ".in-addr.arpa" and ".in-addr.arpa." at the end of a domain override name.

With this code my domain override entries for private reverse lookups work. I can traceroute around my internal network and the traceroute can show me the names that go with the private IP addresses at each hop.
