### PR TITLE
fix Net_IPv6::compress() to properly handle all-zeros address

### DIFF
--- a/etc/inc/IPv6.inc
+++ b/etc/inc/IPv6.inc
@@ -748,6 +748,12 @@ class Net_IPv6
         $cip = preg_replace('/((^:)|(:$))/', '', $cip);
         $cip = preg_replace('/((^:)|(:$))/', '::', $cip);
 
+        if (empty($cip)) {
+
+            $cip = "::";
+
+        }
+
         if ('' != $netmask) {
 
             $cip = $cip.'/'.$netmask;


### PR DESCRIPTION
The existing implementation of Net_IPv6::compress produces an empty
string when compressing the all-zeros ("::") address; fix this by
checking for empty return values and replacing them with "::".