### PR TITLE
Limit unbound so-rcvbuf: 8m

### DIFF
--- a/etc/inc/unbound.inc
+++ b/etc/inc/unbound.inc
@@ -97,8 +97,12 @@ function unbound_optimization() {
 			if ($tunable['tunable'] == 'kern.ipc.maxsockbuf') {
 				$so = floor(($tunable['value']/1024/1024)-1);
 				// Check to ensure that the number is not a negative
-				if ($so > 0)
+				if ($so > 0) {
+					// Limit to 8MB, users might set maxsockbuf very high for other reasons.
+					// We do not want unbound to fail because of that.
+					$so = min($so, 8);
 					$optimization['so_rcvbuf'] = "so-rcvbuf: {$so}m";
+				}
 				else
 					unset($optimization['so_rcvbuf']);
 			}


### PR DESCRIPTION
Issue reported here: https://forum.pfsense.org/index.php?topic=78356.msg472781#msg472781
Most unbound doc places mention setting it at up to 8m. I'm sure it would be possible to investigate more and find a way to make unbound+FreeBSD be able to go higher than 8m. But probably 8m is sufficient for everyone anyway (judging by what the unbound docs seem to assume will be a good value on a busy system).
Anyway, here is my easy fix for this. Someone else feel free to investigate more if they really need to set so-rcvbuf higher.