### PR TITLE
Improve check if no OpenVPN defined

### DIFF
--- a/etc/rc.openvpn
+++ b/etc/rc.openvpn
@@ -76,7 +76,7 @@ if (isset($_GET['interface']))
 else
 	$argument = trim($argv[1], " \n");
 
-if(is_array($config['openvpn']['openvpn-server']) || is_array($config['openvpn']['openvpn-client'])) {
+if(count($config['openvpn']['openvpn-server']) || count($config['openvpn']['openvpn-client'])) {
 	if (empty($argument) || $argument == "all") {
 		$argument = "all"; 
 		$log_text = "all";


### PR DESCRIPTION
Some people used to have OpenVPN instances defined, so $config['openvpn']['openvpn-server'] and/or $config['openvpn']['openvpn-client'] is an (empty) array. In that case they were getting the log message about "OpenVPN: One or more OpenVPN tunnel endpoints may have changed its IP. Reloading" and the code loops zero times through the arrays.
The only issue is that they ask in the forum about why the log message is appearing.
This fixes it by checking if there are actually any array entries. The count() function works fine if an array is not even defined, returning 0, so there is no need to first check is_array() before using count().
Example forum query: https://forum.pfsense.org/index.php?topic=85139.0
