### PR TITLE
Prevent resolvconf(8) from stomping all over our newly generated

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -182,6 +182,15 @@ function system_resolvconf_generate($dynupdate = false) {
 	fwrite($fd, $resolvconf);
 	fclose($fd);
 
+	// Prevent resolvconf(8) from rewriting our resolv.conf
+	$fd = fopen("{$g['varetc_path']}/resolvconf.conf", "w");
+	if (!$fd) {
+		printf("Error: cannot open resolvconf.conf in system_resolvconf_generate().\n");
+		return 1;
+	}
+	fwrite($fd, "resolv_conf=\"/dev/null\"\n");
+	fclose($fd);
+
 	if (!platform_booting()) {
 		/* restart dhcpd (nameservers may have changed) */
 		if (!$dynupdate)

--- a/etc/rc
+++ b/etc/rc
@@ -273,6 +273,11 @@ if [ ! -L /etc/resolv.conf ]; then
     /bin/ln -s /var/etc/resolv.conf /etc/resolv.conf
 fi
 
+if [ ! -L /etc/resolvconf.conf ]; then
+    /bin/rm -rf /etc/resolvconf.conf
+    /bin/ln -s /var/etc/resolvconf.conf /etc/resolvconf.conf
+fi
+
 # Setup compatibility link for packages that
 # have trouble overriding the PREFIX configure
 # argument since we build our packages in a


### PR DESCRIPTION
resolv.conf and subsequent updates.
