### PR TITLE
PEAR static method call warning

### DIFF
--- a/etc/inc/PEAR.inc
+++ b/etc/inc/PEAR.inc
@@ -247,7 +247,7 @@ class PEAR
      * @access  public
      * @return  bool    true if parameter is an error
      */
-    function isError($data, $code = null)
+    public static function isError($data, $code = null)
     {
         if (!is_object($data)) {
              return false;


### PR DESCRIPTION
Forum https://forum.pfsense.org/index.php?topic=86478.0
PEAR is used by
IPv6.inc
auth.inc
captiveportal.inc
radius.inc
xmlrpc_client.inc
radius_accounting.inc
radius_authentication.inc

I have just changed this 1 function to "public static"

Also used are:
PEAR::raiseError
PEAR::loadExtension (Ermal already put "static" 2 months ago)

Not sure if PEAR::raiseError will throw a similar "static method" call
warning, not game to touch it.