### PR TITLE
Ancient bug on upgrade_014_to_015

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -254,7 +254,7 @@ function upgrade_014_to_015() {
 	/* Default route moved */
 	if (isset($config['interfaces']['wan']['gateway']))
 		if ($config['interfaces']['wan']['gateway'] <> "")
-		$config['interfaces']['wan']['gateway'] = $config['interfaces']['wan']['gateway'];
+			$config['system']['gateway'] = $config['interfaces']['wan']['gateway'];
 	unset($config['interfaces']['wan']['gateway']);
 
 	/* Queues are no longer interface specific */


### PR DESCRIPTION
This code looked silly the way it was, with the construct:
$var = $var;
unset($var);

Seems it was accidentally changed to this way many years ago by https://github.com/pfsense/pfsense/commit/588a183b0e58f09932ffef35cc0003cca2313aba
IMHO we want to do the conversion to $config['system']['gateway'] here like it was, so that later config conversion will then process with it as expected.
Note that in a current (2.2) config there is not $config['system']['gateway'] but that is switched over later in upgrade_021_to_022 - which switches back to $config['interfaces']['wan']['gateway'] and then later config conversions do their thing with that.
I guess this will only effect people who upgrade from some really old config (or monowall?)