### PR TITLE
add dhcp6.name-servers option with DHCPD-PD regardless of PD length

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -1091,8 +1091,8 @@ function services_dhcpdv6_configure($blacklist = array()) {
 
 				$dhcpdv6cfg[$ifname]['prefixrange']['from'] = Net_IPv6::compress($range['start']);
 				$dhcpdv6cfg[$ifname]['prefixrange']['to'] = Net_IPv6::compress($range['end']);
-				$dhcpdv6cfg[$ifname]['dns6ip'] = get_interface_ipv6($ifname);
 			}
+			$dhcpdv6cfg[$ifname]['dns6ip'] = get_interface_ipv6($ifname);
 		}
 	}
 
@@ -1210,7 +1210,7 @@ EOD;
 			$dhcpdv6conf .= "	prefix6 {$dhcpv6ifconf['prefixrange']['from']} {$dhcpv6ifconf['prefixrange']['to']} /{$dhcpv6ifconf['prefixrange']['prefixlength']};\n";
 		}
 		if (is_ipaddrv6($dhcpv6ifconf['dns6ip'])) {
-			$dhcpdv6conf .= "       option dhcp6.name-servers {$dhcpv6ifconf['dns6ip']};\n";
+			$dhcpdv6conf .= "	option dhcp6.name-servers {$dhcpv6ifconf['dns6ip']};\n";
 		}
     		// default-lease-time
 		if ($dhcpv6ifconf['defaultleasetime'])


### PR DESCRIPTION
The existing code only includes a v6 name server IP in the
automatically generated dhcpdv6 configuration for tracking interfaces if
there are additional prefixes that can be delegated on to the next
router (i.e., if PD length > 2). The correct behavior is for this option
to be included regardless of the PD length, as implemented in this
change.