### PR TITLE
Update get_possible_traffic_source_addresses returned array format

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -5261,10 +5261,8 @@ function get_possible_traffic_source_addresses($include_ipv6_link_local=false) {
 		if (is_array($config['openvpn']["openvpn-{$mode}"])) {
 			foreach ($config['openvpn']["openvpn-{$mode}"] as $id => $setting) {
 				if (!isset($setting['disable'])) {
-					$vpn = array();
-					$vpn['value'] = 'ovpn' . substr($mode, 0, 1) . $setting['vpnid'];
-					$vpn['name'] = gettext("OpenVPN") . " ".$mode.": ".htmlspecialchars($setting['description']);
-					$sourceips[] = $vpn;
+					$sourceips_key = 'ovpn' . substr($mode, 0, 1) . $setting['vpnid'];
+					$sourceips[$sourceips_key] = gettext("OpenVPN") . " ".$mode.": ".htmlspecialchars($setting['description']);
 				}
 			}
 		}


### PR DESCRIPTION
With this change it looks to me like the way it is intended to be, based on what was done to get_possible_listen_ips()
Please review and check if this is what was intended for the code. With this change it should make the returned $sourceips array be in a consistent format the same way as get_possible_listen_ips()
This is a fix for code that was only committed in master. So at this time the fix is only needed in master.