### PR TITLE
Fix lineup of copyright lines

### DIFF
--- a/etc/ecl.php
+++ b/etc/ecl.php
@@ -2,7 +2,7 @@
 /*  
 	external config loader
 	Copyright (C) 2010 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -7,38 +7,38 @@
 	Copyright (C) 2007, 2008 Scott Ullrich <sullrich@gmail.com>
 	All rights reserved.
 
-        Copyright (C) 2005-2006 Bill Marquette <bill.marquette@gmail.com>
-        All rights reserved.
+	Copyright (C) 2005-2006 Bill Marquette <bill.marquette@gmail.com>
+	All rights reserved.
 
-        Copyright (C) 2006 Paul Taylor <paultaylor@winn-dixie.com>.
-        All rights reserved.
+	Copyright (C) 2006 Paul Taylor <paultaylor@winn-dixie.com>.
+	All rights reserved.
 
-        Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-        All rights reserved.
+	Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
-		pfSense_BUILDER_BINARIES:	/usr/sbin/pw	/bin/cp
-		pfSense_MODULE:	auth
+	pfSense_BUILDER_BINARIES:	/usr/sbin/pw	/bin/cp
+	pfSense_MODULE:	auth
 */
 
 /*

--- a/etc/inc/authgui.inc
+++ b/etc/inc/authgui.inc
@@ -4,37 +4,37 @@
 	Copyright (C) 2007, 2008 Scott Ullrich <sullrich@gmail.com>
 	All rights reserved.
 
-        Copyright (C) 2005-2006 Bill Marquette <bill.marquette@gmail.com>
-        All rights reserved.
+	Copyright (C) 2005-2006 Bill Marquette <bill.marquette@gmail.com>
+	All rights reserved.
 
-        Copyright (C) 2006 Paul Taylor <paultaylor@winn-dixie.com>.
-        All rights reserved.
+	Copyright (C) 2006 Paul Taylor <paultaylor@winn-dixie.com>.
+	All rights reserved.
 
-        Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-        All rights reserved.
+	Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
-		pfSense_MODULE: authgui
+	pfSense_MODULE: authgui
 */
 
 include_once("auth.inc");

--- a/etc/inc/certs.inc
+++ b/etc/inc/certs.inc
@@ -1,32 +1,33 @@
 <?php
 /* $Id$ */
 /*
+	certs.inc
 	Copyright (C) 2008 Shrew Soft Inc
 	Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
 	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
-		pfSense_MODULE:	certificate_managaer
+	pfSense_MODULE:	certificate_manager
 */
 
 define("OPEN_SSL_CONF_PATH", "/etc/ssl/openssl.cnf");

--- a/etc/inc/easyrule.inc
+++ b/etc/inc/easyrule.inc
@@ -1,6 +1,6 @@
 <?php
 /*
-	easyrule.inc.php
+	easyrule.inc
 
 	Copyright (C) 2009-2010 Jim Pingle (jpingle@gmail.com)
 	Originally Sponsored By Anathematic @ pfSense Forums

--- a/etc/inc/gwlb.inc
+++ b/etc/inc/gwlb.inc
@@ -1,29 +1,30 @@
 <?php
 /*
-  Copyright (C) 2008 Bill Marquette, Seth Mos
-  Copyright (C) 2010 Ermal Luçi
-  All rights reserved.
+	gwlb.inc
+	Copyright (C) 2008 Bill Marquette, Seth Mos
+	Copyright (C) 2010 Ermal Luçi
+	All rights reserved.
 
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-  1. Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
 
-  2. Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
 
-  THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-  AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-  AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-  OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-  POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
 	pfSense_BUILDER_BINARIES:	/sbin/route	/usr/local/sbin/apinger
 	pfSense_MODULE:	routing

--- a/etc/inc/ipsec.attributes.php
+++ b/etc/inc/ipsec.attributes.php
@@ -1,29 +1,30 @@
 <?php
 /*
-        Copyright (C) 2011-2012         Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-        All rights reserved.
+	ipsec.attributes.php
+	Copyright (C) 2011-2012         Ermal Luçi
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 if (empty($common_name)) {

--- a/etc/inc/ipsec.auth-user.php
+++ b/etc/inc/ipsec.auth-user.php
@@ -1,33 +1,33 @@
 #!/usr/local/bin/php -f
 <?php
 /*
-    ipsec.auth-user.php
+	ipsec.auth-user.php
 
-    Copyright (C) 2008 Shrew Soft Inc
-    Copyright (C) 2010 Ermal Luçi
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	Copyright (C) 2008 Shrew Soft Inc
+	Copyright (C) 2010 Ermal Luçi
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
 */
 /*

--- a/etc/inc/openvpn.attributes.php
+++ b/etc/inc/openvpn.attributes.php
@@ -1,29 +1,30 @@
 <?php
 /*
-        Copyright (C) 2011-2012         Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-        All rights reserved.
+	openvpn.attributes.php
+	Copyright (C) 2011-2012         Ermal Luçi
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 if (empty($common_name)) {

--- a/etc/inc/openvpn.auth-user.php
+++ b/etc/inc/openvpn.auth-user.php
@@ -2,33 +2,33 @@
 <?php
 /* $Id$ */
 /*
-    openvpn.auth-user.php
+	openvpn.auth-user.php
 
-    Copyright (C) 2008 Shrew Soft Inc
-    Copyright (C) 2010 Ermal Luçi
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	Copyright (C) 2008 Shrew Soft Inc
+	Copyright (C) 2010 Ermal Luçi
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
 */
 /*

--- a/etc/inc/openvpn.tls-verify.php
+++ b/etc/inc/openvpn.tls-verify.php
@@ -5,7 +5,7 @@
 	openvpn.tls-verify.php
 
 	Copyright (C) 2011 Jim Pingle
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/etc/inc/priv.inc
+++ b/etc/inc/priv.inc
@@ -1,41 +1,42 @@
 <?php
 /* $Id$ */
 /*
-		Copyright (C) 2008 Shrew Soft Inc
-		All rights reserved.
+	priv.inc
+	Copyright (C) 2008 Shrew Soft Inc
+	All rights reserved.
 
-		Copyright (C) 2007, 2008 Scott Ullrich <sullrich@gmail.com>
-		All rights reserved.
+	Copyright (C) 2007, 2008 Scott Ullrich <sullrich@gmail.com>
+	All rights reserved.
 
-        Copyright (C) 2005-2006 Bill Marquette <bill.marquette@gmail.com>
-        All rights reserved.
+	Copyright (C) 2005-2006 Bill Marquette <bill.marquette@gmail.com>
+	All rights reserved.
 
-        Copyright (C) 2006 Paul Taylor <paultaylor@winn-dixie.com>.
-        All rights reserved.
+	Copyright (C) 2006 Paul Taylor <paultaylor@winn-dixie.com>.
+	All rights reserved.
 
-        Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-        All rights reserved.
+	Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
 */
 

--- a/etc/inc/radius.inc
+++ b/etc/inc/radius.inc
@@ -1,49 +1,49 @@
 <?php
 /* vim: set expandtab tabstop=4 shiftwidth=4: */
 /*
-    $Id$
+    radius.inc
 
-    Copyright (c) 2003, Michael Bretterklieber <michael@bretterklieber.com>
-    All rights reserved.
+	Copyright (c) 2003, Michael Bretterklieber <michael@bretterklieber.com>
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without 
-    modification, are permitted provided that the following conditions 
-    are met:
+	Redistribution and use in source and binary forms, with or without 
+	modification, are permitted provided that the following conditions 
+	are met:
 
-    1. Redistributions of source code must retain the above copyright 
-       notice, this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright 
-       notice, this list of conditions and the following disclaimer in the 
-       documentation and/or other materials provided with the distribution.
-    3. The names of the authors may not be used to endorse or promote products 
-       derived from this software without specific prior written permission.
+	1. Redistributions of source code must retain the above copyright 
+	   notice, this list of conditions and the following disclaimer.
+	2. Redistributions in binary form must reproduce the above copyright 
+	   notice, this list of conditions and the following disclaimer in the 
+	   documentation and/or other materials provided with the distribution.
+	3. The names of the authors may not be used to endorse or promote products 
+	   derived from this software without specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-    IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY 
-    OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
-    EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+	IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+	INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+	DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY 
+	OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+	NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+	EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-    This code cannot simply be copied and put under the GNU Public License or 
-    any other GPL-like (LGPL, GPL2) License.
+	This code cannot simply be copied and put under the GNU Public License or 
+	any other GPL-like (LGPL, GPL2) License.
 
-        This version of RADIUS.php has been modified by
-        Jonathan De Graeve <m0n0wall@esstec.be> to integrate with M0n0wall <http://www.m0n0.ch/wall>
+	This version of RADIUS.php has been modified by
+	Jonathan De Graeve <m0n0wall@esstec.be> to integrate with M0n0wall <http://www.m0n0.ch/wall>
 
-        Changes made include:
-        * StandardAttributes for M0n0wall use
-        * Removed internal Session-Id creation
-        * Adding of ReplyMessage to getAttributes()
-        * Adding of listAttributes()
-        * Adding of VENDOR Bay Networks (Nortel)
-        * Adding of VENDOR Nomadix
-        * Adding of VENDOR WISPr (Wi-Fi Alliance)
-        * Adding of VENDOR ChilliSpot (bandwidth-attributes only)
+	Changes made include:
+	* StandardAttributes for M0n0wall use
+	* Removed internal Session-Id creation
+	* Adding of ReplyMessage to getAttributes()
+	* Adding of listAttributes()
+	* Adding of VENDOR Bay Networks (Nortel)
+	* Adding of VENDOR Nomadix
+	* Adding of VENDOR WISPr (Wi-Fi Alliance)
+	* Adding of VENDOR ChilliSpot (bandwidth-attributes only)
 
 */
 

--- a/etc/inc/rrd.inc
+++ b/etc/inc/rrd.inc
@@ -1,29 +1,30 @@
 <?php
 /* $Id$ */
 /*
-  Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>
-  All rights reserved.
+	rrd.inc
+	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>
+	All rights reserved.
 
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-  2. Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-  THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-  AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-  AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-  OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-  POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
   */
 

--- a/etc/inc/shaper.inc
+++ b/etc/inc/shaper.inc
@@ -1,5 +1,6 @@
 <?php
 /*
+	shaper.inc
 	Copyright (C) 2008 Ermal Luçi
 	All rights reserved.
 

--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -1,5 +1,6 @@
 <?php
 /*
+	upgrade_config.inc
 	Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
 	All rights reserved.
 
@@ -10,24 +11,24 @@
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice,
-	this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
 	2. Redistributions in binary form must reproduce the above copyright
-	notice, this list of conditions and the following disclaimer in the
-	documentation and/or other materials provided with the distribution.
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
 	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
 	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
 	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
 	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
-	*/
+*/
 
 /*
 	pfSense_BUILDER_BINARIES:	/usr/bin/find	/bin/cd	/usr/local/bin/rrdtool	/usr/bin/nice

--- a/etc/inc/voucher.inc
+++ b/etc/inc/voucher.inc
@@ -1,5 +1,6 @@
 <?php
 /*
+	voucher.inc
 	Copyright (C) 2010-2012 Ermal Luci <eri@pfsense.org>
 	Copyright (C) 2010 Scott Ullrich <sullrich@gmail.com>
     Copyright (C) 2007 Marcel Wiget <mwiget@mac.com>

--- a/etc/inc/vslb.inc
+++ b/etc/inc/vslb.inc
@@ -1,30 +1,30 @@
 <?php
 /* $Id$ */
 /*
-  vslb.inc
-  Copyright (C) 2005-2008 Bill Marquette
-  All rights reserved.
+	vslb.inc
+	Copyright (C) 2005-2008 Bill Marquette
+	All rights reserved.
 
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-  1. Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-  2. Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-  THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-  AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-  AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-  OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-  POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
  */
 

--- a/etc/inc/wizardapp.inc
+++ b/etc/inc/wizardapp.inc
@@ -1,32 +1,33 @@
 <?php
 /*
-        part of pfSense (https://www.pfsense.org/)
+	wizardapp.inc
+	part of pfSense (https://www.pfsense.org/)
 
-        Copyright (C) 2006 Bill Marquette - bill.marquette@gmail.com.
-        Copyright (C) 2006 Scott Ullrich - sullrich@pfsense.com.
-        Copyright (C) 2008-2010 Ermal Luçi
-        All rights reserved.
+	Copyright (C) 2006 Bill Marquette - bill.marquette@gmail.com.
+	Copyright (C) 2006 Scott Ullrich - sullrich@pfsense.com.
+	Copyright (C) 2008-2010 Ermal Luçi
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $gamesplist = array();

--- a/etc/inc/xmlreader.inc
+++ b/etc/inc/xmlreader.inc
@@ -1,7 +1,7 @@
 <?php
 /* $Id$ */
 /*
-	xmlparse.inc
+	xmlreader.inc
 	functions to parse/dump configuration files in XML format
 	part of m0n0wall (http://m0n0.ch/wall)
 

--- a/etc/inc/xmlrpc.inc
+++ b/etc/inc/xmlrpc.inc
@@ -2,30 +2,30 @@
 /*
 	$Id$
 
-        xmlrpc.inc
-        Copyright (C) 2005-2006 Colin Smith
-        All rights reserved.
+	xmlrpc.inc
+	Copyright (C) 2005-2006 Colin Smith
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 /*

--- a/etc/rc.carpbackup
+++ b/etc/rc.carpbackup
@@ -2,7 +2,7 @@
 <?php
 /* $Id$ */
 /*
-    rc.carpdown
+    rc.carpbackup
     part of pfSense (https://www.pfsense.org)
     Copyright (C) 2004 Scott Ullrich
     All rights reserved.

--- a/etc/rc.carpmaster
+++ b/etc/rc.carpmaster
@@ -2,7 +2,7 @@
 <?php
 /* $Id$ */
 /*
-    rc.carpup
+    rc.carpmaster
     part of pfSense (https://www.pfsense.org)
     Copyright (C) 2004 Scott Ullrich
     All rights reserved.

--- a/etc/rc.expireaccounts
+++ b/etc/rc.expireaccounts
@@ -2,7 +2,7 @@
 <?php
 /* $Id$ */
 /*
-	rc.exireaccounts
+	rc.expireaccounts
 	part of pfSense
 	
 	Copyright (C) 2009 Shrew Soft Inc.

--- a/etc/rc.filter_synchronize
+++ b/etc/rc.filter_synchronize
@@ -1,37 +1,37 @@
 #!/usr/local/bin/php -f
 <?php
 /*
-        filter.inc
-        Copyright (C) 2004-2006 Scott Ullrich
-        Copyright (C) 2005              Bill Marquette
-        Copyright (C) 2006              Peter Allgeyer
-        Copyright (C) 2008              Ermal Luci
-        All rights reserved.
+	rc.filter_synchronize
+	Copyright (C) 2004-2006 Scott Ullrich
+	Copyright (C) 2005              Bill Marquette
+	Copyright (C) 2006              Peter Allgeyer
+	Copyright (C) 2008              Ermal Luci
+	All rights reserved.
 
-        originally part of m0n0wall (http://m0n0.ch/wall)
-        Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
-        All rights reserved.
+	originally part of m0n0wall (http://m0n0.ch/wall)
+	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
 */
 

--- a/etc/rc.initial.store_config_to_removable_device
+++ b/etc/rc.initial.store_config_to_removable_device
@@ -2,7 +2,7 @@
 <?php
 /* $Id$ */
 /*
-	rc.initial.setlanip
+	rc.initial.store_config_to_removable_device
 	part of m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.

--- a/etc/rc.initial.toggle_sshd
+++ b/etc/rc.initial.toggle_sshd
@@ -1,6 +1,7 @@
 #! /usr/local/bin/php -f
 <?php
 /*
+	rc.initial.toggle_sshd
 	sshd - Modified to work on disk based system
 	Copyright 2004 Scott K Ullrich
 

--- a/etc/rc.linkup
+++ b/etc/rc.linkup
@@ -1,32 +1,32 @@
 #!/usr/local/bin/php -f
 <?php
 /*
-        rc.linkup - devd hotplug actions
-        part of pfSense
+	rc.linkup - devd hotplug actions
+	part of pfSense
 
-        Copyright (C) 2003-2005 Scott Ullrich <sullrich@gmail.com>.
-        All rights reserved.
+	Copyright (C) 2003-2005 Scott Ullrich <sullrich@gmail.com>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 /* parse the configuration and include all functions used below */

--- a/etc/rc.newipsecdns
+++ b/etc/rc.newipsecdns
@@ -1,7 +1,7 @@
 #!/usr/local/bin/php -f
 <?php
 /*
-	$Id$
+	rc.newipsecdns
 	part of m0n0wall (http://m0n0.ch/wall)
 	
 	Copyright (C) 2007 Manuel Kasper <mk@neon1.net>.

--- a/etc/rc.newroutedns
+++ b/etc/rc.newroutedns
@@ -1,6 +1,7 @@
 #!/usr/local/bin/php -f
 <?php
 /*
+	rc.newroutedns
 	Copyright (C) 2013 Renato Botelho <garga@pfsense.org>.
 	All rights reserved.
 

--- a/etc/rc.newwanipv6
+++ b/etc/rc.newwanipv6
@@ -1,34 +1,34 @@
 #!/usr/local/bin/php -f
 <?php
 /*
-        rc.newwanipv6
-        Copyright (C) 2006 Scott Ullrich (sullrich@gmail.com)
-        part of pfSense (https://www.pfsense.org)
+	rc.newwanipv6
+	Copyright (C) 2006 Scott Ullrich (sullrich@gmail.com)
+	part of pfSense (https://www.pfsense.org)
 
-		Originally part of m0n0wall (http://m0n0.ch)
-        Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
-        All rights reserved.
+	Originally part of m0n0wall (http://m0n0.ch)
+	Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 /* parse the configuration and include all functions used below */

--- a/etc/rc.openvpn
+++ b/etc/rc.openvpn
@@ -1,7 +1,7 @@
 #!/usr/local/bin/php -f
 <?php
 /*
-	$Id$
+	rc.openvpn
 	part of m0n0wall (http://m0n0.ch/wall)
 	
 	Copyright (C) 2007 Manuel Kasper <mk@neon1.net>.

--- a/etc/rc.resolv_conf_generate
+++ b/etc/rc.resolv_conf_generate
@@ -1,29 +1,30 @@
 #!/usr/local/bin/php -f
 <?php
 /*
-        Copyright (C) 2010 Ermal Luçi
-        All rights reserved.
+	rc.resolv_conf_generate
+	Copyright (C) 2010 Ermal Luçi
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 require_once("globals.inc");

--- a/etc/rc.update_alias_url_data
+++ b/etc/rc.update_alias_url_data
@@ -2,7 +2,7 @@
 <?php
 /* $Id$ */
 /*
-	rc.update_alias_url-data.sh
+	rc.update_alias_url_data.sh
 	part of pfSense (https://www.pfsense.org)
 	
 	Copyright (C) 2010 Scott Ullrich <sullrich@gmail.com>

--- a/usr/local/bin/filterparser.php
+++ b/usr/local/bin/filterparser.php
@@ -7,7 +7,7 @@
 	originally based on m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2009 Jim Pingle <myfirstname>@<mylastname>.org
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/captiveportal/index.php
+++ b/usr/local/captiveportal/index.php
@@ -3,8 +3,8 @@
 	$Id$
 	part of m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-	Copyrigth (C) 2009 Ermal Luçi
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2009 Ermal Luçi
 	Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 

--- a/usr/local/sbin/WipePackages.php
+++ b/usr/local/sbin/WipePackages.php
@@ -5,7 +5,7 @@
 	WipePackages.php
 	part of the pfSense project
 	Copyright (C) 2008 Scott Ullrich <sullrich@gmail.com>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/sbin/gmirror_status_check.php
+++ b/usr/local/sbin/gmirror_status_check.php
@@ -3,7 +3,7 @@
 /*
 	gmirror_status_check.php
 	Copyright (C) 2014 Jim Pingle
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:

--- a/usr/local/www/diag_arp.php
+++ b/usr/local/www/diag_arp.php
@@ -3,7 +3,7 @@
 	diag_arp.php
 	part of the pfSense project	(https://www.pfsense.org)
 	Copyright (C) 2004-2009 Scott Ullrich <sullrich@gmail.com>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	originally part of m0n0wall (http://m0n0.ch/wall)
 	Copyright (C) 2005 Paul Taylor (paultaylor@winndixie.com) and Manuel Kasper <mk@neon1.net>.

--- a/usr/local/www/diag_authentication.php
+++ b/usr/local/www/diag_authentication.php
@@ -3,7 +3,7 @@
 	diag_authentication.php
 	part of the pfSense project	(https://www.pfsense.org)
 	Copyright (C) 2010 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_backup.php
+++ b/usr/local/www/diag_backup.php
@@ -3,7 +3,7 @@
 /*
 	diag_backup.php
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_defaults.php
+++ b/usr/local/www/diag_defaults.php
@@ -3,7 +3,7 @@
 /*
 	diag_defaults.php
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_dns.php
+++ b/usr/local/www/diag_dns.php
@@ -3,7 +3,7 @@
 	diag_dns.php
 
 	Copyright (C) 2009 Jim Pingle (jpingle@gmail.com)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_dump_states.php
+++ b/usr/local/www/diag_dump_states.php
@@ -3,7 +3,7 @@
 	diag_dump_states.php
 	Copyright (C) 2005 Colin Smith
 	Copyright (C) 2005-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_dump_states_sources.php
+++ b/usr/local/www/diag_dump_states_sources.php
@@ -1,9 +1,9 @@
 <?php
 /*
-	diag_dump_states.php
+	diag_dump_states_sources.php
 	Copyright (C) 2005 Colin Smith
 	Copyright (C) 2005-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_ipsec.php
+++ b/usr/local/www/diag_ipsec.php
@@ -4,7 +4,7 @@
 	diag_ipsec.php
 	Copyright (C) 2004-2009 Scott Ullrich
 	Copyright (C) 2008 Shrew Soft Inc <mgrooms@shrew.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Parts of this code was originally based on vpn_ipsec_sad.php

--- a/usr/local/www/diag_ipsec_leases.php
+++ b/usr/local/www/diag_ipsec_leases.php
@@ -3,7 +3,7 @@
 /*
 	diag_ipsec_leases.php
 	Copyright (C) 2014 Ermal LUÇi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_ipsec_sad.php
+++ b/usr/local/www/diag_ipsec_sad.php
@@ -3,7 +3,7 @@
 /*
 	diag_ipsec_sad.php
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_ipsec_spd.php
+++ b/usr/local/www/diag_ipsec_spd.php
@@ -3,7 +3,7 @@
 /*
 	diag_ipsec_spd.php
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_ipsec_xml.php
+++ b/usr/local/www/diag_ipsec_xml.php
@@ -4,7 +4,7 @@
 	diag_ipsec_xml.php
 	Copyright (C) 2007 pfSense Project
 	Copyright (C) 2010 Seth Mos
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Parts of this code was originally based on vpn_ipsec_sad.php

--- a/usr/local/www/diag_logs.php
+++ b/usr/local/www/diag_logs.php
@@ -3,7 +3,7 @@
 /*
 	diag_logs.php
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_logs_auth.php
+++ b/usr/local/www/diag_logs_auth.php
@@ -7,7 +7,7 @@
 	All rights reserved.
 
 	part of pfSense
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_logs_dhcp.php
+++ b/usr/local/www/diag_logs_dhcp.php
@@ -3,7 +3,7 @@
 /*
 	diag_logs_dhcp.php
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_logs_filter.php
+++ b/usr/local/www/diag_logs_filter.php
@@ -4,7 +4,7 @@
 	diag_logs_filter.php
 	part of pfSense 
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	originally based on m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2003-2009 Manuel Kasper <mk@neon1.net>,

--- a/usr/local/www/diag_logs_filter_dynamic.php
+++ b/usr/local/www/diag_logs_filter_dynamic.php
@@ -4,7 +4,7 @@
 	diag_logs_filter_dynamic.php
 	part of pfSesne
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	originally based on m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.

--- a/usr/local/www/diag_logs_gateways.php
+++ b/usr/local/www/diag_logs_gateways.php
@@ -4,7 +4,7 @@
 	diag_logs_gateways.php
 	Copyright (C) 2004-2009 Scott Ullrich
 	Copyright (C) 2012 Seth Mos
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_logs_ipsec.php
+++ b/usr/local/www/diag_logs_ipsec.php
@@ -1,9 +1,9 @@
 <?php
 /* $Id$ */
 /*
-	diag_logs.php
+	diag_logs_ipsec.php
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_logs_openvpn.php
+++ b/usr/local/www/diag_logs_openvpn.php
@@ -1,9 +1,9 @@
 <?php
 /* $Id$ */
 /*
-	diag_logs.php
+	diag_logs_openvpn.php
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_logs_ppp.php
+++ b/usr/local/www/diag_logs_ppp.php
@@ -1,9 +1,9 @@
 <?php
 /* $Id$ */
 /*
-	diag_logs.php
+	diag_logs_ppp.php
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_logs_relayd.php
+++ b/usr/local/www/diag_logs_relayd.php
@@ -6,7 +6,7 @@
 
 	Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
 	Copyright (C) 2008 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_logs_resolver.php
+++ b/usr/local/www/diag_logs_resolver.php
@@ -4,7 +4,7 @@
 	diag_logs_resolver.php
 	Copyright (C) 2004-2009 Scott Ullrich
 	Copyright (C) 2012 Seth Mos
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_logs_routing.php
+++ b/usr/local/www/diag_logs_routing.php
@@ -5,7 +5,7 @@
 	part of pfSense
 
 	Copyright (C) 2012 Jim Pingle <jimp@pfsense.org>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_logs_settings.php
+++ b/usr/local/www/diag_logs_settings.php
@@ -3,7 +3,7 @@
 /*
 	diag_logs_settings.php
 	Copyright (C) 2004-2009 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/diag_logs_vpn.php
+++ b/usr/local/www/diag_logs_vpn.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_logs_wireless.php
+++ b/usr/local/www/diag_logs_wireless.php
@@ -7,7 +7,7 @@
 	Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
 	Copyright (C) 2008 Seth Mos <seth.mos@dds.nl>.
 	Copyright (C) 2011 Jim Pingle <jimp@pfsense.org>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_nanobsd.php
+++ b/usr/local/www/diag_nanobsd.php
@@ -2,7 +2,7 @@
 /*
 	diag_nanobsd.php
 	Copyright (C) 2009 Scott Ullrich <sullrich@gmail.com>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_packet_capture.php
+++ b/usr/local/www/diag_packet_capture.php
@@ -1,7 +1,7 @@
 <?php
 /*
-
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+    diag_packet_capture.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_ping.php
+++ b/usr/local/www/diag_ping.php
@@ -6,7 +6,7 @@
 	Copyright (C) 2003-2005 Bob Zoller (bob@kludgebox.com) and Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_pkglogs.php
+++ b/usr/local/www/diag_pkglogs.php
@@ -6,7 +6,7 @@
 	Copyright (C) 2005 Colin Smith
 	All rights reserved.
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/diag_resetstate.php
+++ b/usr/local/www/diag_resetstate.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
 	diag_resetstate.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004-2009 Scott Ullrich
 	All rights reserved.
 

--- a/usr/local/www/diag_routes.php
+++ b/usr/local/www/diag_routes.php
@@ -3,7 +3,7 @@
 /* $Id$ */
 /*
 	diag_routes.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2006 Fernando Lamos
 	All rights reserved.
 

--- a/usr/local/www/diag_smart.php
+++ b/usr/local/www/diag_smart.php
@@ -1,8 +1,9 @@
 <?php
 /*
+	diag_smart.php
 	Part of pfSense
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved
 
 	Some modifications:

--- a/usr/local/www/diag_sockets.php
+++ b/usr/local/www/diag_sockets.php
@@ -3,7 +3,7 @@
 /* $Id$ */
 /*
 	diag_sockets.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2012
 	All rights reserved.
 

--- a/usr/local/www/diag_states_summary.php
+++ b/usr/local/www/diag_states_summary.php
@@ -1,7 +1,7 @@
 <?php
 /*
 	diag_states_summary.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2010-2014 Jim Pingle
 
 	Portions borrowed from diag_dump_states.php:

--- a/usr/local/www/diag_system_activity.php
+++ b/usr/local/www/diag_system_activity.php
@@ -1,7 +1,7 @@
 <?php
 /* $Id$ */
 /*
-    diag_cpu_activity.php
+    diag_system_activity.php
     Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
     Copyright (C) 2008-2009 Scott Ullrich

--- a/usr/local/www/diag_tables.php
+++ b/usr/local/www/diag_tables.php
@@ -1,7 +1,7 @@
 <?php
 /*
 	diag_tables.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2010 Jim Pingle
 
 	Portions borrowed from diag_dump_states.php:

--- a/usr/local/www/diag_testport.php
+++ b/usr/local/www/diag_testport.php
@@ -2,7 +2,7 @@
 /*
 	diag_testport.php
 	Copyright (C) 2013 Jim P (jimp@pfsense.org)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Portions based on diag_ping.php

--- a/usr/local/www/diag_traceroute.php
+++ b/usr/local/www/diag_traceroute.php
@@ -3,7 +3,7 @@
 	diag_traceroute.php
 	part of m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2005 Paul Taylor (paultaylor@winndixie.com) and Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 

--- a/usr/local/www/easyrule.php
+++ b/usr/local/www/easyrule.php
@@ -2,7 +2,7 @@
 /*
 	easyrule.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2009-2010 Jim Pingle (jpingle@gmail.com)
 	Originally Sponsored By Anathematic @ pfSense Forums
 	All rights reserved.

--- a/usr/local/www/edit.php
+++ b/usr/local/www/edit.php
@@ -2,7 +2,7 @@
 /*
 	edit.php
 	Copyright (C) 2004, 2005 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/exec.php
+++ b/usr/local/www/exec.php
@@ -6,7 +6,7 @@
 
 	(modified for m0n0wall by Manuel Kasper <mk@neon1.net>)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:

--- a/usr/local/www/filebrowser/browser.php
+++ b/usr/local/www/filebrowser/browser.php
@@ -4,7 +4,7 @@ require_once("guiconfig.inc");
 
 /*
 	pfSense_MODULE:	shell
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 */
 // Fetch a list of directories and files inside a given directory

--- a/usr/local/www/firewall_aliases.php
+++ b/usr/local/www/firewall_aliases.php
@@ -3,7 +3,7 @@
 /*
 	firewall_aliases.php
 	Copyright (C) 2004 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -5,7 +5,7 @@
 	Copyright (C) 2004 Scott Ullrich
 	Copyright (C) 2009 Ermal Luçi
 	Copyright (C) 2010 Jim Pingle
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/firewall_aliases_import.php
+++ b/usr/local/www/firewall_aliases_import.php
@@ -3,7 +3,7 @@
 /*
 	firewall_aliases_import.php
 	Copyright (C) 2005 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/firewall_nat.php
+++ b/usr/local/www/firewall_nat.php
@@ -3,7 +3,7 @@
 /*
 	firewall_nat.php
 	Copyright (C) 2004 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/firewall_nat_1to1.php
+++ b/usr/local/www/firewall_nat_1to1.php
@@ -7,7 +7,7 @@
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:

--- a/usr/local/www/firewall_nat_1to1_edit.php
+++ b/usr/local/www/firewall_nat_1to1_edit.php
@@ -7,7 +7,7 @@
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:

--- a/usr/local/www/firewall_nat_edit.php
+++ b/usr/local/www/firewall_nat_edit.php
@@ -7,7 +7,7 @@
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:

--- a/usr/local/www/firewall_nat_npt.php
+++ b/usr/local/www/firewall_nat_npt.php
@@ -7,7 +7,7 @@
 	Copyright (C) 2011 Seth Mos <seth.mos@dds.nl>.
 	All rights reserved.
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/firewall_nat_npt_edit.php
+++ b/usr/local/www/firewall_nat_npt_edit.php
@@ -4,7 +4,7 @@
 	firewall_nat_npt_edit.php
 	part of pfSense (https://www.pfsense.org)
 	
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2011 Seth Mos <seth.mos@dds.nl>.
 	All rights reserved.
 	

--- a/usr/local/www/firewall_nat_out.php
+++ b/usr/local/www/firewall_nat_out.php
@@ -3,7 +3,7 @@
 /*
 	firewall_nat_out.php
 	Copyright (C) 2004 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/firewall_nat_out_edit.php
+++ b/usr/local/www/firewall_nat_out_edit.php
@@ -3,7 +3,7 @@
 /*
 	firewall_nat_out_edit.php
 	Copyright (C) 2004 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/firewall_rules.php
+++ b/usr/local/www/firewall_rules.php
@@ -4,7 +4,7 @@
 	firewall_rules.php
 	part of pfSense (https://www.pfsense.org)
 	Copyright (C) 2005 Scott Ullrich (sullrich@gmail.com)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	originally part of m0n0wall (http://m0n0.ch/wall)
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.

--- a/usr/local/www/firewall_rules_edit.php
+++ b/usr/local/www/firewall_rules_edit.php
@@ -4,7 +4,7 @@
 	firewall_rules_edit.php
 	part of pfSense (https://www.pfsense.org)
 	Copyright (C) 2005 Scott Ullrich (sullrich@gmail.com)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	originally part of m0n0wall (http://m0n0.ch/wall)
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.

--- a/usr/local/www/firewall_schedule.php
+++ b/usr/local/www/firewall_schedule.php
@@ -2,7 +2,7 @@
 /*
 	firewall_schedule.php
 	Copyright (C) 2004 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/firewall_schedule_edit.php
+++ b/usr/local/www/firewall_schedule_edit.php
@@ -2,7 +2,7 @@
 /*
 	firewall_schedule_edit.php
 	Copyright (C) 2004 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/firewall_shaper.php
+++ b/usr/local/www/firewall_shaper.php
@@ -4,7 +4,7 @@
 	firewall_shaper.php
 	Copyright (C) 2004, 2005 Scott Ullrich
 	Copyright (C) 2008 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/firewall_shaper_layer7.php
+++ b/usr/local/www/firewall_shaper_layer7.php
@@ -3,7 +3,7 @@
 /*
 	firewall_shaper_layer7.php
 	Copyright (C) 2008 Helder Pereira, André Ribeiro
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/firewall_shaper_queues.php
+++ b/usr/local/www/firewall_shaper_queues.php
@@ -4,7 +4,7 @@
 	firewall_shaper_queues.php
 	Copyright (C) 2004, 2005 Scott Ullrich
 	Copyright (C) 2008 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/firewall_shaper_vinterface.php
+++ b/usr/local/www/firewall_shaper_vinterface.php
@@ -4,7 +4,7 @@
 	firewall_shaper_vinterface.php
 	Copyright (C) 2004, 2005 Scott Ullrich
 	Copyright (C) 2008 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/firewall_shaper_wizards.php
+++ b/usr/local/www/firewall_shaper_wizards.php
@@ -4,7 +4,7 @@
 	firewall_shaper_wizards.php
 	Copyright (C) 2004, 2005 Scott Ullrich
 	Copyright (C) 2008 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/firewall_virtual_ip.php
+++ b/usr/local/www/firewall_virtual_ip.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org/)
 
 	Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Includes code from m0n0wall which is:

--- a/usr/local/www/graph.php
+++ b/usr/local/www/graph.php
@@ -3,7 +3,7 @@
 	graph.php
 	part of m0n0wall (http://m0n0.ch/wall)
 	
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004-2006 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
 	and Jonathan Watt <jwatt@jwatt.org>.
 	All rights reserved.

--- a/usr/local/www/graph_cpu.php
+++ b/usr/local/www/graph_cpu.php
@@ -3,7 +3,7 @@
 	$Id$
 	part of m0n0wall (http://m0n0.ch/wall)
 	
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
 	and Jonathan Watt <jwatt@jwatt.org>.
 	All rights reserved.

--- a/usr/local/www/halt.php
+++ b/usr/local/www/halt.php
@@ -3,7 +3,7 @@
 /*
 	halt.php
 	part of pfSense
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004 Scott Ullrich
 	All rights reserved.
 

--- a/usr/local/www/ifstats.php
+++ b/usr/local/www/ifstats.php
@@ -4,7 +4,7 @@
 	ifstats.php
 	part of pfSense (https://www.pfsense.org)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2005-2006 Scott Ullrich (sullrich@gmail.com)
 	All rights reserved.
 

--- a/usr/local/www/includes/functions.inc.php
+++ b/usr/local/www/includes/functions.inc.php
@@ -1,7 +1,8 @@
 <?
 /*
+	functions.inc.php
 	pfSense_MODULE:	ajax
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 */
 
 if(Connection_Aborted()) {

--- a/usr/local/www/index.php
+++ b/usr/local/www/index.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
 	index.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004-2012 Scott Ullrich
 	All rights reserved.
 

--- a/usr/local/www/installer/installer.php
+++ b/usr/local/www/installer/installer.php
@@ -2,7 +2,7 @@
 /*
 	installer.php (pfSense webInstaller)
 	part of pfSense (https://www.pfsense.org/)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2010 Scott Ullrich <sullrich@gmail.com>
 	All rights reserved.
 

--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
 	interfaces.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004-2008 Scott Ullrich
 	Copyright (C) 2006 Daniel S. Haischt.
 	Copyright (C) 2008-2010 Ermal Luçi

--- a/usr/local/www/interfaces_assign.php
+++ b/usr/local/www/interfaces_assign.php
@@ -4,7 +4,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 	Written by Jim McBeath based on existing m0n0wall files
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 

--- a/usr/local/www/interfaces_bridge.php
+++ b/usr/local/www/interfaces_bridge.php
@@ -3,7 +3,7 @@
 /*
 	interfaces_bridge.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Ermal Luçi
 	All rights reserved.
 

--- a/usr/local/www/interfaces_bridge_edit.php
+++ b/usr/local/www/interfaces_bridge_edit.php
@@ -3,7 +3,7 @@
 /*
 	interfaces_bridge_edit.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Ermal Luçi
 	All rights reserved.
 

--- a/usr/local/www/interfaces_gif.php
+++ b/usr/local/www/interfaces_gif.php
@@ -3,7 +3,7 @@
 /*
 	interfaces_gif.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Ermal Luçi
 	All rights reserved.
 

--- a/usr/local/www/interfaces_gif_edit.php
+++ b/usr/local/www/interfaces_gif_edit.php
@@ -3,7 +3,7 @@
 /*
 	interfaces_gif_edit.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Ermal Luçi
 	All rights reserved.
 

--- a/usr/local/www/interfaces_gre.php
+++ b/usr/local/www/interfaces_gre.php
@@ -3,7 +3,7 @@
 /*
 	interfaces_gre.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Ermal Luçi
 	All rights reserved.
 

--- a/usr/local/www/interfaces_gre_edit.php
+++ b/usr/local/www/interfaces_gre_edit.php
@@ -3,7 +3,7 @@
 /*
 	interfaces_gre_edit.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Ermal Luçi
 	All rights reserved.
 

--- a/usr/local/www/interfaces_groups.php
+++ b/usr/local/www/interfaces_groups.php
@@ -1,6 +1,8 @@
 <?php
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	interfaces_groups.php
+
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2009 Ermal Luçi
 	Copyright (C) 2004 Scott Ullrich
 	All rights reserved.

--- a/usr/local/www/interfaces_groups_edit.php
+++ b/usr/local/www/interfaces_groups_edit.php
@@ -1,6 +1,8 @@
 <?php
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	interfaces_groups_edit.php
+
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2009 Ermal Luçi
 	Copyright (C) 2004 Scott Ullrich
 	All rights reserved.

--- a/usr/local/www/interfaces_lagg.php
+++ b/usr/local/www/interfaces_lagg.php
@@ -3,7 +3,7 @@
 /*
 	interfaces_lagg.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Ermal Luçi
 	All rights reserved.
 

--- a/usr/local/www/interfaces_lagg_edit.php
+++ b/usr/local/www/interfaces_lagg_edit.php
@@ -3,7 +3,7 @@
 /*
 	interfaces_lagg_edit.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Ermal Luçi
 	All rights reserved.
 

--- a/usr/local/www/interfaces_ppps.php
+++ b/usr/local/www/interfaces_ppps.php
@@ -4,7 +4,7 @@
 	interfaces_ppps.php
 	part of m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 

--- a/usr/local/www/interfaces_ppps_edit.php
+++ b/usr/local/www/interfaces_ppps_edit.php
@@ -8,7 +8,7 @@
 	All rights reserved.
 	Copyright (C) 2010 Gabriel B. <gnoahb@gmail.com>.
 	All rights reserved.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/interfaces_qinq.php
+++ b/usr/local/www/interfaces_qinq.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
 	interfaces_qinq.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2009 Ermal Luçi
 	All rights reserved.
 

--- a/usr/local/www/interfaces_qinq_edit.php
+++ b/usr/local/www/interfaces_qinq_edit.php
@@ -1,6 +1,8 @@
 <?php
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	interfaces_qinq_edit.php
+
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2009 Ermal Luçi
 	All rights reserved.
 

--- a/usr/local/www/interfaces_vlan.php
+++ b/usr/local/www/interfaces_vlan.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/interfaces_vlan_edit.php
+++ b/usr/local/www/interfaces_vlan_edit.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/interfaces_wireless.php
+++ b/usr/local/www/interfaces_wireless.php
@@ -4,7 +4,7 @@
 	interfaces_wireless.php
 
 	Copyright (C) 2010 Erik Fonnesbeck
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/interfaces_wireless_edit.php
+++ b/usr/local/www/interfaces_wireless_edit.php
@@ -4,7 +4,7 @@
 	interfaces_wireless_edit.php
 
 	Copyright (C) 2010 Erik Fonnesbeck
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/load_balancer_monitor.php
+++ b/usr/local/www/load_balancer_monitor.php
@@ -4,7 +4,7 @@
 	load_balancer_monitor.php
 	part of pfSense (https://www.pfsense.org/)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
 	All rights reserved.
 

--- a/usr/local/www/load_balancer_monitor_edit.php
+++ b/usr/local/www/load_balancer_monitor_edit.php
@@ -1,33 +1,33 @@
 <?php
 /* $Id$ */
 /*
-        load_balancer_monitor_edit.php
-        part of pfSense (https://www.pfsense.org/)
+	load_balancer_monitor_edit.php
+	part of pfSense (https://www.pfsense.org/)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-        Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
-        All rights reserved.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	routing

--- a/usr/local/www/load_balancer_pool.php
+++ b/usr/local/www/load_balancer_pool.php
@@ -4,7 +4,7 @@
 	load_balancer_pool.php
 	part of pfSense (https://www.pfsense.org/)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2005-2008 Bill Marquette <bill.marquette@gmail.com>.
 	All rights reserved.
 

--- a/usr/local/www/load_balancer_pool_edit.php
+++ b/usr/local/www/load_balancer_pool_edit.php
@@ -1,33 +1,33 @@
 <?php
 /* $Id$ */
 /*
-        load_balancer_pool_edit.php
-        part of pfSense (https://www.pfsense.org/)
+	load_balancer_pool_edit.php
+	part of pfSense (https://www.pfsense.org/)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-        Copyright (C) 2005-2008 Bill Marquette <bill.marquette@gmail.com>.
-        All rights reserved.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2005-2008 Bill Marquette <bill.marquette@gmail.com>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	routing

--- a/usr/local/www/load_balancer_relay_action.php
+++ b/usr/local/www/load_balancer_relay_action.php
@@ -1,10 +1,10 @@
 <?php
 /* $Id$ */
 /*
-	load_balancer_protocol.php
+	load_balancer_relay_action.php
 	part of pfSense (https://www.pfsense.org/)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
 	All rights reserved.
 

--- a/usr/local/www/load_balancer_relay_action_edit.php
+++ b/usr/local/www/load_balancer_relay_action_edit.php
@@ -1,33 +1,33 @@
 <?php
 /* $Id$ */
 /*
-        load_balancer_protocol_edit.php
-        part of pfSense (https://www.pfsense.org/)
+	load_balancer_relay_action_edit.php
+	part of pfSense (https://www.pfsense.org/)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-        Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
-        All rights reserved.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	routing

--- a/usr/local/www/load_balancer_relay_protocol.php
+++ b/usr/local/www/load_balancer_relay_protocol.php
@@ -4,7 +4,7 @@
 	load_balancer_relay_protocol.php
 	part of pfSense (https://www.pfsense.org/)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
 	All rights reserved.
 

--- a/usr/local/www/load_balancer_relay_protocol_edit.php
+++ b/usr/local/www/load_balancer_relay_protocol_edit.php
@@ -1,33 +1,33 @@
 <?php
 /* $Id$ */
 /*
-        load_balancer_protocol_edit.php
-        part of pfSense (https://www.pfsense.org/)
+	load_balancer_relay_protocol_edit.php
+	part of pfSense (https://www.pfsense.org/)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-        Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
-        All rights reserved.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	routing

--- a/usr/local/www/load_balancer_setting.php
+++ b/usr/local/www/load_balancer_setting.php
@@ -6,7 +6,7 @@
 
 	Copyright (C) 2008 Bill Marquette <bill.marquette@gmail.com>.
 	Copyright (C) 2012 Pierre POMES <pierre.pomes@gmail.com>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	All rights reserved.
 

--- a/usr/local/www/load_balancer_virtual_server.php
+++ b/usr/local/www/load_balancer_virtual_server.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org/)
 
 	Copyright (C) 2005-2008 Bill Marquette <bill.marquette@gmail.com>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	All rights reserved.
 

--- a/usr/local/www/load_balancer_virtual_server_edit.php
+++ b/usr/local/www/load_balancer_virtual_server_edit.php
@@ -1,34 +1,34 @@
 <?php
 /* $Id$ */
 /*
-        load_balancer_virtual_server_edit.php
-        part of pfSense (https://www.pfsense.org/)
+	load_balancer_virtual_server_edit.php
+	part of pfSense (https://www.pfsense.org/)
 
-        Copyright (C) 2005-2008 Bill Marquette <bill.marquette@gmail.com>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2005-2008 Bill Marquette <bill.marquette@gmail.com>.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
-        All rights reserved.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	routing

--- a/usr/local/www/pkg_mgr_install.php
+++ b/usr/local/www/pkg_mgr_install.php
@@ -3,7 +3,7 @@
 /*
 	pkg_mgr_install.php
 	part of pfSense (https://www.pfsense.org)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004-2010 Scott Ullrich <sullrich@gmail.com>
  	Copyright (C) 2005 Colin Smith
 	All rights reserved.

--- a/usr/local/www/pkg_mgr_settings.php
+++ b/usr/local/www/pkg_mgr_settings.php
@@ -3,10 +3,10 @@
 /*
 	pkg_mgr_settings.php
 	part of pfSense
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2009 Jim Pingle <jimp@pfsense.org>
-    	Copyright (C) 2004-2010 Scott Ullrich <sullrich@gmail.com>
-        Copyright (C) 2005 Colin Smith
+	Copyright (C) 2004-2010 Scott Ullrich <sullrich@gmail.com>
+	Copyright (C) 2005 Colin Smith
 
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:

--- a/usr/local/www/reboot.php
+++ b/usr/local/www/reboot.php
@@ -4,7 +4,7 @@
 	reboot.php
 	part of m0n0wall (http://m0n0.ch/wall)
 	
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 	

--- a/usr/local/www/restart_httpd.php
+++ b/usr/local/www/restart_httpd.php
@@ -1,30 +1,32 @@
 <?php
 /* $Id$ */
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-        Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
-        All rights reserved.
+	restart_httpd.php
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2005 Bill Marquette <bill.marquette@gmail.com>.
+	All rights reserved.
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_BUILDER_BINARIES:	/bin/chmod

--- a/usr/local/www/services_captiveportal.php
+++ b/usr/local/www/services_captiveportal.php
@@ -3,7 +3,7 @@
 	services_captiveportal.php
 	part of m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
 	All rights reserved.
 

--- a/usr/local/www/services_captiveportal_filemanager.php
+++ b/usr/local/www/services_captiveportal_filemanager.php
@@ -3,7 +3,7 @@
 	services_captiveportal_filemanager.php
 	part of m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2005-2006 Jonathan De Graeve (jonathan.de.graeve@imelda.be)
 	and Paul Taylor (paultaylor@winn-dixie.com).
 	All rights reserved.

--- a/usr/local/www/services_captiveportal_hostname.php
+++ b/usr/local/www/services_captiveportal_hostname.php
@@ -1,7 +1,7 @@
 <?php
 /*
 	services_captiveportal_hostname.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2011 Scott Ullrich <sullrich@gmail.com>
 	All rights reserved.
 

--- a/usr/local/www/services_captiveportal_hostname_edit.php
+++ b/usr/local/www/services_captiveportal_hostname_edit.php
@@ -1,7 +1,7 @@
 <?php 
 /*
 	services_captiveportal_hostname_edit.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2011 Scott Ullrich <sullrich@gmail.com>
 	All rights reserved.
 

--- a/usr/local/www/services_captiveportal_ip.php
+++ b/usr/local/www/services_captiveportal_ip.php
@@ -3,7 +3,7 @@
 	services_captiveportal_ip.php
 	part of m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004 Dinesh Nair <dinesh@alphaque.com>
 	All rights reserved.
 

--- a/usr/local/www/services_captiveportal_ip_edit.php
+++ b/usr/local/www/services_captiveportal_ip_edit.php
@@ -1,7 +1,7 @@
 <?php 
 /*
 	services_captiveportal_ip_edit.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2011 Scott Ullrich <sullrich@gmail.com>
 	All rights reserved.
 

--- a/usr/local/www/services_captiveportal_mac.php
+++ b/usr/local/www/services_captiveportal_mac.php
@@ -3,7 +3,7 @@
 	services_captiveportal_mac.php
 	part of m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004 Dinesh Nair <dinesh@alphaque.com>
 	All rights reserved.
 

--- a/usr/local/www/services_captiveportal_mac_edit.php
+++ b/usr/local/www/services_captiveportal_mac_edit.php
@@ -3,7 +3,7 @@
 	services_captiveportal_mac_edit.php
 	part of m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004 Dinesh Nair <dinesh@alphaque.com>
 	All rights reserved.
 

--- a/usr/local/www/services_captiveportal_vouchers.php
+++ b/usr/local/www/services_captiveportal_vouchers.php
@@ -1,6 +1,8 @@
 <?php 
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	services_captiveportal_vouchers.php
+
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2007 Marcel Wiget <mwiget@mac.com>
 	All rights reserved. 
 	

--- a/usr/local/www/services_captiveportal_vouchers_edit.php
+++ b/usr/local/www/services_captiveportal_vouchers_edit.php
@@ -1,6 +1,8 @@
 <?php 
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	services_captiveportal_vouchers_edit.php
+
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2007 Marcel Wiget <mwiget@mac.com>.
 	All rights reserved. 
 	

--- a/usr/local/www/services_captiveportal_zones.php
+++ b/usr/local/www/services_captiveportal_zones.php
@@ -1,6 +1,8 @@
 <?php
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	services_captiveportal_zones.php
+
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	All rights reserved.
 

--- a/usr/local/www/services_captiveportal_zones_edit.php
+++ b/usr/local/www/services_captiveportal_zones_edit.php
@@ -1,6 +1,6 @@
 <?php
 /*
-	services_captiveportal_mac_edit.php
+	services_captiveportal_zones_edit.php
 	Copyright (C) 2011 Ermal Luci
 	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.

--- a/usr/local/www/services_dhcp_relay.php
+++ b/usr/local/www/services_dhcp_relay.php
@@ -4,7 +4,7 @@
 
 	Copyright (C) 2003-2004 Justin Ellison <justin@techadvise.com>.
 	Copyright (C) 2010 	Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_dhcpv6.php
+++ b/usr/local/www/services_dhcpv6.php
@@ -9,7 +9,7 @@
 
 	part of pfSense (https://www.pfsense.org)
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_dhcpv6_edit.php
+++ b/usr/local/www/services_dhcpv6_edit.php
@@ -6,7 +6,7 @@
 	
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
 	Copyright (C) 2011 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_dhcpv6_relay.php
+++ b/usr/local/www/services_dhcpv6_relay.php
@@ -5,7 +5,7 @@
 	Copyright (C) 2003-2004 Justin Ellison <justin@techadvise.com>.
 	Copyright (C) 2010 	Ermal Luçi
 	Copyright (C) 2010 	Seth Mos
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_dnsmasq.php
+++ b/usr/local/www/services_dnsmasq.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com> and Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_dnsmasq_domainoverride_edit.php
+++ b/usr/local/www/services_dnsmasq_domainoverride_edit.php
@@ -1,32 +1,32 @@
 <?php
 /*
-       services_dnsmasq_domainoverride_edit.php
-       part of m0n0wall (http://m0n0.ch/wall)
+	services_dnsmasq_domainoverride_edit.php
+	part of m0n0wall (http://m0n0.ch/wall)
 
-       Copyright (C) 2003-2005 Bob Zoller <bob@kludgebox.com> and Manuel Kasper <mk@neon1.net>.
-       Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-       All rights reserved.
+	Copyright (C) 2003-2005 Bob Zoller <bob@kludgebox.com> and Manuel Kasper <mk@neon1.net>.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-       Redistribution and use in source and binary forms, with or without
-       modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-       1. Redistributions of source code must retain the above copyright notice,
-          this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-       2. Redistributions in binary form must reproduce the above copyright
-          notice, this list of conditions and the following disclaimer in the
-          documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-       THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-       INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-       AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-       AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-       OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-       SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-       INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-       CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-       POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	dnsforwarder

--- a/usr/local/www/services_dnsmasq_edit.php
+++ b/usr/local/www/services_dnsmasq_edit.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 	
 	Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com> and Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_dyndns.php
+++ b/usr/local/www/services_dyndns.php
@@ -1,8 +1,10 @@
 <?php
 /* $Id$ */
 /*
+	services_dyndns.php
+
 	Copyright (C) 2008 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_dyndns_edit.php
+++ b/usr/local/www/services_dyndns_edit.php
@@ -1,8 +1,10 @@
 <?php
 /* $Id$ */
 /*
+	services_dyndns_edit.php
+
 	Copyright (C) 2008 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_igmpproxy.php
+++ b/usr/local/www/services_igmpproxy.php
@@ -3,7 +3,7 @@
 /*
 	services_igmpproxy.php
 	
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2009 Ermal Luçi
 	Copyright (C) 2004 Scott Ullrich
 	All rights reserved.

--- a/usr/local/www/services_igmpproxy_edit.php
+++ b/usr/local/www/services_igmpproxy_edit.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
 	services_igmpproxy_edit.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2009 Ermal Luçi
 	Copyright (C) 2004 Scott Ullrich
 	All rights reserved.

--- a/usr/local/www/services_ntpd.php
+++ b/usr/local/www/services_ntpd.php
@@ -4,7 +4,7 @@
 
 	Copyright (C) 2013	Dagorlad
 	Copyright (C) 2012	Jim Pingle
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_ntpd_gps.php
+++ b/usr/local/www/services_ntpd_gps.php
@@ -1,7 +1,9 @@
 <?php
 /* $Id$ */
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	services_ntpd_gps.php
+
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2013	Dagorlad
 	Copyright (C) 2012	Jim Pingle
 	All rights reserved.

--- a/usr/local/www/services_ntpd_pps.php
+++ b/usr/local/www/services_ntpd_pps.php
@@ -1,7 +1,9 @@
 <?php
 /* $Id$ */
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	services_ntpd_pps.php
+
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2013	Dagorlad
 	All rights reserved.
 

--- a/usr/local/www/services_rfc2136.php
+++ b/usr/local/www/services_rfc2136.php
@@ -1,8 +1,10 @@
 <?php
 /* $Id$ */
 /*
+	services_rfc2136.php
+
 	Copyright (C) 2008 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_rfc2136_edit.php
+++ b/usr/local/www/services_rfc2136_edit.php
@@ -1,8 +1,10 @@
 <?php
 /* $Id$ */
 /*
+	services_rfc2136_edit.php
+
 	Copyright (C) 2008 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_router_advertisements.php
+++ b/usr/local/www/services_router_advertisements.php
@@ -9,7 +9,7 @@
 
 	part of pfSense (https://www.pfsense.org)
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_snmp.php
+++ b/usr/local/www/services_snmp.php
@@ -8,7 +8,7 @@
 	All rights reserved.
 
 	part of pfSense
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_unbound.php
+++ b/usr/local/www/services_unbound.php
@@ -4,7 +4,7 @@
 	services_unbound.php
 	part of the pfSense project (https://www.pfsense.org)
 	Copyright (C) 2014	Warren Baker (warren@pfsense.org)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_unbound_acls.php
+++ b/usr/local/www/services_unbound_acls.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org/)
 
 	Copyright (C) 2011 Warren Baker <warren@decoy.co.za>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_unbound_advanced.php
+++ b/usr/local/www/services_unbound_advanced.php
@@ -4,7 +4,7 @@
 	services_unbound_advanced.php
 	part of the pfSense project (https://www.pfsense.org)
 	Copyright (C) 2011	Warren Baker (warren@pfsense.org)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_unbound_host_edit.php
+++ b/usr/local/www/services_unbound_host_edit.php
@@ -4,7 +4,7 @@
 	services_unbound_host_edit.php
 	part of the pfSense project (https://www.pfsense.org)
 	Copyright (C) 2014 Warren Baker (warren@decoy.co.za)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Copyright (C) 2003-2004 Bob Zoller <bob@kludgebox.com> and Manuel Kasper <mk@neon1.net>.

--- a/usr/local/www/services_wol.php
+++ b/usr/local/www/services_wol.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/services_wol_edit.php
+++ b/usr/local/www/services_wol_edit.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 	
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/stats.php
+++ b/usr/local/www/stats.php
@@ -2,7 +2,7 @@
 /*
 	$Id$
 	part of pfSense (https://www.pfsense.org)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2007 Scott Ullrich <sullrich@gmail.com>
 	All rights reserved.
 	

--- a/usr/local/www/status_captiveportal.php
+++ b/usr/local/www/status_captiveportal.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 	
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_captiveportal_expire.php
+++ b/usr/local/www/status_captiveportal_expire.php
@@ -1,30 +1,30 @@
 <?php
 /*
-    Copyright (C) 2007 Marcel Wiget <mwiget@mac.com>.
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2007 Marcel Wiget <mwiget@mac.com>.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
-    All rights reserved.
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	captiveportal

--- a/usr/local/www/status_captiveportal_test.php
+++ b/usr/local/www/status_captiveportal_test.php
@@ -1,29 +1,30 @@
 <?php
 /*
-    Copyright (C) 2007 Marcel Wiget <mwiget@mac.com>.
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
-    
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
-    
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	status_captiveportal_test.php
+	Copyright (C) 2007 Marcel Wiget <mwiget@mac.com>.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*	
 	pfSense_MODULE:	captiveportal

--- a/usr/local/www/status_captiveportal_voucher_rolls.php
+++ b/usr/local/www/status_captiveportal_voucher_rolls.php
@@ -1,7 +1,9 @@
 <?php
 /*
+	status_captiveportal_voucher_rolls.php
+
 	Copyright (C) 2007 Marcel Wiget <mwiget@mac.com>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_captiveportal_vouchers.php
+++ b/usr/local/www/status_captiveportal_vouchers.php
@@ -1,29 +1,30 @@
 <?php
 /*
-    Copyright (C) 2007 Marcel Wiget <mwiget@mac.com>.
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	status_captiveportal_vouchers.php
+	Copyright (C) 2007 Marcel Wiget <mwiget@mac.com>.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	captiveportal

--- a/usr/local/www/status_dhcp_leases.php
+++ b/usr/local/www/status_dhcp_leases.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
 	status_dhcp_leases.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004-2009 Scott Ullrich
 	All rights reserved.
 

--- a/usr/local/www/status_dhcpv6_leases.php
+++ b/usr/local/www/status_dhcpv6_leases.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
 	status_dhcpv6_leases.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2011 Seth Mos
 	Copyright (C) 2004-2009 Scott Ullrich
 	All rights reserved.

--- a/usr/local/www/status_filter_reload.php
+++ b/usr/local/www/status_filter_reload.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
 	status_filter_reload.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2006 Scott Ullrich
 	All rights reserved.
 

--- a/usr/local/www/status_gateway_groups.php
+++ b/usr/local/www/status_gateway_groups.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org)
 
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_gateways.php
+++ b/usr/local/www/status_gateways.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org/)
 
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_graph.php
+++ b/usr/local/www/status_graph.php
@@ -3,7 +3,7 @@
 /*
 	status_graph.php
 	Part of pfSense
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004 Scott Ullrich
 	All rights reserved.
 

--- a/usr/local/www/status_graph_cpu.php
+++ b/usr/local/www/status_graph_cpu.php
@@ -4,7 +4,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 	
 	Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_interfaces.php
+++ b/usr/local/www/status_interfaces.php
@@ -4,7 +4,7 @@
 	status_interfaces.php
 	part of pfSense
 	Copyright (C) 2009 Scott Ullrich <sullrich@gmail.com>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/status_lb_pool.php
+++ b/usr/local/www/status_lb_pool.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org/)
 
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_lb_vs.php
+++ b/usr/local/www/status_lb_vs.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org/)
 
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_ntpd.php
+++ b/usr/local/www/status_ntpd.php
@@ -6,7 +6,7 @@
 
 	Copyright (C) 2013 Dagorlad
 	Copyright (C) 2012 Jim Pingle
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_openvpn.php
+++ b/usr/local/www/status_openvpn.php
@@ -1,15 +1,15 @@
 <?php
 /*
-	status_ovpenvpn.php
+	status_openvpn.php
 
-    Copyright (C) 2005 Scott Ullrich, Colin Smith
-    Copyright (C) 2008 Shrew Soft Inc.
-    Copyright (C) 2010 Jim Pingle
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2005 Scott Ullrich, Colin Smith
+	Copyright (C) 2008 Shrew Soft Inc.
+	Copyright (C) 2010 Jim Pingle
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
-    AJAX bits borrowed from diag_dump_states.php
+	AJAX bits borrowed from diag_dump_states.php
 
-    All rights reserved.
+	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:

--- a/usr/local/www/status_queues.php
+++ b/usr/local/www/status_queues.php
@@ -3,10 +3,10 @@
 /* $Id$ */
 /*
 	status_queues.php
-        Part of the pfSense project
+	Part of the pfSense project
 	Copyright (C) 2004, 2005 Scott Ullrich
 	Copyright (C) 2009 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_rrd_graph.php
+++ b/usr/local/www/status_rrd_graph.php
@@ -4,7 +4,7 @@
 	status_rrd_graph.php
 	Part of pfSense
 	Copyright (C) 2007 Seth Mos <seth.mos@dds.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_rrd_graph_img.php
+++ b/usr/local/www/status_rrd_graph_img.php
@@ -4,7 +4,7 @@
 	status_rrd_graph_img.php
 	Part of pfSense
 	Copyright (C) 2009 Seth Mos <seth.mos@dds.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_rrd_graph_settings.php
+++ b/usr/local/www/status_rrd_graph_settings.php
@@ -1,10 +1,10 @@
 <?php
 /* $Id$ */
 /*
-	status_rrd_graph.php
+	status_rrd_graph_settings.php
 	Part of pfSense
 	Copyright (C) 2007 Seth Mos <seth.mos@dds.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_services.php
+++ b/usr/local/www/status_services.php
@@ -1,30 +1,30 @@
 <?php
 /*
-    services_status.php
-    Copyright (C) 2004, 2005 Scott Ullrich
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	status_services.php
+	Copyright (C) 2004, 2005 Scott Ullrich
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INClUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INClUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*	
 	pfSense_BUILDER_BINARIES:	/usr/local/sbin/openvpn	/usr/bin/killall	/bin/ps

--- a/usr/local/www/status_upnp.php
+++ b/usr/local/www/status_upnp.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org/)
 
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/status_wireless.php
+++ b/usr/local/www/status_wireless.php
@@ -2,7 +2,7 @@
 /*
 	status_wireless.php
 	Copyright (C) 2004 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/system.php
+++ b/usr/local/www/system.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/system_advanced_admin.php
+++ b/usr/local/www/system_advanced_admin.php
@@ -5,7 +5,7 @@
 	part of pfSense
 	Copyright (C) 2005-2010 Scott Ullrich
 	Copyright (C) 2008 Shrew Soft Inc
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	originally part of m0n0wall (http://m0n0.ch/wall)
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.

--- a/usr/local/www/system_advanced_firewall.php
+++ b/usr/local/www/system_advanced_firewall.php
@@ -5,7 +5,7 @@
 	part of pfSense
 	Copyright (C) 2005-2007 Scott Ullrich
 	Copyright (C) 2008 Shrew Soft Inc
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	originally part of m0n0wall (http://m0n0.ch/wall)
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.

--- a/usr/local/www/system_advanced_misc.php
+++ b/usr/local/www/system_advanced_misc.php
@@ -5,7 +5,7 @@
 	part of pfSense
 	Copyright (C) 2005-2007 Scott Ullrich
 	Copyright (C) 2008 Shrew Soft Inc
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	originally part of m0n0wall (http://m0n0.ch/wall)
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.

--- a/usr/local/www/system_advanced_network.php
+++ b/usr/local/www/system_advanced_network.php
@@ -4,7 +4,7 @@
 	part of pfSense
 	Copyright (C) 2005-2007 Scott Ullrich
 	Copyright (C) 2008 Shrew Soft Inc
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	originally part of m0n0wall (http://m0n0.ch/wall)
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.

--- a/usr/local/www/system_advanced_notifications.php
+++ b/usr/local/www/system_advanced_notifications.php
@@ -4,7 +4,7 @@
 	system_advanced_notifications.php
 	part of pfSense
 	Copyright (C) 2009 Scott Ullrich <sullrich@gmail.com>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:

--- a/usr/local/www/system_advanced_sysctl.php
+++ b/usr/local/www/system_advanced_sysctl.php
@@ -1,11 +1,11 @@
 <?php
 /* $Id$ */
 /*
-	system_advanced_misc.php
+	system_advanced_sysctl.php
 	part of pfSense
 	Copyright (C) 2005-2007 Scott Ullrich
 	Copyright (C) 2008 Shrew Soft Inc
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	originally part of m0n0wall (http://m0n0.ch/wall)
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.

--- a/usr/local/www/system_authservers.php
+++ b/usr/local/www/system_authservers.php
@@ -1,32 +1,32 @@
 <?php
 /*
-    system_authservers.php
+	system_authservers.php
 
-    Copyright (C) 2008 Shrew Soft Inc.
-    Copyright (C) 2010 Ermal Luçi
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	Copyright (C) 2008 Shrew Soft Inc.
+	Copyright (C) 2010 Ermal Luçi
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	auth

--- a/usr/local/www/system_camanager.php
+++ b/usr/local/www/system_camanager.php
@@ -1,34 +1,34 @@
 <?php
 /*
-    system_camanager.php
+	system_camanager.php
 
-    Copyright (C) 2008 Shrew Soft Inc.
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	Copyright (C) 2008 Shrew Soft Inc.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
-	pfSense_MODULE:	certificate_managaer
+	pfSense_MODULE:	certificate_manager
 */
 
 ##|+PRIV

--- a/usr/local/www/system_certmanager.php
+++ b/usr/local/www/system_certmanager.php
@@ -1,34 +1,34 @@
 <?php
 /*
-    system_certmanager.php
+	system_certmanager.php
 
-    Copyright (C) 2008 Shrew Soft Inc.
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	Copyright (C) 2008 Shrew Soft Inc.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
-	pfSense_MODULE:	certificate_managaer
+	pfSense_MODULE:	certificate_manager
 */
 
 ##|+PRIV

--- a/usr/local/www/system_crlmanager.php
+++ b/usr/local/www/system_crlmanager.php
@@ -3,7 +3,7 @@
 	system_crlmanager.php
 	
 	Copyright (C) 2010 Jim Pingle
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
-	pfSense_MODULE:	certificate_managaer
+	pfSense_MODULE:	certificate_manager
 */
 
 ##|+PRIV

--- a/usr/local/www/system_firmware.php
+++ b/usr/local/www/system_firmware.php
@@ -3,7 +3,7 @@
 /*
 	system_firmware.php
 	Copyright (C) 2008 Scott Ullrich <sullrich@gmail.com>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/system_firmware_auto.php
+++ b/usr/local/www/system_firmware_auto.php
@@ -4,7 +4,7 @@
 	system_firmware_auto.php
 	Copyright (C) 2005 Scott Ullrich
 	Copyright (C) 2008 Scott Ullrich <sullrich@gmail.com>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Based originally on system_firmware.php
 	(C)2003-2004 Manuel Kasper

--- a/usr/local/www/system_firmware_check.php
+++ b/usr/local/www/system_firmware_check.php
@@ -1,9 +1,9 @@
 <?php
 /* $Id$ */
 /*
-	system_firmware.php
+	system_firmware_check.php
 	Copyright (C) 2008 Scott Ullrich <sullrich@gmail.com>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/system_firmware_restorefullbackup.php
+++ b/usr/local/www/system_firmware_restorefullbackup.php
@@ -3,7 +3,7 @@
 /*
 	system_firmware_restorefullbackup.php
 	Copyright (C) 2011 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	originally part of m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/system_firmware_settings.php
+++ b/usr/local/www/system_firmware_settings.php
@@ -2,10 +2,10 @@
 /* $Id$ */
 /*
 	system_firmware_settings.php
-       	part of pfSense
-        Copyright (C) 2005 Colin Smith
+	part of pfSense
+	Copyright (C) 2005 Colin Smith
 	Copyright (C) 2008 Scott Ullrich <sullrich@gmail.com>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:

--- a/usr/local/www/system_gateway_groups.php
+++ b/usr/local/www/system_gateway_groups.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org)
 
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/system_gateway_groups_edit.php
+++ b/usr/local/www/system_gateway_groups_edit.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org)
 	
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/system_gateways.php
+++ b/usr/local/www/system_gateways.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org)
 
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/system_gateways_edit.php
+++ b/usr/local/www/system_gateways_edit.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org)
 
 	Copyright (C) 2010 Seth Mos <seth.mos@dds.nl>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/system_groupmanager.php
+++ b/usr/local/www/system_groupmanager.php
@@ -4,7 +4,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 	part of pfSense
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Copyright (C) 2008 Shrew Soft Inc.

--- a/usr/local/www/system_groupmanager_addprivs.php
+++ b/usr/local/www/system_groupmanager_addprivs.php
@@ -3,7 +3,7 @@
 /*
 	system_groupmanager_addprivs.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2006 Daniel S. Haischt.
 	All rights reserved.
 

--- a/usr/local/www/system_hasync.php
+++ b/usr/local/www/system_hasync.php
@@ -5,7 +5,7 @@
 	part of pfSense (https://www.pfsense.org/)
 
 	Copyright (C) 2012 Darren Embry <dse@webonastick.com>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/system_routes.php
+++ b/usr/local/www/system_routes.php
@@ -6,7 +6,7 @@
 	part of pfSense
 
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/system_routes_edit.php
+++ b/usr/local/www/system_routes_edit.php
@@ -5,7 +5,7 @@
 	part of pfSense
 	Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>.
 	Copyright (C) 2010 Scott Ullrich
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/system_usermanager.php
+++ b/usr/local/www/system_usermanager.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 
 	part of pfSense
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Copyright (C) 2008 Shrew Soft Inc.

--- a/usr/local/www/system_usermanager_addprivs.php
+++ b/usr/local/www/system_usermanager_addprivs.php
@@ -3,7 +3,7 @@
 /*
 	system_usermanager_addprivs.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Copyright (C) 2006 Daniel S. Haischt.

--- a/usr/local/www/system_usermanager_passwordmg.php
+++ b/usr/local/www/system_usermanager_passwordmg.php
@@ -1,30 +1,30 @@
 <?php
 /* $Id$ */
 /*
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    Copyright (C) 2011 Ermal Luçi
-    system_usermanager.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2011 Ermal Luçi
+	system_usermanager_passwordmg.php
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
         pfSense_BUILDER_BINARIES:

--- a/usr/local/www/system_usermanager_settings.php
+++ b/usr/local/www/system_usermanager_settings.php
@@ -1,11 +1,13 @@
 <?php
 /* $Id$ */
 /*
+	system_usermanager_settings.php
+
 	part of pfSense (https://www.pfsense.org/)
 
 	Copyright (C) 2007 Scott Ullrich <sullrich@gmail.com>
 	Copyright (C) 2007 Bill Marquette <bill.marquette@gmail.com>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/system_usermanager_settings_ldapacpicker.php
+++ b/usr/local/www/system_usermanager_settings_ldapacpicker.php
@@ -1,31 +1,32 @@
 <?php
 /* $Id$ */
 /*
-    part of pfSense (https://www.pfsense.org/)
-    Copyright (C) 2007 Scott Ullrich <sullrich@gmail.com>
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	system_usermanager_settings_ldapacpicker.php
+	part of pfSense (https://www.pfsense.org/)
+	Copyright (C) 2007 Scott Ullrich <sullrich@gmail.com>
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	auth

--- a/usr/local/www/system_usermanager_settings_test.php
+++ b/usr/local/www/system_usermanager_settings_test.php
@@ -1,32 +1,33 @@
 <?php
 /* $Id$ */
 /*
-    part of pfSense (https://www.pfsense.org/)
-    Copyright (C) 2007 Scott Ullrich <sullrich@gmail.com>
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    Copyright (C) 2014 Silvio Giunge <desenvolvimento@bluepex.com>
-    All rights reserved.
+	system_usermanager_settings_test.php
+	part of pfSense (https://www.pfsense.org/)
+	Copyright (C) 2007 Scott Ullrich <sullrich@gmail.com>
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2014 Silvio Giunge <desenvolvimento@bluepex.com>
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_MODULE:	auth

--- a/usr/local/www/themes/_corporate/rrdcolors.inc.php
+++ b/usr/local/www/themes/_corporate/rrdcolors.inc.php
@@ -4,7 +4,7 @@
 	rrdcolors.inc.php
 	Part of pfSense
 	Copyright (C) 2006 Seth Mos <seth.mos@xs4all.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/themes/code-red/javascript/transmenu-body.php
+++ b/usr/local/www/themes/code-red/javascript/transmenu-body.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /* ========================================================================== */
 /*
-  transmenu.php
+  transmenu-body.php
   Copyright (C) 2006 Daniel S. Haischt <me@daniel.stefan.haischt.name>
   All rights reserved.
 

--- a/usr/local/www/themes/code-red/javascript/transmenu-head.php
+++ b/usr/local/www/themes/code-red/javascript/transmenu-head.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /* ========================================================================== */
 /*
-  transmenu.php
+  transmenu-head.php
   Copyright (C) 2006 Daniel S. Haischt <me@daniel.stefan.haischt.name>
   All rights reserved.
 

--- a/usr/local/www/themes/code-red/rrdcolors.inc.php
+++ b/usr/local/www/themes/code-red/rrdcolors.inc.php
@@ -4,7 +4,7 @@
 	rrdcolors.inc.php
 	Part of pfSense
 	Copyright (C) 2006 Seth Mos <seth.mos@xs4all.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/themes/metallic/rrdcolors.inc.php
+++ b/usr/local/www/themes/metallic/rrdcolors.inc.php
@@ -4,7 +4,7 @@
 	rrdcolors.inc.php
 	Part of pfSense
 	Copyright (C) 2006 Seth Mos <seth.mos@xs4all.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/themes/nervecenter/javascript/transmenu-body.php
+++ b/usr/local/www/themes/nervecenter/javascript/transmenu-body.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /* ========================================================================== */
 /*
-  transmenu.php
+  transmenu-body.php
   Copyright (C) 2006 Daniel S. Haischt <me@daniel.stefan.haischt.name>
   Copyright (C) 2013-2015 Electric Sheep Fencing, LP
   All rights reserved.

--- a/usr/local/www/themes/nervecenter/javascript/transmenu-head.php
+++ b/usr/local/www/themes/nervecenter/javascript/transmenu-head.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /* ========================================================================== */
 /*
-  transmenu.php
+  transmenu-head.php
   Copyright (C) 2006 Daniel S. Haischt <me@daniel.stefan.haischt.name>
   Copyright (C) 2013-2015 Electric Sheep Fencing, LP
   All rights reserved.

--- a/usr/local/www/themes/nervecenter/rrdcolors.inc.php
+++ b/usr/local/www/themes/nervecenter/rrdcolors.inc.php
@@ -4,7 +4,7 @@
 	rrdcolors.inc.php
 	Part of pfSense
 	Copyright (C) 2006 Seth Mos <seth.mos@xs4all.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/themes/pfsense-dropdown/rrdcolors.inc.php
+++ b/usr/local/www/themes/pfsense-dropdown/rrdcolors.inc.php
@@ -4,7 +4,7 @@
 	rrdcolors.inc.php
 	Part of pfSense
 	Copyright (C) 2006 Seth Mos <seth.mos@xs4all.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/themes/pfsense/rrdcolors.inc.php
+++ b/usr/local/www/themes/pfsense/rrdcolors.inc.php
@@ -4,7 +4,7 @@
 	rrdcolors.inc.php
 	Part of pfSense
 	Copyright (C) 2006 Seth Mos <seth.mos@xs4all.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/themes/pfsense_ng/javascript/transmenu-body.php
+++ b/usr/local/www/themes/pfsense_ng/javascript/transmenu-body.php
@@ -2,7 +2,7 @@
 /* $Id: transmenu-body.php,v 1.1.2.1 2007/01/17 18:43:47 sullrich Exp $ */
 /* ========================================================================== */
 /*
-  transmenu.php
+  transmenu-body.php
   Copyright (C) 2006 Daniel S. Haischt <me@daniel.stefan.haischt.name>
   Copyright (C) 2013-2015 Electric Sheep Fencing, LP
   All rights reserved.

--- a/usr/local/www/themes/pfsense_ng/javascript/transmenu-head.php
+++ b/usr/local/www/themes/pfsense_ng/javascript/transmenu-head.php
@@ -2,7 +2,7 @@
 /* $Id: transmenu-head.php,v 1.2.2.1 2007/01/17 18:43:47 sullrich Exp $ */
 /* ========================================================================== */
 /*
-  transmenu.php
+  transmenu-head.php
   Copyright (C) 2006 Daniel S. Haischt <me@daniel.stefan.haischt.name>
   Copyright (C) 2013-2015 Electric Sheep Fencing, LP
   All rights reserved.

--- a/usr/local/www/themes/pfsense_ng/rrdcolors.inc.php
+++ b/usr/local/www/themes/pfsense_ng/rrdcolors.inc.php
@@ -4,7 +4,7 @@
 	rrdcolors.inc.php
 	Part of pfSense
 	Copyright (C) 2006 Seth Mos <seth.mos@xs4all.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/themes/pfsense_ng_fs/javascript/transmenu-body.php
+++ b/usr/local/www/themes/pfsense_ng_fs/javascript/transmenu-body.php
@@ -2,7 +2,7 @@
 /* $Id: transmenu-body.php,v 1.1.2.1 2007/01/17 18:43:47 sullrich Exp $ */
 /* ========================================================================== */
 /*
-  transmenu.php
+  transmenu-body.php
   Copyright (C) 2006 Daniel S. Haischt <me@daniel.stefan.haischt.name>
   Copyright (C) 2013-2015 Electric Sheep Fencing, LP
   All rights reserved.

--- a/usr/local/www/themes/pfsense_ng_fs/javascript/transmenu-head.php
+++ b/usr/local/www/themes/pfsense_ng_fs/javascript/transmenu-head.php
@@ -2,7 +2,7 @@
 /* $Id: transmenu-head.php,v 1.2.2.1 2007/01/17 18:43:47 sullrich Exp $ */
 /* ========================================================================== */
 /*
-  transmenu.php
+  transmenu-head.php
   Copyright (C) 2006 Daniel S. Haischt <me@daniel.stefan.haischt.name>
   Copyright (C) 2013-2015 Electric Sheep Fencing, LP
   All rights reserved.

--- a/usr/local/www/themes/pfsense_ng_fs/rrdcolors.inc.php
+++ b/usr/local/www/themes/pfsense_ng_fs/rrdcolors.inc.php
@@ -4,7 +4,7 @@
 	rrdcolors.inc.php
 	Part of pfSense
 	Copyright (C) 2006 Seth Mos <seth.mos@xs4all.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/themes/the_wall/javascript/transmenu-body.php
+++ b/usr/local/www/themes/the_wall/javascript/transmenu-body.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /* ========================================================================== */
 /*
-  transmenu.php
+  transmenu-body.php
   Copyright (C) 2006 Daniel S. Haischt <me@daniel.stefan.haischt.name>
   Copyright (C) 2013-2015 Electric Sheep Fencing, LP
   All rights reserved.

--- a/usr/local/www/themes/the_wall/javascript/transmenu-head.php
+++ b/usr/local/www/themes/the_wall/javascript/transmenu-head.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /* ========================================================================== */
 /*
-  transmenu.php
+  transmenu-head.php
   Copyright (C) 2006 Daniel S. Haischt <me@daniel.stefan.haischt.name>
   Copyright (C) 2013-2015 Electric Sheep Fencing, LP
   All rights reserved.

--- a/usr/local/www/themes/the_wall/rrdcolors.inc.php
+++ b/usr/local/www/themes/the_wall/rrdcolors.inc.php
@@ -4,7 +4,7 @@
 	rrdcolors.inc.php
 	Part of pfSense
 	Copyright (C) 2006 Seth Mos <seth.mos@xs4all.nl>
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/uploadconfig.php
+++ b/usr/local/www/uploadconfig.php
@@ -5,7 +5,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 
 	Copyright (C) 2003-2006 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_ipsec.php
+++ b/usr/local/www/vpn_ipsec.php
@@ -6,7 +6,7 @@
 
 	Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
 	Copyright (C) 2008 Shrew Soft Inc
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_ipsec_keys_edit.php
+++ b/usr/local/www/vpn_ipsec_keys_edit.php
@@ -5,7 +5,7 @@
 	part of pfSense
 	
 	Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_ipsec_mobile.php
+++ b/usr/local/www/vpn_ipsec_mobile.php
@@ -3,7 +3,7 @@
 	vpn_ipsec_mobile.php
 	
 	Copyright (C) 2008 Shrew Soft Inc
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_ipsec_phase1.php
+++ b/usr/local/www/vpn_ipsec_phase1.php
@@ -6,7 +6,7 @@
 	Copyright (C) 2008 Shrew Soft Inc
 	Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
 	Copyright (C) 2014 Ermal LUÇI
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_ipsec_phase2.php
+++ b/usr/local/www/vpn_ipsec_phase2.php
@@ -5,7 +5,7 @@
 
 	Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
 	Copyright (C) 2008 Shrew Soft Inc
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_l2tp.php
+++ b/usr/local/www/vpn_l2tp.php
@@ -4,7 +4,7 @@
 	part of pfSense
 
 	Copyright (C) 2005 Scott Ullrich (sullrich@gmail.com)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_l2tp_users.php
+++ b/usr/local/www/vpn_l2tp_users.php
@@ -4,7 +4,7 @@
 	part of pfSense
 
 	Copyright (C) 2005 Scott Ullrich (sullrich@gmail.com)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_l2tp_users_edit.php
+++ b/usr/local/www/vpn_l2tp_users_edit.php
@@ -4,7 +4,7 @@
 	part of pfSense
 
 	Copyright (C) 2006 Scott Ullrich (sullrich@gmail.com)
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_openvpn_client.php
+++ b/usr/local/www/vpn_openvpn_client.php
@@ -3,7 +3,7 @@
 	vpn_openvpn_client.php
 
 	Copyright (C) 2008 Shrew Soft Inc.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_openvpn_csc.php
+++ b/usr/local/www/vpn_openvpn_csc.php
@@ -3,7 +3,7 @@
 	vpn_openvpn_csc.php
 
 	Copyright (C) 2008 Shrew Soft Inc.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved. 
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_openvpn_server.php
+++ b/usr/local/www/vpn_openvpn_server.php
@@ -3,7 +3,7 @@
 	vpn_openvpn_server.php
 
 	Copyright (C) 2008 Shrew Soft Inc.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved. 
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_pppoe.php
+++ b/usr/local/www/vpn_pppoe.php
@@ -1,7 +1,8 @@
 <?php
 /*
+	vpn_pppoe.php
 	Copyright (C) 2010 Ermal Luci
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_pppoe_edit.php
+++ b/usr/local/www/vpn_pppoe_edit.php
@@ -5,7 +5,7 @@
 
 	Copyright (C) 2005 Scott Ullrich (sullrich@gmail.com)
 	Copyright (C) 2010 Ermal Luçi
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_pptp.php
+++ b/usr/local/www/vpn_pptp.php
@@ -4,7 +4,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 	
 	Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_pptp_users.php
+++ b/usr/local/www/vpn_pptp_users.php
@@ -4,7 +4,7 @@
 	part of m0n0wall (http://m0n0.ch/wall)
 	
 	Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 	
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/vpn_pptp_users_edit.php
+++ b/usr/local/www/vpn_pptp_users_edit.php
@@ -5,7 +5,7 @@
 	part of pfSense
 
 	Copyright (C) 2003-2005 Manuel Kasper <mk@neon1.net>.
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without

--- a/usr/local/www/widgets/widgets/captive_portal_status.widget.php
+++ b/usr/local/www/widgets/widgets/captive_portal_status.widget.php
@@ -1,7 +1,7 @@
 <?php 
 /*
 	captive_portal_status.widget.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
 	Copyright (C) 2007 Sam Wenham

--- a/usr/local/www/widgets/widgets/carp_status.widget.php
+++ b/usr/local/www/widgets/widgets/carp_status.widget.php
@@ -1,33 +1,33 @@
 <?php
 /*
 	$Id$
-    carp_status.widget.php
-    Copyright (C) 2007 Sam Wenham
-    All rights reserved.
+	carp_status.widget.php
+	Copyright (C) 2007 Sam Wenham
+	All rights reserved.
 
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
@@ -1,34 +1,34 @@
 <?php
 /*
-    Original status page code from: services_dyndns.php
-    Copyright (C) 2008 Ermal Luci
-    Edits to convert it to a widget: dyn_dns_status.widget.php
-    Copyright (C) 2013 Stanley P. Miller \ stan-qaz
-    All rights reserved.
+	Original status page code from: services_dyndns.php
+	Copyright (C) 2008 Ermal Luci
+	Edits to convert it to a widget: dyn_dns_status.widget.php
+	Copyright (C) 2013 Stanley P. Miller \ stan-qaz
+	All rights reserved.
 
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INClUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INClUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /*
 	pfSense_BUILDER_BINARIES:	/usr/bin/host

--- a/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/usr/local/www/widgets/widgets/gateways.widget.php
@@ -1,33 +1,33 @@
 <?php
 /*
-        $Id$
-        Copyright 2008 Seth Mos
-        Part of pfSense widgets (https://www.pfsense.org)
-        originally based on m0n0wall (http://m0n0.ch/wall)
+	gateways.widget.php
+	Copyright 2008 Seth Mos
+	Part of pfSense widgets (https://www.pfsense.org)
+	originally based on m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/gmirror_status.widget.php
+++ b/usr/local/www/widgets/widgets/gmirror_status.widget.php
@@ -1,30 +1,30 @@
 <?php
 /*
-    gmirror_status.widget.php
-    Copyright (C) 2009-2010 Jim Pingle
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-    All rights reserved.
+	gmirror_status.widget.php
+	Copyright (C) 2009-2010 Jim Pingle
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INClUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INClUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/installed_packages.widget.php
+++ b/usr/local/www/widgets/widgets/installed_packages.widget.php
@@ -1,8 +1,8 @@
 <?php
 /*
-	$Id$
+	installed_packages.widget.php
 
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright 2007 Scott Dale
 	Part of pfSense widgets (https://www.pfsense.org)
 	originally based on m0n0wall (http://m0n0.ch/wall)

--- a/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -1,36 +1,36 @@
 <?php
 /*
-        $Id: interface_statistics.widget.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	$Id: interface_statistics.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
-        Copyright 2007 Scott Dale
-        Part of pfSense widgets (https://www.pfsense.org)
-        originally based on m0n0wall (http://m0n0.ch/wall)
+	Copyright 2007 Scott Dale
+	Part of pfSense widgets (https://www.pfsense.org)
+	originally based on m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-        and Jonathan Watt <jwatt@jwatt.org>.
-        All rights reserved.
+	Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
+	and Jonathan Watt <jwatt@jwatt.org>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -1,36 +1,36 @@
 <?php
 /*
-        $Id$
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	interfaces.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
-        Copyright 2007 Scott Dale
-        Part of pfSense widgets (https://www.pfsense.org)
-        originally based on m0n0wall (http://m0n0.ch/wall)
+	Copyright 2007 Scott Dale
+	Part of pfSense widgets (https://www.pfsense.org)
+	originally based on m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-        and Jonathan Watt <jwatt@jwatt.org>.
-        All rights reserved.
+	Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
+	and Jonathan Watt <jwatt@jwatt.org>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/ipsec.widget.php
+++ b/usr/local/www/widgets/widgets/ipsec.widget.php
@@ -1,36 +1,36 @@
 <?php
 /*
-        $Id$
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	ipsec.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
-        Copyright 2007 Scott Dale
-        Part of pfSense widgets (https://www.pfsense.org)
-        originally based on m0n0wall (http://m0n0.ch/wall)
+	Copyright 2007 Scott Dale
+	Part of pfSense widgets (https://www.pfsense.org)
+	originally based on m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-        and Jonathan Watt <jwatt@jwatt.org>.
-        All rights reserved.
+	Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
+	and Jonathan Watt <jwatt@jwatt.org>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/load_balancer_status.widget.php
+++ b/usr/local/www/widgets/widgets/load_balancer_status.widget.php
@@ -1,6 +1,7 @@
 <?php
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	load_balancer_status.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Copyright 2010 Jim Pingle
 	Portions copied from status_lb_pool.php, status_lb_vs.php, and vslb.inc:

--- a/usr/local/www/widgets/widgets/log.widget.php
+++ b/usr/local/www/widgets/widgets/log.widget.php
@@ -1,7 +1,7 @@
 <?php
 /*
-	$Id$
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	log.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Copyright 2007 Scott Dale
 	Part of pfSense widgets (https://www.pfsense.org)

--- a/usr/local/www/widgets/widgets/ntp_status.widget.php
+++ b/usr/local/www/widgets/widgets/ntp_status.widget.php
@@ -1,36 +1,36 @@
 <?php
 /*
-        $Id$
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	ntp_status.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
-        Copyright 2007 Scott Dale
-        Part of pfSense widgets (https://www.pfsense.org)
-        originally based on m0n0wall (http://m0n0.ch/wall)
+	Copyright 2007 Scott Dale
+	Part of pfSense widgets (https://www.pfsense.org)
+	originally based on m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-        and Jonathan Watt <jwatt@jwatt.org>.
-        All rights reserved.
+	Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
+	and Jonathan Watt <jwatt@jwatt.org>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/openvpn.widget.php
+++ b/usr/local/www/widgets/widgets/openvpn.widget.php
@@ -1,6 +1,31 @@
 <?php
 
-/*        Copyright (C) 2013-2015 Electric Sheep Fencing, LP */
+/*
+	openvpn.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Part of pfSense widgets (https://www.pfsense.org)
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
 
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/picture.widget.php
+++ b/usr/local/www/widgets/widgets/picture.widget.php
@@ -1,30 +1,30 @@
 <?php
 /*
-        $Id$
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-        Copyright 2009 Scott Ullrich
-        Part of pfSense widgets (https://www.pfsense.org)
+	picture.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright 2009 Scott Ullrich
+	Part of pfSense widgets (https://www.pfsense.org)
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/rss.widget.php
+++ b/usr/local/www/widgets/widgets/rss.widget.php
@@ -1,31 +1,31 @@
 <?php
 /*
-        $Id$
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	rss.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
-        Copyright 2009 Scott Ullrich
-        Part of pfSense widgets (https://www.pfsense.org)
+	Copyright 2009 Scott Ullrich
+	Part of pfSense widgets (https://www.pfsense.org)
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/usr/local/www/widgets/widgets/services_status.widget.php
@@ -1,34 +1,34 @@
 <?php
 /*
-    services_status.widget.php
-    Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	services_status.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
-    Copyright (C) 2004, 2005 Scott Ullrich
-    All rights reserved.
+	Copyright (C) 2004, 2005 Scott Ullrich
+	All rights reserved.
 
-    services_status.widget.php
-    Copyright (C) 2007 Sam Wenham
+	services_status.widget.php
+	Copyright (C) 2007 Sam Wenham
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INClUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INClUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 $nocsrf = true;

--- a/usr/local/www/widgets/widgets/smart_status.widget.php
+++ b/usr/local/www/widgets/widgets/smart_status.widget.php
@@ -1,6 +1,7 @@
 <?php
 /*
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	smart_status.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright 2012 mkirbst @ pfSense Forum
 	Part of pfSense widgets (https://www.pfsense.org)
 	All rights reserved.

--- a/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/usr/local/www/widgets/widgets/system_information.widget.php
@@ -1,35 +1,35 @@
 <?php
 /*
-        $Id$
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-        Copyright 2007 Scott Dale
-        Part of pfSense widgets (https://www.pfsense.org)
-        originally based on m0n0wall (http://m0n0.ch/wall)
+	system_information.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright 2007 Scott Dale
+	Part of pfSense widgets (https://www.pfsense.org)
+	originally based on m0n0wall (http://m0n0.ch/wall)
 
-        Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
-        and Jonathan Watt <jwatt@jwatt.org>.
-        All rights reserved.
+	Copyright (C) 2004-2005 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
+	and Jonathan Watt <jwatt@jwatt.org>.
+	All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 require_once("functions.inc");

--- a/usr/local/www/widgets/widgets/thermal_sensors.widget.php
+++ b/usr/local/www/widgets/widgets/thermal_sensors.widget.php
@@ -1,10 +1,10 @@
 <?php
 /*
 	$Id: thermal_sensors.widget.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Description: Thermal Sensors Widget.
-		NOTE: depends on proper cofing in System >> Advanced >> Miscellaneous tab >> Thermal Sensors section.
+		NOTE: depends on proper config in System >> Advanced >> Miscellaneous tab >> Thermal Sensors section.
 
 	File location:
 		\usr\local\www\widgets\widgets\

--- a/usr/local/www/widgets/widgets/traffic_graphs.widget.php
+++ b/usr/local/www/widgets/widgets/traffic_graphs.widget.php
@@ -1,7 +1,7 @@
 <?php
 /*
-	$Id$
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	traffic_graphs.widget.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Copyright 2007 Scott Dale
 	Part of pfSense widgets (https://www.pfsense.org)

--- a/usr/local/www/widgets/widgets/wake_on_lan.widget.php
+++ b/usr/local/www/widgets/widgets/wake_on_lan.widget.php
@@ -1,7 +1,7 @@
 <?php
 /*
 	wake_on_lan.widget.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 
 	Copyright (C) 2010 Yehuda Katz
 

--- a/usr/local/www/wizard.php
+++ b/usr/local/www/wizard.php
@@ -2,7 +2,7 @@
 /* $Id$ */
 /*
 	wizard.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2010 Ermal Luçi
 	Copyright (C) 2004 Scott Ullrich
 	All rights reserved.

--- a/usr/local/www/xmlrpc.php
+++ b/usr/local/www/xmlrpc.php
@@ -1,33 +1,31 @@
 <?php
 /*
-	$Id$
+	xmlrpc.php
+	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
+	Copyright (C) 2009, 2010 Scott Ullrich
+	Copyright (C) 2005 Colin Smith
+	All rights reserved.
 
-        xmlrpc.php
-        Copyright (C) 2013-2015 Electric Sheep Fencing, LP
-        Copyright (C) 2009, 2010 Scott Ullrich
-        Copyright (C) 2005 Colin Smith
-        All rights reserved.
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
 
-        1. Redistributions of source code must retain the above copyright notice,
-           this list of conditions and the following disclaimer.
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
 
-        2. Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in the
-           documentation and/or other materials provided with the distribution.
-
-        THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-        INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-        AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-        OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-        SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-        CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-        POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 
 ##|+PRIV


### PR DESCRIPTION
and module names and other bits of formatting and typos in header
comment sections. I got a bit carried away - but it is all just stuff in comments. IMHO it is good to get this stuff standardized as much as possible so that future changes-additions can be automatically added by scripts.