### PR TITLE
Validation of y/n answers in setlanip

### DIFF
--- a/etc/rc.initial.setlanip
+++ b/etc/rc.initial.setlanip
@@ -91,7 +91,11 @@ function prompt_for_enable_dhcp_server($version = 4) {
 			echo "\n" . sprintf(gettext("Do you want to enable the %s server on %s? [y|n]"),
 			                    $label_DHCP, $upperifname) . "  ";
 			$yn = strtolower(chop(fgets($fp)));
-			if ($yn[0] == "y" or $yn[0] == "n")
+			if ($yn == "yes")
+				$yn = "y";
+			if ($yn == "no")
+				$yn = "n";
+			if ($yn == "y" or $yn == "n")
 				$good = true;
 		} while (!$good);
 	}
@@ -238,10 +242,20 @@ function console_configure_ip_address($version) {
 	$upperifname = strtoupper($interface);
 
 	if($interface == "wan") {
-		echo sprintf(gettext("Configure %s address %s interface via %s?  [y|n]"),
-		             $label_IPvX, $upperifname, $label_DHCP) . "\n> ";
-		$intdhcp = chop(fgets($fp));
-		if(strtolower($intdhcp) == "y" || strtolower($intdhcp) == "yes") {
+		do {
+			$good = false;
+			echo sprintf(gettext("Configure %s address %s interface via %s?  [y|n]"),
+						 $label_IPvX, $upperifname, $label_DHCP) . "\n> ";
+			$yn = strtolower(chop(fgets($fp)));
+			if ($yn == "yes")
+				$yn = "y";
+			if ($yn == "no")
+				$yn = "n";
+			if ($yn == "y" or $yn == "n")
+				$good = true;
+		} while (!$good);
+
+		if ($yn == "y") {
 			$ifppp = console_get_interface_from_ppp(get_real_interface("wan"));
 			if (!empty($ifppp))
 				$ifaceassigned = $ifppp;
@@ -401,6 +415,7 @@ function console_configure_dhcpd($version = 4) {
 			$restart_dhcpd = true;
 		}
 	}
+	return 1;
 }
 
 if (console_configure_dhcpd(4) == 0)
@@ -416,7 +431,11 @@ if ($config['system']['webgui']['protocol'] == "https") {
 		$good = false;
 		echo "\n" . gettext("Do you want to revert to HTTP as the webConfigurator protocol? (y/n)") . " ";
 		$yn = strtolower(chop(fgets($fp)));
-		if ($yn[0] == "y" or $yn[0] == "n")
+		if ($yn == "yes")
+			$yn = "y";
+		if ($yn == "no")
+			$yn = "n";
+		if ($yn == "y" or $yn == "n")
 			$good = true;
 	} while (!$good);
 
@@ -424,6 +443,24 @@ if ($config['system']['webgui']['protocol'] == "https") {
 		$config['system']['webgui']['protocol'] = "http";
 		$restart_webgui = true;
 	}
+}
+
+do {
+	$good = false;
+	echo "\n" . gettext("Do you want to apply these changes? (y/n)") . " ";
+	$yn = strtolower(chop(fgets($fp)));
+	if ($yn == "yes")
+		$yn = "y";
+	if ($yn == "no")
+		$yn = "n";
+	if ($yn == "y" or $yn == "n")
+		$good = true;
+} while (!$good);
+
+if (!($yn == "y")) {
+	echo "\n" . gettext("Changes have not been applied.");
+	fclose($fp);
+	return 0;
 }
 
 if (isset($config['system']['webgui']['noantilockout'])) {


### PR DESCRIPTION
At the moment the user can answer "yes" to most of the questions, but then later code only checks if the answer is "y". Thus you can type in "yes" in some places, have it accepted, but actually the negative action is taken. That is weird and will mess up people who try typing a whole string starting with "y".
With this change it makes the user type one of "y", "yes", "n", "no". When they type 1 of those, it is turned into either "y" or "n". Then the existing implementation logic all works as expected.
Also, it is not obvious when the last question is being asked, before actually implementing. IMHO it would be good to give the user a chance to bail out if they have answered questions wrongly and just want to get back and start again. So "Do you want to apply these changes?" question has been added.
This also includes the "return 1" fix (line 418) that is also in pull request https://github.com/pfsense/pfsense/pull/1371
