### PR TITLE
Provide friendly descr in error message in Interfaces Assign

### DIFF
--- a/usr/local/www/interfaces_assign.php
+++ b/usr/local/www/interfaces_assign.php
@@ -276,7 +276,7 @@ if (isset($_POST['add_x']) && isset($_POST['if_add'])) {
 				' interfaces:'), $portname, count($ifnames));
 
 			foreach ($portifmap[$portname] as $ifn)
-				$errstr .= " " . $ifn;
+				$errstr .= " " . convert_friendly_interface_to_friendly_descr(strtolower($ifn)) . " (" . $ifn . ")";
 
 			$input_errors[] = $errstr;
 		} else if (count($ifnames) == 1 && preg_match('/^bridge[0-9]/', $portname) && is_array($config['bridges']['bridged']) && count($config['bridges']['bridged'])) {


### PR DESCRIPTION
I was doing drastic things testing some stuff, swapping WAN and OPT1 interfaces in Interfaces->Assign. I accidentally pressed Save when I had the same real device selected for both. Thankfully there was input validation! But I noticed that the error message reported just the names WAN and OPT1, but actually I had them named as different things. So the names in the error message did not match the names (friendly descriptions) in the table of interfaces.
This change makes the error text display both names like FRIENDLY_DESC (FRIENDLY_NAME) so there is less room for confusion.
