### PR TITLE
rc.initial.setlanip fix validation of CIDR within range

### DIFF
--- a/etc/rc.initial.setlanip
+++ b/etc/rc.initial.setlanip
@@ -284,7 +284,7 @@ function console_configure_ip_address($version) {
 					echo "\n" . sprintf(gettext("Enter the new %s %s subnet bit count:"),
 							    $upperifname, $label_IPvX) . "\n> ";
 					$intbits = chop(fgets($fp));
-					$intbits_ok = is_numeric($intbits) && (($intbits >= 1) || ($intbits <= $maxbits));
+					$intbits_ok = is_numeric($intbits) && (($intbits >= 1) && ($intbits <= $maxbits));
 					$restart_dhcpd = true;
 
 					if ($version === 4 && $intbits < $maxbits) {


### PR DESCRIPTION
Currently this allows the user to input any number for the CIDR. I happened to try 44 for an IPv4 CIDR when playing.
This fixes that little bug - I think it is good to commit that first/separately so it can be identified apart from the other (y/n) checking/handling I am working on. Better to have separate commits for distinct bugs.
