### PR TITLE
pfSsh.php readline function return value

### DIFF
--- a/usr/local/sbin/pfSsh.php
+++ b/usr/local/sbin/pfSsh.php
@@ -48,8 +48,8 @@ if(!function_exists("readline")) {
 		$fp = fopen('php://stdin', 'r');
 		$textinput = chop(fgets($fp));
 		fclose($fp);
+		return $textinput;
 	}
-	return $textinput;
 }
 
 function more($text, $count=24) {


### PR DESCRIPTION
This just looks wrong. But I guess the code path never comes through here because function readline() already exists in the environment of this script.