### PR TITLE
fixes captive portal bug where long ipfw rules fail to apply bug#4150

### DIFF
--- a/etc/inc/captiveportal.inc
+++ b/etc/inc/captiveportal.inc
@@ -526,25 +526,21 @@ add 65307 deny layer2 not mac-type ip,ipv6
 EOD;
 
 	$rulenum = 65310;
-	$ipcount = 0;
-	$ips = "";
-	foreach ($cpips as $cpip) {
-		if($ipcount == 0) {
-			$ips = "{$cpip} ";
-		} else {
-			$ips .= "or {$cpip} ";
-		}
-		$ipcount++;
+	
+	$ip_chunks = array_chunk($cpips, 100); /* prevent long rules by forming chunks of 100 ips (interfaces) */
+	foreach ($ip_chunks as $ip_chunk) {
+		$ips = join($ip_chunk, " or ");
+	
+		$ips = "{ 255.255.255.255 or {$ips} }";
+		$cprules .= "add {$rulenum} pass ip from any to {$ips} in\n";
+		$rulenum++;
+		$cprules .= "add {$rulenum} pass ip from {$ips} to any out\n";
+		$rulenum++;
+		$cprules .= "add {$rulenum} pass icmp from {$ips} to any out icmptype 0\n";
+		$rulenum++;
+		$cprules .= "add {$rulenum} pass icmp from any to {$ips} in icmptype 8 \n";
+		$rulenum++;
 	}
-	$ips = "{ 255.255.255.255 or {$ips} }";
-	$cprules .= "add {$rulenum} pass ip from any to {$ips} in\n";
-	$rulenum++;
-	$cprules .= "add {$rulenum} pass ip from {$ips} to any out\n";
-	$rulenum++;
-	$cprules .= "add {$rulenum} pass icmp from {$ips} to any out icmptype 0\n";
-	$rulenum++;
-	$cprules .= "add {$rulenum} pass icmp from any to {$ips} in icmptype 8 \n";
-	$rulenum++;
 	/* Allowed ips */
 	$cprules .= "add {$rulenum} pipe tablearg ip from table(3) to any in\n";
 	$rulenum++;


### PR DESCRIPTION
When captive portal creates ipfw rules, too many interface addresses can cause ipfw to return "rule too long"

See iussue #4150: https://redmine.pfsense.org/issues/4150

This is a problem when running a captive portal zone on > ~120 interfaces. This pull request breaks up the rules into chunks of 100 interface addresses. 

$rulenum will overlap 65532 when ~20,000 interfaces are added to CP zone. This patch assumes you will not approach 20K interfaces on a CP zone, a fairly reasonable limitation. 