### PR TITLE
Use `none` instead of a whitespace in sshd_config

### DIFF
--- a/etc/sshd
+++ b/etc/sshd
@@ -125,7 +125,7 @@
 	/* Run the server on another port if we have one defined */
 	$sshconf .= "Port $sshport\n";
 	/* Hide FreeBSD version */
-	$sshconf .= "VersionAddendum \n";
+	$sshconf .= "VersionAddendum none\n";
 
 	/* Apply package SSHDCond settings if config file exists */
 	if (file_exists("/etc/sshd_extra")) {


### PR DESCRIPTION
Use the `none` keyword instead of a whitespace to disable the FreeBSD version in sshd_config.