### PR TITLE
Fix password box in diag_authentication

### DIFF
--- a/usr/local/www/diag_authentication.php
+++ b/usr/local/www/diag_authentication.php
@@ -51,11 +51,11 @@ if ($_POST) {
 	if (!$authcfg)
 		$input_errors[] = $_POST['authmode'] . " " . gettext("is not a valid authentication server");
 
-	if (empty($_POST['username']) || empty($_POST['password']))
+	if (empty($_POST['username']) || empty($_POST['passwordfld']))
 		$input_errors[] = gettext("A username and password must be specified.");
 
 	if (!$input_errors) {
-		if (authenticate_user($_POST['username'], $_POST['password'], $authcfg)) {
+		if (authenticate_user($_POST['username'], $_POST['passwordfld'], $authcfg)) {
 			$savemsg = gettext("User") . ": " . $_POST['username'] . " " . gettext("authenticated successfully.");
 			$groups = getUserGroups($_POST['username'], $authcfg);
 			$savemsg .= "<br />" . gettext("This user is a member of these groups") . ": <br />";
@@ -112,7 +112,7 @@ include("head.inc");
 	<tr>
 		<td width="22%" valign="top" class="vncell"><?=gettext("Password"); ?></td>
 		<td width="78%" class="vtable">
-			<input class="formfld pwd" type="password" size="20" id="password" name="password" value="<?=htmlspecialchars($pconfig['password']);?>" />
+			<input class="formfld pwd" type="password" size="20" id="passwordfld" name="passwordfld" value="<?=htmlspecialchars($pconfig['passwordfld']);?>" />
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
In 2.2 when I go to Diagnostics->Authentication the password field shows the little lock icon, but the text input area starts over the top of the icon and as I type in the field the password "dots" go over the lock icon.
This does not happen in 2.1.5 - the password entry cursor sits after the lock icon. This problem is also not evident on most other password entry fields in 2.2
I stared at it for a while, then saw that in other places the password field is not literally called "password", so I thought what the heck, I will change the field name - it fixed the display issue!!! What???
Anyway, this fixes the display issue on my system. If someone knows really why having the field name/id="password" is a problem then they could fix the underlying reason - but this works around whatever is the issue.
If you think this is an OK fix then I will also find the couple of other places where this happens and make the same "fix".