### PR TITLE
Allow for old settings that have no iketype

### DIFF
--- a/usr/local/www/diag_ipsec.php
+++ b/usr/local/www/diag_ipsec.php
@@ -57,7 +57,7 @@ if ($_GET['act'] == 'connect') {
 	if (ctype_digit($_GET['ikeid'])) {
 		$ph1ent = ipsec_get_phase1($_GET['ikeid']);
 		if (!empty($ph1ent)) {
-			if ($ph1ent['iketype'] == 'ikev1') {
+			if (empty($ph1ent['iketype']) || $ph1ent['iketype'] == 'ikev1') {
 				$ph2entries = ipsec_get_number_of_phase2($_GET['ikeid']);
 				for ($i = 0; $i < $ph2entries; $i++) {
 					$connid = escapeshellarg("con{$_GET['ikeid']}00{$i}");


### PR DESCRIPTION
This bit of code looks like it could do with the same test as https://github.com/pfsense/pfsense/pull/1412
This is executed when the "Connect" button is pressed from Status->IPsec
Somebody with these problematic old IPsec entries could test this - with current code I suspect that disconnect followed by connect - it will not connect. With this change it will (might?) connect again.
