### PR TITLE
Preserve "add routers" value across loop for each interface

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -458,13 +458,13 @@ EOD;
 		$dhcpdconf .= "always-broadcast on\n";
 
 	$dhcpdifs = array();
-	$add_routers = false;
+	$enable_add_routers = false;
 	$gateways_arr = return_gateways_array();
 	/* only add a routers line if the system has any IPv4 gateway at all */
 	/* a static route has a gateway, manually overriding this field always works */
 	foreach($gateways_arr as $gwitem) {
 		if($gwitem['ipprotocol'] == "inet") {
-			$add_routers = true;
+			$enable_add_routers = true;
 			break;
 		}
 	}
@@ -741,6 +741,7 @@ EOPP;
 		} elseif ($dhcpifconf['gateway'] == "none") {
 			$add_routers = false;
 		} else {
+			$add_routers = $enable_add_routers;
 			$routers = $ifcfgip;
 		}
 		if($add_routers)


### PR DESCRIPTION
Forum: https://forum.pfsense.org/index.php?topic=89302.0

If the user put "none" in the 'gateway' field for the DHCP settings of an interface, that would set $add_routers to false at line 742. Coming around the loop again for a subsequent interface, and going through the else line 744, nothing would set $add_routers back to true (actually back to the value originally calculated at line 461).
Use a different var to remember the boolean value calculated at line 461 so it can be remembered and used as needed each time through the loop.

I set Gateway "none" on my LAN and left it blank on OPT1 and came up with the same problem as the forum post - OPT1 got no " option routers" statement in dhcpd.conf

After this code fix it looks good.