### PR TITLE
Base URL must be specified when alturlenable on

### DIFF
--- a/usr/local/www/system_firmware_settings.php
+++ b/usr/local/www/system_firmware_settings.php
@@ -43,6 +43,13 @@
 require("guiconfig.inc");
 
 if ($_POST) {
+	unset($input_errors);
+
+	/* input validation */
+	if(($_POST['alturlenable'] == "yes") && (empty($_POST['firmwareurl']))) {
+		$input_errors[] = gettext("A Firmware Auto Update Base URL must be specified when \"Use an unofficial server for firmware upgrades\" is enabled.");
+	}
+
 	if (!$input_errors) {
 		if($_POST['alturlenable'] == "yes") {
 			$config['system']['firmware']['alturl']['enable'] = true;


### PR DESCRIPTION
I had a 2.1.5 system that I was wondering why the dashboard always said it could not check for updates. I discovered it had "Use an unofficial server for firmware upgrades" checked, but the "Base URL" field was empty.
That can easily be checked with input validation - might as well catch dumb things like that.
I thought about making it parse the string to see if it seemed like a "valid" URL. But so many strings seem like valid URLs:
var_dump(parse_url("abc"));
array(1) {
  ["path"]=>
  string(3) "abc"
}

It seemed a bit pointless to bother - if the user puts something in then hope that it might point to something some day.
