### PR TITLE
Voucher messages using wrong config field name

### DIFF
--- a/usr/local/captiveportal/index.php
+++ b/usr/local/captiveportal/index.php
@@ -169,14 +169,14 @@ EOD;
 			// YES: user is good for $timecredit minutes.
 			captiveportal_logportalauth($voucher,$clientmac,$clientip,"Voucher login good for $timecredit min.");
 		} else {
-			portal_reply_page($redirurl, "error", $config['voucher'][$cpzone]['msgexpired'] ? $config['voucher'][$cpzone]['msgexpired']: $errormsg);
+			portal_reply_page($redirurl, "error", $config['voucher'][$cpzone]['descrmsgexpired'] ? $config['voucher'][$cpzone]['descrmsgexpired']: $errormsg);
 		}
 	} else if (-1 == $timecredit) {  // valid but expired
 		captiveportal_logportalauth($voucher,$clientmac,$clientip,"FAILURE","voucher expired");
-		portal_reply_page($redirurl, "error", $config['voucher'][$cpzone]['msgexpired'] ? $config['voucher'][$cpzone]['msgexpired']: $errormsg);
+		portal_reply_page($redirurl, "error", $config['voucher'][$cpzone]['descrmsgexpired'] ? $config['voucher'][$cpzone]['descrmsgexpired']: $errormsg);
 	} else {
 		captiveportal_logportalauth($voucher,$clientmac,$clientip,"FAILURE");
-		portal_reply_page($redirurl, "error", $config['voucher'][$cpzone]['msgnoaccess'] ? $config['voucher'][$cpzone]['msgnoaccess'] : $errormsg);
+		portal_reply_page($redirurl, "error", $config['voucher'][$cpzone]['descrmsgnoaccess'] ? $config['voucher'][$cpzone]['descrmsgnoaccess'] : $errormsg);
 	}
 
 } else if ($_POST['accept'] && $radius_enable) {


### PR DESCRIPTION
https://forum.pfsense.org/index.php?topic=91168.msg505273#msg505273
$config['voucher'][$cpzone]['msgnoaccess']
and 
$config['voucher'][$cpzone]['msgexpired']
do not exist.
These should be 
$config['voucher'][$cpzone]['descrmsgnoaccess']
and
$config['voucher'][$cpzone]['descrmsgexpired']