### PR TITLE
Be safe use require_once in zeromq

### DIFF
--- a/etc/inc/zeromq.inc
+++ b/etc/inc/zeromq.inc
@@ -32,7 +32,7 @@ define('ZEROMQ_TRUE', 'true');
 define('ZEROMQ_FASLE', 'false');
 
 $do_not_include_config_gui_inc = true;
-require("auth.inc");
+require_once("auth.inc");
 
 //$debug = true; 
 


### PR DESCRIPTION
I was testing code and doing stuff like:
require_once("zeromq.inc");
in Diagnostics->Command Prompt, PHP Execute
That brings an error because underneath that PHP Execute code it has already included auth.inc
I guess zeromq.inc is used quite separately to the rest of the system, and must be OK just having a "require" here. But it seems safer to always use require_once, just in case it gets called in a new way/sequence.
Comments welcome.