### PR TITLE
Check if notification is disabled

### DIFF
--- a/etc/inc/notices.inc
+++ b/etc/inc/notices.inc
@@ -295,14 +295,17 @@ function notify_via_smtp($message, $force = false) {
 	fwrite($fd, $message);
 	fclose($fd);
 
-	send_smtp_message($message, "{$config['system']['hostname']}.{$config['system']['domain']} - Notification");
+	send_smtp_message($message, "{$config['system']['hostname']}.{$config['system']['domain']} - Notification", $force);
 	return;
 }
 
-function send_smtp_message($message, $subject = "(no subject)") {
+function send_smtp_message($message, $subject = "(no subject)", $force = false) {
 	global $config, $g;
 	require_once("sasl.inc");
 	require_once("smtp.inc");
+
+	if(isset($config['notifications']['smtp']['disable']) && !$force)
+		return;
 
 	if(!$config['notifications']['smtp']['ipaddress'])
 		return;


### PR DESCRIPTION
in send_smtp_message()
Other packages like arpwatch sm.php and cron job output as reported in forum https://forum.pfsense.org/index.php?topic=88347.0 call send_smtp_message() directly, currently bypassing notification disabled checks. I think those packages [are intended to | should be] respecting the notifications disabled setting. People in the forum certainly expect them to respect this setting.
If we add the $force parameter here, passing it through from notify_via_smtp() then the default behavior of send_smtp_message() can be to respect the "disable" setting. That should stop other package callers from spamming people who have disabled SMTP notifications.
If a package really wants/needs to send regardless, then it can set $force, just like the "Test SMTP" button does.