### PR TITLE
Interface Status widget keep IP address bold

### DIFF
--- a/usr/local/www/includes/functions.inc.php
+++ b/usr/local/www/includes/functions.inc.php
@@ -336,7 +336,7 @@ function get_interfacestatus() {
 		}
 		$data .= ",";
 		if ($ifinfo['ipaddr'])
-			$data .= htmlspecialchars($ifinfo['ipaddr']);
+			$data .= "<strong>" . htmlspecialchars($ifinfo['ipaddr']) . "</strong>";
 		$data .= ",";
 		if ($ifinfo['status'] != "down")
 			$data .= htmlspecialchars($ifinfo['media']);


### PR DESCRIPTION
The widget uses "strong" so I used "strong" here also to match - "strong" and "bold" can potentially be rendered differently on some specialist device.
Forum: https://forum.pfsense.org/index.php?topic=85187.msg469639#msg469639
