### PR TITLE
Fix bracketing of if statement in unbound

### DIFF
--- a/etc/inc/unbound.inc
+++ b/etc/inc/unbound.inc
@@ -602,11 +602,11 @@ function unbound_acls_config() {
 		$aclcfg = "access-control: 127.0.0.1/32 allow\n";
 		$aclcfg .= "access-control: ::1 allow\n";
 		// Add our networks for active interfaces including localhost
-		if (!empty($config['unbound']['active_interface']))
+		if (!empty($config['unbound']['active_interface'])) {
 			$active_interfaces = array_flip(explode(",", $config['unbound']['active_interface']));
 			if (in_array("all", $active_interfaces, true))
 				$active_interfaces = get_configured_interface_with_descr();
-		else
+		} else
 			$active_interfaces = get_configured_interface_with_descr();
 	
 		$bindints = "";


### PR DESCRIPTION
Stops message:
Warning: in_array() expects parameter 2 to be array, null given in /etc/inc/unbound.inc on line 607
The problem was introduced when lines 607-608 were added without adding these brackets.
IMHO programming standards should include ALWAYS using brackets for "if" and other similar statements. That way this sort of code addition accident does not happen. But I guess there are others who have different opinions.
