### PR TITLE
Check if global IPv6 is present before returning link-local address #4483

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -5320,7 +5320,7 @@ function get_interface_ipv6($interface = "wan", $flush = false) {
 				}
 				break;
 		}
-		if (isset($config['interfaces'][$interface]['dhcp6prefixonly'])) {
+		if (isset($config['interfaces'][$interface]['dhcp6prefixonly']) && empty(find_interface_ipv6($realif, $flush))) {
 			$curip = find_interface_ipv6_ll($realif, $flush);
 			if ($curip && is_ipaddrv6($curip) && ($curip != "::")) {
 				return $curip;


### PR DESCRIPTION
Do not assume that global IPv6 address is not present when we are not requesting stateful address via DHCPv6,

since SLAAC address might be configured. Fixes #4483