### PR TITLE
Fixup misleading comment

### DIFF
--- a/etc/rc.newwanip
+++ b/etc/rc.newwanip
@@ -119,7 +119,7 @@ if (file_exists("{$g['vardb_path']}/{$interface}_cacheip"))
 /* regenerate resolv.conf if DNS overrides are allowed */
 system_resolvconf_generate(true);
 
-/* write current WAN IP to file */
+/* write the current interface IP to file */
 if (is_ipaddr($curwanip))
 	@file_put_contents("{$g['vardb_path']}/{$interface}_ip", $curwanip);
 


### PR DESCRIPTION
This comment was misleading - this is the IP of whatever interface that is being processed, not just WAN IP. Might as well fix while noticed, to save someone else from misunderstanding in future.
The curwanip var is really "Current Interface IP" and could be called curinterfaceip, but I was not about to search/replace all that at this point, since it is only a var name.
