### PR TITLE
Automatically choose some interface combinations

### DIFF
--- a/etc/inc/config.console.inc
+++ b/etc/inc/config.console.inc
@@ -559,23 +559,52 @@ EOD;
 function check_for_alternate_interfaces() {
 	global $config;
 
-	// If the factory default configured WAN and/or LAN devices do not exist,
-	// then use alternate devices if they exist.
-	// These are devices on Alix (vr) and APU (re) systems, and this lets them boot a
-	// factory default config without being forced to do interface assignment
-	// over the serial port.
+	// If the WAN and/or LAN devices in the factory default config do not exist,
+	// then look for alternate devices.
+	// This lets many systems boot a factory default config without being
+	// forced to do interface assignment on the console.
 
-	$other_devices_arr['wan'] = array("vr1", "re1");
-	$other_devices_arr['lan'] = array("vr0", "re2");
+	$specplatform = system_identify_specific_platform();
+	$default_device = array();
+
+	// If we recognise the platform, then specify the devices directly.
+	switch ($specplatform['name']) {
+		case 'alix':
+			$default_device['wan'] = "vr1";
+			$default_device['lan'] = "vr0";
+			break;
+		case 'APU':
+			$default_device['wan'] = "re1";
+			$default_device['lan'] = "re2";
+			break;
+		case 'RCC-VE':
+			$default_device['wan'] = "igb0";
+			$default_device['lan'] = "igb1";
+			break;
+		default:
+			$default_device['wan'] = "";
+			$default_device['lan'] = "";
+			break;
+	}
+
+	// Other common device names can be put here and will be looked for
+	// if the system was not one of the known platforms.
+	$other_devices_arr['wan'] = array("vr1", "re1", "igb0", "em0");
+	$other_devices_arr['lan'] = array("vr0", "re2", "igb1", "em1");
 	$interface_assignment_changed = false;
 
 	foreach ($other_devices_arr as $ifname => $other_devices) {
 		if (!does_interface_exist($config['interfaces'][$ifname]['if'])) {
-			foreach ($other_devices as $other_device) {
-				if (does_interface_exist($other_device)) {
-					$config['interfaces'][$ifname]['if'] = $other_device;
-					$interface_assignment_changed = true;
-					break;
+			if (does_interface_exist($default_device[$ifname])) {
+				$config['interfaces'][$ifname]['if'] = $default_device[$ifname];
+				$interface_assignment_changed = true;
+			} else {
+				foreach ($other_devices as $other_device) {
+					if (does_interface_exist($other_device)) {
+						$config['interfaces'][$ifname]['if'] = $other_device;
+						$interface_assignment_changed = true;
+						break;
+					}
 				}
 			}
 		}

--- a/etc/inc/config.console.inc
+++ b/etc/inc/config.console.inc
@@ -556,4 +556,34 @@ EOD;
 	}
 }
 
+function check_for_alternate_interfaces() {
+	global $config;
+
+	// If the factory default configured WAN and/or LAN devices do not exist,
+	// then use alternate devices if they exist.
+	// These are devices on Alix (vr) and APU (re) systems, and this lets them boot a
+	// factory default config without being forced to do interface assignment
+	// over the serial port.
+
+	$other_devices_arr['wan'] = array("vr1", "re1");
+	$other_devices_arr['lan'] = array("vr0", "re2");
+	$interface_assignment_changed = false;
+
+	foreach ($other_devices_arr as $ifname => $other_devices) {
+		if (!does_interface_exist($config['interfaces'][$ifname]['if'])) {
+			foreach ($other_devices as $other_device) {
+				if (does_interface_exist($other_device)) {
+					$config['interfaces'][$ifname]['if'] = $other_device;
+					$interface_assignment_changed = true;
+					break;
+				}
+			}
+		}
+	}
+
+	if ($interface_assignment_changed) {
+		write_config("Factory default boot detected WAN " . $config['interfaces']['wan']['if'] . " and LAN " . $config['interfaces']['lan']['if']);
+	}
+}
+
 ?>

--- a/etc/rc.bootup
+++ b/etc/rc.bootup
@@ -163,6 +163,10 @@ echo "Loading configuration...";
 parse_config_bootup();
 echo "done.\n";
 
+if (file_exists("/conf/trigger_initial_wizard")) {
+	check_for_alternate_interfaces();
+}
+
 if ($g['platform'] == "jail") {
 	/* We must determine what network settings have been configured for us */
 	$wanif = "lo0";	/* defaults, if the jail admin hasn't set us up */


### PR DESCRIPTION
on factory default boot.
This allows the system to switch interfaces from the newer ones in the
default config (e.g. em0 em1) back to the interfaces used by:
Alix - vr1 vr0
APU - re1 re2
that match the WAN and LAN labels printed on many existing devices.
It means these devices can boot the default config and this will
automatically detect that there is no em0/em1 and will instead select
whatever exists out of vr1/vr0 or re1/re2. This avoids the user having
to use the serial cable to do interface assignment when starting a brand
new image, or when resetting to factory defaults. It could easily be
extended to other common interface combinations.
For me, this (or similar) would be very beneficial. At remote sites it
is really good if it is possible to do reset to factory defaults, or put
a fresh CF/SD card in, and the system boots without needing to connect a
serial cable and do interface assignment that way.