### PR TITLE
make computation of start of DHCPv6 range consistent with actual check

### DIFF
--- a/usr/local/www/services_dhcpv6.php
+++ b/usr/local/www/services_dhcpv6.php
@@ -568,7 +568,6 @@ display_top_tabs($tab_array);
 			<td width="78%" class="vtable">
 			<?php
 				$range_from = gen_subnetv6($ifcfgip, $ifcfgsn);
-				$range_from++;
 				echo $range_from;
 
 			?>


### PR DESCRIPTION
When computing the start IP for the 'available range' field,
services_dhcpv6.php attempts to increment a colon-formatted v6 address.
Since this always fails, so the value that's printed is not actually
incremented, so remove the bogus addition.

Note that this is actually matches the behavior of the range checks that
services_dhcpv6.php performs: The actual check uses the range
[gen_subnetv6()..gen_subnetv6_max()], which does include the first
(= all-zeroes host part) v6 address in the prefix.