### PR TITLE
Change the default PHP session ID cookie name

### DIFF
--- a/etc/inc/functions.inc
+++ b/etc/inc/functions.inc
@@ -85,7 +85,7 @@ if (!function_exists("get_menu_messages")) {
 
 			## Get Query Arguments from URL ###
 			foreach ($_REQUEST as $key => $value) {
-				if ($key != "PHPSESSID") {
+				if ($key != session_name()) {
 					$requests[] = $key.'='.$value;
 				}
 			}

--- a/etc/rc.php_ini_setup
+++ b/etc/rc.php_ini_setup
@@ -177,6 +177,7 @@ TIMEZONE=`cat /conf/config.xml | egrep -E '<timezone>(.*?)</timezone>' | awk -F'
 ; File generated from /etc/rc.php_ini_setup
 output_buffering = "0"
 expose_php = Off
+session.name = "sessionId"
 implicit_flush = true
 magic_quotes_gpc = Off
 max_execution_time = 900


### PR DESCRIPTION
By default PHP uses `PHPSESSID` as the name of the cookie that stores the session Id.

For example:

    $ curl -Ik https://portal.pfsense
    HTTP/1.1 200 OK
    ...
    Set-Cookie: PHPSESSID=00000000000000000000000000000000; path=/; secure; HttpOnly
    ...

This commit changes the name to `sessionId`.

References:

http://php.net/manual/en/session.configuration.php#ini.session.name