### PR TITLE
Improve check if no OpenVPN defined

### DIFF
--- a/etc/rc.openvpn
+++ b/etc/rc.openvpn
@@ -76,7 +76,8 @@ if (isset($_GET['interface']))
 else
 	$argument = trim($argv[1], " \n");
 
-if(is_array($config['openvpn']['openvpn-server']) || is_array($config['openvpn']['openvpn-client'])) {
+if((is_array($config['openvpn']['openvpn-server']) && count($config['openvpn']['openvpn-server'])) || 
+   (is_array($config['openvpn']['openvpn-client']) && count($config['openvpn']['openvpn-client']))) {
 	if (empty($argument) || $argument == "all") {
 		$argument = "all"; 
 		$log_text = "all";


### PR DESCRIPTION
Alternate version of https://github.com/pfsense/pfsense/pull/1376
This version retains the is_array() checks and then only does the count() if the is_array() is true.
Take whichever version you like.
