### PR TITLE
Fix unbound shortcut links

### DIFF
--- a/usr/local/www/diag_logs_resolver.php
+++ b/usr/local/www/diag_logs_resolver.php
@@ -65,7 +65,11 @@ if ($filtertext)
 	$filtertextmeta="?filtertext=$filtertext";
 
 $pgtitle = array(gettext("Status"),gettext("System logs"),gettext("Resolver"));
-$shortcut_section = "resolver";
+if (isset($config['dnsmasq']['enable']))
+	$shortcut_section = "forwarder";
+else
+	$shortcut_section = "resolver";
+
 include("head.inc");
 
 ?>

--- a/usr/local/www/services_dnsmasq.php
+++ b/usr/local/www/services_dnsmasq.php
@@ -151,7 +151,7 @@ if ($_GET['act'] == "del") {
 
 $closehead = false;
 $pgtitle = array(gettext("Services"),gettext("DNS forwarder"));
-$shortcut_section = "resolver";
+$shortcut_section = "forwarder";
 include("head.inc");
 
 ?>

--- a/usr/local/www/services_dnsmasq_domainoverride_edit.php
+++ b/usr/local/www/services_dnsmasq_domainoverride_edit.php
@@ -120,7 +120,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"),gettext("DNS forwarder"),gettext("Edit Domain Override"));
-$shortcut_section = "resolver";
+$shortcut_section = "forwarder";
 include("head.inc");
 
 ?>

--- a/usr/local/www/services_dnsmasq_edit.php
+++ b/usr/local/www/services_dnsmasq_edit.php
@@ -180,7 +180,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"),gettext("DNS forwarder"),gettext("Edit host"));
-$shortcut_section = "resolver";
+$shortcut_section = "forwarder";
 include("head.inc");
 
 ?>

--- a/usr/local/www/services_unbound.php
+++ b/usr/local/www/services_unbound.php
@@ -202,7 +202,7 @@ if ($_GET['act'] == "del") {
 
 $closehead = false;
 $pgtitle = array(gettext("Services"),gettext("DNS Resolver"));
-$shortcut_section = "unbound";
+$shortcut_section = "resolver";
 include_once("head.inc");
 
 ?>

--- a/usr/local/www/services_unbound_acls.php
+++ b/usr/local/www/services_unbound_acls.php
@@ -145,6 +145,7 @@ if ($_POST) {
 
 $closehead = false;
 $pgtitle = "Services: DNS Resolver: Access Lists";
+$shortcut_section = "resolver";
 include("head.inc");
 
 ?>

--- a/usr/local/www/services_unbound_advanced.php
+++ b/usr/local/www/services_unbound_advanced.php
@@ -184,6 +184,7 @@ if ($_POST) {
 
 $closehead = false;
 $pgtitle = array(gettext("Services"),gettext("DNS Resolver"),gettext("Advanced"));
+$shortcut_section = "resolver";
 include_once("head.inc");
 
 ?>

--- a/usr/local/www/services_unbound_host_edit.php
+++ b/usr/local/www/services_unbound_host_edit.php
@@ -32,13 +32,13 @@
 	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
-	pfSense_MODULE:	dnsforwarder
+	pfSense_MODULE:	dnsresolver
 */
 
 ##|+PRIV
 ##|*IDENT=page-services-dnsresolver-edithost
-##|*NAME=Services: DNS Forwarder: Edit host page
-##|*DESCR=Allow access to the 'Services: DNS Forwarder: Edit host' page.
+##|*NAME=Services: DNS Resolver: Edit host page
+##|*DESCR=Allow access to the 'Services: DNS Resolver: Edit host' page.
 ##|*MATCH=services_unbound_host_edit.php*
 ##|-PRIV
 

--- a/usr/local/www/shortcuts.inc
+++ b/usr/local/www/shortcuts.inc
@@ -220,15 +220,15 @@ $shortcuts['trafficshaper-limiters'] = array();
 $shortcuts['trafficshaper-limiters']['main'] = "firewall_shaper_vinterface.php";
 $shortcuts['trafficshaper-limiters']['status'] = "diag_limiter_info.php";
 
-$shortcuts['resolver'] = array();
-$shortcuts['resolver']['main'] = "services_dnsmasq.php";
-$shortcuts['resolver']['log'] = "diag_logs_resolver.php";
-$shortcuts['resolver']['service'] = "dnsmasq";
+$shortcuts['forwarder'] = array();
+$shortcuts['forwarder']['main'] = "services_dnsmasq.php";
+$shortcuts['forwarder']['log'] = "diag_logs_resolver.php";
+$shortcuts['forwarder']['service'] = "dnsmasq";
 
-$shortcuts['unbound'] = array();
-$shortcuts['unbound']['main'] = "services_unbound.php";
-$shortcuts['unbound']['log'] = "diag_logs_resolver.php";
-$shortcuts['unbound']['service'] = "unbound";
+$shortcuts['resolver'] = array();
+$shortcuts['resolver']['main'] = "services_unbound.php";
+$shortcuts['resolver']['log'] = "diag_logs_resolver.php";
+$shortcuts['resolver']['service'] = "unbound";
 
 $shortcuts['wireless'] = array();
 $shortcuts['wireless']['main'] = "interfaces_wireless.php";


### PR DESCRIPTION
Fixes redmine #4151
1) Make the naming in shortcuts.inc more clear - forwarder=dnsmasq resolver=unbound
2) Make the value of $shortcuts_section correct in each dnsmasq and unbound php code
3) Make diag_logs_resolver.php smarter, so if dnsmasq is enabled, then show shortcuts for dnsmasq, otherwise show shortcuts for unbound.
4) Fix some references to forwarder in unbound code - should be resolver.
