### PR TITLE
When deleting a VIP check it is not used by OpenVPN

### DIFF
--- a/usr/local/www/firewall_virtual_ip.php
+++ b/usr/local/www/firewall_virtual_ip.php
@@ -108,6 +108,26 @@ if ($_GET['act'] == "del") {
 			}
 		}
 
+		/* make sure no OpenVPN server or client references this entry */
+		$openvpn_types_a = array("openvpn-server" => gettext("server"), "openvpn-client" => gettext("client"));
+		foreach ($openvpn_types_a as $openvpn_type => $openvpn_type_text) {
+			if (is_array($config['openvpn'][$openvpn_type])) {
+				foreach ($config['openvpn'][$openvpn_type] as $openvpn) {
+					if ($openvpn['ipaddr'] <> "") {
+						if ($openvpn['ipaddr'] == $a_vip[$_GET['id']]['subnet']) {
+							if (strlen($openvpn['description'])) {
+								$openvpn_desc = $openvpn['description'];
+							} else {
+								$openvpn_desc = $openvpn['ipaddr'] . ":" . $openvpn['local_port'];
+							}
+							$input_errors[] = sprintf(gettext("This entry cannot be deleted because it is still referenced by OpenVPN %s %s."), $openvpn_type_text, $openvpn_desc);
+							break;
+						}
+					}
+				}
+			}
+		}
+
 		if (is_ipaddrv6($a_vip[$_GET['id']]['subnet'])) {
 			$is_ipv6 = true;
 			$subnet = gen_subnetv6($a_vip[$_GET['id']]['subnet'], $a_vip[$_GET['id']]['subnet_bits']);


### PR DESCRIPTION
I noticed this when cleaning up VIPs and OpenVPN server when testing for this forum post https://forum.pfsense.org/index.php?topic=92174.0
The system let me delete my test VIP before I deleted the OpenVPN server using, probably not a good thing.
This is a better version of #1604  - the similar loops for server and client are combined, and the error message shows the description (or IP address:port) of the offending OpenVPN instance so the user has a clue about which OpenVPN instance uses the VIP.