### PR TITLE
Update interfaces.php - Allow /31 Subnets

### DIFF
--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -1768,11 +1768,9 @@ $types6 = array("none" => gettext("None"), "staticv6" => gettext("Static IPv6"),
 											<select name="subnet" class="formselect" id="subnet">
 												<?php
 												for ($i = 32; $i > 0; $i--) {
-													if($i <> 31) {
 														echo "<option value=\"{$i}\" ";
 														if ($i == $pconfig['subnet']) echo "selected=\"selected\"";
 														echo ">" . $i . "</option>";
-													}
 												}
 												?>
 											</select>
@@ -2004,11 +2002,9 @@ $types6 = array("none" => gettext("None"), "staticv6" => gettext("Static IPv6"),
 											<select name="alias-subnet" class="formselect" id="alias-subnet">
 												<?php
 												for ($i = 32; $i > 0; $i--) {
-													if($i <> 31) {
 														echo "<option value=\"{$i}\" ";
 														if ($i == $pconfig['alias-subnet']) echo "selected=\"selected\"";
 														echo ">" . $i . "</option>";
-													}
 												}
 												?>
 											</select>


### PR DESCRIPTION
Removed exclusion of 31 from subnet list boxes. Starting in FreeBSD 9.x and above, the operating system supports /31 (255.255.255.254) subnets. This allows the use of point-to-point addresses for interfaces. Some ISP's (Cox Communications) are implementing IP-VPN services that use these 31-bit subnet masks. Customers are provided a point-to-point IP and a Gateway. There is no need for the 2 extra IP addresses that a /30 will give you, so a /31 is used instead.