### PR TITLE
Validation of y/n answers in setlanip

### DIFF
--- a/etc/rc.initial.setlanip
+++ b/etc/rc.initial.setlanip
@@ -61,7 +61,7 @@ function console_prompt_for_yn ($prompt_text) {
 	$good_answer = false;
 
 	do {
-		echo "\n" . gettext($prompt_text) . " (y/n) ";
+		echo "\n" . $prompt_text . " (y/n) ";
 		$yn = strtolower(chop(fgets($fp)));
 		if (($yn == "y") || ($yn == "yes")) {
 			$boolean_answer = true;
@@ -423,13 +423,13 @@ if (console_configure_dhcpd(6) == 0)
 
 if ($config['system']['webgui']['protocol'] == "https") {
 
-	if (console_prompt_for_yn ("Do you want to revert to HTTP as the webConfigurator protocol?")) {
+	if (console_prompt_for_yn (gettext("Do you want to revert to HTTP as the webConfigurator protocol?"))) {
 		$config['system']['webgui']['protocol'] = "http";
 		$restart_webgui = true;
 	}
 }
 
-if (!(console_prompt_for_yn ("Do you want to apply these changes?"))) {
+if (!(console_prompt_for_yn (gettext("Do you want to apply these changes?")))) {
 	echo "\n" . gettext("Changes have not been applied.\n");
 	fclose($fp);
 	return 0;


### PR DESCRIPTION
At the moment the user can answer "yes" to most of the questions, but then later code only checks if the answer is "y". Thus you can type in "yes" in some places, have it accepted, but actually the negative action is taken. That is weird and will mess up people who try typing a whole string starting with "y".
With this change it makes the user type one of "y", "yes", "n", "no". When they type 1 of those, it is turned into either "y" or "n". Then the existing implementation logic all works as expected.
Also, it is not obvious when the last question is being asked, before actually implementing. IMHO it would be good to give the user a chance to bail out if they have answered questions wrongly and just want to get back and start again. So "Do you want to apply these changes?" question has been added.
Also there was a bug in checking $intbits value at line 299 - I could enter a big number for CIDR and it accepted it and blew up later trying to implement something like 10.11.12.1/99

Should address redmine #4100 
