### PR TITLE
Process RRD backup compression in var

### DIFF
--- a/etc/rc.backup_rrd.sh
+++ b/etc/rc.backup_rrd.sh
@@ -7,16 +7,20 @@
 if [ -d "${RRDDBPATH}" ]; then
 	[ -z "$NO_REMOUNT" ] && /etc/rc.conf_mount_rw
 	[ -f "${CF_CONF_PATH}/rrd.tgz" ] && /bin/rm -f "${CF_CONF_PATH}"/rrd.tgz
-		
+	
+	tgzlist=""
+
 	for rrdfile in "${RRDDBPATH}"/*.rrd ; do
 		xmlfile="${rrdfile%.rrd}.xml"
+		tgzfile="${rrdfile%.rrd}.tgz"
 		/usr/bin/nice -n20 /usr/local/bin/rrdtool dump "$rrdfile" "$xmlfile"
-		cd / && /usr/bin/tar -rf "${CF_CONF_PATH}"/rrd.tar -C / "${RRDDBPATH#/}"/*.xml
+		cd / && /usr/bin/tar -czf "${tgzfile}" -C / "${RRDDBPATH#/}"/*.xml
 		/bin/rm -f "${RRDDBPATH}"/*.xml
+		tgzlist="${tgzlist} @${tgzfile}"
 	done
-	if [ -f "${CF_CONF_PATH}/rrd.tar" ]; then
-		/usr/bin/gzip "${CF_CONF_PATH}/rrd.tar"
-		/bin/mv "${CF_CONF_PATH}/rrd.tar.gz" "${CF_CONF_PATH}/rrd.tgz"
+	if [ -n "${tgzlist}" ]; then
+		cd / && /usr/bin/tar -czf "${CF_CONF_PATH}/rrd.tgz" ${tgzlist}
+		/bin/rm -f "${RRDDBPATH}"/*.tgz
 	fi
 	[ -z "$NO_REMOUNT" ] && /etc/rc.conf_mount_ro
 fi


### PR DESCRIPTION
Prior to this the RRD xml files were added uncompressed to the archive in /cf/conf and then that archive was compressed at the end.
My /cf partition is only 50MB. The uncompressed archive of all the xml files is already 35MB. With a few config backups, or a few more VLANs (xml files) I will soon run into the 50MB limit.
This change creates each xml from rrd one at a time, then compresses that 1 xml into a tgz in /var/db/rrd, deletes the xml then loops to the next rrd file.
At the end of the loop, there are a bunch of /var/db/rrd/*.tgz files, which are small (they take up <2MB on my system, from XMLs that total 35MB). They are then unpacked and put into 1 /cf/conf/rrd.tgz in a single command.
Thus there is no time when 35MB of xml content has to be stored anywhere.
This should work for systems with a lot of RRD files that turn into XML and then TGZ one at a time.
