### PR TITLE
Use subnet address in OPT net rules

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -2430,11 +2430,11 @@ function filter_generate_address(& $rule, $target = "source", $isnat = false) {
 			$matches = "";
 			if ($rule['ipprotocol'] == "inet6") {
 				if (preg_match("/opt([0-9]*)$/", $rule[$target]['network'], $optmatch)) {
-					$opt_ip = $FilterIflist["opt{$optmatch[1]}"]['ipv6'];
-					if (!is_ipaddrv6($opt_ip)) {
+					$opt_sa = $FilterIflist["opt{$optmatch[1]}"]['sav6'];
+					if (!is_ipaddrv6($opt_sa)) {
 						return "";
 					}
-					$src = $opt_ip . "/" . $FilterIflist["opt{$optmatch[1]}"]['snv6'];
+					$src = $opt_sa . "/" . $FilterIflist["opt{$optmatch[1]}"]['snv6'];
 				/* check for opt$NUMip here */
 				} else if (preg_match("/opt([0-9]*)ip/", $rule[$target]['network'], $matches)) {
 					$src = $FilterIflist["opt{$matches[1]}"]['ipv6'];
@@ -2447,11 +2447,11 @@ function filter_generate_address(& $rule, $target = "source", $isnat = false) {
 				}
 			} else {
 				if (preg_match("/opt([0-9]*)$/", $rule[$target]['network'], $optmatch)) {
-					$opt_ip = $FilterIflist["opt{$optmatch[1]}"]['ip'];
-					if (!is_ipaddrv4($opt_ip)) {
+					$opt_sa = $FilterIflist["opt{$optmatch[1]}"]['sa'];
+					if (!is_ipaddrv4($opt_sa)) {
 						return "";
 					}
-					$src = $opt_ip . "/" . $FilterIflist["opt{$optmatch[1]}"]['sn'];
+					$src = $opt_sa . "/" . $FilterIflist["opt{$optmatch[1]}"]['sn'];
 				/* check for opt$NUMip here */
 				} else if (preg_match("/opt([0-9]*)ip/", $rule[$target]['network'], $matches)) {
 					$src = $FilterIflist["opt{$matches[1]}"]['ip'];


### PR DESCRIPTION
Example: LAN IP 10.0.1.1/24 OPT1 IP 10.0.2.1/24
Rules with SRC or DST LANnet correctly have 10.0.0.0/24 (the subnet base address) in /tmp/rules.debug
Rules with SRC or DST OPT1net have 10.0.2.1/24 (the OPT1 IP address with OPT1 net mask) in /tmp/rules.debug
It still works (I think) because actually 10.0.2.1/24 and 10.0.2.0/24 interpreted as a subnet still describes the same set of IP addresses, but it looks odd, as reported by: https://forum.pfsense.org/index.php?topic=90096.msg498474#msg498474
Same issue with IPv6 for OPT1net rules.
This fixes the rule generation to that OPT1net uses the base subnet address in the rule, in the same way that LANnet and WANnet does.