### PR TITLE
ipsec_smp_dump_status get out of loop if error

### DIFF
--- a/etc/inc/ipsec.inc
+++ b/etc/inc/ipsec.inc
@@ -382,9 +382,16 @@ function ipsec_smp_dump_status() {
 	$response = "";
 	while (!strstr($sread, "</message>")) {
 		$sread = fgets($fd);
+		if ($sread === false)
+			break;
 		$response .= $sread;
 	}
 	fclose($fd);
+
+	if ($sread === false) {
+		log_error("Error during reading of status from IPsec");
+		return;
+	}
 
 	@file_put_contents("{$g['tmp_path']}/smp_status.xml", $response);
 	unset($response, $sread);


### PR DESCRIPTION
when reading response from socket.
Otherwise it would be in a loop and end up like: https://forum.pfsense.org/index.php?topic=86039.msg471848#msg471848
PHP Fatal error:  Maximum execution time of 900 seconds exceeded in /etc/inc/ipsec.inc on line 383

This code runs on my system, but I do not know how to induce the possible loop condition to actually test if it would really break out and return nicely.
