### PR TITLE
interface_netgraph_needed can miss setting found equals true

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -134,9 +134,10 @@ function interface_netgraph_needed($interface = "wan") {
 		foreach ($config['pppoes']['pppoe'] as $pppoe) {
 			if ($pppoe['mode'] != "server")
 				continue;
-			if ($pppoe['interface'] == $interface)
+			if ($pppoe['interface'] == $interface) {
 				$found = true;
 				break;
+			}
 		}
 	}
 	if ($found == false)


### PR DESCRIPTION
This routine seems to go looking to see if the passed-in interface is PPP-style. At the end, if it is not PPP-style then it calls pfsense_ngctl_detach.
This foreach loop in its current state will always exit after the first iteration that is not mode "server". But it looks like it should look through all the 'pppoe' entries until it finds the interface or gets to the end.
In theory the code will sometimes miss setting $found = true when it should have. And thus pfsense_ngctl_detach would get called later for a PPP-style interface. The issue might only effect systems with multiple PPPoE clients?
I noticed this while reviewing for code style guide - it is an example where the indenting shows the intention but there are no curlies to implement it.