### PR TITLE
multiple allow/deny entries for UPnP

### DIFF
--- a/usr/local/pkg/miniupnpd.inc
+++ b/usr/local/pkg/miniupnpd.inc
@@ -98,26 +98,29 @@
 			$input_errors[] = 'You must specify a valid traffic shaping queue.';
 
 		/* user permissions validation */
-		for($i=1; $i<=4; $i++) {
-			if($post["permuser{$i}"]) {
-				$perm = explode(' ',$post["permuser{$i}"]);
+		if($post["permuser"]) {
+			/* explode permission entries separated by comma */
+			$subperm = explode(',',$post["permuser"]);
+			foreach($subperm as $eachentry) {
+				/* explode each entry */
+				$perm = explode(' ',$eachentry);
 				/* should explode to 4 args */
 				if(count($perm) != 4) {
-					$input_errors[] = "You must follow the specified format in the 'User specified permissions {$i}' field";
+					$input_errors[] = "You must follow the specified format in the 'User specified permissions entry '$eachentry'";
 				} else {
 					/* must with allow or deny */
 					if(!($perm[0] == 'allow' || $perm[0] == 'deny'))
-						$input_errors[] = "You must begin with allow or deny in the 'User specified permissions {$i}' field";
+						$input_errors[] = "You must begin with allow or deny in the 'User specified permissions entry '$eachentry'";
 					/* verify port or port range */
 					if(!upnp_validate_port($perm[1]) || !upnp_validate_port($perm[3]))
 						$input_errors[] = "You must specify a port or port range between 0 and 65535 in the 'User specified
-							permissions {$i}' field";
+							permissions entry '$eachentry'";
 					/* verify ip address */
 					if(!upnp_validate_ip($perm[2],true))
-						$input_errors[] = "You must specify a valid ip address in the 'User specified permissions {$i}' field";
+						$input_errors[] = "You must specify a valid ip address in the 'User specified permissions entry '$eachentry'";
 				}
 			}
-		}		
+		}	
 	}
 
 	function sync_package_miniupnpd() {
@@ -209,9 +212,11 @@
 				$config_text .= "model_number=".file_get_contents("/etc/version")."\n";
 	
 				/* upnp access restrictions */
-				for($i=1; $i<=4; $i++) {
-					if($upnp_config["permuser{$i}"])
-						$config_text .= "{$upnp_config["permuser{$i}"]}\n";
+				if($upnp_config["permuser"]) {
+					$subperm = explode(',',$upnp_config["permuser"]);
+					foreach($subperm as $eachentry) {
+						$config_text .= "$eachentry\n";
+					}
 				}
 
 				if($upnp_config['permdefault'])

--- a/usr/local/pkg/miniupnpd.xml
+++ b/usr/local/pkg/miniupnpd.xml
@@ -116,34 +116,15 @@
 			<type>checkbox</type>
 		</field>
 		<field>
-			<fielddescr>User specified permissions 1</fielddescr>
-			<fieldname>permuser1</fieldname>
+			<fielddescr>User specified permissions</fielddescr>
+			<fieldname>permuser</fieldname>
 			<description>Format: [allow or deny] [ext port or range] [int ipaddr or ipaddr/CIDR] [int port or range]
-			&lt;br /&gt;Example: allow 1024-65535 192.168.0.0/24 1024-65535</description>
-			<type>input</type>
-			<size>60</size>
+			&lt;br /&gt;Example: allow 1024-65535 192.168.0.0/24 1024-65535
+			&lt;br /&gt;Use comma to separate multiple entries</description>
+			<type>textarea</type>
+			<rows>5</rows>
+			<cols>60</cols>
 		</field>
-		<field>
-			<fielddescr>User specified permissions 2</fielddescr>
-			<fieldname>permuser2</fieldname>
-			<description>Format: [allow or deny] [ext port or range] [int ipaddr or ipaddr/CIDR] [int port or range]</description>
-			<type>input</type>
-			<size>60</size>
-		</field>
-		<field>
-			<fielddescr>User specified permissions 3</fielddescr>
-			<fieldname>permuser3</fieldname>
-			<description>Format: [allow or deny] [ext port or range] [int ipaddr or ipaddr/CIDR] [int port or range]</description>
-			<type>input</type>
-			<size>60</size>
-		</field>
-		<field>
-			<fielddescr>User specified permissions 4</fielddescr>
-			<fieldname>permuser4</fieldname>
-			<description>Format: [allow or deny] [ext port or range] [int ipaddr or ipaddr/CIDR] [int port or range]</description>
-			<type>input</type>
-			<size>60</size>
-		</field>	
 	</fields>
 	<custom_php_command_before_form>
 		before_form_miniupnpd($pkg);


### PR DESCRIPTION
This patch will allow the web GUI for UPnP to enter more user specified
entries rather than just 4, I replaced the 4 boxes with one single one
which would allow to add more entries separated by a comma