### PR TITLE
Adding ability to run dhcp6c in debug mode #4534

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -3864,13 +3864,8 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$rtsoldscript .= "\t/bin/pkill -F {$g['varrun_path']}/dhcp6c_{$wanif}.pid\n";
 	$rtsoldscript .= "\t/bin/sleep 1\n";
 	$rtsoldscript .= "fi\n";
-
-	if (!isset($wancfg['dhcp6debug'])) {
-		$rtsoldscript .= "/usr/local/sbin/dhcp6c -d -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
-	} else {
-		// dhcp6c only supports -D debug option in foreground mode -f and outputs messages to stderr instead of syslog
-		$rtsoldscript .= "/usr/local/sbin/dhcp6c -f -d -D -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif} 2>&1 | /usr/bin/awk '{ print substr($0,23); fflush(stdout) }' | /usr/bin/logger -t dhcp6c &\n";
-	}
+	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
+	$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
 	$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
 	/* Add wide-dhcp6c shell script here. Because we can not pass a argument to it. */
 	if (!@file_put_contents("{$g['varetc_path']}/rtsold_{$wanif}_script.sh", $rtsoldscript)) {

--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -3864,7 +3864,13 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$rtsoldscript .= "\t/bin/pkill -F {$g['varrun_path']}/dhcp6c_{$wanif}.pid\n";
 	$rtsoldscript .= "\t/bin/sleep 1\n";
 	$rtsoldscript .= "fi\n";
-	$rtsoldscript .= "/usr/local/sbin/dhcp6c -d -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
+
+	if (!isset($wancfg['dhcp6debug'])) {
+		$rtsoldscript .= "/usr/local/sbin/dhcp6c -d -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
+	} else {
+		// dhcp6c only supports -D debug option in foreground mode -f and outputs messages to stderr instead of syslog
+		$rtsoldscript .= "/usr/local/sbin/dhcp6c -f -d -D -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif} 2>&1 | /usr/bin/awk '{ print substr($0,23); fflush(stdout) }' | /usr/bin/logger -t dhcp6c &\n";
+	}
 	$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
 	/* Add wide-dhcp6c shell script here. Because we can not pass a argument to it. */
 	if (!@file_put_contents("{$g['varetc_path']}/rtsold_{$wanif}_script.sh", $rtsoldscript)) {

--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -286,6 +286,7 @@ switch($wancfg['ipaddrv6']) {
 		$pconfig['type6'] = "dhcp6";
 		$pconfig['dhcp6prefixonly'] = isset($wancfg['dhcp6prefixonly']);
 		$pconfig['dhcp6usev4iface'] = isset($wancfg['dhcp6usev4iface']);
+		$pconfig['dhcp6debug'] = isset($wancfg['dhcp6debug']);
 		break;
 	case "6to4":
 		$pconfig['type6'] = "6to4";
@@ -916,6 +917,7 @@ if ($_POST['apply']) {
 		unset($wancfg['dhcp6-ia-pd-send-hint']);
 		unset($wancfg['dhcp6prefixonly']);
 		unset($wancfg['dhcp6usev4iface']);
+		unset($wancfg['dhcp6debug']);
 		unset($wancfg['track6-interface']);
 		unset($wancfg['track6-prefix-id']);
 		unset($wancfg['prefix-6rd']);
@@ -1140,6 +1142,8 @@ if ($_POST['apply']) {
 					$wancfg['dhcp6prefixonly'] = true;
 				if($_POST['dhcp6usev4iface'] == "yes")
 					$wancfg['dhcp6usev4iface'] = true;
+				if($_POST['dhcp6debug'] == "yes")
+					$wancfg['dhcp6debug'] = true;
 
 				if (!empty($_POST['adv_dhcp6_interface_statement_send_options']))
 					$wancfg['adv_dhcp6_interface_statement_send_options'] = $_POST['adv_dhcp6_interface_statement_send_options'];
@@ -2323,7 +2327,13 @@ $types6 = array("none" => gettext("None"), "staticv6" => gettext("Static IPv6"),
 											<?=gettext("Send an IPv6 prefix hint to indicate the desired prefix size for delegation"); ?>
 										</td>
 									</tr>
-
+									<tr style='display:none' id="basicdhcp6_show_dhcp6_debug">
+										<td width="22%" valign="top" class="vncell"><?=gettext("Debug"); ?></td>
+										<td width="78%" class="vtable">
+											<input name="dhcp6debug" type="checkbox" id="dhcp6debug" value="yes" <?php if ($pconfig['dhcp6debug'] == true) echo "checked=\"checked\""; ?> />
+											<?=gettext("Start DHCP6 client in debug mode"); ?>
+										</td>
+									</tr>
 									<tr style='display:none' id="show_adv_dhcp6_interface_statement">
 										<td width="22%" valign="top" class="vncell">
 											<?=gettext("<a target=\"FreeBSD_DHCP\" href=\"http://www.freebsd.org/cgi/man.cgi?query=dhcp6c.conf&amp;sektion=5&amp;apropos=0&amp;manpath=FreeBSD+10.1-RELEASE+and+Ports#Interface_statement\">Interface Statement</a>"); ?>
@@ -2483,6 +2493,7 @@ $types6 = array("none" => gettext("None"), "staticv6" => gettext("Static IPv6"),
 											document.getElementById("basicdhcp6_show_dhcp6_prefix_delegation_size").style.display = basic;
 											document.getElementById("basicdhcp6_show_dhcp6_prefix_send_hint").style.display = basic;
 											document.getElementById("basicdhcp6_show_dhcp6_prefix_only").style.display = basic;
+											document.getElementById("basicdhcp6_show_dhcp6_debug").style.display = basic;
 
 											document.getElementById("show_adv_dhcp6_interface_statement").style.display = advanced;
 											document.getElementById("show_adv_dhcp6_id_assoc_statement").style.display = advanced;


### PR DESCRIPTION
Adding checkbox under DHCP6 configuration on interface page and backend code. dhcp6c only supports debug mode when running in foreground so it needs to be piped to awk to remove date and time stamp and then to logger to be logged to syslog. AWK needs to flush stdout buffer else logger only logs in infrequent intervals or when dhcp6c is closed.