### PR TITLE
Fix password box cursor position

### DIFF
--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -114,8 +114,8 @@ if ($wancfg['if'] == $a_ppps[$pppid]['if']) {
 	$pconfig['ptpid'] = $a_ppps[$pppid]['ptpid'];
 	$pconfig['port'] = $a_ppps[$pppid]['ports'];
 	if ($a_ppps[$pppid]['type'] == "ppp") {
-		$pconfig['username'] = $a_ppps[$pppid]['username'];
-		$pconfig['password'] = base64_decode($a_ppps[$pppid]['password']);
+		$pconfig['ppp_username'] = $a_ppps[$pppid]['username'];
+		$pconfig['ppp_password'] = base64_decode($a_ppps[$pppid]['password']);
 
 		$pconfig['phone'] = $a_ppps[$pppid]['phone'];
 		$pconfig['apn'] = $a_ppps[$pppid]['apn'];
@@ -982,8 +982,8 @@ if ($_POST['apply']) {
 				$a_ppps[$pppid]['type'] = $_POST['type'];
 				$a_ppps[$pppid]['if'] = $_POST['type'].$_POST['ptpid'];
 				$a_ppps[$pppid]['ports'] = $_POST['port'];
-				$a_ppps[$pppid]['username'] = $_POST['username'];
-				$a_ppps[$pppid]['password'] = base64_encode($_POST['password']);
+				$a_ppps[$pppid]['username'] = $_POST['ppp_username'];
+				$a_ppps[$pppid]['password'] = base64_encode($_POST['ppp_password']);
 				$a_ppps[$pppid]['phone'] = $_POST['phone'];
 				$a_ppps[$pppid]['apn'] = $_POST['apn'];
 				$wancfg['if'] = $_POST['type'] . $_POST['ptpid'];
@@ -1597,8 +1597,8 @@ $types6 = array("none" => gettext("None"), "staticv6" => gettext("Static IPv6"),
 			success: function(data,textStatus,response) {
 				var xmldoc = response.responseXML;
 				var provider = xmldoc.getElementsByTagName('connection')[0];
-				jQuery('#username').val('');
-				jQuery('#password').val('');
+				jQuery('#ppp_username').val('');
+				jQuery('#ppp_password').val('');
 				if(provider.getElementsByTagName('apn')[0].firstChild.data == "CDMA") {
 					jQuery('#phone').val('#777');
 					jQuery('#apn').val('');
@@ -1606,10 +1606,10 @@ $types6 = array("none" => gettext("None"), "staticv6" => gettext("Static IPv6"),
 					jQuery('#phone').val('*99#');
 					jQuery('#apn').val(provider.getElementsByTagName('apn')[0].firstChild.data);
 				}
-				username = provider.getElementsByTagName('username')[0].firstChild.data;
-				password = provider.getElementsByTagName('password')[0].firstChild.data;
-				jQuery('#username').val(username);
-				jQuery('#password').val(password);
+				ppp_username = provider.getElementsByTagName('ppp_username')[0].firstChild.data;
+				ppp_password = provider.getElementsByTagName('ppp_password')[0].firstChild.data;
+				jQuery('#ppp_username').val(ppp_username);
+				jQuery('#ppp_password').val(ppp_password);
 			}
 		});
 	}
@@ -2615,13 +2615,13 @@ $types6 = array("none" => gettext("None"), "staticv6" => gettext("Static IPv6"),
 									<tr>
 										<td width="22%" valign="top" class="vncell"><?=gettext("Username"); ?></td>
 										<td width="78%" class="vtable">
-										<input name="username" type="text" class="formfld user" id="username" size="20" value="<?=htmlspecialchars($pconfig['username']);?>" />
+										<input name="ppp_username" type="text" class="formfld user" id="ppp_username" size="20" value="<?=htmlspecialchars($pconfig['ppp_username']);?>" />
 										</td>
 									</tr>
 									<tr>
 										<td width="22%" valign="top" class="vncell"><?=gettext("Password"); ?></td>
 										<td width="78%" class="vtable">
-										<input name="password" type="password" class="formfld pwd" id="password" size="20" value="<?=htmlspecialchars($pconfig['password']);?>" />
+										<input name="ppp_password" type="password" class="formfld pwd" id="ppp_password" size="20" value="<?=htmlspecialchars($pconfig['ppp_password']);?>" />
 										</td>
 									</tr>
 									<tr id="phone_num">

--- a/usr/local/www/interfaces_ppps_edit.php
+++ b/usr/local/www/interfaces_ppps_edit.php
@@ -195,10 +195,10 @@ if ($_POST) {
 			break;
 		case "pppoe":
 			if ($_POST['ondemand']) {
-				$reqdfields = explode(" ", "interfaces username password ondemand idletimeout");
+				$reqdfields = explode(" ", "interfaces username passwordfld ondemand idletimeout");
 				$reqdfieldsn = array(gettext("Link Interface(s)"),gettext("Username"),gettext("Password"),gettext("Dial on demand"),gettext("Idle timeout value"));
 			} else {
-				$reqdfields = explode(" ", "interfaces username password");
+				$reqdfields = explode(" ", "interfaces username passwordfld");
 				$reqdfieldsn = array(gettext("Link Interface(s)"),gettext("Username"),gettext("Password"));
 			}
 			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
@@ -206,10 +206,10 @@ if ($_POST) {
 		case "l2tp":
 		case "pptp":
 			if ($_POST['ondemand']) {
-				$reqdfields = explode(" ", "interfaces username password localip subnet gateway ondemand idletimeout");
+				$reqdfields = explode(" ", "interfaces username passwordfld localip subnet gateway ondemand idletimeout");
 				$reqdfieldsn = array(gettext("Link Interface(s)"),gettext("Username"),gettext("Password"),gettext("Local IP address"),gettext("Subnet"),gettext("Remote IP address"),gettext("Dial on demand"),gettext("Idle timeout value"));
 			} else {
-				$reqdfields = explode(" ", "interfaces username password localip subnet gateway");
+				$reqdfields = explode(" ", "interfaces username passwordfld localip subnet gateway");
 				$reqdfieldsn = array(gettext("Link Interface(s)"),gettext("Username"),gettext("Password"),gettext("Local IP address"),gettext("Subnet"),gettext("Remote IP address"));
 			}
 			do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
@@ -276,7 +276,7 @@ if ($_POST) {
 		$ppp['if'] = $ppp['type'].$ppp['ptpid'];
 		$ppp['ports'] = implode(',',$_POST['interfaces']);
 		$ppp['username'] = $_POST['username'];
-		$ppp['password'] = base64_encode($_POST['password']);
+		$ppp['password'] = base64_encode($_POST['passwordfld']);
 		$ppp['ondemand'] = $_POST['ondemand'] ? true : false;
 		if (!empty($_POST['idletimeout']))
 			$ppp['idletimeout'] = $_POST['idletimeout'];
@@ -528,7 +528,7 @@ $types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE"
 		<tr>
 			<td width="22%" valign="top" class="vncell"><?= gettext("Password"); ?></td>
 			<td width="78%" class="vtable">
-			<input name="password" type="password" class="formfld pwd" id="password" size="20" value="<?=htmlspecialchars($pconfig['password']);?>" />
+			<input name="passwordfld" type="password" class="formfld pwd" id="passwordfld" size="20" value="<?=htmlspecialchars($pconfig['password']);?>" />
 			</td>
 		</tr>
 

--- a/usr/local/www/services_dyndns_edit.php
+++ b/usr/local/www/services_dyndns_edit.php
@@ -100,7 +100,7 @@ if ($_POST) {
 	if ($pconfig['type'] != "custom" && $pconfig['type'] != "custom-v6") {
 		$reqdfields[] = "host";
 		$reqdfieldsn[] = gettext("Hostname");
-		$reqdfields[] = "password";
+		$reqdfields[] = "passwordfld";
 		$reqdfieldsn[] = gettext("Password");
  		$reqdfields[] = "username";
  		$reqdfieldsn[] = gettext("Username");
@@ -133,7 +133,7 @@ if ($_POST) {
 		$dyndns = array();
 		$dyndns['type'] = $_POST['type'];
 		$dyndns['username'] = $_POST['username'];
-		$dyndns['password'] = $_POST['password'];
+		$dyndns['password'] = $_POST['passwordfld'];
 		$dyndns['host'] = $_POST['host'];
 		$dyndns['mx'] = $_POST['mx'];
 		$dyndns['wildcard'] = $_POST['wildcard'] ? true : false;
@@ -370,7 +370,7 @@ function _onTypeChange(type){
                 <tr>
                   <td width="22%" valign="top" class="vncellreq"><?=gettext("Password");?></td>
                   <td width="78%" class="vtable">
-                    <input name="password" type="password" class="formfld pwd" id="password" size="20" value="<?=htmlspecialchars($pconfig['password']);?>" />
+                    <input name="passwordfld" type="password" class="formfld pwd" id="passwordfld" size="20" value="<?=htmlspecialchars($pconfig['password']);?>" />
                     <br />
                     <?=gettext("FreeDNS (freedns.afraid.org): Enter your \"Authentication Token\" provided by FreeDNS.");?>
                     <br /><?= gettext("Route 53: Enter your Secret Access Key.");?>

--- a/usr/local/www/vpn_pptp_users_edit.php
+++ b/usr/local/www/vpn_pptp_users_edit.php
@@ -78,7 +78,7 @@ if ($_POST) {
 		$reqdfields = explode(" ", "username");
 		$reqdfieldsn = array(gettext("Username"));
 	} else {
-		$reqdfields = explode(" ", "username password");
+		$reqdfields = explode(" ", "username passwordfld1");
 		$reqdfieldsn = array(gettext("Username"),gettext("Password"));
 	}
 
@@ -87,13 +87,13 @@ if ($_POST) {
 	if (preg_match("/[^a-zA-Z0-9\.\-_]/", $_POST['username']))
 		$input_errors[] = gettext("The username contains invalid characters.");
 
-	if (preg_match("/^!/", $_POST['password']))
+	if (preg_match("/^!/", $_POST['passwordfld1']))
 		$input_errors[] = gettext("The password cannot start with '!'.");
 
-	if (!preg_match("/^[\x20-\x7E]*$/", $_POST['password']))
+	if (!preg_match("/^[\x20-\x7E]*$/", $_POST['passwordfld1']))
 		$input_errors[] = gettext("The password contains invalid characters.");
 
-	if (($_POST['password']) && ($_POST['password'] != $_POST['password2'])) {
+	if (($_POST['passwordfld1']) && ($_POST['passwordfld1'] != $_POST['passwordfld2'])) {
 		$input_errors[] = gettext("The passwords do not match.");
 	}
 	if (($_POST['ip'] && !is_ipaddr($_POST['ip']))) {
@@ -118,8 +118,8 @@ if ($_POST) {
 		$secretent['name'] = $_POST['username'];
 		$secretent['ip'] = $_POST['ip'];
 
-		if ($_POST['password'])
-			$secretent['password'] = $_POST['password'];
+		if ($_POST['passwordfld1'])
+			$secretent['password'] = $_POST['passwordfld1'];
 
 		if (isset($id) && $a_secret[$id])
 			$a_secret[$id] = $secretent;
@@ -155,8 +155,8 @@ include("head.inc");
                 <tr>
                   <td width="22%" valign="top" class="vncellreq"><?=gettext("Password");?></td>
                   <td width="78%" class="vtable">
-                    <?=$mandfldhtml;?><input name="password" type="password" class="formfld pwd" id="password" size="20" />
-                    <br /><?=$mandfldhtml;?><input name="password2" type="password" class="formfld pwd" id="password2" size="20" />
+                    <?=$mandfldhtml;?><input name="passwordfld1" type="password" class="formfld pwd" id="passwordfld1" size="20" />
+                    <br /><?=$mandfldhtml;?><input name="passwordfld2" type="password" class="formfld pwd" id="passwordfld2" size="20" />
                     &nbsp;(<?=gettext("confirmation");?>)<?php if (isset($id) && $a_secret[$id]): ?><br />
                     <span class="vexpl"><?=gettext("If you want to change the users' password, ".
                     "enter it here twice.");?></span><?php endif; ?></td>


### PR DESCRIPTION
Similar to
https://github.com/pfsense/pfsense/commit/dedc40f7ded5f88aee4720aa8a3a57667b975254
The password field shows the little lock icon, but the text input area
starts over the top of the icon and as I type in the field the password
"dots" go over the lock icon in each of these data entry places.
Changing the field name/id to not be "password" but to be "passwordfld",
"passwordfld1" "passwordfld2" and the like fixes it. Something does not
like the field being called just "password".
In interfaces.php I also changed the field "username" to be
"ppp_username". This standardized it to work in a similar way to
pppoe_username pptp_username fields. It looks easier to understand for
me.