### PR TITLE
Use web-gui setting for pap or chap instead of having it hard-coded

### DIFF
--- a/etc/inc/vpn.inc
+++ b/etc/inc/vpn.inc
@@ -1646,7 +1646,7 @@ l2tp_standard:
 	set iface down-script /usr/local/sbin/vpn-linkdown
 	set link yes acfcomp protocomp
 	set link no pap chap
-	set link enable chap
+	{$paporchap}
 	set link keep-alive 10 180
 
 EOD;


### PR DESCRIPTION
I have no idea if this is a bug or by design.

This is the thread describing my problem:
https://forum.pfsense.org/index.php?topic=88071.0

What I found is that the "l2tp_standard" config is hard-coded to "chap" and does not care about the substitution beeing done at line 1592 under vpn_l2tp_configure().

