### PR TITLE
Unbound domain override IP:port validation

### DIFF
--- a/usr/local/www/services_unbound_domainoverride_edit.php
+++ b/usr/local/www/services_unbound_domainoverride_edit.php
@@ -86,7 +86,7 @@ if ($_POST) {
     if ($_POST['ip']) {
         if (strpos($_POST['ip'],'@') !== false) {
             $ip_details = explode("@", $_POST['ip']);
-            if (!is_ipaddr($ip_details[0]) && !is_port($ip_details[1]))
+            if (!is_ipaddr($ip_details[0]) || !is_port($ip_details[1]))
                 $input_errors[] = gettext("A valid IP address and port must be specified, for example 192.168.100.10@5353.");
         } else if (!is_ipaddr($_POST['ip']))
             $input_errors[] = gettext("A valid IP address must be specified, for example 192.168.100.10.");


### PR DESCRIPTION
The domain override is IP:port is invalid if either the IP address OR port is invalid.
Previously you could put an invalid IP with valid port, or valid IP with invalid port.