### PR TITLE
Fix POST typo in interfaces_assign.php

### DIFF
--- a/usr/local/www/interfaces_assign.php
+++ b/usr/local/www/interfaces_assign.php
@@ -196,7 +196,7 @@ if (isset($_POST['add_x']) && isset($_POST['if_add'])) {
 	/* Be sure this port is not being used */
 	$portused = false;
 	foreach ($config['interfaces'] as $ifname => $ifdata) {
-		if ($ifdata['if'] == $_PORT['if_add']) {
+		if ($ifdata['if'] == $_POST['if_add']) {
 			$portused = true;
 			break;
 		}


### PR DESCRIPTION
Obviously a typo. But this section is inside:
if (isset($_POST['add_x']) && isset($_POST['if_add'])) {
and I cannot find where 'add_x' is ever sent here, so I do not see how this whole code section is ever executed (and that will be why this typo bug has no symptoms). What is the history here? Can the whole block of code be removed?
The code normally executed is the section for 'Submit' lower down.