### PR TITLE
Fixes range displayed by the 6rd prefix validation message ticket #4475

### DIFF
--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -610,8 +610,9 @@ if ($_POST['apply']) {
 				$input_errors[] = gettext("You must enter a valid hexadecimal number for the IPv6 prefix ID.");
 			} else {
 				$track6_prefix_id = intval($_POST['track6-prefix-id--hex'], 16);
-				if ($track6_prefix_id < 0 || $track6_prefix_id > $_POST['ipv6-num-prefix-ids-' . $_POST['track6-interface']]) {
-					$input_errors[] = gettext("You specified an IPv6 prefix ID that is out of range. ({$_POST['track6-interface']}) - ({$_POST['ipv6-num-prefix-ids-' . $_POST['track6-interface']]}) - ({$ipv6_delegation_length})");
+				$ipv6_delegation_length = $_POST['ipv6-num-prefix-ids-' . $_POST['track6-interface']];
+				if ($track6_prefix_id < 0 || $track6_prefix_id > $ipv6_delegation_length) {
+					$input_errors[] = gettext("You specified an IPv6 prefix ID that is out of range. ({$_POST['track6-interface']}) - (0) - ({$ipv6_delegation_length})");
 				} else {
 					foreach ($ifdescrs as $ifent => $ifdescr) {
 						if ($if == $ifent)


### PR DESCRIPTION
Range always starts from 0
$ipv6_delegation_length is not set