### PR TITLE
Support checking overlapping subnets

### DIFF
--- a/etc/inc/pfsense-utils.inc
+++ b/etc/inc/pfsense-utils.inc
@@ -2711,12 +2711,40 @@ function load_mac_manufacturer_table() {
  * INPUTS
  *   IP Address to check.
  *   If ignore_if is a VIP (not carp), vip array index is passed after string _virtualip
+ *   check_localip - if true then also check for matches with PPTP and LT2P addresses
+ *   check_subnets - if true then check if the given ipaddr is contained anywhere in the subnet of any other configured IP address
+ *   cidrprefix - the CIDR prefix (16, 20, 24, 64...) of ipaddr.
+ *     If check_subnets is true and cidrprefix is specified, 
+ *     then check if the ipaddr/cidrprefix subnet overlaps the subnet of any other configured IP address
  * RESULT
- *   returns true if the IP Address is
- *   configured and present on this device.
+ *   returns true if the IP Address is configured and present on this device or overlaps a configured subnet.
 */
-function is_ipaddr_configured($ipaddr, $ignore_if = "", $check_localip = false, $check_subnets = false) {
+function is_ipaddr_configured($ipaddr, $ignore_if = "", $check_localip = false, $check_subnets = false, $cidrprefix = "") {
+	if (count(where_is_ipaddr_configured($ipaddr, $ignore_if, $check_localip, $check_subnets, $cidrprefix))) {
+		return true;
+	}
+	return false;
+}
+
+/****f* pfsense-utils/where_is_ipaddr_configured
+ * NAME
+ *   where_is_ipaddr_configured
+ * INPUTS
+ *   IP Address to check.
+ *   If ignore_if is a VIP (not carp), vip array index is passed after string _virtualip
+ *   check_localip - if true then also check for matches with PPTP and LT2P addresses
+ *   check_subnets - if true then check if the given ipaddr is contained anywhere in the subnet of any other configured IP address
+ *   cidrprefix - the CIDR prefix (16, 20, 24, 64...) of ipaddr.
+ *     If check_subnets is true and cidrprefix is specified, 
+ *     then check if the ipaddr/cidrprefix subnet overlaps the subnet of any other configured IP address
+ * RESULT
+ *   Returns an array of the interfaces 'if' plus IP address or subnet 'ip_or_subnet' that match or overlap the IP address to check.
+ *   If there are no matches then an empty array is returned.
+*/
+function where_is_ipaddr_configured($ipaddr, $ignore_if = "", $check_localip = false, $check_subnets = false, $cidrprefix = "") {
 	global $config;
+
+	$where_configured = array();
 
 	$pos = strpos($ignore_if, '_virtualip');
 	if ($pos !== false) {
@@ -2730,26 +2758,40 @@ function is_ipaddr_configured($ipaddr, $ignore_if = "", $check_localip = false, 
 	$isipv6 = is_ipaddrv6($ipaddr);
 
 	if ($check_subnets) {
+		$cidrprefix = intval($cidrprefix);
+		if ($isipv6) {
+			if (($cidrprefix < 1) || ($cidrprefix > 128)) {
+				$cidrprefix = 128;
+			}
+		} else {
+			if (($cidrprefix < 1) || ($cidrprefix > 32)) {
+				$cidrprefix = 32;
+			}
+		}
 		$iflist = get_configured_interface_list();
 		foreach ($iflist as $if => $ifname) {
 			if ($ignore_if == $if) {
 				continue;
 			}
 
-			if ($isipv6 === true) {
-				$bitmask = get_interface_subnetv6($if);
-				$subnet = gen_subnetv6(get_interface_ipv6($if), $bitmask);
+			if ($isipv6) {
+				if (check_subnetsv6_overlap($ipaddr, $cidrprefix, get_interface_ipv6($if), get_interface_subnetv6($if))) {
+					$where_entry = array();
+					$where_entry['if'] = $if;
+					$where_entry['ip_or_subnet'] = get_interface_ipv6($if) . "/" . get_interface_subnetv6($if);
+					$where_configured[] = $where_entry;
+				}
 			} else {
-				$bitmask = get_interface_subnet($if);
-				$subnet = gen_subnet(get_interface_ip($if), $bitmask);
-			}
-
-			if (ip_in_subnet($ipaddr, $subnet . '/' . $bitmask)) {
-				return true;
+				if (check_subnets_overlap($ipaddr, $cidrprefix, get_interface_ip($if), get_interface_subnet($if))) {
+					$where_entry = array();
+					$where_entry['if'] = $if;
+					$where_entry['ip_or_subnet'] = get_interface_ip($if) . "/" . get_interface_subnet($if);
+					$where_configured[] = $where_entry;
+				}
 			}
 		}
 	} else {
-		if ($isipv6 === true) {
+		if ($isipv6) {
 			$interface_list_ips = get_configured_ipv6_addresses();
 		} else {
 			$interface_list_ips = get_configured_ip_addresses();
@@ -2760,7 +2802,10 @@ function is_ipaddr_configured($ipaddr, $ignore_if = "", $check_localip = false, 
 				continue;
 			}
 			if (strcasecmp($ipaddr, $ilips) == 0) {
-				return true;
+				$where_entry = array();
+				$where_entry['if'] = $if;
+				$where_entry['ip_or_subnet'] = $ilips;
+				$where_configured[] = $where_entry;
 			}
 		}
 	}
@@ -2772,21 +2817,30 @@ function is_ipaddr_configured($ipaddr, $ignore_if = "", $check_localip = false, 
 			continue;
 		}
 		if (strcasecmp($ipaddr, $vip['ipaddr']) == 0) {
-			return true;
+			$where_entry = array();
+			$where_entry['if'] = $vip['if'];
+			$where_entry['ip_or_subnet'] = $vip['ipaddr'];
+			$where_configured[] = $where_entry;
 		}
 	}
 
 	if ($check_localip) {
 		if (is_array($config['pptpd']) && !empty($config['pptpd']['localip']) && (strcasecmp($ipaddr, $config['pptpd']['localip']) == 0)) {
-			return true;
+			$where_entry = array();
+			$where_entry['if'] = 'pptp';
+			$where_entry['ip_or_subnet'] = $config['pptpd']['localip'];
+			$where_configured[] = $where_entry;
 		}
 
 		if (!is_array($config['l2tp']) && !empty($config['l2tp']['localip']) && (strcasecmp($ipaddr, $config['l2tp']['localip']) == 0)) {
-			return true;
+			$where_entry = array();
+			$where_entry['if'] = 'l2tp';
+			$where_entry['ip_or_subnet'] = $config['l2tp']['localip'];
+			$where_configured[] = $where_entry;
 		}
 	}
 
-	return false;
+	return $where_configured;
 }
 
 /****f* pfsense-utils/pfSense_handle_custom_code


### PR DESCRIPTION
This allows the caller to specify $check_subnets and also provide a $cidrprefix so that the code can check if the proposed IPaddress/CIDRprefix will make a subnet that overlaps with any other subnet defined on other interfaces.
is_ipaddr_configured() returns a simple true/false answer, like it always has.
where_is_ipaddr_configured() returns an array of the conflicting interfaces and subnets. This is handy for front-end validation so that the caller can be returned information about what addresses conflicted and display it to the user.
This should be helpful for stopping stupidity by users that put overlapping subnets on various interfaces.