### PR TITLE
OpenVPN backend authentication fix key and translation

### DIFF
--- a/usr/local/www/vpn_openvpn_server.php
+++ b/usr/local/www/vpn_openvpn_server.php
@@ -801,12 +801,12 @@ if ($savemsg)
 							<?php $authmodes = explode(",", $pconfig['authmode']); ?>
                                                         <?php
 								$auth_servers = auth_get_authserver_list();
-                                                                foreach ($auth_servers as $auth_server):
+                                                                foreach ($auth_servers as $auth_server_key => $auth_server):
                                                                         $selected = "";
-                                                                        if (in_array($auth_server['name'], $authmodes))
+                                                                        if (in_array($auth_server_key, $authmodes))
                                                                                 $selected = "selected=\"selected\"";
                                                         ?>
-                                                                <option value="<?=$auth_server['name'];?>" <?=$selected;?>><?=$auth_server['name'];?></option>
+                                                                <option value="<?=$auth_server_key;?>" <?=$selected;?>><?=$auth_server['name'];?></option>
                                                         <?php 	endforeach; ?>
                                                         </select>
                                                 </td>


### PR DESCRIPTION
The array returned by auth_get_authserver_list() has key as the fixed name of each available authentication mode - e.g. "Local Database".
The array value ["name"] has the name string translated into the selected GUI language.
Use the key do determine which items are selected, and as the value that ends up being stored in the config.
Use ["name"] for display.
Forum report: https://forum.pfsense.org/index.php?topic=86326.0
Redmine Bug #4180