### PR TITLE
diag_arp allow underscore in resolved host names

### DIFF
--- a/usr/local/www/diag_arp.php
+++ b/usr/local/www/diag_arp.php
@@ -251,7 +251,7 @@ function _getHostName($mac,$ip) {
 		return $dhcpip[$ip];
 	else{
 		exec("host -W 1 " . escapeshellarg($ip), $output);
-		if (preg_match('/.*pointer ([A-Za-z0-9.-]+)\..*/',$output[0],$matches)) {
+		if (preg_match('/.*pointer ([A-Za-z_0-9.-]+)\..*/',$output[0],$matches)) {
 			if ($matches[1] <> $ip)
 				return $matches[1]; 
 		}


### PR DESCRIPTION
is_hostname() and is_domain() allow underscore in the names. So it is possible to have underscore in host names, for example in DHCP server static mapped entries I have some things like:
10.42.3.4 client-pc-01_LAN
10.42.3.5 client-pc-01_WIFI
These reverse-resolve fine - 10.42.3.4 becomes client-pc-01_LAN
But the preg_match here misses such names that have an underscore in them.
I noticed this when looking into forum post: https://forum.pfsense.org/index.php?topic=88956.0