### PR TITLE
Allow IPv6 on loopback needs quick

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -2747,8 +2747,8 @@ function filter_rules_generate() {
 
 	if(!isset($config['system']['ipv6allow'])) {
 		$ipfrules .= "# Allow IPv6 on loopback\n";
-		$ipfrules .= "pass in {$log['pass']} on \$loopback inet6 all tracker {$increment_tracker($tracker)} label \"pass IPv6 loopback\"\n";
-		$ipfrules .= "pass out {$log['pass']} on \$loopback inet6 all tracker {$increment_tracker($tracker)} label \"pass IPv6 loopback\"\n";
+		$ipfrules .= "pass in {$log['pass']} quick on \$loopback inet6 all tracker {$increment_tracker($tracker)} label \"pass IPv6 loopback\"\n";
+		$ipfrules .= "pass out {$log['pass']} quick on \$loopback inet6 all tracker {$increment_tracker($tracker)} label \"pass IPv6 loopback\"\n";
 		$ipfrules .= "# Block all IPv6\n";
 		$ipfrules .= "block in {$log['block']} quick inet6 all tracker {$increment_tracker($tracker)} label \"Block all IPv6\"\n";
 		$ipfrules .= "block out {$log['block']} quick inet6 all tracker {$increment_tracker($tracker)} label \"Block all IPv6\"\n";


### PR DESCRIPTION
The following block uses "quick" which causes that block to come into effect before the "pass in" here. The pass rule also needs to be "quick".
Problem noted by Andy Sayler on https://redmine.pfsense.org/issues/4074
Before this change, an attempt to manually do something local with IPv6 fails:
[2.2-RC][root@xxx]/root: ntpq -pn
ntpq: write to localhost failed: Operation not permitted
After this change, it works:
[2.2-RC][root@xxx]/root: ntpq -pn
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*27.114.150.12   193.190.230.65   2 u   21   64  377  1424.66  -126.52 371.131

Note that there are other pass rules later for IPv6 necessary functions, loopback... that do not have "quick". Those are correct and help to allow various essential IPv6 stuff, but still let someone block it with user rules (which will have quick), in the case when IPv6 Allow is checked.
This one here is just for the special case of IPv6 Allow not set, and in this case this special IPv6 pass-block sequence needs to be done with "quick" so we can be sure it applies regardless of whatever other IPv6 might come later.