### PR TITLE
Improve Firewall Log widget

### DIFF
--- a/usr/local/www/widgets/widgets/log.widget.php
+++ b/usr/local/www/widgets/widgets/log.widget.php
@@ -105,11 +105,18 @@ else
 
 /* Called by the AJAX updater */
 function format_log_line(row) {
-	var line = '<td class="listMRlr" align="center">' + row[0] + '<\/td>' +
-		'<td class="listMRr ellipsis" title="' + row[1] + '">' + row[1].slice(0,-3) + '<\/td>' +
-		'<td class="listMRr ellipsis" title="' + row[2] + '">' + row[2] + '<\/td>' +
-		'<td class="listMRr ellipsis" title="' + row[3] + '">' + row[3] + '<\/td>' +
-		'<td class="listMRr ellipsis" title="' + row[4] + '">' + row[4] + '<\/td>';
+	var rrText = "<?php echo gettext("Reverse Resolve with DNS"); ?>";
+	var row4parts = row[4].split(':');
+	if ( row4parts.length == 1 )
+		destPort = '';
+	else
+		destPort = ':' + row4parts[1];
+
+	var line = '<td class="listMRlr" align="center">' + row[0] + '</td>' +
+		'<td class="listMRr ellipsis" title="' + row[1] + '">' + row[1].slice(0,-3) + '</td>' +
+		'<td class="listMRr ellipsis" title="' + row[2] + '">' + row[2] + '</td>' +
+		'<td class="listMRr ellipsis" title="' + row[3] + '"><a href="diag_dns.php?host=' + row[3] + '" title="' + rrText + '">' + row[3] + '</a></td>' +
+		'<td class="listMRr ellipsis" title="' + row[4] + '"><a href="diag_dns.php?host=' + row4parts[0] + '" title="' + rrText + '">' + row4parts[0] + '</a>' + destPort + '</td>';
 
 	var nentriesacts = "<?php echo $nentriesacts; ?>";
 	var nentriesinterfaces = "<?php echo $nentriesinterfaces; ?>";
@@ -202,14 +209,13 @@ function format_log_line(row) {
 				<?php echo htmlspecialchars($filterent['srcip']);?></a></td>
 			<td class="listMRr ellipsis nowrap" title="<?php echo htmlspecialchars($filterent['dst']);?>">
 				<a href="diag_dns.php?host=<?php echo "{$filterent['dstip']}"; ?>" title="<?=gettext("Reverse Resolve with DNS");?>">
-				<?php echo htmlspecialchars($filterent['dstip']);?></a><?php echo ":" . htmlspecialchars($filterent['dstport']);?></td>
+				<?php echo htmlspecialchars($filterent['dstip']);?></a><?php if ($filterent['dstport']) echo ":" . htmlspecialchars($filterent['dstport']);?></td>
 			<?php
 				if ($filterent['proto'] == "TCP")
 					$filterent['proto'] .= ":{$filterent['tcpflags']}";
 			?>
 		</tr>
 	<?php endforeach; ?>
-		<tr style="display:none;"><td></td></tr>
 	</tbody>
 </table>
 


### PR DESCRIPTION
1) New firewall log data that is queried by the AJAX each 30 seconds did not have the "Reverse Resolve with DNS" link attached to it - do that.
2) Some Java string generation of the HTML was using "\/" sequence, apparently to get a literal "/" into the string. That is not necessary, as "/" is not a char that needs escaping in Java strings. Actually I am not sure what the "\/" sequence would have done - maybe Jave harmlessly puts a literal "/" for this.
3) Original rows that had no destination port still had a ":" at the end of the IP address (e.g. when the block was for a ping) like "1.2.3.4:". Do not put the colon on the end if there is no destination port.
4) An extra hidden blank row had been put at the end of the table. That was making the table size query from JavaScript get 1 bigger than the really displayed rows. This was causing the calculation errors that resulted in rows gradually disappearing from the table on the dashboard (as reported at forum: https://forum.pfsense.org/index.php?topic=85635.0 )

There were similar issues when the logs were in reverse mode, skipping table rows rather than losing them. The same fix removing the "bonus" table row seems to have fixed the row counting and updating for the time-reversed list also.
