### PR TITLE
IPsec Widget allow for old settings that have no iketype

### DIFF
--- a/usr/local/www/widgets/widgets/ipsec.widget.php
+++ b/usr/local/www/widgets/widgets/ipsec.widget.php
@@ -78,7 +78,7 @@ if (isset($config['ipsec']['phase1'])) { ?>
 			if (isset($ph1ent['disabled']) || isset($ph2ent['disabled']))
 				continue;
 
-			if ($ph1ent['iketype'] == 'ikev1') {
+			if (empty($ph1ent['iketype']) || $ph1ent['iketype'] == 'ikev1') {
 				if (!isset($ikev1num[$ph1ent['ikeid']]))
 					$ikev1num[$ph1ent['ikeid']] = 0;
 				else


### PR DESCRIPTION
as mentioned in https://forum.pfsense.org/index.php?topic=84527.msg471919#msg471919
This change makes it work like similar if tests in /usr/local/www/vpn_ipsec.php, and code in /etc/inc/vpn.inc that effectively defaults to ikev1 when iketype is not specified.
This should make the code here be executed and make $ikeid get the correct value to be used in later code. We shall see if someone with the issue can confirm if this fixes it.
