### PR TITLE
Disable lighttpd server header

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -1365,6 +1365,9 @@ url.access-deny             = ( "~", ".inc" )
 
 ######### Options that are good to be but not necessary to be changed #######
 
+## disable server header
+server.tag = ""
+
 ## bind to port (default: 80)
 
 EOD;


### PR DESCRIPTION
Set the `server.tag` to an empty string to prevent lighttpd from
displaying the version number in the header.