### PR TITLE
Be consistent about Unbound service descriptive name

### DIFF
--- a/etc/inc/service-utils.inc
+++ b/etc/inc/service-utils.inc
@@ -264,7 +264,7 @@ function get_services() {
 	if (isset($config['unbound']['enable'])) {
 		$pconfig = array();
 		$pconfig['name'] = "unbound";
-		$pconfig['description'] = gettext("Unbound DNS Resolver");
+		$pconfig['description'] = gettext("DNS Resolver");
 		$services[] = $pconfig;
 	}
 


### PR DESCRIPTION
Forum: https://forum.pfsense.org/index.php?topic=91075.0

For DNS Forwarder (dnsmasq)
1) dnsmasq is the name of the service
2) DNS Forwarder is the text description

Make Unbound consistent with that, so that menu names and services status display and... work in the same way:
1) unbound is the name of the service
2) DNS Resolver is the text description