### PR TITLE
Fix SNMP Bind Interface list in master

### DIFF
--- a/usr/local/www/services_snmp.php
+++ b/usr/local/www/services_snmp.php
@@ -425,8 +425,8 @@ function enable_change(whichone) {
 						if ($lip == $pconfig['bindip'])
 							$selected = "selected=\"selected\"";
 				?>
-					<option value="<?=$ldescr;?>" <?=$selected;?>>
-						<?=htmlspecialchars($lip['name']);?>
+					<option value="<?=$lip;?>" <?=$selected;?>>
+						<?=htmlspecialchars($ldescr);?>
 					</option>
 				<?php endforeach;
 				    unset($listenips);


### PR DESCRIPTION
The format of the array returned by get_possible_listen_ips() was changed.
This use of the returned array was not quite changed correctly. This fixes it so the drop-down list of SNMP Bind Interfaces is displayed correctly.
Note that the change to get_possible_listen_ips() (which also moved the function from system.inc to interfaces.inc) and associated effects is only in master. It has not been applied to RELENG_2_2 yet. So this fix is only needed in master. Other uses of get_possible_listen_ips() in master (services_dnsmasq.php services_unbound.php) were already changed correctly and work well.
I noticed this when using various files from master on a test system.