### PR TITLE
When deleting a VIP check it is not used by OpenVPN

### DIFF
--- a/usr/local/www/firewall_virtual_ip.php
+++ b/usr/local/www/firewall_virtual_ip.php
@@ -108,6 +108,30 @@ if ($_GET['act'] == "del") {
 			}
 		}
 
+		/* make sure no OpenVPN server references this entry */
+		if (is_array($config['openvpn']['openvpn-server'])) {
+			foreach ($config['openvpn']['openvpn-server'] as $openvpn) {
+				if ($openvpn['ipaddr'] <> "") {
+					if ($openvpn['ipaddr'] == $a_vip[$_GET['id']]['subnet']) {
+						$input_errors[] = gettext("This entry cannot be deleted because it is still referenced by at least one OpenVPN server.");
+						break;
+					}
+				}
+			}
+		}
+
+		/* make sure no OpenVPN client references this entry */
+		if (is_array($config['openvpn']['openvpn-client'])) {
+			foreach ($config['openvpn']['openvpn-client'] as $openvpn) {
+				if ($openvpn['ipaddr'] <> "") {
+					if ($openvpn['ipaddr'] == $a_vip[$_GET['id']]['subnet']) {
+						$input_errors[] = gettext("This entry cannot be deleted because it is still referenced by at least one OpenVPN client.");
+						break;
+					}
+				}
+			}
+		}
+
 		if (is_ipaddrv6($a_vip[$_GET['id']]['subnet'])) {
 			$is_ipv6 = true;
 			$subnet = gen_subnetv6($a_vip[$_GET['id']]['subnet'], $a_vip[$_GET['id']]['subnet_bits']);


### PR DESCRIPTION
I noticed this when cleaning up VIPs and OpenVPN server when testing for this forum post https://forum.pfsense.org/index.php?topic=92174.0
The system let me delete my test VIP before I deleted the OpenVPN server using, probably not a good thing.