### PR TITLE
Check if global IPv6 is present before returning link-local address #4483

### DIFF
--- a/etc/inc/interfaces.inc
+++ b/etc/inc/interfaces.inc
@@ -5323,10 +5323,6 @@ function get_interface_ipv6($interface = "wan", $flush = false) {
 		return get_interface_linklocal($interface);
 	}
 
-	/*
-	 * NOTE: On the case when only the prefix is requested,
-	 * the communication on WAN will be done over link-local.
-	 */
 	if (is_array($config['interfaces'][$interface])) {
 		switch ($config['interfaces'][$interface]['ipaddr']) {
 			case 'pppoe':
@@ -5338,20 +5334,24 @@ function get_interface_ipv6($interface = "wan", $flush = false) {
 				}
 				break;
 		}
-		if (isset($config['interfaces'][$interface]['dhcp6prefixonly'])) {
-			$curip = find_interface_ipv6_ll($realif, $flush);
-			if ($curip && is_ipaddrv6($curip) && ($curip != "::")) {
-				return $curip;
-			}
-		}
 	}
 
 	$curip = find_interface_ipv6($realif, $flush);
 	if ($curip && is_ipaddrv6($curip) && ($curip != "::")) {
 		return $curip;
 	} else {
-		return null;
+		/*
+		 * NOTE: On the case when only the prefix is requested,
+		 * the communication on WAN will be done over link-local.
+		 */
+		if (is_array($config['interfaces'][$interface]) && isset($config['interfaces'][$interface]['dhcp6prefixonly'])) {
+			$curip = find_interface_ipv6_ll($realif, $flush);
+			if ($curip && is_ipaddrv6($curip) && ($curip != "::")) {
+				return $curip;
+			}
+		}
 	}
+	return null;
 }
 
 function get_interface_linklocal($interface = "wan") {


### PR DESCRIPTION
Return link-local address when we are only requesting IPv6 prefix only if there is no global IPv6 address. In some cases global SLAAC IPv6 address might be present when using DHCPv6. Fixes 
#4483

'dhcp6prefixonly' check was originally introduced in f253e92, possibly as part of fix for #2627. The comment states '...return the link-local address of the interface in this case rather than nothing.' so this change should not impact that logic.
