### PR TITLE
Few minor text typos

### DIFF
--- a/etc/inc/shaper.inc
+++ b/etc/inc/shaper.inc
@@ -273,7 +273,7 @@ class altq_root_queue {
 	var $link;
 	var $available_bw; /* in b/s */
 
-	/* Accesor functions */
+	/* Accessor functions */
 	function GetAvailableBandwidth() {
 		return $this->available_bw;
 	}
@@ -857,7 +857,7 @@ class priq_queue {
 	/* This is here to help with form building and building rules/lists */
 	var $subqueues = array();
 
-	/* Accesor functions */
+	/* Accessor functions */
 	function GetAvailableBandwidth() {
 		return $this->available_bw;
 	}

--- a/usr/local/www/services_ntpd.php
+++ b/usr/local/www/services_ntpd.php
@@ -348,7 +348,7 @@ include("head.inc");
 					<input type="button" onclick="show_advanced('showstatisticsbox', 'showstatistics')" value="<?=gettext("Advanced");?>" /> - <?=gettext("Show statistics logging options");?>
 					</div>
 					<div id="showstatistics" style="display:none">
-					<strong><?php echo gettext("Warning: ")?></strong><?php echo gettext("these options will create persistant daily log files in /var/log/ntp."); ?>
+					<strong><?php echo gettext("Warning: ")?></strong><?php echo gettext("these options will create persistent daily log files in /var/log/ntp."); ?>
 					<br /><br />
 					<input name="clockstats" type="checkbox" class="formcheckbox" id="clockstats"<?php if($pconfig['clockstats']) echo " checked=\"checked\""; ?> />
 					<?php echo gettext("Enable logging of reference clock statistics (default: disabled)."); ?>
@@ -397,7 +397,7 @@ include("head.inc");
 					<input type="button" onclick="show_advanced('showleapsecbox', 'showleapsec')" value="<?=gettext("Advanced");?>" /> - <?=gettext("Show Leap second configuration");?>
 					</div>
 					<div id="showleapsec" style="display:none">
-					<?php echo gettext("A leap second file allows NTP to advertize an upcoming leap second addition or subtraction.");?>
+					<?php echo gettext("A leap second file allows NTP to advertise an upcoming leap second addition or subtraction.");?>
 					<?php echo gettext("Normally this is only useful if this server is a stratum 1 time server.");?>
 					<br /><br />
 					<?php echo gettext("Enter Leap second configuration as text:");?><br />

--- a/usr/local/www/widgets/include/thermal_sensors.inc
+++ b/usr/local/www/widgets/include/thermal_sensors.inc
@@ -1,12 +1,11 @@
 <?php
 /*
 	$Id: thermal_sensors.inc
-	File location: 
+	File location:
 		\usr\local\www\widgets\include\
 
 	Used by:
 		\usr\local\www\widgets\widgets\thermal_sensors.widget.php
-
 
 */
 
@@ -16,12 +15,12 @@ $thermal_sensors_widget_title = "Thermal Sensors";
 
 
 //returns core temp data (from coretemp.ko or amdtemp.ko driver) as "|"-delimited string.
-//NOTE: depends on proper cofing in System >> Advanced >> Miscellaneous tab >> Thermal Sensors section.
+//NOTE: depends on proper config in System >> Advanced >> Miscellaneous tab >> Thermal Sensors section.
 function getThermalSensorsData() {
 
 	$_gb = exec("/sbin/sysctl -a | grep temperature", $dfout);
 	$thermalSensorsData = join("|", $dfout);
 	return $thermalSensorsData;
-	
+
 }
 ?>

--- a/usr/local/www/widgets/javascript/thermal_sensors.js
+++ b/usr/local/www/widgets/javascript/thermal_sensors.js
@@ -2,7 +2,7 @@
 	$Id: thermal_sensors.js
 	Description:	
 		Javascript functions to get and show thermal sensors data in thermal_sensors.widget.php.
-		NOTE: depends on proper cofing in System >> Advanced >> Miscellaneous tab >> Thermal Sensors section.
+		NOTE: depends on proper config in System >> Advanced >> Miscellaneous tab >> Thermal Sensors section.
 	File location: 
 		\usr\local\www\widgets\javascript\
 	Used by:


### PR DESCRIPTION
I noticed these at random times, might as well fix the spelling while I see it.
Note that advertise is spelt with an "s" in other places in the GUI, so
making it consistent in services_ntpd - but maybe Americans do spell it
"advertize" these days?