### PR TITLE
Fixed not being able to save custom and custom-v6 dyndns

### DIFF
--- a/usr/local/www/services_dyndns_edit.php
+++ b/usr/local/www/services_dyndns_edit.php
@@ -106,7 +106,7 @@ if ($_POST) {
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, &$input_errors);
 
-	if (isset($_POST['host'])) {
+	if (isset($_POST['host']) && in_array("host", $reqdfields)) {
 		/* Namecheap can have a @. in hostname */
 		if ($pconfig['type'] == "namecheap" && substr($_POST['host'], 0, 2) == '@.')
 			$host_to_check = substr($_POST['host'], 2);


### PR DESCRIPTION
due to "host" being posted empty, and thus failing
is_domain() check.

This also happens on 2.2.