### PR TITLE
Standardise css list padding

### DIFF
--- a/usr/local/www/themes/pfsense_ng/all.css
+++ b/usr/local/www/themes/pfsense_ng/all.css
@@ -864,7 +864,7 @@ ul#wzdnav a:active {
 }
 .listn {
 	font-size: 11px;
-	padding-right: 16px;
+	padding-right: 6px;
 	padding-left: 6px;
 	padding-top: 4px;
 	padding-bottom: 4px;
@@ -875,7 +875,7 @@ ul#wzdnav a:active {
 	font-size: 11px;
 	color: #FFFFFF;
 	background-color: #990000;
-	padding-right: 16px;
+	padding-right: 6px;
 	padding-left: 6px;
 	padding-top: 4px;
 	padding-bottom: 4px;
@@ -885,14 +885,14 @@ ul#wzdnav a:active {
         border-bottom: 1px solid #999999;
         font-size: 11px;
         background-color: #999999;
-        padding-right: 16px;
+        padding-right: 6px;
         padding-left: 6px;
         padding-top: 4px;
         padding-bottom: 4px;
 }
 .listhdr {
 	background-color: #BBBBBB;
-	padding-right: 16px;
+	padding-right: 6px;
 	padding-left: 6px;
 	font-weight: bold;
 	border-bottom: 1px solid #999999;
@@ -905,7 +905,7 @@ ul#wzdnav a:active {
 }
 .listhdrr {
 	background-color: #BBBBBB;
-	padding-right: 16px;
+	padding-right: 6px;
 	padding-left: 6px;
 	font-weight: bold;
 	border-right: 1px solid #999999;


### PR DESCRIPTION
On Status->Services and the Services Status widget, when a service status is down, the red "x" button does not line up with the green "running" button in the column.
This is because listbg has:
padding-right: 16px;
But the normal listr has:
padding-right: 6px;
It seems really odd that listbg has 16 pixels right padding. I expected it to have all the same padding as listr, just with a different color.
listn and listbggrey have the same "feature" of extra padding-right.
listn does not seem to be used anywhere anyway - might as well "fix" it in case something uses it some time.
listbggrey seems to only be used by pkg_mgr_installed.php in the case when an installed package version is in advance of the online version - quite an unusual thing! Changing padding-right from 16px back to 6px is fine for that.
This "feature" is also in listhdr and listhdrr - lots of examples like firewall_aliases.php have the column headings as listhdr or listhdrr, so in theory if the column is not so wide already, it will put 16px on the right after the column heading text. But the actual rows of data underneath use listr and listbg, which only specify 6px right padding. In the end it usually does not make any difference - there is space already and the browser lines all the table up anyway. But it seems to me an odd difference in the css.
listtopic also has this 16px right padding thing - but it seems to be used just for text display that is not in table columns, so I did not mess with that.
Changing this css fixes the lineup of the red "x" in the services status column and does not seem to break anything else. In theory it could make other things better also.
Someone who knows how the css was intended to be used could comment on this! If I have got the right idea, and these "16px" things were just a mistake from the past, then it should be checked in the css for all themes and corrected appropriately... 
I am happy to do that, once someone confirms it is the thing to do.
Before this change, with ntpd stopped:
![status-services-1-unfixed](https://cloud.githubusercontent.com/assets/1535615/5330669/c80fd6d0-7e2b-11e4-86a7-8b78b34e9974.png)
After this change the red "x" lines up in the column:
![status-services-2-after](https://cloud.githubusercontent.com/assets/1535615/5330670/c8135256-7e2b-11e4-8919-7669ab7e2e0b.png)
