### PR TITLE
Minimise config updates when checking cron jobs

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -2392,13 +2392,7 @@ function install_cron_job($command, $active=false, $minute="0", $hour="*", $mont
 			$config['cron']['item'][] = $cron_item;
 			write_config(sprintf(gettext("Installed cron job for %s"), $command));
 		} else {
-			if (($config['cron']['item'][$x]['minute'] == $cron_item['minute']) && 
-			    ($config['cron']['item'][$x]['hour'] == $cron_item['hour']) && 
-			    ($config['cron']['item'][$x]['mday'] == $cron_item['mday']) && 
-			    ($config['cron']['item'][$x]['month'] == $cron_item['month']) && 
-			    ($config['cron']['item'][$x]['wday'] == $cron_item['wday']) && 
-			    ($config['cron']['item'][$x]['who'] == $cron_item['who']) && 
-			    ($config['cron']['item'][$x]['command'] == $cron_item['command'])) {
+			if ($config['cron']['item'][$x] == $cron_item) {
 				$cron_changed = false;
 				log_error(sprintf(gettext("Checked cron job for %s, no change needed"), $command));
 			} else {


### PR DESCRIPTION
I noticed this morning that whenever some event happens like interface status change, and a package restart is triggered, bandwidthd goes through its paces - including installing its cron job. That causes a config update to be written in /cf/conf and the old versions purge in /cf/conf/backup and quite quickly all that is in /cf/conf/backup is recent copies of the same thing. On a system using AutoConfigBackup there are loads of config backups that also end up with the same thing in them.
I could have made bandwidthd check if its cron job is already installed and correct, but it seems to me that this can be an issue for any package or bit of the system that calls install_cron_job(). If the cron job is already installed exactly as requested by the caller, then we do not want to touch the config and do not want to make a config backup...
I have attached a sample listing of the Auto Config Backups that happened in the last day on one of my systems to illustrate that this can be a pain.
![bandwidthd-updating-cron](https://cloud.githubusercontent.com/assets/1535615/5566803/ceeec5ec-8f5b-11e4-81fd-903f49aaf2b6.png)

This pull request does that - it minimizes config updating due to calling install_cron_job.
