### PR TITLE
Tweak aes-gcm options, add ecp for DH

### DIFF
--- a/etc/inc/ipsec.inc
+++ b/etc/inc/ipsec.inc
@@ -77,9 +77,9 @@ $p1_ealgos = array(
 global $p2_ealgos;
 $p2_ealgos = array(
 	'aes' => array( 'name' => 'AES', 'keysel' => array( 'lo' => 128, 'hi' => 256, 'step' => 64 ) ),
-	'aes128gcm' => array( 'name' => 'AES128-GCM', 'keysel' => array( 'lo' => 64, 'hi' => 128, 'step' => 32 ) ),
-	'aes192gcm' => array( 'name' => 'AES192-GCM', 'keysel' => array( 'lo' => 64, 'hi' => 128, 'step' => 32 ) ),
-	'aes256gcm' => array( 'name' => 'AES256-GCM', 'keysel' => array( 'lo' => 64, 'hi' => 128, 'step' => 32 ) ),
+	'aes128gcm16' => array( 'name' => 'AES128-GCM' ),
+	'aes192gcm16' => array( 'name' => 'AES192-GCM' ),
+	'aes256gcm16' => array( 'name' => 'AES256-GCM' ),
 	'blowfish' => array( 'name' => 'Blowfish', 'keysel' => array( 'lo' => 128, 'hi' => 256, 'step' => 64 ) ),
 	'3des' => array( 'name' => '3DES' ),
 	'cast128' => array( 'name' => 'CAST128' ),
@@ -105,6 +105,9 @@ $p1_dhgroups = array(
 	16 => '16 (4096 bit)',
 	17 => '17 (6144 bit)',
 	18 => '18 (8192 bit)',
+	19 => '19 (nist ecp256)',
+	20 => '20 (nist ecp384)',
+	21 => '21 (nist ecp521)',
 	22 => '22 (1024(sub 160) bit)',
 	23 => '23 (2048(sub 224) bit)',
 	24 => '24 (2048(sub 256) bit)'

--- a/etc/inc/vpn.inc
+++ b/etc/inc/vpn.inc
@@ -62,36 +62,31 @@ function vpn_ipsec_configure_loglevels($forconfig = false)
 /* include all configuration functions */
 function vpn_ipsec_convert_to_modp($index)
 {
-
-	$convertion = "";
 	switch ($index) {
 	case '1':
-		$convertion = "modp768";
-		break;
+		return "modp768";
 	case '2':
-		$convertion = "modp1024";
-		break;
+		return "modp1024";
 	case '5':
-		$convertion = "modp1536";
-		break;
+		return "modp1536";
 	case '14':
-		$convertion = "modp2048";
-		break;
+		return "modp2048";
 	case '15':
-		$convertion = "modp3072";
-		break;
-	case '16':      
-		$convertion = "modp4096";
-		break;
+		return "modp3072";
+	case '16':
+		return "modp4096";
 	case '17':
-		$convertion = "modp6144";
-		break;
+		return "modp6144";
 	case '18':
-		$convertion = "modp8192";
-		break;
+		return "modp8192";
+	case '19':
+		return "ecp256";
+	case '20':
+		return "ecp384";
+	case '21':
+		return "ecp512";
 	}
-
-	return $convertion;
+	return "";
 }
 
 function vpn_ipsec_configure($restart = false)


### PR DESCRIPTION
These changes allow configuring pfsense/strongswan according to RFC 6379
(Suite B Cryptographic Suites for IPsec). The change to the gcm options
I think simplifies the UI (prior you could choose aes128gcm with a
256bit key, which didn't make any sense).

I tested this by patching a running pfsense box and configuring two site to site VPNs, one using aes in cbc mode and one in gcm with a suite b configuration.

If this moves closer to "yes, we want this patch" I'll happily sign the contributor agreement.