### PR TITLE
Fix #4640 IPsec Auto-exclude LAN address toggles

### DIFF
--- a/usr/local/www/vpn_ipsec_settings.php
+++ b/usr/local/www/vpn_ipsec_settings.php
@@ -376,7 +376,7 @@ function maxmss_checked(obj) {
 					<tr>
 						<td width="22%" valign="top" class="vncell"><?=gettext("Auto-exclude LAN address"); ?></td>
 						<td width="78%" class="vtable">
-							<input name="noshuntlaninterfaces" type="checkbox" id="noshuntlaninterfaces" value="yes" <?php if (!$pconfig['noshuntlaninterfaces'] == true) echo "checked=\"checked\""; ?> />
+							<input name="noshuntlaninterfaces" type="checkbox" id="noshuntlaninterfaces" value="yes" <?php if ($pconfig['noshuntlaninterfaces'] == true) echo "checked=\"checked\""; ?> />
 							<strong><?=gettext("Enable bypass for LAN interface IP"); ?></strong>
 							<br />
 							<?=gettext("Exclude traffic from LAN subnet to LAN IP address from IPsec."); ?>


### PR DESCRIPTION
every time save is pressed.
Actually the GUI is displaying the opposite setting to what is in the config. When the user pressed save that opposite setting was saved, but then again it displays the opposite of the opposite...