### PR TITLE
Fix OpenVPN server listening on associated IPv6 address

### DIFF
--- a/etc/inc/openvpn.inc
+++ b/etc/inc/openvpn.inc
@@ -519,8 +519,8 @@ function openvpn_reconfigure($mode, $settings) {
 	$digest = !empty($settings['digest']) ? $settings['digest'] : "SHA1";
 
 	$interface = get_failover_interface($settings['interface']);
+	// The IP address in the settings can be an IPv4 or IPv6 address associated with the interface
 	$ipaddr = $settings['ipaddr'];
-	$ipaddrv6 = $settings['ipaddrv6'];
 
 	// If a specific ip address (VIP) is requested, use it.
 	// Otherwise, if a specific interface is requested, use it
@@ -532,8 +532,8 @@ function openvpn_reconfigure($mode, $settings) {
 			$iface_ip=get_interface_ip($interface);
 		}
 	}
-	if (is_ipaddrv6($ipaddrv6)) {
-		$iface_ipv6=$ipaddrv6;
+	if (is_ipaddrv6($ipaddr)) {
+		$iface_ipv6=$ipaddr;
 	} else {
 		if ((!empty($interface)) && (strcmp($interface, "any"))) {
 			$iface_ipv6=get_interface_ipv6($interface);


### PR DESCRIPTION
As reported in forum https://forum.pfsense.org/index.php?topic=92174.0
If the ordinary interface is selected for an OpenVPN server and an IPV6 protocol is selected (e.g. UDP6) then al is good, the "local" line in the server1.conf is written with the primary IPv6 address of the interface.
If the interface has other associated VIPs (e.g. a CARP VIP) and the related IPv6 entry is selected as the OpenVPN server interface, then the "local" line was being omitted from server1.conf
Regardless of the IP address family, vpn_openvpn_server.php always writes the associated IP address into the settings key 'ipaddr' - which looks like a good and reasonable thing - we only want 1 IP address of some flavor to be remembered here.
This changes fixes openvpn.inc so it understands that $settings['ipaddr'] can be IPv4 or IPv6 as does the appropriate stuff with it.