### PR TITLE
Do not process dhcpd implementation if input errors

### DIFF
--- a/usr/local/www/services_dhcp.php
+++ b/usr/local/www/services_dhcp.php
@@ -536,7 +536,7 @@ if (isset($_POST['submit'])) {
 	}
 }
 
-if (isset($_POST['submit']) || isset($_POST['apply'])) {
+if ((isset($_POST['submit']) || isset($_POST['apply'])) && (!$input_errors)) {
 	$retval = 0;
 	$retvaldhcp = 0;
 	$retvaldns = 0;


### PR DESCRIPTION
If I go to Service->DHCP Server, make some edits that are invalid (e.g. change range start or end to some invalid string) and press Save then the page comes back displaying the input error(s). But it also says:
"The changes have been applied successfully."
Actually, the changes (which were invalid) have not been applied to the config - all is well there - but dhcpd has been stopped and started and dnsmasq or unbound has been kicked... which is all unnecessary processing since the user has not yet provided valid values to save.