### PR TITLE
Reboot not required for password protect console menu

### DIFF
--- a/usr/local/www/system_advanced_admin.php
+++ b/usr/local/www/system_advanced_admin.php
@@ -599,8 +599,6 @@ function prot_change() {
 								<td width="78%" class="vtable">
 									<input name="disableconsolemenu" type="checkbox" id="disableconsolemenu" value="yes" <?php if ($pconfig['disableconsolemenu']) echo "checked=\"checked\""; ?>  />
 									<strong><?=gettext("Password protect the console menu"); ?></strong>
-									<br />
-									<span class="vexpl"><?=gettext("Changes to this option will take effect after a reboot."); ?></span>
 								</td>
 							</tr>
 							<tr>


### PR DESCRIPTION
On my systems I can toggle and save "Password protect the console menu" back and forth and the console switches back and forth from the menu to a login prompt in real time. IMHO a reboot is no longer needed. Remove this note might save some people unnecessary reboot time.
