### PR TITLE
Always include general setup DNS servers in unbound.conf

### DIFF
--- a/etc/inc/unbound.inc
+++ b/etc/inc/unbound.inc
@@ -233,7 +233,7 @@ EOF;
 	$verbosity = isset($config['unbound']['log_verbosity']) ? $config['unbound']['log_verbosity'] : 1;
 	$use_caps = isset($config['unbound']['use_caps']) ? "yes" : "no";
 
-	// Set up forwarding if it configured
+	// Set up forwarding if it is configured
 	if (isset($config['unbound']['forwarding'])) {
 		$dnsservers = array();
 		if (isset($config['system']['dnsallowoverride'])) {
@@ -243,12 +243,11 @@ EOF;
 					$dnsservers[] = $nameserver;
 				}
 			}
-		} else {
-			$ns = array_unique(get_dns_servers());
-			foreach ($ns as $nameserver) {
-				if ($nameserver) {
-					$dnsservers[] = $nameserver;
-				}
+		}
+		$sys_dnsservers = array_unique(get_dns_servers());
+		foreach ($sys_dnsservers as $sys_dnsserver) {
+			if ($sys_dnsserver && (!in_array($sys_dnsserver, $ns))) {
+				$dnsservers[] = $sys_dnsserver;
 			}
 		}
 


### PR DESCRIPTION
when forwarding mode is on.
The General Setup setting "Allow DNS server list to be overridden by DHCP/PPP on WAN" has always been used in dnsmasq to ADD DHCP/PPP provided DNS servers to the list, while also keeping the DNS servers specified in General Setup. That behavior is needed if:
1) WAN1 static IP with upstream DNS server/s specified in General Setup and selecting the WAN1 gateway. WAN2 uses DHCP, DNS server/s received by DHCP from upstream. The user needs to tick "Allow DNS server list to be overridden by DHCP/PPP on WAN" to get the WAN2 DNS server to be used, but also wants the DNS server from General Setup to be used.
2) WAN1 static IP, DNS server/s specified in General Setup. For whatever reason the user has also ticked "Allow DNS server list to be overridden by DHCP/PPP on WAN". In actual fact there are no WAN-style interfaces set to DHCP, so "allowing to be overridden" should not come into effect anyway - the DNS servers in General Setup should be used.
3) WAN1 DHCP, but the upstream DHCP does not give out any DNS server/s. "Allow DNS server list to be overridden by DHCP/PPP on WAN" is ticked. Again there are no DNS servers received via DHCP, so any "override" should not be invoked.

In all cases, it turns out that actually we want any General Setup DNS servers to be included in the DNS forwarder/resolver conf in addition to whatever (if any) DNS servers happen to be provided from a DHPC-WAN.

This change makes unbound behave that way - the same as dnsmasq already does.