### PR TITLE
Fix unbound warning when dnsallowoverride off and forwarding on

### DIFF
--- a/etc/inc/unbound.inc
+++ b/etc/inc/unbound.inc
@@ -243,6 +243,8 @@ EOF;
 					$dnsservers[] = $nameserver;
 				}
 			}
+		} else {
+			$ns = array();
 		}
 		$sys_dnsservers = array_unique(get_dns_servers());
 		foreach ($sys_dnsservers as $sys_dnsserver) {


### PR DESCRIPTION
Reported in forum: https://forum.pfsense.org/index.php?topic=92437.0

The $ns array was being used further down, but if dnsallowoverride was off, the array never got created.