### PR TITLE
Semi-colon went AWOL in dyndns.class

### DIFF
--- a/etc/inc/dyndns.class
+++ b/etc/inc/dyndns.class
@@ -355,7 +355,7 @@
 					$server = "https://dynupdate.no-ip.com/ducupdate.php";
 					$port = "";
 					if ($this->_dnsServer) {
-						$server = $this->_dnsServer
+						$server = $this->_dnsServer;
 					}
 					if ($this->_dnsPort) {
 						$port = ":" . $this->_dnsPort;


### PR DESCRIPTION
when I did the style guide changes.
After putting it back the code runs much better :)