### PR TITLE
Combine Cache-Control header in one line

### DIFF
--- a/usr/local/captiveportal/index.php
+++ b/usr/local/captiveportal/index.php
@@ -40,7 +40,7 @@ require_once("captiveportal.inc");
 $errormsg = "Invalid credentials specified.";
 
 header("Expires: 0");
-header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0");
+header("Cache-Control: no-cache, no-store, must-revalidate");
 header("Pragma: no-cache");
 header("Connection: close");
 

--- a/usr/local/captiveportal/index.php
+++ b/usr/local/captiveportal/index.php
@@ -40,8 +40,7 @@ require_once("captiveportal.inc");
 $errormsg = "Invalid credentials specified.";
 
 header("Expires: 0");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
+header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0");
 header("Pragma: no-cache");
 header("Connection: close");
 

--- a/usr/local/www/getstats.php
+++ b/usr/local/www/getstats.php
@@ -39,8 +39,7 @@
 
 header("Last-Modified: " . gmdate( "D, j M Y H:i:s" ) . " GMT" );
 header("Expires: " . gmdate( "D, j M Y H:i:s", time() ) . " GMT" );
-header("Cache-Control: no-store, no-cache, must-revalidate" ); // HTTP/1.1
-header("Cache-Control: post-check=0, pre-check=0", FALSE );
+header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0" ); // HTTP/1.1
 header("Pragma: no-cache"); // HTTP/1.0
 
 require_once("guiconfig.inc");

--- a/usr/local/www/getstats.php
+++ b/usr/local/www/getstats.php
@@ -39,7 +39,7 @@
 
 header("Last-Modified: " . gmdate( "D, j M Y H:i:s" ) . " GMT" );
 header("Expires: " . gmdate( "D, j M Y H:i:s", time() ) . " GMT" );
-header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0" ); // HTTP/1.1
+header("Cache-Control: no-cache, no-store, must-revalidate" ); // HTTP/1.1
 header("Pragma: no-cache"); // HTTP/1.0
 
 require_once("guiconfig.inc");

--- a/usr/local/www/graph.php
+++ b/usr/local/www/graph.php
@@ -2,22 +2,22 @@
 /*
 	graph.php
 	part of m0n0wall (http://m0n0.ch/wall)
-	
+
 	Copyright (C) 2013-2015 Electric Sheep Fencing, LP
 	Copyright (C) 2004-2006 T. Lechat <dev@lechat.org>, Manuel Kasper <mk@neon1.net>
 	and Jonathan Watt <jwatt@jwatt.org>.
 	All rights reserved.
-	
+
 	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions are met:
-	
+
 	1. Redistributions of source code must retain the above copyright notice,
 	   this list of conditions and the following disclaimer.
-	
+
 	2. Redistributions in binary form must reproduce the above copyright
 	   notice, this list of conditions and the following disclaimer in the
 	   documentation and/or other materials provided with the distribution.
-	
+
 	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
 	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
 	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
@@ -45,8 +45,7 @@ require("guiconfig.inc");
 
 header("Last-Modified: " . gmdate( "D, j M Y H:i:s" ) . " GMT" );
 header("Expires: " . gmdate( "D, j M Y H:i:s", time() ) . " GMT" );
-header("Cache-Control: no-store, no-cache, must-revalidate" ); // HTTP/1.1
-header("Cache-Control: post-check=0, pre-check=0", FALSE );
+header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0" ); // HTTP/1.1
 header("Pragma: no-cache"); // HTTP/1.0
 header("Content-type: image/svg+xml");
 
@@ -99,7 +98,7 @@ $fetch_link = "ifstats.php?if=" . htmlspecialchars($ifnum);
 if(file_exists("/usr/local/www/themes/{$g['theme']}/graph.php")) {
 	$themetxt = file_get_contents("/usr/local/www/themes/{$g['theme']}/graph.php");
 	eval($themetxt);
-} 
+}
 
 /********* Graph DATA **************/
 print('<?xml version="1.0" encoding="UTF-8"?>' . "\n");?>
@@ -315,7 +314,7 @@ function plot_data(obj) {
         rmax *= 1.25;
       else
         rmax *= 2;
-      
+
       if (i == 8)
         rmax *= 1.024;
     }

--- a/usr/local/www/graph.php
+++ b/usr/local/www/graph.php
@@ -45,7 +45,7 @@ require("guiconfig.inc");
 
 header("Last-Modified: " . gmdate( "D, j M Y H:i:s" ) . " GMT" );
 header("Expires: " . gmdate( "D, j M Y H:i:s", time() ) . " GMT" );
-header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0" ); // HTTP/1.1
+header("Cache-Control: no-cache, no-store, must-revalidate" ); // HTTP/1.1
 header("Pragma: no-cache"); // HTTP/1.0
 header("Content-type: image/svg+xml");
 

--- a/usr/local/www/graph_cpu.php
+++ b/usr/local/www/graph_cpu.php
@@ -44,8 +44,7 @@ require_once("guiconfig.inc");
 
 header("Last-Modified: " . gmdate( "D, j M Y H:i:s" ) . " GMT" );
 header("Expires: " . gmdate( "D, j M Y H:i:s", time() ) . " GMT" );
-header("Cache-Control: no-store, no-cache, must-revalidate" ); // HTTP/1.1
-header("Cache-Control: post-check=0, pre-check=0", FALSE );
+header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0" ); // HTTP/1.1
 header("Pragma: no-cache"); // HTTP/1.0
 header("Content-type: image/svg+xml");
 

--- a/usr/local/www/graph_cpu.php
+++ b/usr/local/www/graph_cpu.php
@@ -44,7 +44,7 @@ require_once("guiconfig.inc");
 
 header("Last-Modified: " . gmdate( "D, j M Y H:i:s" ) . " GMT" );
 header("Expires: " . gmdate( "D, j M Y H:i:s", time() ) . " GMT" );
-header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0" ); // HTTP/1.1
+header("Cache-Control: no-cache, no-store, must-revalidate" ); // HTTP/1.1
 header("Pragma: no-cache"); // HTTP/1.0
 header("Content-type: image/svg+xml");
 

--- a/usr/local/www/guiconfig.inc
+++ b/usr/local/www/guiconfig.inc
@@ -47,8 +47,7 @@ if(!$nocsrf) {
 if (!$omit_nocacheheaders) {
 	header("Expires: 0");
 	header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-	header("Cache-Control: no-store, no-cache, must-revalidate");
-	header("Cache-Control: post-check=0, pre-check=0", false);
+	header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0");
 	header("Pragma: no-cache");
 }
 

--- a/usr/local/www/guiconfig.inc
+++ b/usr/local/www/guiconfig.inc
@@ -47,7 +47,7 @@ if(!$nocsrf) {
 if (!$omit_nocacheheaders) {
 	header("Expires: 0");
 	header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-	header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0");
+	header("Cache-Control: no-cache, no-store, must-revalidate");
 	header("Pragma: no-cache");
 }
 

--- a/usr/local/www/ifstats.php
+++ b/usr/local/www/ifstats.php
@@ -54,11 +54,10 @@
 
 	$temp = gettimeofday();
 	$timing = (double)$temp["sec"] + (double)$temp["usec"] / 1000000.0;
-	
+
 	header("Last-Modified: " . gmdate( "D, j M Y H:i:s" ) . " GMT" );
 	header("Expires: " . gmdate( "D, j M Y H:i:s", time() ) . " GMT" );
-	header("Cache-Control: no-store, no-cache, must-revalidate" ); // HTTP/1.1
-	header("Cache-Control: post-check=0, pre-check=0", FALSE );
+	header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0" ); // HTTP/1.1
 	header("Pragma: no-cache"); // HTTP/1.0
 
 	echo "$timing|" . $ifinfo['inbytes'] . "|" . $ifinfo['outbytes'] . "\n";

--- a/usr/local/www/ifstats.php
+++ b/usr/local/www/ifstats.php
@@ -57,7 +57,7 @@
 
 	header("Last-Modified: " . gmdate( "D, j M Y H:i:s" ) . " GMT" );
 	header("Expires: " . gmdate( "D, j M Y H:i:s", time() ) . " GMT" );
-	header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0" ); // HTTP/1.1
+	header("Cache-Control: no-cache, no-store, must-revalidate" ); // HTTP/1.1
 	header("Pragma: no-cache"); // HTTP/1.0
 
 	echo "$timing|" . $ifinfo['inbytes'] . "|" . $ifinfo['outbytes'] . "\n";

--- a/usr/local/www/status_queues.php
+++ b/usr/local/www/status_queues.php
@@ -30,7 +30,7 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-/*	
+/*
 	pfSense_BUILDER_BINARIES:	/sbin/pfctl
 	pfSense_MODULE:	shaper
 */
@@ -44,14 +44,13 @@
 
 header("Last-Modified: " . gmdate( "D, j M Y H:i:s" ) . " GMT" );
 header("Expires: " . gmdate( "D, j M Y H:i:s", time() ) . " GMT" );
-header("Cache-Control: no-store, no-cache, must-revalidate" ); // HTTP/1.1
-header("Cache-Control: post-check=0, pre-check=0", FALSE );
+header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0" ); // HTTP/1.1
 header("Pragma: no-cache"); // HTTP/1.0
 
 require("guiconfig.inc");
 class QueueStats {
 	public $queuename;
-	public $queuelength;	
+	public $queuelength;
 	public $pps;
 	public $bandwidth;
 	public $borrows;
@@ -59,7 +58,7 @@ class QueueStats {
 	public $drops;
 }
 if (!file_exists("{$g['varrun_path']}/qstats.pid") || !isvalidpid("{$g['varrun_path']}/qstats.pid")) {
-	/* Start in the background so we don't hang up the GUI */	
+	/* Start in the background so we don't hang up the GUI */
 	mwexec_bg("/usr/local/sbin/qstats -p {$g['varrun_path']}/qstats.pid");
 	/* Give it a moment to start up */
 	sleep(1);
@@ -77,7 +76,7 @@ $fd = @fsockopen("unix://{$g['varrun_path']}/qstats");
 	if ($altqstats == -1)
 		$error = "No queue statistics could be read.";
 }
-if ($_REQUEST['getactivity']) {	
+if ($_REQUEST['getactivity']) {
 	$statistics = array();
 	$bigger_stat = 0;
 	$stat_type = $_REQUEST['stats'];
@@ -99,7 +98,7 @@ if ($_REQUEST['getactivity']) {
 			if ($bigger_stat < $q->bandwidth)
 				$bigger_stat = $q->bandwidth;
 		}
-	}	
+	}
 	$finscript = "";
 	foreach($statistics as $q) {
 		if ($stat_type == "0")
@@ -176,9 +175,9 @@ if(!is_array($config['shaper']['queue']) || count($config['shaper']['queue']) < 
 		<td class="listhdr" width="1%"><?=gettext("Borrows"); ?></td>
 		<td class="listhdr" width="1%"><?=gettext("Suspends"); ?></td>
 		<td class="listhdr" width="1%"><?=gettext("Drops"); ?></td>
-		<td class="listhdr" width="1%"><?=gettext("Length"); ?></td>		
+		<td class="listhdr" width="1%"><?=gettext("Length"); ?></td>
 	</tr>
-	<?php 
+	<?php
 	$if_queue_list = get_configured_interface_list_by_realif(false, true);
 	processQueues($altqstats, 0, "")?>
 <?php endif; ?>
@@ -203,7 +202,7 @@ if(!is_array($config['shaper']['queue']) || count($config['shaper']['queue']) < 
 <?php include("fend.inc"); ?>
 </body>
 </html>
-<?php 
+<?php
 function processQueues($altqstats, $level, $parent_name){
 	global $g;
 	global $if_queue_list;
@@ -252,7 +251,7 @@ function processQueues($altqstats, $level, $parent_name){
 			echo "<td width=\"1%\" bgcolor=\"#{$row_background}\"><input style='border: 0px solid white; background-color:#{$row_background}; color:#000000;width:70px;text-align:right;' size='10' name='queue{$q['name']}{$q['interface']}borrows' id='queue{$q['name']}{$q['interface']}borrows' value='' align='right' /></td>";
 			echo "<td width=\"1%\" bgcolor=\"#{$row_background}\"><input style='border: 0px solid white; background-color:#{$row_background}; color:#000000;width:70px;text-align:right;' size='10' name='queue{$q['name']}{$q['interface']}suspends' id='queue{$q['name']}{$q['interface']}suspends' value='' align='right' /></td>";
 			echo "<td width=\"1%\" bgcolor=\"#{$row_background}\"><input style='border: 0px solid white; background-color:#{$row_background}; color:#000000;width:70px;text-align:right;' size='10' name='queue{$q['name']}{$q['interface']}drops' id='queue{$q['name']}{$q['interface']}drops' value='' align='right' /></td>";
-			echo "<td width=\"1%\" bgcolor=\"#{$row_background}\"><input style='border: 0px solid white; background-color:#{$row_background}; color:#000000;width:70px;text-align:right;' size='10' name='queue{$q['name']}{$q['interface']}length' id='queue{$q['name']}{$q['interface']}length' value='' align='right' /></td>";			
+			echo "<td width=\"1%\" bgcolor=\"#{$row_background}\"><input style='border: 0px solid white; background-color:#{$row_background}; color:#000000;width:70px;text-align:right;' size='10' name='queue{$q['name']}{$q['interface']}length' id='queue{$q['name']}{$q['interface']}length' value='' align='right' /></td>";
 			?>
 		</tr>
 		<?php
@@ -266,7 +265,7 @@ function statsQueues($xml){
 	$current = new QueueStats();
 	$child = new QueueStats();
 	$current->queuename = $xml['name'] . $xml['interface'];
-	$current->queuelength = $xml['qlength'];		
+	$current->queuelength = $xml['qlength'];
 	$current->pps = $xml['measured'];
 	$current->bandwidth = $xml['measuredspeedint'];
 	$current->borrows = intval($xml['borrows']);

--- a/usr/local/www/status_queues.php
+++ b/usr/local/www/status_queues.php
@@ -44,7 +44,7 @@
 
 header("Last-Modified: " . gmdate( "D, j M Y H:i:s" ) . " GMT" );
 header("Expires: " . gmdate( "D, j M Y H:i:s", time() ) . " GMT" );
-header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0" ); // HTTP/1.1
+header("Cache-Control: no-cache, no-store, must-revalidate" ); // HTTP/1.1
 header("Pragma: no-cache"); // HTTP/1.0
 
 require("guiconfig.inc");

--- a/usr/local/www/status_rrd_graph_img.php
+++ b/usr/local/www/status_rrd_graph_img.php
@@ -28,7 +28,7 @@
 	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
-/*	
+/*
 	pfSense_BUILDER_BINARIES:	/bin/rm	/usr/local/bin/rrdtool
 	pfSense_MODULE:	system
 */
@@ -554,11 +554,11 @@ elseif(strstr($curdatabase, "-throughput.rrd")) {
 		$g++;
 	}
 	$graphcmd .= "CDEF:\"tput-in_bits_pass={$graphtputbip}{$operand}\" ";
-	$graphcmd .= "CDEF:\"tput-out_bits_pass={$graphtputbop}{$operand}\" "; 
+	$graphcmd .= "CDEF:\"tput-out_bits_pass={$graphtputbop}{$operand}\" ";
 	$graphcmd .= "CDEF:\"tput-bits_io_pass={$graphtputbtp}{$operand}\" ";
 
 	$graphcmd .= "CDEF:\"tput-in_bits_block={$graphtputbib}{$operand}\" ";
-	$graphcmd .= "CDEF:\"tput-out_bits_block={$graphtputbob}{$operand}\" "; 
+	$graphcmd .= "CDEF:\"tput-out_bits_block={$graphtputbob}{$operand}\" ";
 	$graphcmd .= "CDEF:\"tput-bits_io_block={$graphtputbtb}{$operand}\" ";
 
 	$graphcmd .= "CDEF:\"tput-out_bits_pass_neg=tput-out_bits_pass,$multiplier,*\" ";
@@ -996,7 +996,7 @@ elseif((strstr($curdatabase, "-queues.rrd")) && (file_exists("$rrddbpath$curdata
 	$graphcmd .= "--height 200 --width 620 ";
 	if ($altq) {
 		$a_queues =& $altq->get_queue_list();
-		$t = 0; 
+		$t = 0;
 	} else {
 		$a_queues = array();
 		$i = 0;
@@ -1155,7 +1155,7 @@ elseif((strstr($curdatabase, "-loggedin.rrd")) && (file_exists("$rrddbpath$curda
 	$graphcmd .= "AREA:\"$curif-totalusers_d#{$colorcaptiveportalusers[0]}:Total logged in users\" ";
 	$graphcmd .= "GPRINT:\"$curif-totalusers_d:MAX:%8.0lf \\n\" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t" . strftime('%b %d %H\:%M\:%S %Y') . "\" ";	
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t" . strftime('%b %d %H\:%M\:%S %Y') . "\" ";
 }
 elseif((strstr($curdatabase, "-concurrent.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for online Captive Portal users stats */
@@ -1177,7 +1177,7 @@ elseif((strstr($curdatabase, "-concurrent.rrd")) && (file_exists("$rrddbpath$cur
 	$graphcmd .= "GPRINT:\"$curif-concurrentusers:AVERAGE:%8.0lf      \" ";
 	$graphcmd .= "GPRINT:\"$curif-concurrentusers:MAX:%8.0lf \" ";
 	$graphcmd .= "COMMENT:\"\\n\" ";
-	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t" . strftime('%b %d %H\:%M\:%S %Y') . "\" ";	
+	$graphcmd .= "COMMENT:\"\t\t\t\t\t\t\t\t\t\t\t\t\t" . strftime('%b %d %H\:%M\:%S %Y') . "\" ";
 }
 elseif((strstr($curdatabase, "ntpd.rrd")) && (file_exists("$rrddbpath$curdatabase"))) {
 	/* define graphcmd for ntpd (was: mbuf) usage stats */
@@ -1226,7 +1226,7 @@ elseif((strstr($curdatabase, "ntpd.rrd")) && (file_exists("$rrddbpath$curdatabas
 else {
 	$data = false;
 	log_error(sprintf(gettext("Sorry we do not have data to graph for %s"),$curdatabase));
-} 
+}
 
 /* check modification time to see if we need to generate image */
 if (file_exists("$rrdtmppath$curdatabase-$curgraph.png")) {
@@ -1236,7 +1236,7 @@ if (file_exists("$rrdtmppath$curdatabase-$curgraph.png")) {
 			$graphcmdoutput = implode(" ", $graphcmdoutput) . $graphcmd;
 			flush();
 			usleep(500);
-	}			
+	}
 } else {
 	if($data)
 		$_gb = exec("$graphcmd 2>&1", $graphcmdoutput, $graphcmdreturn);
@@ -1263,8 +1263,7 @@ if(($graphcmdreturn <> 0) || (! $data)) {
 	header("Content-type: image/png");
 	header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
 	header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-	header("Cache-Control: no-store, no-cache, must-revalidate");
-	header("Cache-Control: post-check=0, pre-check=0", false);
+	header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0");
 	header("Pragma: no-cache");
 	$file= "/usr/local/www/themes/{$g['theme']}/images/misc/rrd_error.png";
 	readfile($file);
@@ -1274,8 +1273,7 @@ if(($graphcmdreturn <> 0) || (! $data)) {
 		header("Content-type: image/png");
 		header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
 		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-		header("Cache-Control: no-store, no-cache, must-revalidate");
-		header("Cache-Control: post-check=0, pre-check=0", false);
+		header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0");
 		header("Pragma: no-cache");
 		readfile($file);
 	}

--- a/usr/local/www/status_rrd_graph_img.php
+++ b/usr/local/www/status_rrd_graph_img.php
@@ -1263,7 +1263,7 @@ if(($graphcmdreturn <> 0) || (! $data)) {
 	header("Content-type: image/png");
 	header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
 	header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-	header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0");
+	header("Cache-Control: no-cache, no-store, must-revalidate");
 	header("Pragma: no-cache");
 	$file= "/usr/local/www/themes/{$g['theme']}/images/misc/rrd_error.png";
 	readfile($file);
@@ -1273,7 +1273,7 @@ if(($graphcmdreturn <> 0) || (! $data)) {
 		header("Content-type: image/png");
 		header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
 		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-		header("Cache-Control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0");
+		header("Cache-Control: no-cache, no-store, must-revalidate");
 		header("Pragma: no-cache");
 		readfile($file);
 	}


### PR DESCRIPTION
Sorted by RFC 2616:

Section 14.9.1 `no-cache`
Section 14.9.2 `no-store`
Section 14.9.4 `must-revalidate`

Combined into one line with IE's `pre-check` and `post-check`.  However, when both are set to `0`, both are entirely ignored:

http://blogs.msdn.com/b/ieinternals/archive/2009/07/20/using-post_2d00_check-and-pre_2d00_check-cache-directives.aspx