### PR TITLE
Bug #4566 Only route-to a gateway if it is not force_down

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -848,7 +848,7 @@ function filter_generate_gateways() {
 			if (!is_ipaddr($gwip)) {
 				$gwip = get_interface_gateway($gateway['friendlyiface']);
 			}
-			if (is_ipaddr($gwip) && !empty($int)) {
+			if (is_ipaddr($gwip) && !empty($int) && !isset($gateway['force_down'])) {
 				$route = "route-to ( {$int} {$gwip} )";
 			}
 			if (($route === "") && isset($config['system']['skip_rules_gw_down'])) {


### PR DESCRIPTION
When generating policy-routing rules there was no check if a gateway had force-down set, so gateway with force_down set would still get policy-routing rules written for it, even if skip_rules_gw_down was enabled.