### PR TITLE
Deprecated and non-static method messages

### DIFF
--- a/etc/inc/shaper.inc
+++ b/etc/inc/shaper.inc
@@ -405,16 +405,16 @@ class altq_root_queue {
 
 		switch ($this->GetScheduler()) {
 		case "PRIQ":
-			$q =& new priq_queue();
+			$q = new priq_queue();
 			break;
 		case "HFSC":
-			$q =& new hfsc_queue();
+			$q = new hfsc_queue();
 			break;
 		case "CBQ":
-			$q =& new cbq_queue();
+			$q = new cbq_queue();
 			break;
 		case "FAIRQ":
-			$q =& new fairq_queue();
+			$q = new fairq_queue();
 			break;
 		default:
 			/* XXX: but should not happen anyway */
@@ -1428,7 +1428,7 @@ class hfsc_queue extends priq_queue {
 
 		if (!is_array($this->subqueues))
 			$this->subqueues = array();
-		$q =& new hfsc_queue();
+		$q = new hfsc_queue();
 		$q->SetInterface($this->GetInterface());
 		$q->SetParent($this);
 		$q->ReadConfig($qname);
@@ -2141,7 +2141,7 @@ class cbq_queue extends priq_queue {
 
 		if (!is_array($this->subqueues))
 			$this->subqueues = array();
-		$q =& new cbq_queue();
+		$q = new cbq_queue();
 		$q->SetInterface($this->GetInterface());
 		$q->SetParent($this);
 		$q->ReadConfig($qname);
@@ -2993,7 +2993,7 @@ class dnpipe_class extends dummynet_class {
 		if (!is_array($this->subqueues))
 			$this->subqueues = array();
 
-		$q =& new dnqueue_class();
+		$q = new dnqueue_class();
 		$q->SetLink($path);
 		$q->SetEnabled("on");
 		$q->SetPipe($this->GetQname());
@@ -4086,7 +4086,7 @@ function read_layer7_config() {
 	foreach ($l7cs as $conf) {
 		if (empty($conf['name']))
 			continue; /* XXX: grrrrrr at php */
-		$root =& new layer7();
+		$root = new layer7();
 		$root->ReadConfig($conf['name'],$conf);
 		$layer7_rules_list[$root->GetRName()] = &$root;
 	}
@@ -4322,7 +4322,7 @@ function read_altq_config() {
 
 	foreach ($a_int as $key => $conf) {
 		$int = $conf['interface'];
-		$root =& new altq_root_queue();
+		$root = new altq_root_queue();
 		$root->SetInterface($int);
 		$altq_list_queues[$root->GetInterface()] = &$root;
 		$root->ReadConfig($conf);
@@ -4362,7 +4362,7 @@ function read_dummynet_config() {
 	foreach ($a_int as $key => $conf) {
 		if (empty($conf['name']))
 			continue; /* XXX: grrrrrr at php */
-		$root =& new dnpipe_class();
+		$root = new dnpipe_class();
 		$root->ReadConfig($conf);
 		$dummynet_pipe_list[$root->GetQname()] = &$root;
 		array_push($path, $key);

--- a/etc/inc/simplepie/simplepie.inc
+++ b/etc/inc/simplepie/simplepie.inc
@@ -717,7 +717,7 @@ class SimplePie
 	function SimplePie($feed_url = null, $cache_location = null, $cache_duration = null)
 	{
 		// Other objects, instances created here so we can set options on them
-		$this->sanitize =& new SimplePie_Sanitize;
+		$this->sanitize = new SimplePie_Sanitize;
 
 		// Set options if they're passed to the constructor
 		if ($cache_location !== null)
@@ -1084,7 +1084,7 @@ class SimplePie
 	{
 		if (SimplePie_Misc::is_subclass_of($class, 'SimplePie_Sanitize'))
 		{
-			$this->sanitize =& new $class;
+			$this->sanitize = new $class;
 			return true;
 		}
 		return false;
@@ -1592,7 +1592,7 @@ function embed_wmedia(width, height, link) {
 								{
 									$headers['if-none-match'] = '"' . $this->data['headers']['etag'] . '"';
 								}
-								$file =& new $this->file_class($this->feed_url, $this->timeout/10, 5, $headers, $this->useragent, $this->force_fsockopen);
+								$file = new $this->file_class($this->feed_url, $this->timeout/10, 5, $headers, $this->useragent, $this->force_fsockopen);
 								if ($file->success)
 								{
 									if ($file->status_code == 304)
@@ -1633,7 +1633,7 @@ function embed_wmedia(width, height, link) {
 					}
 					else
 					{
-						$file =& new $this->file_class($this->feed_url, $this->timeout, 5, null, $this->useragent, $this->force_fsockopen);
+						$file = new $this->file_class($this->feed_url, $this->timeout, 5, null, $this->useragent, $this->force_fsockopen);
 					}
 				}
 				// If the file connection has an error, set SimplePie::error to that and quit
@@ -1653,7 +1653,7 @@ function embed_wmedia(width, height, link) {
 				if (!$this->force_feed)
 				{
 					// Check if the supplied URL is a feed, if it isn't, look for it.
-					$locate =& new $this->locator_class($file, $this->timeout, $this->useragent, $this->file_class, $this->max_checked_feeds, $this->content_type_sniffer_class);
+					$locate = new $this->locator_class($file, $this->timeout, $this->useragent, $this->file_class, $this->max_checked_feeds, $this->content_type_sniffer_class);
 					if (!$locate->is_feed($file))
 					{
 						// We need to unset this so that if SimplePie::set_file() has been called that object is untouched
@@ -1753,7 +1753,7 @@ function embed_wmedia(width, height, link) {
 				if ($utf8_data = SimplePie_Misc::change_encoding($data, $encoding, 'UTF-8'))
 				{
 					// Create new parser
-					$parser =& new $this->parser_class();
+					$parser = new $this->parser_class();
 
 					// If it's parsed fine
 					if ($parser->parse($utf8_data, 'UTF-8'))
@@ -1957,7 +1957,7 @@ function embed_wmedia(width, height, link) {
 				}
 				else
 				{
-					$file =& new $this->file_class($favicon, $this->timeout / 10, 5, array('X-FORWARDED-FOR' => $_SERVER['REMOTE_ADDR']), $this->useragent, $this->force_fsockopen);
+					$file = new $this->file_class($favicon, $this->timeout / 10, 5, array('X-FORWARDED-FOR' => $_SERVER['REMOTE_ADDR']), $this->useragent, $this->force_fsockopen);
 
 					if ($file->success && ($file->status_code == 200 || ($file->status_code > 206 && $file->status_code < 300)) && strlen($file->body) > 0)
 					{
@@ -2355,19 +2355,19 @@ function embed_wmedia(width, height, link) {
 			{
 				$label = $this->sanitize($category['attribs']['']['label'], SIMPLEPIE_CONSTRUCT_TEXT);
 			}
-			$categories[] =& new $this->category_class($term, $scheme, $label);
+			$categories[] = new $this->category_class($term, $scheme, $label);
 		}
 		foreach ((array) $this->get_channel_tags('', 'category') as $category)
 		{
-			$categories[] =& new $this->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$categories[] = new $this->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_channel_tags(SIMPLEPIE_NAMESPACE_DC_11, 'subject') as $category)
 		{
-			$categories[] =& new $this->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$categories[] = new $this->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_channel_tags(SIMPLEPIE_NAMESPACE_DC_10, 'subject') as $category)
 		{
-			$categories[] =& new $this->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$categories[] = new $this->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 
 		if (!empty($categories))
@@ -2415,7 +2415,7 @@ function embed_wmedia(width, height, link) {
 			}
 			if ($name !== null || $email !== null || $uri !== null)
 			{
-				$authors[] =& new $this->author_class($name, $uri, $email);
+				$authors[] = new $this->author_class($name, $uri, $email);
 			}
 		}
 		if ($author = $this->get_channel_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'author'))
@@ -2437,20 +2437,20 @@ function embed_wmedia(width, height, link) {
 			}
 			if ($name !== null || $email !== null || $url !== null)
 			{
-				$authors[] =& new $this->author_class($name, $url, $email);
+				$authors[] = new $this->author_class($name, $url, $email);
 			}
 		}
 		foreach ((array) $this->get_channel_tags(SIMPLEPIE_NAMESPACE_DC_11, 'creator') as $author)
 		{
-			$authors[] =& new $this->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$authors[] = new $this->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_channel_tags(SIMPLEPIE_NAMESPACE_DC_10, 'creator') as $author)
 		{
-			$authors[] =& new $this->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$authors[] = new $this->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_channel_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'author') as $author)
 		{
-			$authors[] =& new $this->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$authors[] = new $this->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 
 		if (!empty($authors))
@@ -2498,7 +2498,7 @@ function embed_wmedia(width, height, link) {
 			}
 			if ($name !== null || $email !== null || $uri !== null)
 			{
-				$contributors[] =& new $this->author_class($name, $uri, $email);
+				$contributors[] = new $this->author_class($name, $uri, $email);
 			}
 		}
 		foreach ((array) $this->get_channel_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'contributor') as $contributor)
@@ -2520,7 +2520,7 @@ function embed_wmedia(width, height, link) {
 			}
 			if ($name !== null || $email !== null || $url !== null)
 			{
-				$contributors[] =& new $this->author_class($name, $url, $email);
+				$contributors[] = new $this->author_class($name, $url, $email);
 			}
 		}
 
@@ -2924,7 +2924,7 @@ function embed_wmedia(width, height, link) {
 				$keys = array_keys($items);
 				foreach ($keys as $key)
 				{
-					$this->data['items'][] =& new $this->item_class($this, $items[$key]);
+					$this->data['items'][] = new $this->item_class($this, $items[$key]);
 				}
 			}
 			if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'entry'))
@@ -2932,7 +2932,7 @@ function embed_wmedia(width, height, link) {
 				$keys = array_keys($items);
 				foreach ($keys as $key)
 				{
-					$this->data['items'][] =& new $this->item_class($this, $items[$key]);
+					$this->data['items'][] = new $this->item_class($this, $items[$key]);
 				}
 			}
 			if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'item'))
@@ -2940,7 +2940,7 @@ function embed_wmedia(width, height, link) {
 				$keys = array_keys($items);
 				foreach ($keys as $key)
 				{
-					$this->data['items'][] =& new $this->item_class($this, $items[$key]);
+					$this->data['items'][] = new $this->item_class($this, $items[$key]);
 				}
 			}
 			if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'item'))
@@ -2948,7 +2948,7 @@ function embed_wmedia(width, height, link) {
 				$keys = array_keys($items);
 				foreach ($keys as $key)
 				{
-					$this->data['items'][] =& new $this->item_class($this, $items[$key]);
+					$this->data['items'][] = new $this->item_class($this, $items[$key]);
 				}
 			}
 			if ($items = $this->get_channel_tags('', 'item'))
@@ -2956,7 +2956,7 @@ function embed_wmedia(width, height, link) {
 				$keys = array_keys($items);
 				foreach ($keys as $key)
 				{
-					$this->data['items'][] =& new $this->item_class($this, $items[$key]);
+					$this->data['items'][] = new $this->item_class($this, $items[$key]);
 				}
 			}
 		}
@@ -3297,19 +3297,19 @@ class SimplePie_Item
 			{
 				$label = $this->sanitize($category['attribs']['']['label'], SIMPLEPIE_CONSTRUCT_TEXT);
 			}
-			$categories[] =& new $this->feed->category_class($term, $scheme, $label);
+			$categories[] = new $this->feed->category_class($term, $scheme, $label);
 		}
 		foreach ((array) $this->get_item_tags('', 'category') as $category)
 		{
-			$categories[] =& new $this->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$categories[] = new $this->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'subject') as $category)
 		{
-			$categories[] =& new $this->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$categories[] = new $this->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'subject') as $category)
 		{
-			$categories[] =& new $this->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$categories[] = new $this->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 
 		if (!empty($categories))
@@ -3370,7 +3370,7 @@ class SimplePie_Item
 			}
 			if ($name !== null || $email !== null || $uri !== null)
 			{
-				$contributors[] =& new $this->feed->author_class($name, $uri, $email);
+				$contributors[] = new $this->feed->author_class($name, $uri, $email);
 			}
 		}
 		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'contributor') as $contributor)
@@ -3392,7 +3392,7 @@ class SimplePie_Item
 			}
 			if ($name !== null || $email !== null || $url !== null)
 			{
-				$contributors[] =& new $this->feed->author_class($name, $url, $email);
+				$contributors[] = new $this->feed->author_class($name, $url, $email);
 			}
 		}
 
@@ -3431,7 +3431,7 @@ class SimplePie_Item
 			}
 			if ($name !== null || $email !== null || $uri !== null)
 			{
-				$authors[] =& new $this->feed->author_class($name, $uri, $email);
+				$authors[] = new $this->feed->author_class($name, $uri, $email);
 			}
 		}
 		if ($author = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'author'))
@@ -3453,24 +3453,24 @@ class SimplePie_Item
 			}
 			if ($name !== null || $email !== null || $url !== null)
 			{
-				$authors[] =& new $this->feed->author_class($name, $url, $email);
+				$authors[] = new $this->feed->author_class($name, $url, $email);
 			}
 		}
 		if ($author = $this->get_item_tags('', 'author'))
 		{
-			$authors[] =& new $this->feed->author_class(null, null, $this->sanitize($author[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT));
+			$authors[] = new $this->feed->author_class(null, null, $this->sanitize($author[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT));
 		}
 		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'creator') as $author)
 		{
-			$authors[] =& new $this->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$authors[] = new $this->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'creator') as $author)
 		{
-			$authors[] =& new $this->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$authors[] = new $this->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'author') as $author)
 		{
-			$authors[] =& new $this->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$authors[] = new $this->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 
 		if (!empty($authors))
@@ -3780,7 +3780,7 @@ class SimplePie_Item
 					{
 						$caption_text = $this->sanitize($caption['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 					}
-					$captions_parent[] =& new $this->feed->caption_class($caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text);
+					$captions_parent[] = new $this->feed->caption_class($caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text);
 				}
 			}
 			elseif ($captions = $parent->get_channel_tags(SIMPLEPIE_NAMESPACE_MEDIARSS, 'text'))
@@ -3812,7 +3812,7 @@ class SimplePie_Item
 					{
 						$caption_text = $this->sanitize($caption['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 					}
-					$captions_parent[] =& new $this->feed->caption_class($caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text);
+					$captions_parent[] = new $this->feed->caption_class($caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text);
 				}
 			}
 			if (is_array($captions_parent))
@@ -3842,7 +3842,7 @@ class SimplePie_Item
 				{
 					$label = $this->sanitize($category['attribs']['']['label'], SIMPLEPIE_CONSTRUCT_TEXT);
 				}
-				$categories_parent[] =& new $this->feed->category_class($term, $scheme, $label);
+				$categories_parent[] = new $this->feed->category_class($term, $scheme, $label);
 			}
 			foreach ((array) $parent->get_channel_tags(SIMPLEPIE_NAMESPACE_MEDIARSS, 'category') as $category)
 			{
@@ -3865,7 +3865,7 @@ class SimplePie_Item
 				{
 					$label = $this->sanitize($category['attribs']['']['label'], SIMPLEPIE_CONSTRUCT_TEXT);
 				}
-				$categories_parent[] =& new $this->feed->category_class($term, $scheme, $label);
+				$categories_parent[] = new $this->feed->category_class($term, $scheme, $label);
 			}
 			foreach ((array) $parent->get_channel_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'category') as $category)
 			{
@@ -3876,7 +3876,7 @@ class SimplePie_Item
 				{
 					$label = $this->sanitize($category['attribs']['']['text'], SIMPLEPIE_CONSTRUCT_TEXT);
 				}
-				$categories_parent[] =& new $this->feed->category_class($term, $scheme, $label);
+				$categories_parent[] = new $this->feed->category_class($term, $scheme, $label);
 
 				if (isset($category['child'][SIMPLEPIE_NAMESPACE_ITUNES]['category']))
 				{
@@ -3886,7 +3886,7 @@ class SimplePie_Item
 						{
 							$label = $this->sanitize($subcategory['attribs']['']['text'], SIMPLEPIE_CONSTRUCT_TEXT);
 						}
-						$categories_parent[] =& new $this->feed->category_class($term, $scheme, $label);
+						$categories_parent[] = new $this->feed->category_class($term, $scheme, $label);
 					}
 				}
 			}
@@ -3908,7 +3908,7 @@ class SimplePie_Item
 				{
 					$copyright_label = $this->sanitize($copyright[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 				}
-				$copyrights_parent =& new $this->feed->copyright_class($copyright_url, $copyright_label);
+				$copyrights_parent = new $this->feed->copyright_class($copyright_url, $copyright_label);
 			}
 			elseif ($copyright = $parent->get_channel_tags(SIMPLEPIE_NAMESPACE_MEDIARSS, 'copyright'))
 			{
@@ -3922,7 +3922,7 @@ class SimplePie_Item
 				{
 					$copyright_label = $this->sanitize($copyright[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 				}
-				$copyrights_parent =& new $this->feed->copyright_class($copyright_url, $copyright_label);
+				$copyrights_parent = new $this->feed->copyright_class($copyright_url, $copyright_label);
 			}
 
 			// CREDITS
@@ -3949,7 +3949,7 @@ class SimplePie_Item
 					{
 						$credit_name = $this->sanitize($credit['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 					}
-					$credits_parent[] =& new $this->feed->credit_class($credit_role, $credit_scheme, $credit_name);
+					$credits_parent[] = new $this->feed->credit_class($credit_role, $credit_scheme, $credit_name);
 				}
 			}
 			elseif ($credits = $parent->get_channel_tags(SIMPLEPIE_NAMESPACE_MEDIARSS, 'credit'))
@@ -3975,7 +3975,7 @@ class SimplePie_Item
 					{
 						$credit_name = $this->sanitize($credit['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 					}
-					$credits_parent[] =& new $this->feed->credit_class($credit_role, $credit_scheme, $credit_name);
+					$credits_parent[] = new $this->feed->credit_class($credit_role, $credit_scheme, $credit_name);
 				}
 			}
 			if (is_array($credits_parent))
@@ -4164,7 +4164,7 @@ class SimplePie_Item
 					{
 						$rating_value = $this->sanitize($rating['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 					}
-					$ratings_parent[] =& new $this->feed->rating_class($rating_scheme, $rating_value);
+					$ratings_parent[] = new $this->feed->rating_class($rating_scheme, $rating_value);
 				}
 			}
 			elseif ($ratings = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'explicit'))
@@ -4177,7 +4177,7 @@ class SimplePie_Item
 					{
 						$rating_value = $this->sanitize($rating['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 					}
-					$ratings_parent[] =& new $this->feed->rating_class($rating_scheme, $rating_value);
+					$ratings_parent[] = new $this->feed->rating_class($rating_scheme, $rating_value);
 				}
 			}
 			elseif ($ratings = $parent->get_channel_tags(SIMPLEPIE_NAMESPACE_MEDIARSS, 'rating'))
@@ -4198,7 +4198,7 @@ class SimplePie_Item
 					{
 						$rating_value = $this->sanitize($rating['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 					}
-					$ratings_parent[] =& new $this->feed->rating_class($rating_scheme, $rating_value);
+					$ratings_parent[] = new $this->feed->rating_class($rating_scheme, $rating_value);
 				}
 			}
 			elseif ($ratings = $parent->get_channel_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'explicit'))
@@ -4211,7 +4211,7 @@ class SimplePie_Item
 					{
 						$rating_value = $this->sanitize($rating['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 					}
-					$ratings_parent[] =& new $this->feed->rating_class($rating_scheme, $rating_value);
+					$ratings_parent[] = new $this->feed->rating_class($rating_scheme, $rating_value);
 				}
 			}
 			if (is_array($ratings_parent))
@@ -4239,7 +4239,7 @@ class SimplePie_Item
 					{
 						$restriction_value = $this->sanitize($restriction['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 					}
-					$restrictions_parent[] =& new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
+					$restrictions_parent[] = new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
 				}
 			}
 			elseif ($restrictions = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'block'))
@@ -4253,7 +4253,7 @@ class SimplePie_Item
 					{
 						$restriction_relationship = 'deny';
 					}
-					$restrictions_parent[] =& new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
+					$restrictions_parent[] = new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
 				}
 			}
 			elseif ($restrictions = $parent->get_channel_tags(SIMPLEPIE_NAMESPACE_MEDIARSS, 'restriction'))
@@ -4275,7 +4275,7 @@ class SimplePie_Item
 					{
 						$restriction_value = $this->sanitize($restriction['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 					}
-					$restrictions_parent[] =& new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
+					$restrictions_parent[] = new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
 				}
 			}
 			elseif ($restrictions = $parent->get_channel_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'block'))
@@ -4289,7 +4289,7 @@ class SimplePie_Item
 					{
 						$restriction_relationship = 'deny';
 					}
-					$restrictions_parent[] =& new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
+					$restrictions_parent[] = new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
 				}
 			}
 			if (is_array($restrictions_parent))
@@ -4493,7 +4493,7 @@ class SimplePie_Item
 								{
 									$caption_text = $this->sanitize($caption['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$captions[] =& new $this->feed->caption_class($caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text);
+								$captions[] = new $this->feed->caption_class($caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text);
 							}
 							if (is_array($captions))
 							{
@@ -4529,7 +4529,7 @@ class SimplePie_Item
 								{
 									$caption_text = $this->sanitize($caption['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$captions[] =& new $this->feed->caption_class($caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text);
+								$captions[] = new $this->feed->caption_class($caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text);
 							}
 							if (is_array($captions))
 							{
@@ -4565,7 +4565,7 @@ class SimplePie_Item
 								{
 									$label = $this->sanitize($category['attribs']['']['label'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$categories[] =& new $this->feed->category_class($term, $scheme, $label);
+								$categories[] = new $this->feed->category_class($term, $scheme, $label);
 							}
 						}
 						if (isset($group['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['category']))
@@ -4591,7 +4591,7 @@ class SimplePie_Item
 								{
 									$label = $this->sanitize($category['attribs']['']['label'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$categories[] =& new $this->feed->category_class($term, $scheme, $label);
+								$categories[] = new $this->feed->category_class($term, $scheme, $label);
 							}
 						}
 						if (is_array($categories) && is_array($categories_parent))
@@ -4620,7 +4620,7 @@ class SimplePie_Item
 							{
 								$copyright_label = $this->sanitize($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['copyright'][0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 							}
-							$copyrights =& new $this->feed->copyright_class($copyright_url, $copyright_label);
+							$copyrights = new $this->feed->copyright_class($copyright_url, $copyright_label);
 						}
 						elseif (isset($group['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['copyright']))
 						{
@@ -4634,7 +4634,7 @@ class SimplePie_Item
 							{
 								$copyright_label = $this->sanitize($group['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['copyright'][0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 							}
-							$copyrights =& new $this->feed->copyright_class($copyright_url, $copyright_label);
+							$copyrights = new $this->feed->copyright_class($copyright_url, $copyright_label);
 						}
 						else
 						{
@@ -4665,7 +4665,7 @@ class SimplePie_Item
 								{
 									$credit_name = $this->sanitize($credit['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$credits[] =& new $this->feed->credit_class($credit_role, $credit_scheme, $credit_name);
+								$credits[] = new $this->feed->credit_class($credit_role, $credit_scheme, $credit_name);
 							}
 							if (is_array($credits))
 							{
@@ -4695,7 +4695,7 @@ class SimplePie_Item
 								{
 									$credit_name = $this->sanitize($credit['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$credits[] =& new $this->feed->credit_class($credit_role, $credit_scheme, $credit_name);
+								$credits[] = new $this->feed->credit_class($credit_role, $credit_scheme, $credit_name);
 							}
 							if (is_array($credits))
 							{
@@ -4848,7 +4848,7 @@ class SimplePie_Item
 								{
 									$rating_value = $this->sanitize($rating['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$ratings[] =& new $this->feed->rating_class($rating_scheme, $rating_value);
+								$ratings[] = new $this->feed->rating_class($rating_scheme, $rating_value);
 							}
 							if (is_array($ratings))
 							{
@@ -4873,7 +4873,7 @@ class SimplePie_Item
 								{
 									$rating_value = $this->sanitize($rating['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$ratings[] =& new $this->feed->rating_class($rating_scheme, $rating_value);
+								$ratings[] = new $this->feed->rating_class($rating_scheme, $rating_value);
 							}
 							if (is_array($ratings))
 							{
@@ -4905,7 +4905,7 @@ class SimplePie_Item
 								{
 									$restriction_value = $this->sanitize($restriction['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$restrictions[] =& new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
+								$restrictions[] = new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
 							}
 							if (is_array($restrictions))
 							{
@@ -4931,7 +4931,7 @@ class SimplePie_Item
 								{
 									$restriction_value = $this->sanitize($restriction['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$restrictions[] =& new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
+								$restrictions[] = new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
 							}
 							if (is_array($restrictions))
 							{
@@ -4985,7 +4985,7 @@ class SimplePie_Item
 							$title = $title_parent;
 						}
 
-						$this->data['enclosures'][] =& new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions, $categories, $channels, $copyrights, $credits, $description, $duration, $expression, $framerate, $hashes, $height, $keywords, $lang, $medium, $player, $ratings, $restrictions, $samplingrate, $thumbnails, $title, $width);
+						$this->data['enclosures'][] = new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions, $categories, $channels, $copyrights, $credits, $description, $duration, $expression, $framerate, $hashes, $height, $keywords, $lang, $medium, $player, $ratings, $restrictions, $samplingrate, $thumbnails, $title, $width);
 					}
 				}
 			}
@@ -5114,7 +5114,7 @@ class SimplePie_Item
 								{
 									$caption_text = $this->sanitize($caption['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$captions[] =& new $this->feed->caption_class($caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text);
+								$captions[] = new $this->feed->caption_class($caption_type, $caption_lang, $caption_startTime, $caption_endTime, $caption_text);
 							}
 							if (is_array($captions))
 							{
@@ -5150,7 +5150,7 @@ class SimplePie_Item
 								{
 									$label = $this->sanitize($category['attribs']['']['label'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$categories[] =& new $this->feed->category_class($term, $scheme, $label);
+								$categories[] = new $this->feed->category_class($term, $scheme, $label);
 							}
 						}
 						if (is_array($categories) && is_array($categories_parent))
@@ -5183,7 +5183,7 @@ class SimplePie_Item
 							{
 								$copyright_label = $this->sanitize($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['copyright'][0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 							}
-							$copyrights =& new $this->feed->copyright_class($copyright_url, $copyright_label);
+							$copyrights = new $this->feed->copyright_class($copyright_url, $copyright_label);
 						}
 						else
 						{
@@ -5214,7 +5214,7 @@ class SimplePie_Item
 								{
 									$credit_name = $this->sanitize($credit['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$credits[] =& new $this->feed->credit_class($credit_role, $credit_scheme, $credit_name);
+								$credits[] = new $this->feed->credit_class($credit_role, $credit_scheme, $credit_name);
 							}
 							if (is_array($credits))
 							{
@@ -5318,7 +5318,7 @@ class SimplePie_Item
 								{
 									$rating_value = $this->sanitize($rating['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$ratings[] =& new $this->feed->rating_class($rating_scheme, $rating_value);
+								$ratings[] = new $this->feed->rating_class($rating_scheme, $rating_value);
 							}
 							if (is_array($ratings))
 							{
@@ -5350,7 +5350,7 @@ class SimplePie_Item
 								{
 									$restriction_value = $this->sanitize($restriction['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 								}
-								$restrictions[] =& new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
+								$restrictions[] = new $this->feed->restriction_class($restriction_relationship, $restriction_type, $restriction_value);
 							}
 							if (is_array($restrictions))
 							{
@@ -5389,7 +5389,7 @@ class SimplePie_Item
 							$title = $title_parent;
 						}
 
-						$this->data['enclosures'][] =& new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions, $categories, $channels, $copyrights, $credits, $description, $duration, $expression, $framerate, $hashes, $height, $keywords, $lang, $medium, $player, $ratings, $restrictions, $samplingrate, $thumbnails, $title, $width);
+						$this->data['enclosures'][] = new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions, $categories, $channels, $copyrights, $credits, $description, $duration, $expression, $framerate, $hashes, $height, $keywords, $lang, $medium, $player, $ratings, $restrictions, $samplingrate, $thumbnails, $title, $width);
 					}
 				}
 			}
@@ -5425,7 +5425,7 @@ class SimplePie_Item
 					}
 
 					// Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor
-					$this->data['enclosures'][] =& new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width);
+					$this->data['enclosures'][] = new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width);
 				}
 			}
 
@@ -5460,7 +5460,7 @@ class SimplePie_Item
 					}
 
 					// Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor
-					$this->data['enclosures'][] =& new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width);
+					$this->data['enclosures'][] = new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width);
 				}
 			}
 
@@ -5495,14 +5495,14 @@ class SimplePie_Item
 					}
 
 					// Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor
-					$this->data['enclosures'][] =& new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width);
+					$this->data['enclosures'][] = new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width);
 				}
 			}
 
 			if (sizeof($this->data['enclosures']) == 0 && ($url || $type || $length || $bitrate || $captions_parent || $categories_parent || $channels || $copyrights_parent || $credits_parent || $description_parent || $duration_parent || $expression || $framerate || $hashes_parent || $height || $keywords_parent || $lang || $medium || $player_parent || $ratings_parent || $restrictions_parent || $samplingrate || $thumbnails_parent || $title_parent || $width))
 			{
 				// Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor
-				$this->data['enclosures'][] =& new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width);
+				$this->data['enclosures'][] = new $this->feed->enclosure_class($url, $type, $length, $this->feed->javascript, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width);
 			}
 
 			$this->data['enclosures'] = array_values(SimplePie_Misc::array_unique($this->data['enclosures']));
@@ -5787,19 +5787,19 @@ class SimplePie_Source
 			{
 				$label = $this->sanitize($category['attribs']['']['label'], SIMPLEPIE_CONSTRUCT_TEXT);
 			}
-			$categories[] =& new $this->item->feed->category_class($term, $scheme, $label);
+			$categories[] = new $this->item->feed->category_class($term, $scheme, $label);
 		}
 		foreach ((array) $this->get_source_tags('', 'category') as $category)
 		{
-			$categories[] =& new $this->item->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$categories[] = new $this->item->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_source_tags(SIMPLEPIE_NAMESPACE_DC_11, 'subject') as $category)
 		{
-			$categories[] =& new $this->item->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$categories[] = new $this->item->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_source_tags(SIMPLEPIE_NAMESPACE_DC_10, 'subject') as $category)
 		{
-			$categories[] =& new $this->item->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$categories[] = new $this->item->feed->category_class($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 
 		if (!empty($categories))
@@ -5847,7 +5847,7 @@ class SimplePie_Source
 			}
 			if ($name !== null || $email !== null || $uri !== null)
 			{
-				$authors[] =& new $this->item->feed->author_class($name, $uri, $email);
+				$authors[] = new $this->item->feed->author_class($name, $uri, $email);
 			}
 		}
 		if ($author = $this->get_source_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'author'))
@@ -5869,20 +5869,20 @@ class SimplePie_Source
 			}
 			if ($name !== null || $email !== null || $url !== null)
 			{
-				$authors[] =& new $this->item->feed->author_class($name, $url, $email);
+				$authors[] = new $this->item->feed->author_class($name, $url, $email);
 			}
 		}
 		foreach ((array) $this->get_source_tags(SIMPLEPIE_NAMESPACE_DC_11, 'creator') as $author)
 		{
-			$authors[] =& new $this->item->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$authors[] = new $this->item->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_source_tags(SIMPLEPIE_NAMESPACE_DC_10, 'creator') as $author)
 		{
-			$authors[] =& new $this->item->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$authors[] = new $this->item->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 		foreach ((array) $this->get_source_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'author') as $author)
 		{
-			$authors[] =& new $this->item->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
+			$authors[] = new $this->item->feed->author_class($this->sanitize($author['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null);
 		}
 
 		if (!empty($authors))
@@ -5930,7 +5930,7 @@ class SimplePie_Source
 			}
 			if ($name !== null || $email !== null || $uri !== null)
 			{
-				$contributors[] =& new $this->item->feed->author_class($name, $uri, $email);
+				$contributors[] = new $this->item->feed->author_class($name, $uri, $email);
 			}
 		}
 		foreach ((array) $this->get_source_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'contributor') as $contributor)
@@ -5952,7 +5952,7 @@ class SimplePie_Source
 			}
 			if ($name !== null || $email !== null || $url !== null)
 			{
-				$contributors[] =& new $this->item->feed->author_class($name, $url, $email);
+				$contributors[] = new $this->item->feed->author_class($name, $url, $email);
 			}
 		}
 
@@ -6389,7 +6389,7 @@ class SimplePie_Enclosure
 		$this->width = $width;
 		if (class_exists('idna_convert'))
 		{
-			$idn =& new idna_convert;
+			$idn = new idna_convert;
 			$parsed = SimplePie_Misc::parse_url($link);
 			$this->link = SimplePie_Misc::compress_parse_url($parsed['scheme'], $idn->encode($parsed['authority']), $parsed['path'], $parsed['query'], $parsed['fragment']);
 		}
@@ -7585,7 +7585,7 @@ class SimplePie_File
 	{
 		if (class_exists('idna_convert'))
 		{
-			$idn =& new idna_convert;
+			$idn = new idna_convert;
 			$parsed = SimplePie_Misc::parse_url($url);
 			$url = SimplePie_Misc::compress_parse_url($parsed['scheme'], $idn->encode($parsed['authority']), $parsed['path'], $parsed['query'], $parsed['fragment']);
 		}
@@ -7646,7 +7646,7 @@ class SimplePie_File
 					curl_close($fp);
 					$this->headers = explode("\r\n\r\n", $this->headers, $info['redirect_count'] + 1);
 					$this->headers = array_pop($this->headers);
-					$parser =& new SimplePie_HTTP_Parser($this->headers);
+					$parser = new SimplePie_HTTP_Parser($this->headers);
 					if ($parser->parse())
 					{
 						$this->headers = $parser->headers;
@@ -7727,7 +7727,7 @@ class SimplePie_File
 					}
 					if (!$info['timed_out'])
 					{
-						$parser =& new SimplePie_HTTP_Parser($this->headers);
+						$parser = new SimplePie_HTTP_Parser($this->headers);
 						if ($parser->parse())
 						{
 							$this->headers = $parser->headers;
@@ -8556,7 +8556,7 @@ class SimplePie_Cache
 	 * @static
 	 * @access public
 	 */
-	function create($location, $filename, $extension)
+	public static function create($location, $filename, $extension)
 	{
 		return new SimplePie_Cache_File($location, $filename, $extension);
 	}
@@ -8673,7 +8673,7 @@ class SimplePie_Misc
 		return $time;
 	}
 
-	function absolutize_url($relative, $base)
+	public static function absolutize_url($relative, $base)
 	{
 		if ($relative !== '')
 		{
@@ -8745,7 +8745,7 @@ class SimplePie_Misc
 		return $return;
 	}
 
-	function remove_dot_segments($input)
+	public static function remove_dot_segments($input)
 	{
 		$output = '';
 		while (strpos($input, './') !== false || strpos($input, '/.') !== false || $input == '.' || $input == '..')
@@ -8799,7 +8799,7 @@ class SimplePie_Misc
 		return $output . $input;
 	}
 
-	function get_element($realname, $string)
+	public static function get_element($realname, $string)
 	{
 		$return = array();
 		$name = preg_quote($realname, '/');
@@ -8836,7 +8836,7 @@ class SimplePie_Misc
 		return $return;
 	}
 
-	function element_implode($element)
+	public static function element_implode($element)
 	{
 		$full = "<$element[tag]";
 		foreach ($element['attribs'] as $key => $value)
@@ -8920,7 +8920,7 @@ class SimplePie_Misc
 		die('Cached file for ' . $identifier_url . ' cannot be found.');
 	}
 
-	function fix_protocol($url, $http = 1)
+	public static function fix_protocol($url, $http = 1)
 	{
 		$url = SimplePie_Misc::normalize_url($url);
 		$parsed = SimplePie_Misc::parse_url($url);
@@ -8952,7 +8952,7 @@ class SimplePie_Misc
 		}
 	}
 
-	function parse_url($url)
+	public static function parse_url($url)
 	{
 		static $cache = array();
 		if (isset($cache[$url]))
@@ -8973,7 +8973,7 @@ class SimplePie_Misc
 		}
 	}
 
-	function compress_parse_url($scheme = '', $authority = '', $path = '', $query = '', $fragment = '')
+	public static function compress_parse_url($scheme = '', $authority = '', $path = '', $query = '', $fragment = '')
 	{
 		$return = '';
 		if ($scheme !== '')
@@ -8999,7 +8999,7 @@ class SimplePie_Misc
 		return $return;
 	}
 
-	function normalize_url($url)
+	public static function normalize_url($url)
 	{
 		$url = preg_replace_callback('/%([0-9A-Fa-f]{2})/', array('SimplePie_Misc', 'percent_encoding_normalization'), $url);
 		$url = SimplePie_Misc::parse_url($url);
@@ -9012,7 +9012,7 @@ class SimplePie_Misc
 		return SimplePie_Misc::compress_parse_url($url['scheme'], $url['authority'], $url['path'], $url['query'], $url['fragment']);
 	}
 
-	function percent_encoding_normalization($match)
+	public static function percent_encoding_normalization($match)
 	{
 		$integer = hexdec($match[1]);
 		if ($integer >= 0x41 && $integer <= 0x5A || $integer >= 0x61 && $integer <= 0x7A || $integer >= 0x30 && $integer <= 0x39 || $integer == 0x2D || $integer == 0x2E || $integer == 0x5F || $integer == 0x7E)
@@ -9075,7 +9075,7 @@ class SimplePie_Misc
 		return strtr($string, $convert_table);
 	}
 
-	function change_encoding($data, $input, $output)
+	public static function change_encoding($data, $input, $output)
 	{
 		$input = SimplePie_Misc::encoding($input);
 		$output = SimplePie_Misc::encoding($output);
@@ -9116,7 +9116,7 @@ class SimplePie_Misc
 		}
 	}
 
-	function encoding($charset)
+	public static function encoding($charset)
 	{
 		/* Character sets are case-insensitive, and also need some further
 		normalization in the real world (though we'll return them in the form given
@@ -10459,7 +10459,7 @@ class SimplePie_Misc
 		}
 	}
 
-	function get_curl_version()
+	public static function get_curl_version()
 	{
 		if (is_array($curl = curl_version()))
 		{
@@ -10553,7 +10553,7 @@ class SimplePie_Misc
 	 * @param string $data Input data
 	 * @return string Output data
 	 */
-	function entities_decode($data)
+	public static function entities_decode($data)
 	{
 		$decoder = new SimplePie_Decode_HTML_Entities($data);
 		return $decoder->parse();
@@ -10733,7 +10733,7 @@ class SimplePie_Misc
 		}
 	}
 
-	function is_isegment_nz_nc($string)
+	public static function is_isegment_nz_nc($string)
 	{
 		return (bool) preg_match('/^([A-Za-z0-9\-._~\x{A0}-\x{D7FF}\x{F900}-\x{FDCF}\x{FDF0}-\x{FFEF}\x{10000}-\x{1FFFD}\x{20000}-\x{2FFFD}\x{30000}-\x{3FFFD}\x{40000}-\x{4FFFD}\x{50000}-\x{5FFFD}\x{60000}-\x{6FFFD}\x{70000}-\x{7FFFD}\x{80000}-\x{8FFFD}\x{90000}-\x{9FFFD}\x{A0000}-\x{AFFFD}\x{B0000}-\x{BFFFD}\x{C0000}-\x{CFFFD}\x{D0000}-\x{DFFFD}\x{E1000}-\x{EFFFD}!$&\'()*+,;=@]|(%[0-9ABCDEF]{2}))+$/u', $string);
 	}
@@ -10757,7 +10757,7 @@ class SimplePie_Misc
 		return $tokens;
 	}
 
-	function array_unique($array)
+	public static function array_unique($array)
 	{
 		if (version_compare(PHP_VERSION, '5.2', '>='))
 		{
@@ -10807,7 +10807,7 @@ class SimplePie_Misc
 	 * @param int $codepoint Unicode codepoint
 	 * @return string UTF-8 character
 	 */
-	function codepoint_to_utf8($codepoint)
+	public static function codepoint_to_utf8($codepoint)
 	{
 		static $cache = array();
 		$codepoint = (int) $codepoint;
@@ -10924,7 +10924,7 @@ class SimplePie_Misc
 	 * @param string $data XML data
 	 * @return array Possible encodings
 	 */
-	function xml_encoding($data)
+	public static function xml_encoding($data)
 	{
 		// UTF-32 Big Endian BOM
 		if (substr($data, 0, 4) === "\x00\x00\xFE\xFF")
@@ -11769,7 +11769,7 @@ class SimplePie_Parse_Date
 	 *
 	 * @access public
 	 */
-	function get()
+	public static function get()
 	{
 		static $object;
 		if (!$object)
@@ -12918,7 +12918,7 @@ class SimplePie_Locator
 				if (!in_array($href, $done) && in_array('feed', $rel) || (in_array('alternate', $rel) && !empty($link['attribs']['type']['data']) && in_array(strtolower(SimplePie_Misc::parse_mime($link['attribs']['type']['data'])), array('application/rss+xml', 'application/atom+xml'))))
 				{
 					$this->checked_feeds++;
-					$feed =& new $this->file_class($href, $this->timeout, 5, null, $this->useragent);
+					$feed = new $this->file_class($href, $this->timeout, 5, null, $this->useragent);
 					if ($this->is_feed($feed))
 					{
 						return $feed;
@@ -12983,7 +12983,7 @@ class SimplePie_Locator
 			if (in_array(strtolower(strrchr($value, '.')), array('.rss', '.rdf', '.atom', '.xml')))
 			{
 				$this->checked_feeds++;
-				$feed =& new $this->file_class($value, $this->timeout, 5, null, $this->useragent);
+				$feed = new $this->file_class($value, $this->timeout, 5, null, $this->useragent);
 				if ($this->is_feed($feed))
 				{
 					return $feed;
@@ -13008,7 +13008,7 @@ class SimplePie_Locator
 			if (preg_match('/(rss|rdf|atom|xml)/i', $value))
 			{
 				$this->checked_feeds++;
-				$feed =& new $this->file_class($value, $this->timeout, 5, null, $this->useragent);
+				$feed = new $this->file_class($value, $this->timeout, 5, null, $this->useragent);
 				if ($this->is_feed($feed))
 				{
 					return $feed;
@@ -13571,7 +13571,7 @@ class SimplePie_Sanitize
 							}
 							else
 							{
-								$file =& new $this->file_class($img['attribs']['src']['data'], $this->timeout, 5, array('X-FORWARDED-FOR' => $_SERVER['REMOTE_ADDR']), $this->useragent, $this->force_fsockopen);
+								$file = new $this->file_class($img['attribs']['src']['data'], $this->timeout, 5, array('X-FORWARDED-FOR' => $_SERVER['REMOTE_ADDR']), $this->useragent, $this->force_fsockopen);
 								$headers = $file->headers;
 
 								if ($file->success && ($file->status_code == 200 || ($file->status_code > 206 && $file->status_code < 300)))

--- a/usr/local/www/firewall_shaper.php
+++ b/usr/local/www/firewall_shaper.php
@@ -203,7 +203,7 @@ if ($_GET) {
 	unset($input_errors);
 
 	if ($addnewaltq) {
-		$altq =& new altq_root_queue();
+		$altq = new altq_root_queue();
 		$altq->SetInterface($interface);
 		
 		switch ($altq->GetBwscale()) {

--- a/usr/local/www/firewall_shaper_layer7.php
+++ b/usr/local/www/firewall_shaper_layer7.php
@@ -130,7 +130,7 @@ else if ($_POST) {
 			$l7r = $layer7_rules_list[$name];
 			$_POST['divert_port'] = $l7r->GetRPort();
 		} else {
-			$l7r =& new layer7();
+			$l7r = new layer7();
 			$_POST['divert_port'] = $l7r->gen_divert_port();
 		}
 		for($i=0; $_POST['protocol'][$i] <> ""; $i++) {

--- a/usr/local/www/firewall_shaper_vinterface.php
+++ b/usr/local/www/firewall_shaper_vinterface.php
@@ -204,7 +204,7 @@ if ($_GET) {
 		if (!empty($dummynet_pipe_list[$qname]))
 			$input_errors[] = gettext("You cannot name a child queue with the same name as a parent limiter");
 		else {
-			$dnpipe =& new dnpipe_class();
+			$dnpipe = new dnpipe_class();
 			
 			$dnpipe->ReadConfig($_POST);
 			$dnpipe->validate_input($_POST, $input_errors);

--- a/usr/local/www/wizards/traffic_shaper_wizard_dedicated.inc
+++ b/usr/local/www/wizards/traffic_shaper_wizard_dedicated.inc
@@ -671,7 +671,7 @@ function apply_all_choosen_items() {
 	for ($i = 0; $i < $steps; $i++) {
 
 		$tmppath = array();
-		$altq =& new altq_root_queue();
+		$altq = new altq_root_queue();
 
 		$altq->SetInterface($config['ezshaper']['step2']["conn{$i}interface"]);
 		$interfacelist[] = $config['ezshaper']['step2']["conn{$i}interface"];
@@ -768,9 +768,9 @@ function apply_all_choosen_items() {
 
 			if ($sched != "PRIQ") {
 				if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qInternet";
 				//$tmpcf['priority'] = 6;
@@ -799,11 +799,11 @@ function apply_all_choosen_items() {
 			}
 
 			if ($sched == "PRIQ")
-				$q =& new priq_queue();
+				$q = new priq_queue();
 			else if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qACK";
 			$tmpcf['priority'] = 6;
@@ -829,11 +829,11 @@ function apply_all_choosen_items() {
 			$qtmp->wconfig();
 
 			if ($sched == "PRIQ")
-				$q =& new priq_queue();
+				$q = new priq_queue();
 			else if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			if ($p2pcatchall)
 				$tmpcf['name'] = "qOthersDefault";
@@ -861,11 +861,11 @@ function apply_all_choosen_items() {
 
 			if ($p2p) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qP2P";
 				$tmpcf['priority'] = 1;
@@ -911,11 +911,11 @@ function apply_all_choosen_items() {
 
 			if ($voip) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qVoIP";
 				$tmpcf['priority'] = 7;
@@ -951,11 +951,11 @@ function apply_all_choosen_items() {
 
 			if ($games) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qGames";
 				$tmpcf['priority'] = 5;
@@ -982,11 +982,11 @@ function apply_all_choosen_items() {
 
 			if ($otherpriority) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qOthersHigh";
 				$tmpcf['priority'] = 4;
@@ -1012,11 +1012,11 @@ function apply_all_choosen_items() {
 
 
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qOthersLow";
 				$tmpcf['priority'] = 2;
@@ -1057,7 +1057,7 @@ function apply_all_choosen_items() {
 			$downbw = floatval($config['ezshaper']['step2']["conn{$i}download"]) * $downfactor;
 
 			$tmppath = array();
-			$altq =& new altq_root_queue();
+			$altq = new altq_root_queue();
 
 			$altq->SetInterface($config['ezshaper']['step2']["local{$i}interface"]);
 			$altq->SetScheduler($config['ezshaper']['step2']["local{$i}downloadscheduler"]);
@@ -1152,11 +1152,11 @@ function apply_all_choosen_items() {
 
 		if (!$p2pcatchall) {
 			if ($sched == "PRIQ")
-				$q =& new priq_queue();
+				$q = new priq_queue();
 			else if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qLink";
 			$tmpcf['priority'] = 2;
@@ -1182,9 +1182,9 @@ function apply_all_choosen_items() {
 
 		if ($sched != "PRIQ") {
 			if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qInternet";
 			//$tmpcf['priority'] = 6;
@@ -1212,11 +1212,11 @@ function apply_all_choosen_items() {
 		}
 
 		if ($sched == "PRIQ")
-			$q =& new priq_queue();
+			$q = new priq_queue();
 		else if ($sched == "CBQ")
-			$q =& new cbq_queue();
+			$q = new cbq_queue();
 		else if ($sched == "HFSC")
-			$q =& new hfsc_queue();
+			$q = new hfsc_queue();
 		$tmpcf = array();
 		$tmpcf['name'] = "qACK";
 		$tmpcf['priority'] = 6;
@@ -1242,11 +1242,11 @@ function apply_all_choosen_items() {
 
 		if ($p2p) {
 			if ($sched == "PRIQ")
-				$q =& new priq_queue();
+				$q = new priq_queue();
 			else if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qP2P";
 			$tmpcf['priority'] = 1;
@@ -1292,11 +1292,11 @@ function apply_all_choosen_items() {
 
 		if ($voip) {
 			if ($sched == "PRIQ")
-				$q =& new priq_queue();
+				$q = new priq_queue();
 			else if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qVoIP";
 			$tmpcf['priority'] = 7;
@@ -1332,11 +1332,11 @@ function apply_all_choosen_items() {
 
 		if ($games) {
 			if ($sched == "PRIQ")
-				$q =& new priq_queue();
+				$q = new priq_queue();
 			else if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qGames";
 			$tmpcf['priority'] = 5;
@@ -1363,11 +1363,11 @@ function apply_all_choosen_items() {
 
 		if ($otherpriority) {
 			if ($sched == "PRIQ")
-				$q =& new priq_queue();
+				$q = new priq_queue();
 			else if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qOthersHigh";
 			$tmpcf['priority'] = 4;
@@ -1392,11 +1392,11 @@ function apply_all_choosen_items() {
 			$qtmp->wconfig();
 
 			if ($sched == "PRIQ")
-				$q =& new priq_queue();
+				$q = new priq_queue();
 			else if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qOthersLow";
 			$tmpcf['priority'] = 3;

--- a/usr/local/www/wizards/traffic_shaper_wizard_multi_all.inc
+++ b/usr/local/www/wizards/traffic_shaper_wizard_multi_all.inc
@@ -719,7 +719,7 @@ function apply_all_choosen_items() {
 	for ($i = 0; $i < $steps; $i++) {
 
 		$tmppath = array();
-		$altq =& new altq_root_queue();
+		$altq = new altq_root_queue();
 
 		$altq->SetInterface($config['ezshaper']['step2']["conn{$i}interface"]);
 		$interfacelist[] = $config['ezshaper']['step2']["conn{$i}interface"];
@@ -817,9 +817,9 @@ function apply_all_choosen_items() {
 
 		if ($sched != "PRIQ") {
 			if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qInternet";
 			//$tmpcf['priority'] = 6;
@@ -851,11 +851,11 @@ function apply_all_choosen_items() {
 		}
 
 		if ($sched == "PRIQ")
-			$q =& new priq_queue();
+			$q = new priq_queue();
 		else if ($sched == "CBQ")
-			$q =& new cbq_queue();
+			$q = new cbq_queue();
 		else if ($sched == "HFSC")
-			$q =& new hfsc_queue();
+			$q = new hfsc_queue();
 		$tmpcf = array();
 		$tmpcf['name'] = "qACK";
 		$tmpcf['priority'] = 6;
@@ -881,11 +881,11 @@ function apply_all_choosen_items() {
 		$qtmp->wconfig();
 
 		if ($sched == "PRIQ")
-			$q =& new priq_queue();
+			$q = new priq_queue();
 		else if ($sched == "CBQ")
-			$q =& new cbq_queue();
+			$q = new cbq_queue();
 		else if ($sched == "HFSC")
-			$q =& new hfsc_queue();
+			$q = new hfsc_queue();
 		$tmpcf = array();
 		if ($p2pcatchall)
 			$tmpcf['name'] = "qOthersDefault";
@@ -913,11 +913,11 @@ function apply_all_choosen_items() {
 
 			if ($p2p) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qP2P";
 				$tmpcf['priority'] = 1;
@@ -963,11 +963,11 @@ function apply_all_choosen_items() {
 
 			if ($voip) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qVoIP";
 				$tmpcf['priority'] = 7;
@@ -1003,11 +1003,11 @@ function apply_all_choosen_items() {
 
 			if ($games) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qGames";
 				$tmpcf['priority'] = 5;
@@ -1034,11 +1034,11 @@ function apply_all_choosen_items() {
 
 			if ($otherpriority) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qOthersHigh";
 				$tmpcf['priority'] = 4;
@@ -1064,11 +1064,11 @@ function apply_all_choosen_items() {
 
 
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qOthersLow";
 				$tmpcf['priority'] = 2;
@@ -1118,7 +1118,7 @@ function apply_all_choosen_items() {
 	for ($i = 0; $i < $localint; $i++) {
 
 		$tmppath = array();
-		$altq =& new altq_root_queue();
+		$altq = new altq_root_queue();
 
 		$altq->SetInterface($config['ezshaper']['step2']["local{$i}interface"]);
 		$altq->SetScheduler($config['ezshaper']['step2']["local{$i}downloadscheduler"]);
@@ -1215,11 +1215,11 @@ function apply_all_choosen_items() {
 
 		if (!$p2pcatchall) {
 			if ($sched == "PRIQ")
-				$q =& new priq_queue();
+				$q = new priq_queue();
 			else if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qLink";
 			$tmpcf['priority'] = 2;
@@ -1245,9 +1245,9 @@ function apply_all_choosen_items() {
 
 		if ($sched != "PRIQ") {
 			if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-				$q =& new hfsc_queue();
+				$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qInternet";
 			//$tmpcf['priority'] = 6;
@@ -1275,11 +1275,11 @@ function apply_all_choosen_items() {
 		}
 
 			if ($sched == "PRIQ")
-				$q =& new priq_queue();
+				$q = new priq_queue();
 			else if ($sched == "CBQ")
-				$q =& new cbq_queue();
+				$q = new cbq_queue();
 			else if ($sched == "HFSC")
-			$q =& new hfsc_queue();
+			$q = new hfsc_queue();
 			$tmpcf = array();
 			$tmpcf['name'] = "qACK";
 			$tmpcf['priority'] = 6;
@@ -1306,11 +1306,11 @@ function apply_all_choosen_items() {
 
 			if ($p2p) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qP2P";
 				$tmpcf['priority'] = 1;
@@ -1356,11 +1356,11 @@ function apply_all_choosen_items() {
 
 			if ($voip) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qVoIP";
 				$tmpcf['priority'] = 7;
@@ -1396,11 +1396,11 @@ function apply_all_choosen_items() {
 
 			if ($games) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qGames";
 				$tmpcf['priority'] = 5;
@@ -1427,11 +1427,11 @@ function apply_all_choosen_items() {
 
 			if ($otherpriority) {
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qOthersHigh";
 				$tmpcf['priority'] = 4;
@@ -1457,11 +1457,11 @@ function apply_all_choosen_items() {
 
 
 				if ($sched == "PRIQ")
-					$q =& new priq_queue();
+					$q = new priq_queue();
 				else if ($sched == "CBQ")
-					$q =& new cbq_queue();
+					$q = new cbq_queue();
 				else if ($sched == "HFSC")
-					$q =& new hfsc_queue();
+					$q = new hfsc_queue();
 				$tmpcf = array();
 				$tmpcf['name'] = "qOthersLow";
 				$tmpcf['priority'] = 3;


### PR DESCRIPTION
Fix various files that can emit messages like:
PHP Strict Standards:  Non-static method SimplePie_Misc::array_unique()
should not be called statically, assuming $this from incompatible
context in /etc/inc/simplepie/simplepie.inc on line 5508
php-fpm[16262]: /rc.newipsecdns: PHP ERROR: Type: 8192, File:
/etc/inc/shaper.inc, Line: 4365, Message: Assigning the return value of
new by reference is deprecated

Some of these style messages have been reported on the forum, e.g.
https://forum.pfsense.org/index.php?topic=86448.0

I had RSS widget on, and simplepie sent the system beserk telling about
all this stuff.