### PR TITLE
Make auth_get_authserver_list available to vpn.inc

### DIFF
--- a/etc/rc.newipsecdns
+++ b/etc/rc.newipsecdns
@@ -37,6 +37,7 @@ require_once("gwlb.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");
+require_once("auth.inc");
 require_once("ipsec.inc");
 require_once("vpn.inc");
 


### PR DESCRIPTION
This is a follow-up to PR #1612 and avoids a crash in /etc/rc.newipsecdns at random times.