### PR TITLE
Support for Radius OTP login and fetching groups from Radius

### DIFF
--- a/etc/inc/auth.inc
+++ b/etc/inc/auth.inc
@@ -1336,7 +1336,11 @@ function radius_backed($username, $passwd, $authcfg, &$attributes = array()) {
 		if ($debug) {
 			printf(gettext("Radius Auth succeeded")."<br />\n");
 		}
-		$ret = true;
+		if($attributes) {
+			$ret = $attributes;
+		} else {
+			$ret = true;
+		}
 	} else {
 		$retvalue['auth_val'] = 3;
 		if ($debug) {
@@ -1409,7 +1413,7 @@ function auth_get_authserver_list() {
 }
 
 function getUserGroups($username, $authcfg) {
-	global $config;
+	global $config,$radiusgroups;
 
 	$allowed_groups = array();
 
@@ -1418,6 +1422,7 @@ function getUserGroups($username, $authcfg) {
 			$allowed_groups = @ldap_get_groups($username, $authcfg);
 			break;
 		case 'radius':
+			 $allowed_groups = $radiusgroups;
 			break;
 		default:
 			$user = getUserEntry($username);
@@ -1438,6 +1443,7 @@ function getUserGroups($username, $authcfg) {
 }
 
 function authenticate_user($username, $password, $authcfg = NULL, &$attributes = array()) {
+	global $radiusgroups;
 
 	if (!$authcfg) {
 		return local_backed($username, $password);
@@ -1451,8 +1457,11 @@ function authenticate_user($username, $password, $authcfg = NULL, &$attributes =
 			}
 			break;
 		case 'radius':
-			if (radius_backed($username, $password, $authcfg, $attributes)) {
-				$authenticated = true;
+			$radius_backed = radius_backed($username, $password, $authcfg, $attributes);
+			if ($radius_backed) {
+				$authenticated = $radius_backed;
+				$radiusgroups = $authenticated['groups'];
+				$_SESSION['radiusgroups'] = $radiusgroups;
 			}
 			break;
 		default:

--- a/etc/inc/priv.inc
+++ b/etc/inc/priv.inc
@@ -279,7 +279,7 @@ function getPrivPages(& $entry, & $allowed_pages) {
 }
 
 function getAllowedPages($username) {
-	global $config, $_SESSION;
+	global $config, $_SESSION, $radiusgroups;
 
 	if (!function_exists("ldap_connect")) {
 		return;
@@ -292,6 +292,9 @@ function getAllowedPages($username) {
 	// obtain ldap groups if we are in ldap mode
 	if ($authcfg['type'] == "ldap") {
 		$allowed_groups = @ldap_get_groups($username, $authcfg);
+	} else if ($authcfg['type'] == "radius") {
+		if(array_key_exists('radiusgroups',$_SESSION))
+			$allowed_groups = $_SESSION['radiusgroups'];
 	} else {
 		// search for a local user by name
 		$local_user = getUserEntry($username);

--- a/etc/inc/radius.inc
+++ b/etc/inc/radius.inc
@@ -683,6 +683,17 @@ class Auth_RADIUS extends PEAR {
                     }
                 }
 
+		elseif ($vendor == 15000) { /* pfSense */
+			switch($attrv) {
+				case 1: /* pfSense-Group-Name */
+					if(!array_key_exists('groups',$this->attributes)) {
+						$this->attributes['groups'] = array();
+					}
+					array_push($this->attributes['groups'],radius_cvt_string($datav));
+					break;
+			}
+		}
+
                 break;
 
             case 85: /* Acct-Interim-Interval: RFC 2869 */


### PR DESCRIPTION
Hi,

I have succesfully setup pfSense to work with Radius for TOTP instead of static passwords.
Tested setup:
- LinOTP for TOTP management and Auth to Radius. Users are fetched from SQL Database and Active Directory.

in LinOTP  you can define if a valid passcode consists of:
Pin + Token (otppin=0)
or 
User Password + Token (otppin=1)
or 
Token only (otppin=2)

This has to be setup in the linOTP authentication policies ( action = "otppin=0|1|2" )


- FreeRadius fetches user information from Active Directory ( Group membership ) and adds, besides the auth_accept message, also a pfSense-Group-Name parameter to pfSense
- pfSense maps a user, either to a local account, and groups OR to an Active Directory user and Group.

This way, we can authenticate and map users into different groups, for example for GUI access, or VPN.
I have tested this with both OpenVPN and IPSec, as well as the admin access to the pfSense web GUI.


For freeradius (2.x), a few configration changes need to be done.
I am assuming that freeradius is setup correctly for both both Active Directory and LinOTP 
So the changes documented here only apply for the pfSense part.

First create /usr/share/freeradius/dictionary.pfsense

````
# -*- text -*-
##############################################################################
#
#       pfSense's VSA's
#
#       $Id$
#
##############################################################################

#
#       pfSense VSA's
#

VENDOR          pfSense                 15000

BEGIN-VENDOR    pfSense
ATTRIBUTE       pfSense-Group-Name                      1       string

# Add more ATTRIBUTES for pfSense here

#
# Integer Translations
#

END-VENDOR pfSense
````

enable the pfsense dictionary in /usr/share/freeradius/dictionary

````
$INCLUDES dictionary.pfsense
````

create a client entry for pfSense in
/etc/raddb/client.conf

````
client pfsenseadmin {
        ipaddr = <ipaddress of pfsense lan>
        netmask = 32
        secret = 'YOURSECRET'
        shortname = 'pfsenseadmin'
        nastype = pfsense
}
````

I have created two groups on the pfSense box, PFSense Admins with all pfSense admin privileges,
and a VPNusers group with User - VPN - IPsec xauth Dialin access.
When freeradius gets a request from the pfsense box, it should return pfSense-Group-Name attributes.
So we will set that up in /etc/raddb/sites-enabled/default.
This should go in the post-auth section:

````
# Map AD/LDAP groups Domain Admins and Network Admins to the PFSense Admins group , make sure this group exists on pfSense and has admin privs
        if ("%{client:shortname}" =~ /^pfsenseadmin/ && ( LDAP-Group == "Domain Admins" || LDAP-Group == "Network Admins")){
                        update reply {
                                pfSense-Group-Name += "PFSense Admins"
                        }
       }

        # Map AD/LDAP group VPNusers to pfSense Group VPNusers
        if ("%{client:shortname}" =~ /^pfsenseadmin/ &&  LDAP-Group == "VPNusers" ){
                        update reply {
                                pfSense-Group-Name += "VPNusers"
                        }
        }
        # Add more group mappings for pfSense here
}
````

in freeradius 3.x it is possible  to use a foreach loop, to add all groups  a user is member of , automatically 
to the pfSense-Group-Name attribute.
But I havent played around with 3.x yet