### PR TITLE
Firewall Rules Apply be friendly to other languages

### DIFF
--- a/usr/local/www/firewall_rules.php
+++ b/usr/local/www/firewall_rules.php
@@ -291,7 +291,7 @@ if($_REQUEST['undodrag']) {
 		$dragtable .= "&dragtable[]={$dt}";
 	print_info_box_np_undo(gettext("The firewall rule configuration has been changed.<br />You must apply the changes in order for them to take effect."), "apply" , gettext("Apply changes") , "firewall_rules.php?if={$_REQUEST['if']}&dragdroporder=true&{$dragtable}");
 } else {
-	print_info_box_np(gettext("The firewall rule configuration has been changed.<br />You must apply the changes in order for them to take effect."));
+	print_info_box_np(gettext("The firewall rule configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."), "apply", "", true);
 }
 ?>
 <br />


### PR DESCRIPTION
Forum: https://forum.pfsense.org/index.php?topic=86808.0
Redmine: https://redmine.pfsense.org/issues/3886

print_info_box_np() when called with just the first $msg parameter has some rough tests to decide if the "Apply" button should be displayed. It checks if the translation of "apply", "save" or "create" appears in the $msg string (which is a translated string itself). If the $msg string did not translate, and thus remains in English, but gettext("apply") does translate then the e.g. Turkish word for "apply" is not going to appear in the English $msg string. So things go wrong.

print_info_box_np already has extra parameters to tell it explicitly $showapply - and for this stuff we know we want the apply button, regardless of how the various text string translations work out. Thus I have provided those parameters here.

I also changed the construction of the text to pass as $msg, breaking it up like in firewall_aliases.php - this means that the string "You must apply the changes in order for them to take effect." translates and you get at least that Turkish displayed.

IMHO it would be beneficial to change lots of these print_info_box_np calls to explicitly set $showapply=true - that will ensure that the apply button shows (and thus the user can perform the needed actions) regardless of how well/not well the translation of the text turns out.