### PR TITLE
Firewall Log does not display logged IGMP packets

### DIFF
--- a/etc/inc/filter_log.inc
+++ b/etc/inc/filter_log.inc
@@ -238,6 +238,9 @@ function parse_filter_line($line) {
 				break;
 			}
 
+		} else if ($flent['protoid'] == '2') { // IGMP
+			$flent['src'] = $flent['srcip'];
+			$flent['dst'] = $flent['dstip'];
 		} else if ($flent['protoid'] == '112') { // CARP
 			$flent['type'] = $rule_data[$field++];
 			$flent['ttl'] = $rule_data[$field++];


### PR DESCRIPTION
If IGMP packets are logged (either pass or block) then parse_filter_line did not set their src and dst IP. 
Later in the subroutine, it zapped the filter line because it did not have a src and dst.
This fixes it. Now the IGMP lines in /var/log/filter.log appear on the Firewall Log GUI.