### PR TITLE
Setup rrd dir before calling create_gateway_quality_rrd

### DIFF
--- a/etc/inc/gwlb.inc
+++ b/etc/inc/gwlb.inc
@@ -151,6 +151,13 @@ target default {
 
 EOD;
 
+	if (is_dir("{$g['tmp_path']}"))
+		chmod("{$g['tmp_path']}", 01777);
+	if (!is_dir("{$g['vardb_path']}/rrd"))
+		mkdir("{$g['vardb_path']}/rrd", 0775);
+
+	@chown("{$g['vardb_path']}/rrd", "nobody");
+
 	$monitor_ips = array();
 	foreach($gateways_arr as $name => $gateway) {
 		/* Do not monitor if such was requested */
@@ -336,13 +343,6 @@ EOD;
 	}
 	@file_put_contents("{$g['varetc_path']}/apinger.conf", $apingerconfig);
 	unset($apingerconfig);
-
-	if (is_dir("{$g['tmp_path']}"))
-		chmod("{$g['tmp_path']}", 01777);
-	if (!is_dir("{$g['vardb_path']}/rrd"))
-		mkdir("{$g['vardb_path']}/rrd", 0775);
-
-	@chown("{$g['vardb_path']}/rrd", "nobody");
 
  	/* Restart apinger process */
 	if (isvalidpid("{$g['varrun_path']}/apinger.pid"))


### PR DESCRIPTION
Stops error:
ERROR: opening '/var/db/rrd/WAN_DHCP-quality.rrd': No such file or directory
in system log during boot.
Forum: https://forum.pfsense.org/index.php?topic=84627.0
