### PR TITLE
Setup serial gps port for raw output and speed

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -1575,6 +1575,30 @@ function system_ntp_setup_gps($serialport) {
 	unlink_if_exists($gps_device);
 	@symlink($serialport, $gps_device);
 
+	$gpsbaud = '4800';
+	if (is_array($config['ntpd']) && is_array($config['ntpd']['gps']) && !empty($config['ntpd']['gps']['speed'])) {
+		switch ($config['ntpd']['gps']['speed']) {
+			case '16':
+				$gpsbaud = '9600';
+				break;
+			case '32':
+				$gpsbaud = '19200';
+				break;
+			case '48':
+				$gpsbaud = '38400';
+				break;
+			case '64':
+				$gpsbaud = '57600';
+				break;
+			case '80':
+				$gpsbaud = '115200';
+				break;
+		}
+	}
+
+	/* Configure the serial port for raw IO and set the speed */
+	`stty -f {$serialport}.init raw speed {$gpsbaud}`
+
 	/* Send the following to the GPS port to initialize the GPS */
 	if (is_array($config['ntpd']) && is_array($config['ntpd']['gps']) && !empty($config['ntpd']['gps']['type'])) {
 		$gps_init = base64_decode($config['ntpd']['gps']['initcmd']);
@@ -1588,26 +1612,6 @@ function system_ntp_setup_gps($serialport) {
 
 	/* Add /etc/remote entry in case we need to read from the GPS with tip */
 	if (intval(`grep -c '^gps0' /etc/remote`) == 0) {
-		$gpsbaud = '4800';
-		if (is_array($config['ntpd']) && is_array($config['ntpd']['gps']) && !empty($config['ntpd']['gps']['speed'])) {
-			switch ($config['ntpd']['gps']['speed']) {
-				case '16':
-					$gpsbaud = '9600';
-					break;
-				case '32':
-					$gpsbaud = '19200';
-					break;
-				case '48':
-					$gpsbaud = '38400';
-					break;
-				case '64':
-					$gpsbaud = '57600';
-					break;
-				case '80':
-					$gpsbaud = '115200';
-					break;
-			}
-		}
 		@file_put_contents("/etc/remote", "gps0:dv={$serialport}:br#{$gpsbaud}:pa=none:", FILE_APPEND);
 	}
 


### PR DESCRIPTION
We need to at least setup the serial port before we try to blast config data to it.  My system was hanging during boot because cat couldn't output gps.init to the port.