### PR TITLE
Allow dot at end of FQDN for a host

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -686,8 +686,13 @@ function is_hostname($hostname) {
 	if (!is_string($hostname))
 		return false;
 
-	if (preg_match('/^(?:(?:[a-z0-9_]|[a-z0-9_][a-z0-9_\-]*[a-z0-9_])\.)*(?:[a-z0-9_]|[a-z0-9_][a-z0-9_\-]*[a-z0-9_])$/i', $hostname))
-		return true;
+	if (is_domain($hostname))
+		if ((substr_count($hostname, ".") == 1) && ($hostname[strlen($hostname)-1] == ".")) {
+			/* Only a single dot at the end like "test." - hosts cannot be directly in the root domain. */
+			return false;
+		} else {
+			return true;
+		}
 	else
 		return false;
 }


### PR DESCRIPTION
Redmine #4124 has discussion of this.
I cannot think of things that will break by allowing this. But expanding this validation in a routine used by so many things might need a bit of thought and extensive testing at this point in the RC cycle!
Comments very welcome.
