### PR TITLE
carp, don't show status icon from previous carp ip in case the ip is not present on the interface

### DIFF
--- a/usr/local/www/carp_status.php
+++ b/usr/local/www/carp_status.php
@@ -193,7 +193,8 @@ include("head.inc");
 								$icon = "<img {$align} src=\"/themes/".$g['theme']."/images/icons/icon_pass_d.gif\" alt=\"backup\" />";
 							} else if($status == "INIT") {
 								$icon = "<img {$align} src=\"/themes/".$g['theme']."/images/icons/icon_log.gif\" alt=\"init\" />";
-							}
+							} else
+								$icon = "";
 						}
 						echo "<td class=\"listlr\" align=\"center\">" . convert_friendly_interface_to_friendly_descr($carp['interface']) . "@{$vhid} &nbsp;</td>";
 						echo "<td class=\"listlr\" align=\"center\">" . $ipaddress . "&nbsp;</td>";


### PR DESCRIPTION
carp, don't show status icon from previous carp ip in case the ip is not present on the interface (test with ifconfig em0 1.2.3.4 delete)