### PR TITLE
Pencil symbols

### DIFF
--- a/usr/local/www/diag_dns.php
+++ b/usr/local/www/diag_dns.php
@@ -187,7 +187,7 @@ include("head.inc"); ?>
             <?=$mandfldhtml;?>
 			<table summary="results">
 				<tr><td valign="top">
-			<input name="host" type="text" class="formfld" id="host" size="20" value="<?=htmlspecialchars($host);?>" />
+			<input name="host" type="text" class="formfld unknown" id="host" size="20" value="<?=htmlspecialchars($host);?>" />
 			</td>
 			<?php if ($resolved && $type) { ?>
 			<td valign="middle">&nbsp;=&nbsp;</td><td>

--- a/usr/local/www/diag_ping.php
+++ b/usr/local/www/diag_ping.php
@@ -99,7 +99,7 @@ include("head.inc"); ?>
 <tr>
 	<td width="22%" valign="top" class="vncellreq"><?=gettext("Host"); ?></td>
 	<td width="78%" class="vtable">
-		<?=$mandfldhtml;?><input name="host" type="text" class="formfldunknown" id="host" size="20" value="<?=htmlspecialchars($host);?>" /></td>
+		<?=$mandfldhtml;?><input name="host" type="text" class="formfld unknown" id="host" size="20" value="<?=htmlspecialchars($host);?>" /></td>
 </tr>
 <tr>
 	<td width="22%" valign="top" class="vncellreq"><?=gettext("IP Protocol"); ?></td>

--- a/usr/local/www/diag_testport.php
+++ b/usr/local/www/diag_testport.php
@@ -112,18 +112,18 @@ include("head.inc"); ?>
 			<td width="22%" valign="top" class="vncellreq"><?=gettext("Host"); ?></td>
 			<td width="78%" class="vtable">
 			<?=$mandfldhtml;?>
-			<input name="host" type="text" class="formfld" id="host" size="20" value="<?=htmlspecialchars($host);?>" /></td>
+			<input name="host" type="text" class="formfld unknown" id="host" size="20" value="<?=htmlspecialchars($host);?>" /></td>
 		</tr>
 		<tr>
 			<td width="22%" valign="top" class="vncellreq"><?= gettext("Port"); ?></td>
 			<td width="78%" class="vtable">
-				<input name="port" type="text" class="formfld" id="port" size="10" value="<?=htmlspecialchars($port);?>" />
+				<input name="port" type="text" class="formfld unknown" id="port" size="10" value="<?=htmlspecialchars($port);?>" />
 			</td>
 		</tr>
 		<tr>
 			<td width="22%" valign="top" class="vncell"><?= gettext("Source Port"); ?></td>
 			<td width="78%" class="vtable">
-				<input name="srcport" type="text" class="formfld" id="srcport" size="10" value="<?=htmlspecialchars($srcport);?>" />
+				<input name="srcport" type="text" class="formfld unknown" id="srcport" size="10" value="<?=htmlspecialchars($srcport);?>" />
 				<br /><br /><?php echo gettext("This should typically be left blank."); ?>
 			</td>
 		</tr>

--- a/usr/local/www/diag_traceroute.php
+++ b/usr/local/www/diag_traceroute.php
@@ -99,7 +99,7 @@ if (!isset($do_traceroute)) {
 <tr>
 	<td width="22%" valign="top" class="vncellreq"><?=gettext("Host");?></td>
 	<td width="78%" class="vtable">
-		<?=$mandfldhtml;?><input name="host" type="text" class="formfld" id="host" size="20" value="<?=htmlspecialchars($host);?>" /></td>
+		<?=$mandfldhtml;?><input name="host" type="text" class="formfld unknown" id="host" size="20" value="<?=htmlspecialchars($host);?>" /></td>
 </tr>
 <tr>
 	<td width="22%" valign="top" class="vncellreq"><?=gettext("IP Protocol"); ?></td>

--- a/usr/local/www/firewall_nat_1to1_edit.php
+++ b/usr/local/www/firewall_nat_1to1_edit.php
@@ -335,7 +335,7 @@ if ($input_errors)
 		<tr>
 			<td width="22%" valign="top" class="vncellreq"><?=gettext("External subnet IP"); ?></td>
 			<td width="78%" class="vtable">
-				<input name="external" type="text" class="formfld" id="external" size="20" value="<?=htmlspecialchars($pconfig['external']);?>" />
+				<input name="external" type="text" class="formfld unknown" id="external" size="20" value="<?=htmlspecialchars($pconfig['external']);?>" />
 				<br />
 				<span class="vexpl">
 					<?=gettext("Enter the external (usually on a WAN) subnet's starting address for the 1:1 mapping.  " .

--- a/usr/local/www/services_rfc2136_edit.php
+++ b/usr/local/www/services_rfc2136_edit.php
@@ -188,7 +188,7 @@ include("head.inc");
                 <tr>
                   <td width="22%" valign="top" class="vncellreq"><?=gettext("Server");?></td>
                   <td width="78%" class="vtable">
-                    <input name="server" type="text" class="formfld" id="server" size="30" value="<?=htmlspecialchars($pconfig['server'])?>" />
+                    <input name="server" type="text" class="formfld unknown" id="server" size="30" value="<?=htmlspecialchars($pconfig['server'])?>" />
                   </td>
                 </tr>
                 <tr>

--- a/usr/local/www/services_unbound_host_edit.php
+++ b/usr/local/www/services_unbound_host_edit.php
@@ -215,7 +215,7 @@ include("head.inc");
 			<tr>
 				<td width="22%" valign="top" class="vncell"><?=gettext("Host");?></td>
 				<td width="78%" class="vtable">
-					<input name="host" type="text" class="formfld" id="host" size="40" value="<?=htmlspecialchars($pconfig['host']);?>" /><br />
+					<input name="host" type="text" class="formfld unknown" id="host" size="40" value="<?=htmlspecialchars($pconfig['host']);?>" /><br />
 					<span class="vexpl"><?=gettext("Name of the host, without domain part"); ?><br />
 					<?=gettext("e.g."); ?> <em><?=gettext("myhost"); ?></em></span>
 				</td>
@@ -223,7 +223,7 @@ include("head.inc");
 			<tr>
 				<td width="22%" valign="top" class="vncellreq"><?=gettext("Domain");?></td>
 				<td width="78%" class="vtable">
-					<input name="domain" type="text" class="formfld" id="domain" size="40" value="<?=htmlspecialchars($pconfig['domain']);?>" /><br />
+					<input name="domain" type="text" class="formfld unknown" id="domain" size="40" value="<?=htmlspecialchars($pconfig['domain']);?>" /><br />
 					<span class="vexpl"><?=gettext("Domain of the host"); ?><br />
 						<?=gettext("e.g."); ?> <em><?=gettext("example.com"); ?></em></span>
 				</td>
@@ -231,7 +231,7 @@ include("head.inc");
 			<tr>
 				<td width="22%" valign="top" class="vncellreq"><?=gettext("IP address");?></td>
 				<td width="78%" class="vtable">
-					<input name="ip" type="text" class="formfld" id="ip" size="40" value="<?=htmlspecialchars($pconfig['ip']);?>" /><br />
+					<input name="ip" type="text" class="formfld unknown" id="ip" size="40" value="<?=htmlspecialchars($pconfig['ip']);?>" /><br />
 					<span class="vexpl"><?=gettext("IP address of the host"); ?><br />
 						<?=gettext("e.g."); ?> <em>192.168.100.100</em> <?=gettext("or"); ?> <em>fd00:abcd::1</em></span>
 				</td>
@@ -239,7 +239,7 @@ include("head.inc");
 			<tr>
 				<td width="22%" valign="top" class="vncell"><?=gettext("Description");?></td>
 				<td width="78%" class="vtable">
-					<input name="descr" type="text" class="formfld" id="descr" size="40" value="<?=htmlspecialchars($pconfig['descr']);?>" /><br />
+					<input name="descr" type="text" class="formfld unknown" id="descr" size="40" value="<?=htmlspecialchars($pconfig['descr']);?>" /><br />
 					<span class="vexpl"><?=gettext("You may enter a description here for your reference (not parsed).");?></span>
 				</td>
 			</tr>

--- a/usr/local/www/services_wol_edit.php
+++ b/usr/local/www/services_wol_edit.php
@@ -143,7 +143,7 @@ include("head.inc");
 				<tr>
                   <td width="22%" valign="top" class="vncellreq"><?=gettext("MAC address");?></td>
                   <td width="78%" class="vtable"> 
-                    <input name="mac" type="text" class="formfld" id="mac" size="20" value="<?=htmlspecialchars($pconfig['mac']);?>" />
+                    <input name="mac" type="text" class="formfld unknown" id="mac" size="20" value="<?=htmlspecialchars($pconfig['mac']);?>" />
                     <br /> 
                     <span class="vexpl"><?=gettext("Enter a MAC address  in the following format: ".
                     "xx:xx:xx:xx:xx:xx");?></span></td>
@@ -151,7 +151,7 @@ include("head.inc");
 				<tr>
                   <td width="22%" valign="top" class="vncell"><?=gettext("Description");?></td>
                   <td width="78%" class="vtable"> 
-                    <input name="descr" type="text" class="formfld" id="descr" size="40" value="<?=htmlspecialchars($pconfig['descr']);?>" />
+                    <input name="descr" type="text" class="formfld unknown" id="descr" size="40" value="<?=htmlspecialchars($pconfig['descr']);?>" />
                     <br /> <span class="vexpl"><?=gettext("You may enter a description here".
                    " for your reference (not parsed).");?></span></td>
                 </tr>

--- a/usr/local/www/status_rrd_graph.php
+++ b/usr/local/www/status_rrd_graph.php
@@ -568,9 +568,9 @@ function get_dates($curperiod, $graph) {
 						$end_fmt   = strftime("%m/%d/%Y %H:%M:%S", $end);
 						?>
 						<?=gettext("Start:");?>
-						<input id="startDateTime" title="<?= htmlentities($tz_msg); ?>." type="text" name="start" class="formfldunknown" size="24" value="<?= htmlentities($start_fmt); ?>" />
+						<input id="startDateTime" title="<?= htmlentities($tz_msg); ?>." type="text" name="start" class="formfld unknown" size="24" value="<?= htmlentities($start_fmt); ?>" />
 						<?=gettext("End:");?>
-						<input id="endDateTime" title="<?= htmlentities($tz_msg); ?>." type="text" name="end" class="formfldunknown" size="24" value="<?= htmlentities($end_fmt); ?>" />
+						<input id="endDateTime" title="<?= htmlentities($tz_msg); ?>." type="text" name="end" class="formfld unknown" size="24" value="<?= htmlentities($end_fmt); ?>" />
 						<input type="submit" name="Submit" value="<?=gettext("Go"); ?>" />
 						</td></tr>
 						<?php


### PR DESCRIPTION
These are places in the GUI where the cursor sits not in the far left
side of the input box and there is odd-looking white space to the left
of the cursor. Normally there would be a little input graphic in the
white space to the left of the cursor (a pencil, a computer screen, a
lock symbol...)
This change makes the pencil be displayed in all those places.
Note: There are other inconsistent-looking input boxes, where the cursor sits at the far left of the box without any symbol in front of it. I am not trying to change or "fix" any of that, because I do not know what the intention was in those places.
I am just fixing the places that already have the cursor offset a bit, expecting a "pencil" or similar symbol.