### PR TITLE
Link local interfaces don't have subnet.. don't create access-control

### DIFF
--- a/etc/inc/unbound.inc
+++ b/etc/inc/unbound.inc
@@ -622,11 +622,13 @@ function unbound_acls_config() {
 			}
 			$ifip = get_interface_ipv6($ubif);
 			if (is_ipaddrv6($ifip)) {
-				$subnet_bits = get_interface_subnetv6($ubif);
-				$subnet_ip = gen_subnetv6($ifip, $subnet_bits);
-				// only add LAN-type interfaces 
-				if (!interface_has_gateway($ubif))
-					$aclcfg .= "access-control: {$subnet_ip}/{$subnet_bits} allow\n";
+				if (!is_linklocal($ifip)) {
+					$subnet_bits = get_interface_subnetv6($ubif);
+					$subnet_ip = gen_subnetv6($ifip, $subnet_bits);
+					// only add LAN-type interfaces 
+					if (!interface_has_gateway($ubif))
+						$aclcfg .= "access-control: {$subnet_ip}/{$subnet_bits} allow\n";
+				}
 				// add for IPv6 static routes to local networks
 				// for safety, we include only routes reachable on an interface with no
 				// gateway specified - read: not an Internet connection. 


### PR DESCRIPTION
Selecting link local interface for unbound causes invalid access-control
statement in unbound config since link local address doesn't have
subnet.
