### PR TITLE
Fix IPsec Advanced Settings uniqueids

### DIFF
--- a/etc/inc/vpn.inc
+++ b/etc/inc/vpn.inc
@@ -627,9 +627,8 @@ EOD;
 
 	$uniqueids = 'yes';
 	if (!empty($config['ipsec']['uniqueids'])) {
-		if (in_array($uniqueids, $ipsec_idhandling)) {
+		if (array_key_exists($config['ipsec']['uniqueids'], $ipsec_idhandling))
 			$uniqueids = $config['ipsec']['uniqueids'];
-		}
 	}
 	$natfilterrules = false;
 	/* begin ipsec.conf */

--- a/usr/local/www/vpn_ipsec_settings.php
+++ b/usr/local/www/vpn_ipsec_settings.php
@@ -51,6 +51,7 @@ $pconfig['enableinterfacesuse'] = isset($config['ipsec']['enableinterfacesuse'])
 $pconfig['acceptunencryptedmainmode'] = isset($config['ipsec']['acceptunencryptedmainmode']);
 $pconfig['maxmss_enable'] = isset($config['system']['maxmss_enable']);
 $pconfig['maxmss'] = $config['system']['maxmss'];
+$pconfig['uniqueids'] = $config['ipsec']['uniqueids'];
 
 if ($_POST) {
 


### PR DESCRIPTION
It was neither set in strongswan ipsec.conf, nor picked up correctly in the UI.