### PR TITLE
remove pointless filter on dhcp static mappings table

### DIFF
--- a/usr/local/www/services_dhcp.php
+++ b/usr/local/www/services_dhcp.php
@@ -107,7 +107,7 @@ if($config['installedpackages']['olsrd']) {
 				break;
 			}
 	}
-}	
+}
 
 $iflist = get_configured_interface_with_descr();
 
@@ -1259,7 +1259,6 @@ include("head.inc");
 		</tr>
 			<?php if(is_array($a_maps)): ?>
 			<?php $i = 0; foreach ($a_maps as $mapent): ?>
-			<?php if($mapent['mac'] <> "" or $mapent['ipaddr'] <> ""): ?>
 		<tr>
 		<td align="center" class="listlr" ondblclick="document.location='services_dhcp_edit.php?if=<?=htmlspecialchars($if);?>&amp;id=<?=$i;?>';">
 			<?php if (isset($mapent['arp_table_static_entry'])): ?>
@@ -1287,7 +1286,6 @@ include("head.inc");
 			</table>
 		</td>
 		</tr>
-		<?php endif; ?>
 		<?php $i++; endforeach; ?>
 		<?php endif; ?>
 		<tr>

--- a/usr/local/www/status_dhcp_leases.php
+++ b/usr/local/www/status_dhcp_leases.php
@@ -340,7 +340,7 @@ foreach ($pools as $data) {
 // Load MAC-Manufacturer table
 $mac_man = load_mac_manufacturer_table();
 foreach ($leases as $data) {
-	if (($data['act'] == "active") || ($data['act'] == "static") || ($_GET['all'] == 1)) {
+	if (($data['act'] == "active") || ($data['act'] == "static" && !empty($data['ip'])) || ($_GET['all'] == 1)) {
 		if ($data['act'] != "active" && $data['act'] != "static") {
 			$fspans = "<span class=\"gray\">";
 			$fspane = "&nbsp;</span>";


### PR DESCRIPTION
The filtering on the static mappings table (services_dhcp.php) seems backwards; this page should show all configured static mappings regardless of how they are configured.

It does, however, make sense to hide some from status_dhcp_leases.php, as any static mappings without an IP  configured will appear in the list twice.