### PR TITLE
Remove latin-1 encoding of RSS feed

### DIFF
--- a/usr/local/www/widgets/widgets/rss.widget.php
+++ b/usr/local/www/widgets/widgets/rss.widget.php
@@ -157,7 +157,6 @@ else
 	$feed->set_cache_location("/tmp/simplepie/");
 	$feed->set_feed_url($rss_feed_s);
 	$feed->init();
-	$feed->set_output_encoding('latin-1');
 	$feed->handle_content_type();
 	$counter = 1;
 	foreach($feed->get_items() as $item) {


### PR DESCRIPTION
Many thanks to Gertjan in forum https://forum.pfsense.org/index.php?topic=87504.msg484017#msg484017
Specifically setting the output encoding to latin-1 was causing the "black diamonds" for special characters in the http://blog.pfsense.org RSS feed (e.g. the registered trademark sign after pfSense did not come out).
It should all work by letting simplepie do its default stuff with the RSS feed.