### PR TITLE
OpenVPN server improve handling of authmode

### DIFF
--- a/usr/local/www/vpn_openvpn_server.php
+++ b/usr/local/www/vpn_openvpn_server.php
@@ -370,7 +370,7 @@ if ($_POST) {
 		if ($_POST['disable'] == "yes")
 			$server['disable'] = true;
 		$server['mode'] = $pconfig['mode'];
-		if (!empty($pconfig['authmode']))
+		if (!empty($pconfig['authmode']) && (($pconfig['mode'] == "server_user") || ($pconfig['mode'] == "server_tls_user")))
 			$server['authmode'] = implode(",", $pconfig['authmode']);
 		$server['protocol'] = $pconfig['protocol'];
 		$server['dev_mode'] = $pconfig['dev_mode'];
@@ -795,22 +795,26 @@ if ($savemsg)
 						</td>
 					</tr>
 					<tr id="authmodetr" style="display:none">
-                                                <td width="22%" valign="top" class="vncellreq"><?=gettext("Backend for authentication");?></td>
-                                                        <td width="78%" class="vtable">
-                                                        <select name='authmode[]' id='authmode' class="formselect" multiple="multiple" size="<?php echo count($auth_servers); ?>">
-							<?php $authmodes = explode(",", $pconfig['authmode']); ?>
-                                                        <?php
+						<td width="22%" valign="top" class="vncellreq"><?=gettext("Backend for authentication");?></td>
+						<td width="78%" class="vtable">
+							<select name='authmode[]' id='authmode' class="formselect" multiple="multiple" size="<?php echo count($auth_servers); ?>">
+							<?php
+								$authmodes = explode(",", $pconfig['authmode']);
 								$auth_servers = auth_get_authserver_list();
-                                                                foreach ($auth_servers as $auth_server_key => $auth_server):
-                                                                        $selected = "";
-                                                                        if (in_array($auth_server_key, $authmodes))
-                                                                                $selected = "selected=\"selected\"";
-                                                        ?>
-                                                                <option value="<?=$auth_server_key;?>" <?=$selected;?>><?=$auth_server['name'];?></option>
-                                                        <?php 	endforeach; ?>
-                                                        </select>
-                                                </td>
-                                        </tr>
+								// If no authmodes set then default to selecting the first entry in auth_servers
+								if (empty($authmodes[0]) && !empty(key($auth_servers)))
+									$authmodes[0] = key($auth_servers);
+
+								foreach ($auth_servers as $auth_server_key => $auth_server):
+									$selected = "";
+									if (in_array($auth_server_key, $authmodes))
+										$selected = "selected=\"selected\"";
+							?>
+								<option value="<?=$auth_server_key;?>" <?=$selected;?>><?=$auth_server['name'];?></option>
+							<?php endforeach; ?>
+							</select>
+						</td>
+					</tr>
 					<tr>
 						<td width="22%" valign="top" class="vncellreq"><?=gettext("Protocol");?></td>
 							<td width="78%" class="vtable">


### PR DESCRIPTION
Currently if the user is clicking around while they are setting up an OpenVPN server, they can do stuff like this:
a) Select Server Mode - Remote Access (SSL/TLS + User Auth)
b) Select something in Backend for authentication
c) Change their mind and select Server Mode - Peer to Peer (SSL/TLS)
d) Enter the other settings and Save
Now the OpenVPN server config has an 'authmode' key in it.
Probably does no harm, I suspect it will simply not be used when building the server.conf for Peer to Peer, but it looks a bit odd when analysing/diagnosing a config for problems.
Other fields that are mode-specific have tests to only save the values at the end if the appropriate mode is the one finally selected.

While I am here, I also constantly forget to click on "Local Database" authmode when setting up a new server. It gives the validation error message, then I click on "Local Database" again and save. Seems unnecessary - when defining a new OpenVPN server why not default this to have the first entry in the list be the one selected? So I did that. What do you think? 1 place less for many users to need to click.