### PR TITLE
Provide success return indication from console_configure_dhcpd

### DIFF
--- a/etc/rc.initial.setlanip
+++ b/etc/rc.initial.setlanip
@@ -401,6 +401,7 @@ function console_configure_dhcpd($version = 4) {
 			$restart_dhcpd = true;
 		}
 	}
+	return 1;
 }
 
 if (console_configure_dhcpd(4) == 0)


### PR DESCRIPTION
Recent commit https://github.com/pfsense/pfsense/commit/9ea554ee5cb25ea3bf5bb6bf7997c6c7379ce349 added testing of the return status of console_configure_dhcpd() - this let a user effectively abort from doing anything if they have answered "y" to prompt_for_enable_dhcp_server() and are being asked for the start and end of the range, and then decide they do not want to proceed.
However, even when they gave good answers, status 0 was being returned. This prevented changes ever being implemented.
Redmine: https://redmine.pfsense.org/issues/4080
The fix is to return 1 at the routine end, when all is good and the code should proceed.
