### PR TITLE
Handle release number in installer

### DIFF
--- a/usr/local/www/installer/installer.php
+++ b/usr/local/www/installer/installer.php
@@ -1138,7 +1138,8 @@ EOF;
 function return_rowhelper_row($rownum, $mountpoint, $fstype, $disk, $size, $encpass) {
 		global $g, $select_txt, $custom_disks, $savemsg;
 		$release = php_uname("r");
-		$release = trim($release[0]);
+		// Get release number like 8.3 or 10.1
+		$relnum = strtok($release, "-");
 
 		// Mount point
 		$disks = installer_find_all_disks();
@@ -1155,7 +1156,7 @@ function return_rowhelper_row($rownum, $mountpoint, $fstype, $disk, $size, $encp
 		);
 
 		// UFS + Journaling was introduced in 9.0
-		if($release == "9") {
+		if($relnum >= 9) {
 			$types['UFS+J'] = "UFS + Journaling";
 			$types['UFS+J.eli'] = "Encrypted UFS + Journaling";
 		}


### PR DESCRIPTION
This code just looked wrong. It was considering 10.1-RELEASE-p6 to be release number "1" and comparing it to "9".
These changes do what it seems to intend. This will make that UFS+J stuff appear, if that is of any consequence. If you actually do not want these UFS options to appear, then the code should be removed rather than fixed.