### PR TITLE
Use IPv4 for ntpq if IPv6 not allowed in widget #4074

### DIFF
--- a/usr/local/www/widgets/widgets/ntp_status.widget.php
+++ b/usr/local/www/widgets/widgets/ntp_status.widget.php
@@ -43,7 +43,12 @@ require_once("/usr/local/www/widgets/include/ntp_status.inc");
 
 if($_REQUEST['updateme']) {
 //this block displays only on ajax refresh
-	exec("/usr/local/sbin/ntpq -pn | /usr/bin/tail +3", $ntpq_output);
+	if (isset($config['system']['ipv6allow']))
+		$inet_version = "";
+	else
+		$inet_version = " -4";
+
+	exec("/usr/local/sbin/ntpq -pn $inet_version | /usr/bin/tail +3", $ntpq_output);
 	$ntpq_counter = 0;
 	foreach ($ntpq_output as $line) {
 		if (substr($line, 0, 1) == "*") {
@@ -65,7 +70,7 @@ if($_REQUEST['updateme']) {
 		}
 	}
 
-	exec("/usr/local/sbin/ntpq -c clockvar", $ntpq_clockvar_output);
+	exec("/usr/local/sbin/ntpq -c clockvar $inet_version", $ntpq_clockvar_output);
 	foreach ($ntpq_clockvar_output as $line) {
 		if (substr($line, 0, 9) == "timecode=") {
 			$tmp = explode('"', $line);


### PR DESCRIPTION
Similar code here. Shame it was not in a subroutine called from both places, but not about to re-engineer that now:)
