### PR TITLE
Do not return disabled dynamic gateways

### DIFF
--- a/etc/inc/gwlb.inc
+++ b/etc/inc/gwlb.inc
@@ -446,6 +446,7 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 	global $config, $g;
 
 	$gateways_arr = array();
+	$gateways_arr_temp = array();
 
 	$found_defaultv4 = 0;
 	$found_defaultv6 = 0;
@@ -471,7 +472,7 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 			$wancfg = $config['interfaces'][$gateway['interface']];
 
 			/* skip disabled interfaces */
-			if ($disabled === false && (!isset($wancfg['enable']) || isset($gateway['disabled'])))
+			if ($disabled === false && (!isset($wancfg['enable'])))
 				continue;
 
 			/* if the gateway is dynamic and we can find the IPv4, Great! */
@@ -532,7 +533,13 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 			/* include the gateway index as the attribute */
 			$gateway['attribute'] = $i;
 
-			$gateways_arr[$gateway['name']] = $gateway;
+			/* Remember all the gateway names, even ones to be skipped because they are disabled. */
+			/* Then we can easily know and match them later when attempting to add dynamic gateways to the list. */
+			$gateways_arr_temp[$gateway['name']] = $gateway;
+
+			/* skip disabled gateways if the caller has not asked for them to be returned. */
+			if (!($disabled === false && isset($gateway['disabled'])))
+				$gateways_arr[$gateway['name']] = $gateway;
 		}
 	}
 	unset($gateway);
@@ -609,8 +616,8 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 		if (!is_ipaddrv4($gateway['gateway']) && $gateway['dynamic'] == true)
 			$gateway['gateway'] = "dynamic";
 
-		/* automatically skip known static and dynamic gateways we have a array entry for */
-		foreach($gateways_arr as $gateway_item) {
+		/* automatically skip known static and dynamic gateways that were previously processed */
+		foreach($gateways_arr_temp as $gateway_item) {
 			if ((($ifname == $gateway_item['friendlyiface'] && $friendly == $gateway_item['name'])&& ($gateway['ipprotocol'] == $gateway_item['ipprotocol'])) ||
 				($ifname == $gateway_item['friendlyiface'] && $gateway_item['dynamic'] == true) && ($gateway['ipprotocol'] == $gateway_item['ipprotocol']))
 					continue 2;
@@ -701,8 +708,8 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 		if (!is_ipaddrv6($gateway['gateway']) && $gateway['dynamic'] == true)
 			$gateway['gateway'] = "dynamic";
 
-		/* automatically skip known static and dynamic gateways we have a array entry for */
-		foreach($gateways_arr as $gateway_item) {
+		/* automatically skip known static and dynamic gateways that were previously processed */
+		foreach($gateways_arr_temp as $gateway_item) {
 			if ((($ifname == $gateway_item['friendlyiface'] && $friendly == $gateway_item['name']) && ($gateway['ipprotocol'] == $gateway_item['ipprotocol'])) ||
 				($ifname == $gateway_item['friendlyiface'] && $gateway_item['dynamic'] == true) && ($gateway['ipprotocol'] == $gateway_item['ipprotocol']))
 					continue 2;


### PR DESCRIPTION
When a dynamic gateway is disabled (by the user through the webGUI), it was still being returned by return_gateways_array(). But when called like that, disabled gateways should not be returned. The first part of the routine was correctly skipping disabled gateways, but then the later part would effectively re-generate those dynamic gateways on-the-fly and not realise they should be skipped because they were disabled.
This code now remembers gateway details of all the gateways, including skipped ones, so the dynamic gateway code can easily realise all gateways that have been already processed, even those that were processed and skipped.
Forum: https://forum.pfsense.org/index.php?topic=86565.0
It fixes Gateway Status Widget - now if a dynamic gateway is disabled, it does not appear on the display.
This will also stop disabled dynamic gateways from being returned to other callers. So there may/will be impacts on other parts of the system when a user disables a dynamic gateway. e.g. filter.inc - a gateway that has been disabled by a user canot be used in rules any more.