### PR TITLE
php error logging, helps identify when php 'crashes' due to for example a double function declaration

### DIFF
--- a/etc/inc/config.lib.inc
+++ b/etc/inc/config.lib.inc
@@ -924,13 +924,12 @@ function pfSense_clear_globals() {
 		$errtype = $error["type"];
 		if ($errtype != E_NOTICE) {
 			// there are a lot of 'innocent' errors.. so skip reporting E_NOTICE
-		$errfile = $error["file"];
+			$errfile = $error["file"];
 			$errline = $error["line"];
 			$errstr  = $error["message"];
 			$str = "PHP ERROR Type:$errtype, File:$errfile, Line: $errline, Message: $errstr";
 			print($str);
 			log_error($str);
-			file_notice("phperror", $str, "General", "", 2);
 		}
 	}
 		

--- a/etc/inc/config.lib.inc
+++ b/etc/inc/config.lib.inc
@@ -919,6 +919,21 @@ function get_config_backup_count() {
 function pfSense_clear_globals() {
 	global $config, $FilterIfList, $GatewaysList, $filterdns, $aliases, $aliastable;
 
+	$error = error_get_last();
+	if( $error !== NULL) {
+		$errtype = $error["type"];
+		if ($errtype != E_NOTICE) {
+			// there are a lot of 'innocent' errors.. so skip reporting E_NOTICE
+		$errfile = $error["file"];
+			$errline = $error["line"];
+			$errstr  = $error["message"];
+			$str = "PHP ERROR Type:$errtype, File:$errfile, Line: $errline, Message: $errstr";
+			print($str);
+			log_error($str);
+			file_notice("phperror", $str, "General", "", 2);
+		}
+	}
+		
 	if (isset($FilterIfList))
 		unset($FilterIfList);
 


### PR DESCRIPTION
php error logging, helps identify when php 'crashes' due to for example a double function declaration, redmine: https://redmine.pfsense.org/issues/4143