### PR TITLE
Status DHCP Leases handle expire never

### DIFF
--- a/usr/local/www/status_dhcp_leases.php
+++ b/usr/local/www/status_dhcp_leases.php
@@ -192,7 +192,7 @@ foreach($leases_content as $lease) {
 				if ($data[$f+1] == "never") {
 					// Quote from dhcpd.leases(5) man page:
 					// If a lease will never expire, date is never instead of an actual date.
-					$leases[$l]['end'] = $data[$f+1];
+					$leases[$l]['end'] = gettext("Never");
 					$f = $f+1;
 				} else {
 					$leases[$l]['end'] = $data[$f+2];

--- a/usr/local/www/status_dhcp_leases.php
+++ b/usr/local/www/status_dhcp_leases.php
@@ -107,9 +107,12 @@ function adjust_gmt($dt) {
 	}
 	if ($dhcpleaseinlocaltime == "yes") {
 		$ts = strtotime($dt . " GMT");
-		return strftime("%Y/%m/%d %I:%M:%S%p", $ts);
-	} else
-		return $dt;
+		if ($ts !== false) {
+			return strftime("%Y/%m/%d %I:%M:%S%p", $ts);
+		}
+	}
+	/* If we did not need to convert to local time or the conversion failed, just return the input. */
+	return $dt;
 }
 
 function remove_duplicate($array, $field)
@@ -186,9 +189,16 @@ foreach($leases_content as $lease) {
 				$f = $f+3;
 				break;
 			case "ends":
-				$leases[$l]['end'] = $data[$f+2];
-				$leases[$l]['end'] .= " " . $data[$f+3];
-				$f = $f+3;
+				if ($data[$f+1] == "never") {
+					// Quote from dhcpd.leases(5) man page:
+					// If a lease will never expire, date is never instead of an actual date.
+					$leases[$l]['end'] = $data[$f+1];
+					$f = $f+1;
+				} else {
+					$leases[$l]['end'] = $data[$f+2];
+					$leases[$l]['end'] .= " " . $data[$f+3];
+					$f = $f+3;
+				}
 				break;
 			case "tstp":
 				$f = $f+3;


### PR DESCRIPTION
Note: We can let the code pass "never" (or any other unexpected stuff) to adjust_gmt()
adjust_gmt() should anyway handle the case when strtotime() cannot understand the input string and thus returns false. In that case we return the input string as-is so it will be displayed as the time. That way the user will see it and can report easily whatever other unexpected char data was in the leases file.
It also prevents "false" (zero) being converted to the date-time string and thus becoming the Unix epoch 1 Jan 1970 on the display.
Latest forum report of this kind of thing: https://forum.pfsense.org/index.php?topic=90083.0