### PR TITLE
"Like with like" - move a few functions to better places in the code (they are placed strangely)

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -440,6 +440,16 @@ function ip_greater_than($ip1, $ip2) {
 	return ip2ulong($ip1) > ip2ulong($ip2);
 }
 
+/* compare two IP addresses */
+function ipcmp($a, $b) {
+	if (ip_less_than($a, $b))
+		return -1;
+	else if (ip_greater_than($a, $b))
+		return 1;
+	else
+		return 0;
+}
+
 /* Convert a range of IPv4 addresses to an array of individual addresses. */
 /* Note: IPv6 ranges are not yet supported here. */
 function ip_range_to_address_array($startip, $endip, $max_size = 5000) {
@@ -680,6 +690,84 @@ function is_subnetoralias($subnet) {
 		return true;
 	else
 		return is_subnet($subnet);
+}
+
+function subnet_size($subnet) {
+	if (is_subnetv4($subnet)) {
+		list ($ip, $bits) = explode("/", $subnet);
+		return round(exp(log(2) * (32 - $bits)));
+	}
+	else if (is_subnetv6($subnet)) {
+		list ($ip, $bits) = explode("/", $subnet);
+		return round(exp(log(2) * (128 - $bits)));
+	}
+	else {
+		return 0;
+	}
+}
+
+
+function subnet_expand($subnet) {
+	if (is_subnetv4($subnet)) {
+		return subnetv4_expand($subnet);
+	} else if (is_subnetv6($subnet)) {
+		return subnetv6_expand($subnet);
+	} else {
+		return $subnet;
+	}
+}
+
+function subnetv4_expand($subnet) {
+	$result = array();
+	list ($ip, $bits) = explode("/", $subnet);
+	$net  = ip2long($ip);
+	$mask = (0xffffffff << (32 - $bits));
+	$net &= $mask;
+	$size = round(exp(log(2) * (32 - $bits)));
+	for ($i = 0; $i < $size; $i += 1) {
+		$result[] = long2ip($net | $i);
+	}
+	return $result;
+}
+
+/* find out whether two subnets overlap */
+function check_subnets_overlap($subnet1, $bits1, $subnet2, $bits2) {
+
+	if (!is_numeric($bits1))
+		$bits1 = 32;
+	if (!is_numeric($bits2))
+		$bits2 = 32;
+
+	if ($bits1 < $bits2)
+		$relbits = $bits1;
+	else
+		$relbits = $bits2;
+
+	$sn1 = gen_subnet_mask_long($relbits) & ip2long($subnet1);
+	$sn2 = gen_subnet_mask_long($relbits) & ip2long($subnet2);
+
+	return ($sn1 == $sn2);
+}
+
+/* find out whether two IPv6 subnets overlap */
+function check_subnetsv6_overlap($subnet1, $bits1, $subnet2, $bits2) {
+	$sub1_min = gen_subnetv6($subnet1, $bits1);
+	$sub1_max = gen_subnetv6_max($subnet1, $bits1);
+	$sub2_min = gen_subnetv6($subnet2, $bits2);
+	$sub2_max = gen_subnetv6_max($subnet2, $bits2);
+
+	return (is_inrange_v6($sub1_min, $sub2_min, $sub2_max) || is_inrange_v6($sub1_max, $sub2_min, $sub2_max) || is_inrange_v6($sub2_min, $sub1_min, $sub1_max));
+}
+
+/* return true if $addr is in $subnet, false if not */
+function ip_in_subnet($addr,$subnet) {
+	if(is_ipaddrv6($addr)) {
+		return (Net_IPv6::isInNetmask($addr, $subnet));
+	} else { /* XXX: Maybe check for IPv4 */
+		list($ip, $mask) = explode('/', $subnet);
+		$mask = (0xffffffff << (32 - $mask)) & 0xffffffff;
+		return ((ip2long($addr) & $mask) == (ip2long($ip) & $mask));
+	}
 }
 
 /* returns true if $hostname is just a valid hostname (top part without any of the domain part) */
@@ -1367,93 +1455,6 @@ function alias_expand_urltable($name) {
 		}
 	}
 	return null;
-}
-
-function subnet_size($subnet) {
-	if (is_subnetv4($subnet)) {
-		list ($ip, $bits) = explode("/", $subnet);
-		return round(exp(log(2) * (32 - $bits)));
-	}
-	else if (is_subnetv6($subnet)) {
-		list ($ip, $bits) = explode("/", $subnet);
-		return round(exp(log(2) * (128 - $bits)));
-	}
-	else {
-		return 0;
-	}
-}
-
-function subnet_expand($subnet) {
-	if (is_subnetv4($subnet)) {
-		return subnetv4_expand($subnet);
-	} else if (is_subnetv6($subnet)) {
-		return subnetv6_expand($subnet);
-	} else {
-		return $subnet;
-	}
-}
-
-function subnetv4_expand($subnet) {
-	$result = array();
-	list ($ip, $bits) = explode("/", $subnet);
-	$net  = ip2long($ip);
-	$mask = (0xffffffff << (32 - $bits));
-	$net &= $mask;
-	$size = round(exp(log(2) * (32 - $bits)));
-	for ($i = 0; $i < $size; $i += 1) {
-		$result[] = long2ip($net | $i);
-	}
-	return $result;
-}
-
-/* find out whether two subnets overlap */
-function check_subnets_overlap($subnet1, $bits1, $subnet2, $bits2) {
-
-	if (!is_numeric($bits1))
-		$bits1 = 32;
-	if (!is_numeric($bits2))
-		$bits2 = 32;
-
-	if ($bits1 < $bits2)
-		$relbits = $bits1;
-	else
-		$relbits = $bits2;
-
-	$sn1 = gen_subnet_mask_long($relbits) & ip2long($subnet1);
-	$sn2 = gen_subnet_mask_long($relbits) & ip2long($subnet2);
-
-	return ($sn1 == $sn2);
-}
-
-/* find out whether two IPv6 subnets overlap */
-function check_subnetsv6_overlap($subnet1, $bits1, $subnet2, $bits2) {
-	$sub1_min = gen_subnetv6($subnet1, $bits1);
-	$sub1_max = gen_subnetv6_max($subnet1, $bits1);
-	$sub2_min = gen_subnetv6($subnet2, $bits2);
-	$sub2_max = gen_subnetv6_max($subnet2, $bits2);
-
-	return (is_inrange_v6($sub1_min, $sub2_min, $sub2_max) || is_inrange_v6($sub1_max, $sub2_min, $sub2_max) || is_inrange_v6($sub2_min, $sub1_min, $sub1_max));
-}
-
-/* compare two IP addresses */
-function ipcmp($a, $b) {
-	if (ip_less_than($a, $b))
-		return -1;
-	else if (ip_greater_than($a, $b))
-		return 1;
-	else
-		return 0;
-}
-
-/* return true if $addr is in $subnet, false if not */
-function ip_in_subnet($addr,$subnet) {
-	if(is_ipaddrv6($addr)) {
-		return (Net_IPv6::isInNetmask($addr, $subnet));
-	} else { /* XXX: Maybe check for IPv4 */
-		list($ip, $mask) = explode('/', $subnet);
-		$mask = (0xffffffff << (32 - $mask)) & 0xffffffff;
-		return ((ip2long($addr) & $mask) == (ip2long($ip) & $mask));
-	}
 }
 
 /* verify (and remove) the digital signature on a file - returns 0 if OK */


### PR DESCRIPTION
A few basic functions for ip comparison and subnet overlap testing are in an illogical place - 1000 lines away from all the other basic IP/subnet functions, in the middle of alias handling, CARP interface, and sig checking library functions. 

Moving to earlier in the file (next to other IP compare and subnet functions) for ease of future contributors.