### PR TITLE
Restart PHP-FPM mount RW to setup ini file

### DIFF
--- a/etc/rc.php-fpm_restart
+++ b/etc/rc.php-fpm_restart
@@ -6,7 +6,9 @@ sleep 2
 
 # Run the php.ini setup file and populate
 # /usr/local/etc/php.ini and /usr/local/lib/php.ini
+/etc/rc.conf_mount_rw
 /etc/rc.php_ini_setup 2>/tmp/php_errors.txt
+/etc/rc.conf_mount_rw
 echo ">>> Restarting php-fpm" | /usr/bin/logger -p daemon.info -i -t rc.php-fpm_restart
 echo ">>> Starting php-fpm"
 /usr/local/sbin/php-fpm -c /usr/local/lib/php.ini -y /usr/local/lib/php-fpm.conf -RD 2>&1 >/dev/null

--- a/etc/rc.php-fpm_restart
+++ b/etc/rc.php-fpm_restart
@@ -8,7 +8,7 @@ sleep 2
 # /usr/local/etc/php.ini and /usr/local/lib/php.ini
 /etc/rc.conf_mount_rw
 /etc/rc.php_ini_setup 2>/tmp/php_errors.txt
-/etc/rc.conf_mount_rw
+/etc/rc.conf_mount_ro
 echo ">>> Restarting php-fpm" | /usr/bin/logger -p daemon.info -i -t rc.php-fpm_restart
 echo ">>> Starting php-fpm"
 /usr/local/sbin/php-fpm -c /usr/local/lib/php.ini -y /usr/local/lib/php-fpm.conf -RD 2>&1 >/dev/null


### PR DESCRIPTION
I was just using console menu option 16 Restart PHP-FPM and it hung on a nanoBSD system.
I found /tmp/php_errors.txt with this in it:
"override rw-r--r--  root/wheel for /usr/local/etc/php.ini?"
Flying blind at the console I entered "y", then /tmp/php_errors.txt had this:
--------
rm: /usr/local/etc/php.ini: Read-only file system
override rw-r--r--  root/wheel for /usr/local/lib/php.ini?
--------
Pressed return at the console and it proceeded, presumably without re-writing php.ini

It works much better when the file system is mounted RW :)