### PR TITLE
Fall back to getting local user pages and groups

### DIFF
--- a/etc/inc/priv.inc
+++ b/etc/inc/priv.inc
@@ -292,13 +292,14 @@ function getAllowedPages($username) {
 	// obtain ldap groups if we are in ldap mode
 	if ($authcfg['type'] == "ldap") {
 		$allowed_groups = @ldap_get_groups($username, $authcfg);
-	} else {
+	}
+	if (!$allowed_groups) {
 		// search for a local user by name
 		$local_user = getUserEntry($username);
-		getPrivPages($local_user, $allowed_pages);
 
-		// obtain local groups if we have a local user
+		// obtain local user pages and groups if we have a local user
 		if ($local_user) {
+			getPrivPages($local_user, $allowed_pages);
 			$allowed_groups = local_user_get_groups($local_user);
 		}
 	}


### PR DESCRIPTION
if the groups could not be found from LDAP and there is a local user.
Forum: https://forum.pfsense.org/index.php?topic=80169.0
The code to authenticate a user already falls back to checking the local user database when a user did not authenticate OK with LDAP (user does not exist in LDAP, LDAP server cannot be contacted,...). But then getAllowedPages only uses LDAP to find out the groups that the user is in.This results in the user login succeeding but a message being displayed "No page assigned to this user! Click here to logout."
If the user is not in LDAP, but is actually a local user, then it needs to check locally for pages and groups.
The only trick I can see here is if there is a user in LDAP and in the local system with the same username, then if something unexpected happens during ldap_get_groups the code will now check for local pages and groups - so the user will get potentially different page access if the LDAP server is up or down. But I guess that is true about the existing login authentication also - you can have an LDAP "user1" password "abc123" and a local "user1" password "xyz456" - if the LDAP server is up then password "abc123" is required. If the LDAP server is down then password "xyz456" has to be used.
So give this a bit of thought in case there might be some other odd case that might grant unexpected access to pages in some set of LDAP server up/down/bouncing-around conditions.