### PR TITLE
Remove "link", "vlink" and "alink" from BODY tag

### DIFF
--- a/usr/local/www/themes/_corporate/all.css
+++ b/usr/local/www/themes/_corporate/all.css
@@ -99,6 +99,22 @@ form {
 a {
 	text-decoration: none;
 }
+a:link {
+	color: #0000CC;
+}
+
+a:visited {
+	color: #0000CC;
+}
+
+a:active {
+	color: #0000CC;
+}
+
+a:hover {
+	color: #0000CC;
+}
+
 form input {
 	font-size: 1.1em;
 }

--- a/usr/local/www/themes/code-red/all.css
+++ b/usr/local/www/themes/code-red/all.css
@@ -154,6 +154,23 @@ form {
 a {
 	text-decoration: none;
 }
+
+a:link {
+	color: #0000CC;
+}
+
+a:visited {
+	color: #0000CC;
+}
+
+a:active {
+	color: #0000CC;
+}
+
+a:hover {
+	color: #0000CC;
+}
+
 form input {
 	font-size: 1.1em;
 }

--- a/usr/local/www/themes/metallic/all.css
+++ b/usr/local/www/themes/metallic/all.css
@@ -142,6 +142,23 @@ form {
 a {
 	text-decoration: none;
 }
+
+a:link {
+	color: #0000CC;
+}
+
+a:visited {
+	color: #0000CC;
+}
+
+a:active {
+	color: #0000CC;
+}
+
+a:hover {
+	color: #0000CC;
+}
+
 form input {
 	font-size: 1.1em;
 }

--- a/usr/local/www/themes/nervecenter/all.css
+++ b/usr/local/www/themes/nervecenter/all.css
@@ -154,6 +154,23 @@ form {
 a {
 	text-decoration: none;
 }
+
+a:link {
+	color: #0000CC;
+}
+
+a:visited {
+	color: #0000CC;
+}
+
+a:active {
+	color: #0000CC;
+}
+
+a:hover {
+	color: #0000CC;
+}
+
 form input {
 	font-size: 1.1em;
 }

--- a/usr/local/www/themes/pfsense-dropdown/all.css
+++ b/usr/local/www/themes/pfsense-dropdown/all.css
@@ -76,6 +76,23 @@ form {
 a {
 	text-decoration: none;
 }
+
+a:link {
+	color: #0000CC;
+}
+
+a:visited {
+	color: #0000CC;
+}
+
+a:active {
+	color: #0000CC;
+}
+
+a:hover {
+	color: #0000CC;
+}
+
 form input {
 	font-size: 1.1em;
 }

--- a/usr/local/www/themes/pfsense/all.css
+++ b/usr/local/www/themes/pfsense/all.css
@@ -75,6 +75,23 @@ form {
 a {
 	text-decoration: none;
 }
+
+a:link {
+	color: #0000CC;
+}
+
+a:visited {
+	color: #0000CC;
+}
+
+a:active {
+	color: #0000CC;
+}
+
+a:hover {
+	color: #0000CC;
+}
+
 form input {
 	font-size: 1.1em;
 }


### PR DESCRIPTION
This is a positional change to remove "link", "vlink" and "alink" from the BODY tag, the following themes do not have Anchor tags defined in CSS, so they use the colours defined in the BODY tag, which is blue (#0000CC).

_corporate
code-red
metallic
nervecenter
pfsense
pfsense-dropdown

Update the CSS file "all.css" in the above themes with Anchor tags defined, so that the colour definition can be removed from the BODY tag.
