### PR TITLE
Missing double equals in ipsec.inc

### DIFF
--- a/etc/inc/ipsec.inc
+++ b/etc/inc/ipsec.inc
@@ -637,7 +637,7 @@ function ipsec_find_id(& $ph1ent, $side = "local", $rgmap = array()) {
 		$addr = ipsec_get_phase1_src($ph1ent);
 		if (!$addr)
 			return array();
-	} elseif ($side = "peer") {
+	} elseif ($side == "peer") {
 		$id_type = $ph1ent['peerid_type'];
 		$id_data = $ph1ent['peerid_data'];
 


### PR DESCRIPTION
This would have done no harm as long as ipsec_find_id() is always called with $side = empty, local or peer