### PR TITLE
Do not allow VLAN tag zero

### DIFF
--- a/usr/local/www/interfaces_vlan_edit.php
+++ b/usr/local/www/interfaces_vlan_edit.php
@@ -80,7 +80,7 @@ if ($_POST) {
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
-	if ($_POST['tag'] && (!is_numericint($_POST['tag']) || ($_POST['tag'] < '1') || ($_POST['tag'] > '4094'))) {
+	if (!is_numericint($_POST['tag']) || ($_POST['tag'] < '1') || ($_POST['tag'] > '4094')) {
 		$input_errors[] = gettext("The VLAN tag must be an integer between 1 and 4094.");
 	}
 


### PR DESCRIPTION
At the moment you can make a VLAN with tag 0. The input validation does not catch it because when $_POST['tag'] = "0" that evaluates to false by PHP.
There is no need for that check here, because do_input_validation already checks that $_POST['tag'] is non-empty, and we really always want the other numericint and limit checks here.