### PR TITLE
Mention interface name on DHCP edit GUI

### DIFF
--- a/usr/local/www/services_dhcp_edit.php
+++ b/usr/local/www/services_dhcp_edit.php
@@ -368,7 +368,7 @@ include("head.inc");
             <form action="services_dhcp_edit.php" method="post" name="iform" id="iform">
               <table class="tabcont" width="100%" border="0" cellpadding="6" cellspacing="0" summary="static mapping">
 				<tr>
-					<td colspan="2" valign="top" class="listtopic"><?=gettext("Static DHCP Mapping");?></td>
+					<td colspan="2" valign="top" class="listtopic"><?=sprintf(gettext("Static DHCP Mapping on %s"),$ifcfgdescr);?></td>
 				</tr>
                 <tr>
                   <td width="22%" valign="top" class="vncell"><?=gettext("MAC address");?></td>


### PR DESCRIPTION
IMHO it can be confusing on the DHCP edit page for static mapped entries to know which interface the entry is being edited/added for. Specially if the user comes from the Status DHCP Leases page, the lease they are editing/adding could be for 1 of many LAN-style interfaces.
This also made it easier for me to see which interface entry I was editing when I was testing https://github.com/pfsense/pfsense/pull/1504