### PR TITLE
Add static mapping interface not set when IP in a pool

### DIFF
--- a/usr/local/www/status_dhcp_leases.php
+++ b/usr/local/www/status_dhcp_leases.php
@@ -371,6 +371,17 @@ foreach ($leases as $data) {
 					$data['if'] = $dhcpif;
 					break;
 				}
+				// Check if the IP is in the range of any DHCP pools
+				if (is_array($dhcpifconf['pool'])) {
+					foreach ($dhcpifconf['pool'] as $dhcppool) {
+						if (is_array($dhcppool['range'])) {
+							if (($lip >= ip2ulong($dhcppool['range']['from'])) && ($lip <= ip2ulong($dhcppool['range']['to']))) {
+								$data['if'] = $dhcpif;
+								break 2;
+							}
+						}
+					}
+				}
 			}
 		}
 		echo "<tr>\n";


### PR DESCRIPTION
If the DHCP IP address is in a pool (not in the main DHCP range for the interface) then the interface that corresponds to the IP address is not found. This results in the link to "add static mapping for this MAC address" not having any value for "if=" and thus clicking on the "+" button does not work.
Reported in redmine bug #4649
Process any pools when checking for which interface contains the IP address.