### PR TITLE
diag_arp allow in a host name whatever can be returned by gethostbyaddr(...

### DIFF
--- a/usr/local/www/diag_arp.php
+++ b/usr/local/www/diag_arp.php
@@ -249,12 +249,10 @@ function _getHostName($mac,$ip) {
 		return $dhcpmac[$mac];
 	else if ($dhcpip[$ip])
 		return $dhcpip[$ip];
-	else{
-		exec("host -W 1 " . escapeshellarg($ip), $output);
-		if (preg_match('/.*pointer ([A-Za-z0-9.-]+)\..*/',$output[0],$matches)) {
-			if ($matches[1] <> $ip)
-				return $matches[1]; 
-		}
+	else {
+		$output = gethostbyaddr($ip);
+		if ($output <> $ip)
+			return $output;
 	}
 	return "";
 }


### PR DESCRIPTION
...)

Valid chars like underscore were missing from the regex at line 254.
Using gethostbyaddr() avoids having to get the regex right for whatever host name permutations might be valid, now it displays whatever host names are there.