### PR TITLE
Put -4 in the right place in ntpq clockvar command #4074

### DIFF
--- a/usr/local/www/status_ntpd.php
+++ b/usr/local/www/status_ntpd.php
@@ -100,7 +100,7 @@ if(!isset($config['ntpd']['noquery'])) {
 		$ntpq_servers[] = $server;
 	}
 
-	exec("/usr/local/sbin/ntpq -c $inet_version clockvar", $ntpq_clockvar_output);
+	exec("/usr/local/sbin/ntpq -c clockvar $inet_version", $ntpq_clockvar_output);
 	foreach ($ntpq_clockvar_output as $line) {
 		if (substr($line, 0, 9) == "timecode=") {
 			$tmp = explode('"', $line);


### PR DESCRIPTION
I had pasted it in here between "-c" and "clockvar", that was not good.
That's all I have for #4074 (I hope)
