### PR TITLE
Clarify switch case statement

### DIFF
--- a/etc/inc/ipsec.inc
+++ b/etc/inc/ipsec.inc
@@ -675,16 +675,16 @@ function ipsec_find_id(& $ph1ent, $side = "local", $rgmap = array()) {
 		$thisid_data = $rgmap[$ph1ent['remote-gateway']];
 		break;
 
-	case "address";
+	case "address":
 		$thisid_data = $id_data;
 		break;
 
-	case "fqdn";
-	case "keyid tag";
-	case "user_fqdn";
+	case "fqdn":
+	case "keyid tag":
+	case "user_fqdn":
 		$thisid_data = $id_data;
 		break;
-	case "asn1dn";
+	case "asn1dn":
 		$thisid_data = $id_data;
 		if( $thisid_data && $thisid_data[0] != '"')
 			$thisid_data = "\"{$thisid_data}\"";


### PR DESCRIPTION
Ermal made these semi-colons into colons on master some time ago with https://github.com/pfsense/pfsense/commit/83b8ed6b2bec13d3b60acd9bd4786e5a7df4de90 which also references bug 4202. For some reason that change did not get into RELENG_2_2.
Actually semi-colon is legal syntax (surprised me) so I do not see how that commit really changed anything.
In any case, using semi-colon here is so unusual that it seems good to fix it up in RELENG_2_2, hence this pull request.
If https://github.com/pfsense/pfsense/pull/1626 is also cherry-picked into RELENG_2_2 that will get rid of the remaining places where switch-case-semicolon appears in the code.