### PR TITLE
Edit gateway max weight

### DIFF
--- a/usr/local/www/system_gateways_edit.php
+++ b/usr/local/www/system_gateways_edit.php
@@ -754,7 +754,7 @@ function enable_change() {
 								<td width="78%" class="vtable">
 									<select name='weight' class='formfldselect' id='weight'>
 									<?php
-										for ($i = 1; $i < 6; $i++) {
+										for ($i = 1; $i < 21; $i++) {
 											$selected = "";
 											if ($pconfig['weight'] == $i)
 												$selected = "selected='selected'";


### PR DESCRIPTION
Useful for load balancing, where you have more than a 5:1 difference in gateway speed.

In my case, this is required for balancing CABLE & ADSL WAN connections properly, where I need to set the CABLE weight to 8, which is higher than the current maximum (5)