### PR TITLE
Tell unbound about new IPV6 addresses

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -3145,6 +3145,9 @@ function interface_track6_configure($interface = "lan", $wancfg, $linkupevent = 
 	if ($linkupevent == false) {
 		if (!function_exists('services_dhcpd_configure'))
 			require_once("services.inc");
+		if (isset($config['unbound']['enable'])) {
+			services_unbound_configure();
+		}
 
 		services_dhcpd_configure("inet6");
 	}


### PR DESCRIPTION
When IPV6 addresses change we need to reconfigure unbound
