### PR TITLE
Allow option to specify just 1 of user and pass in OpenVPN .up file

### DIFF
--- a/etc/inc/openvpn.inc
+++ b/etc/inc/openvpn.inc
@@ -712,11 +712,15 @@ function openvpn_reconfigure($mode, $settings) {
 				$conf .= "ifconfig-ipv6 {$ipv6_2} {$prefix}\n";
 		}
 
-		if ($settings['auth_user'] && $settings['auth_pass']) {
+		if ($settings['auth_user'] || $settings['auth_pass']) {
 			$up_file = "{$g['varetc_path']}/openvpn/{$mode_id}.up";
 			$conf .= "auth-user-pass {$up_file}\n";
-			$userpass = "{$settings['auth_user']}\n";
-			$userpass .= "{$settings['auth_pass']}\n";
+			if ($settings['auth_user'])
+				$userpass = "{$settings['auth_user']}\n";
+			if ($settings['auth_pass'])
+				$userpass .= "{$settings['auth_pass']}\n";
+			if (!($settings['auth_user'] && $settings['auth_pass']))
+				$userpass .= "\n";
 			file_put_contents($up_file, $userpass);
 		}
 

--- a/usr/local/www/vpn_openvpn_client.php
+++ b/usr/local/www/vpn_openvpn_client.php
@@ -265,7 +265,7 @@ if ($_POST) {
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (($pconfig['mode'] != "p2p_shared_key") && empty($pconfig['certref']) && empty($pconfig['auth_user']) && empty($pconfig['auth_pass'])) {
-		$input_errors[] = gettext("If no Client Certificate is selected, a username and password must be entered.");
+		$input_errors[] = gettext("If no Client Certificate is selected, a username and/or password must be entered.");
 	}
 
 	if (!$input_errors) {
@@ -676,7 +676,7 @@ if ($savemsg)
 					<tr id='userpass'>
 						<td width="22%" valign="top" class="vncell"><?=gettext("User name/pass"); ?></td>
 						<td width="78%" class="vtable">
-							<?=gettext("Leave empty when no user name and password are needed."); ?>
+							<?=gettext("Leave empty when no user name and/or password are needed."); ?>
 							<br/>
 							<table border="0" cellpadding="2" cellspacing="0" summary="user name password">
 								<tr>
@@ -788,7 +788,7 @@ if ($savemsg)
 							?>
 								<option value="<?=$cert['refid'];?>" <?=$selected;?>><?=$cert['descr'] . $caname . $inuse . $revoked;?></option>
 							<?php endforeach; ?>
-								<option value="" <?PHP if (empty($pconfig['certref'])) echo "selected=\"selected\""; ?>>None (Username and Password required)</option>
+								<option value="" <?PHP if (empty($pconfig['certref'])) echo "selected=\"selected\""; ?>>None (Username and/or Password required)</option>
 							</select>
 							<?php if (!count($a_cert)): ?>
 								<b>No Certificates defined.</b> <br />Create one under <a href="system_certmanager.php">System &gt; Cert Manager</a> if one is required for this connection.


### PR DESCRIPTION
As per comment in https://redmine.pfsense.org/issues/3633 sometimes the server end only requires a password, no username. Usually 1 long string that serves as the hard-to-guess authentication. OpenVPN expects something to be on the first line of the ".up" file - traditionally called the username. It also insists on the second line being present, but is happy with it being empty - this is the authentication information traditionally called "password".
Let the user put the single piece of authentication information in either the Username or Password field on the web GUI - whichever they feel comfortable calling it. In the ".up" file it has to always be the first line to keep OpenVPN happy.