### PR TITLE
Iterate array and append each line instead of using array_merge()

### DIFF
--- a/usr/local/www/services_dhcp.php
+++ b/usr/local/www/services_dhcp.php
@@ -81,8 +81,10 @@ function dhcp_clean_leases() {
 				$i++;
 			} while ($leases_contents[$i-1] != "}");
 			/* Check for a matching MAC address and if not present, keep it. */
-			if (! in_array($thismac, $staticmacs))
-				$newleases_contents = array_merge($newleases_contents, $templease);
+			if (! in_array($thismac, $staticmacs)) {
+				foreach ($templease as $value)
+					$newleases_contents[] = $value;
+			}
 		} else {
 			/* It's a line we want to keep, copy it over. */
 			$newleases_contents[] = $leases_contents[$i];


### PR DESCRIPTION
The array_merge() operation takes a long time to complete (especially for large input arrays), and with a large enough DHCP scope the dhcp_clean_leases() function will result in a PHP timeout.

This code runs significantly faster and should produce identical output in all cases since there will never be any string keys in either the $templease or the $newleases_contents arrays.