### PR TITLE
Status_dhcp_leases fix edit button for static entries with no IP address

### DIFF
--- a/usr/local/www/status_dhcp_leases.php
+++ b/usr/local/www/status_dhcp_leases.php
@@ -354,7 +354,7 @@ foreach ($leases as $data) {
 				if(is_array($dhcpifconf['staticmap'])) {
 					$staticmap_array_index = 0;
 					foreach ($dhcpifconf['staticmap'] as $staticent) {
-						if ($data['ip'] == $staticent['ipaddr']) {
+						if (($data['ip'] && ($data['ip'] == $staticent['ipaddr'])) || ($data['mac'] && ($data['mac'] == $staticent['mac']))) {
 							$data['if'] = $dhcpif;
 							break;
 						}


### PR DESCRIPTION
The edit button for static entries always has an index id=0 and thus pressing the edit button goes to (mostly) edit the wrong entry.
We need to check for a match on the IP or MAC, whichever is defined. Probably could just check for match on MAC, since I think there has to be a MAC for every static mapped entry. But I have left the IP match check also to make sure.
Forum: https://forum.pfsense.org/index.php?topic=89072.msg493241#msg493241