### PR TITLE
Only list nameservers once in resolv.conf

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -176,15 +176,16 @@ function system_resolvconf_generate($dynupdate = false) {
 			}
 		}
 	} else {
+		$ns = array();
 		// Do not create blank search/domain lines, it can break tools like dig.
 		if ($syscfg['domain']) {
 			$resolvconf .= "search {$syscfg['domain']}\n";
 		}
 	}
 	if (is_array($syscfg['dnsserver'])) {
-		foreach ($syscfg['dnsserver'] as $ns) {
-			if ($ns) {
-				$resolvconf .= "nameserver $ns\n";
+		foreach ($syscfg['dnsserver'] as $sys_dnsserver) {
+			if ($sys_dnsserver && (!in_array($sys_dnsserver, $ns)) {
+				$resolvconf .= "nameserver $sys_dnsserver\n";
 			}
 		}
 	}


### PR DESCRIPTION
I was on a test system and had an upstream DNS server IP specified in System-General Setup. WAN was setup with a static IP and a gateway to that upstream device. All good.
Then I also checked "Allow DNS server list to be overridden by DHCP/PPP on WAN" and changed WAN to be DHCP. It received by DHCP the same DNS server IP that already happened to be in General Setup (and the same gateway IP - that is fine, not the issue here).
/var/etc/resolv.conf had the name server line twice with the same IP address - once from the DHCP acquired data, and once from the General Setup data.
I don't think it broke anything, but it does look odd.
This change makes sure that DNS servers from General Setup are only added to resolv.conf once.