### PR TITLE
Process unbound start from status services

### DIFF
--- a/etc/inc/service-utils.inc
+++ b/etc/inc/service-utils.inc
@@ -540,6 +540,9 @@ function service_control_start($name, $extras) {
 		case 'dnsmasq':
 			services_dnsmasq_configure();
 			break;
+		case 'unbound':
+			services_unbound_configure();
+			break;
 		case 'dhcpd':
 			services_dhcpd_configure();
 			break;


### PR DESCRIPTION
This was missing, so nothing happened when the user tried to start Unbound from Status->Services
