### PR TITLE
Cleanup code path when adding a new user

### DIFF
--- a/usr/local/www/system_usermanager.php
+++ b/usr/local/www/system_usermanager.php
@@ -299,7 +299,7 @@ if ($_POST['save']) {
 		isset($_POST['utype']) ? $userent['scope'] = $_POST['utype'] : $userent['scope'] = "system";
 
 		/* the user name was modified */
-		if ($_POST['usernamefld'] <> $_POST['oldusername']) {
+		if (!empty($_POST['oldusername']) && ($_POST['usernamefld'] <> $_POST['oldusername'])) {
 			$_SERVER['REMOTE_USER'] = $_POST['usernamefld'];
 			local_user_del($userent);
 		}
@@ -361,8 +361,8 @@ if ($_POST['save']) {
 			$a_user[] = $userent;
 		}
 
-		local_user_set_groups($userent,$_POST['groups']);
 		local_user_set($userent);
+		local_user_set_groups($userent,$_POST['groups']);
 		write_config();
 
 		if(is_dir("/etc/inc/privhooks"))


### PR DESCRIPTION
1) Only attempt to delete the oldusername if it actually was non-empty - at the moment errors are logged in the system log when adding a new user, because the code was trying to delete the user name "".
2) Call local_user_set() first to create (change, whatever) the user record. This makes the user record exist for a new user. Then call local_user_set_groups() to sort out what groups the user should be in or not in. The existing code would fail to add a new user to the specified group/s because local_user_set_groups() was called too early, before the user actually existed.

Typical system log errors from the old code:
Mar 18 17:10:31 	php-fpm[9542]: /system_usermanager.php: Tried to remove user but got user pw instead. Bailing.
Mar 18 17:10:31 	php-fpm[9542]: /system_usermanager.php: The command '/usr/sbin/pw groupmod admins -g 1999 -M '0,2003,2006,2008' 2>&1' returned exit code '67', the output was 'pw: user `2008' does not exist'

From looking at the code history, I think this has been this way for a long time, not a new bug at all.

Discussed in forum: https://forum.pfsense.org/index.php?topic=90700.msg501766#msg501766