### PR TITLE
diag_sockets show sockets listening on localhost

### DIFF
--- a/usr/local/www/diag_sockets.php
+++ b/usr/local/www/diag_sockets.php
@@ -74,8 +74,8 @@ $showAllOption = $showAll ? "" : "?showAll";
 		$internet4 = shell_exec('sockstat -4');
 		$internet6 = shell_exec('sockstat -6');
 	} else {
-		$internet4 = shell_exec('sockstat -4lL');
-		$internet6 = shell_exec('sockstat -6lL');
+		$internet4 = shell_exec('sockstat -4l');
+		$internet6 = shell_exec('sockstat -6l');
 	}
 	foreach (array(&$internet4, &$internet6) as $tabindex => $table) {
 		$elements = ($tabindex == 0 ? 7 : 7);


### PR DESCRIPTION
diag_sockets show sockets listening on localhost
this helps pick a free port for services using sockets bound to localhost, and helps determine if the service has at least started and bound the port without needing to go through all 'connected' sockets as well