### PR TITLE
Adding description to 'Descriptive name' field for Authentication Server...

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -1513,7 +1513,7 @@ function interface_ppps_configure($interface) {
 				}
 				break;
 			default:
-				log_error(sprintf(gettext("Unkown %s configured as ppp interface."), $type));
+				log_error(sprintf(gettext("Unknown %s configured as ppp interface."), $type));
 				break;
 		}
 	}
@@ -3534,7 +3534,7 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$rtsoldscript .= "# This shell script launches dhcp6c and configured gateways for this interface.\n";
 	$rtsoldscript .= "echo $2 > {$g['tmp_path']}/{$wanif}_routerv6\n";
 	$rtsoldscript .= "echo $2 > {$g['tmp_path']}/{$wanif}_defaultgwv6\n";
-	$rtsoldscript .= "/usr/bin/logger -t rtsold \"Recieved RA specifying route \$2 for interface {$interface}({$wanif})\"\n";
+	$rtsoldscript .= "/usr/bin/logger -t rtsold \"Received RA specifying route \$2 for interface {$interface}({$wanif})\"\n";
 	$rtsoldscript .= "if [ -f {$g['varrun_path']}/dhcp6c_{$wanif}.pid ]; then\n";
 	$rtsoldscript .= "\t/bin/pkill -F {$g['varrun_path']}/dhcp6c_{$wanif}.pid\n";
 	$rtsoldscript .= "\t/bin/sleep 1\n";

--- a/usr/local/www/system_authservers.php
+++ b/usr/local/www/system_authservers.php
@@ -464,12 +464,13 @@ function select_clicked() {
 						<tr>
 							<td width="22%" valign="top" class="vncellreq"><?=gettext("Descriptive name");?></td>
 							<td width="78%" class="vtable">
-							<?php if (!isset($id)): ?>
-								<input name="name" type="text" class="formfld unknown" id="name" size="20" value="<?=htmlspecialchars($pconfig['name']);?>"/>
-							<?php else: ?>
-                                                                <strong><?=htmlspecialchars($pconfig['name']);?></strong>
-                                                                <input name='name' type='hidden' id='name' value="<?=htmlspecialchars($pconfig['name']);?>"/>
-                                                                <?php endif; ?>
+								<?php if (!isset($id)): ?>
+									<input name="name" type="text" class="formfld unknown" id="name" size="20" value="<?=htmlspecialchars($pconfig['name']);?>"/>
+									<?= gettext("NOTE: Do NOT use the term 'local' anywhere in here unless you are utilising a local authentication mechanism."); ?>
+								<?php else: ?>
+									<strong><?=htmlspecialchars($pconfig['name']);?></strong>
+									<input name='name' type='hidden' id='name' value="<?=htmlspecialchars($pconfig['name']);?>"/>
+								<?php endif; ?>
 							</td>
 						</tr>
 						<tr>

--- a/usr/local/www/system_authservers.php
+++ b/usr/local/www/system_authservers.php
@@ -532,24 +532,24 @@ function select_clicked() {
 						</tr>
 						<tr id="tls_ca">
 							<td width="22%" valign="top" class="vncell"><?=gettext("Peer Certificate Authority"); ?></td>
-                                                        <td width="78%" class="vtable">
-                                                        <?php if (count($a_ca)): ?>
+							<td width="78%" class="vtable">
+							<?php if (count($a_ca)): ?>
 								<select id='ldap_caref' name='ldap_caref' class="formselect">
-                                                        <?php
-                                                                foreach ($a_ca as $ca):
-                                                                        $selected = "";
-                                                                        if ($pconfig['ldap_caref'] == $ca['refid'])
-                                                                                $selected = "selected=\"selected\"";
-                                                        ?>
-									<option value="<?=$ca['refid'];?>" <?=$selected;?>><?=$ca['descr'];?></option>
-                                                        <?php	endforeach; ?>
+									<?php
+										foreach ($a_ca as $ca):
+											$selected = "";
+											if ($pconfig['ldap_caref'] == $ca['refid'])
+													$selected = "selected=\"selected\"";
+									?>
+										<option value="<?=$ca['refid'];?>" <?=$selected;?>><?=$ca['descr'];?></option>
+									<?php	endforeach; ?>
 								</select>
-								<br /><span><?=gettext("This option is used if 'SSL Encrypted' option is choosen.");?> <br />
+								<br /><span><?=gettext("This option is used if 'SSL Encrypted' option is chosen.");?><br />
 								<?=gettext("It must match with the CA in the AD otherwise problems will arise.");?></span>
-                                                        <?php else: ?>
-                                                                <b>No Certificate Authorities defined.</b> <br />Create one under <a href="system_camanager.php">System &gt; Cert Manager</a>.
-                                                        <?php endif; ?>
-                                                        </td>
+							<?php else: ?>
+									<b>No Certificate Authorities defined.</b> <br />Create one under <a href="system_camanager.php">System &gt; Cert Manager</a>.
+							<?php endif; ?>
+							</td>
 						</tr>
 						<tr>
 							<td width="22%" valign="top" class="vncellreq"><?=gettext("Protocol version");?></td>


### PR DESCRIPTION
Using the string "local" anywhere within the descriptive name whilst using any remote auth server (for example, ldap.localdomain, or localradius.mydomain.com that resolves to an IP other than the pfSense box) will cause the selected authentication mechanism to fail.

I believe line 131 of ./etc/inc/ipsec.auth-user.php is relevant. I don't really have a better suggestion of how to approach/fix this, so at least notifying the user before they waste too much time would be great.

Arguably, using the term 'local' in a network hostname is asking for trouble.

Also, fixing some minor spelling and indentation issues that I found while searching through the code.