### PR TITLE
Correctly delete xml file after restore and conversion to rrd

### DIFF
--- a/etc/inc/rrd.inc
+++ b/etc/inc/rrd.inc
@@ -80,7 +80,7 @@ function restore_rrd() {
 				continue;
 			}
 			unset($output);
-			@unlink($xml_file);
+			@unlink("/{$xml_file}");
 		}
 		unset($rrdrestore);
 		@unlink("{$g['tmp_path']}/rrd_restore");


### PR DESCRIPTION
When doing "Generating RRD graphs" at bootup, the data is restored from /cf/conf/rrd.tgz into xml format files in /var/db/rrd. Those xml files are then convert to rrd files. After that, the xml files should be deleted - but the xml file path was not quite right, so they were not being deleted.
This fixes it.
