### PR TITLE
Missing double equals in captiveportal.inc

### DIFF
--- a/etc/inc/captiveportal.inc
+++ b/etc/inc/captiveportal.inc
@@ -2068,7 +2068,7 @@ function portal_allow($clientip,$clientmac,$username,$password = null, $attribut
 					$mac['logintype'] = "voucher";
 				}
 			}
-			if ($username = "unauthenticated") {
+			if ($username == "unauthenticated") {
 				$mac['descr'] =  "Auto-added";
 			} else {
 				$mac['descr'] =  "Auto-added for user {$username}";


### PR DESCRIPTION
Looking at where this is nested inside various if statements, I do not think this error did too much harm - only to the $mac['descr'] - in this particular code flow $username is not used for important stuff after this point.