### PR TITLE
Fix DHCPv6 Dynamic DNS

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -1307,6 +1307,7 @@ EOD;
 			if ($dhcpv6ifconf['ddnsdomain'] <> "") {
 				$dnscfgv6 .= "	ddns-domainname \"{$dhcpv6ifconf['ddnsdomain']}\";\n";
 			}
+			$dnscfgv6 .= "	deny client-updates;\n";
 			$dnscfgv6 .= "	ddns-update-style interim;\n";
 			$nsupdate = true;
 		}
@@ -1327,19 +1328,25 @@ EOD;
 			}
 		}
 
-		if ($dhcpv6ifconf['domain']) {
-			$newzone = array();
-			$newzone['domain-name'] = $dhcpv6ifconf['domain'];
-			$newzone['dns-servers'][] = $dhcpv6ifconf['ddnsdomainprimary'];
-			$ddns_zones[] = $newzone;
+		if (!is_ipaddrv6($ifcfgipv6)) {
+			$ifcfgsnv6 = "64";
+			$subnetv6 = gen_subnetv6($dhcpv6ifconf['range']['from'], $ifcfgsnv6);
 		}
 
-		if (is_ipaddrv6($ifcfgipv6)) {
-			$dhcpdv6conf .= "subnet6 {$subnetv6}/{$ifcfgsnv6}";
-		} else {
-			$subnet6 = gen_subnetv6($dhcpv6ifconf['range']['from'], "64");
-			$dhcpdv6conf .= "subnet6 {$subnet6}/64";
+		$dhcpdv6conf .= "subnet6 {$subnetv6}/{$ifcfgsnv6}";
+
+		if ($dhcpv6ifconf['ddnsdomain']) {
+			$newzone = array();
+			$newzone['domain-name'] = $dhcpv6ifconf['ddnsdomain'];
+			$newzone['dns-servers'][] = $dhcpv6ifconf['ddnsdomainprimary'];
+			$ddns_zones[] = $newzone;
+			$reversezone = array();
+			$unpacked = unpack('H*hex', inet_pton($subnetv6));
+			$reversezone['domain-name'] = implode('.', array_reverse(str_split(substr($unpacked['hex'], 0, 16)))).'.ip6.arpa';
+			$reversezone['dns-servers'][] = $dhcpv6ifconf['ddnsdomainprimary'];
+			$ddns_zones[] = $reversezone;
 		}
+
 		$dhcpdv6conf .= " {\n";
 
 		$dhcpdv6conf .= <<<EOD
@@ -1437,7 +1444,7 @@ EOD;
 			}
 		}
 
-		if ($dhcpv6ifconf['domain']) {
+		if ($dhcpv6ifconf['ddnsdomain']) {
 			$dhcpdv6conf .= dhcpdkey($dhcpv6ifconf);
 			$dhcpdv6conf .= dhcpdzones($ddns_zones, $dhcpv6ifconf);
 		}

--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -1307,7 +1307,7 @@ EOD;
 			if ($dhcpv6ifconf['ddnsdomain'] <> "") {
 				$dnscfgv6 .= "	ddns-domainname \"{$dhcpv6ifconf['ddnsdomain']}\";\n";
 			}
-			$dnscfgv6 .= "	deny client-updates;\n";
+			$dnscfgv6 .= "	{$dhcpv6ifconf['ddnsclientupdates']} client-updates;\n";
 			$dnscfgv6 .= "	ddns-update-style interim;\n";
 			$nsupdate = true;
 		}

--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -1308,8 +1308,9 @@ EOD;
 				$dnscfgv6 .= "	ddns-domainname \"{$dhcpv6ifconf['ddnsdomain']}\";\n";
 			}
 			$dnscfgv6 .= "	{$dhcpv6ifconf['ddnsclientupdates']} client-updates;\n";
-			$dnscfgv6 .= "	ddns-update-style interim;\n";
 			$nsupdate = true;
+		} else {
+			$dnscfgv6 .= "	do-forward-updates false;\n";
 		}
 
 		if (is_array($dhcpv6ifconf['dnsserver']) && ($dhcpv6ifconf['dnsserver'][0])) {
@@ -1335,16 +1336,18 @@ EOD;
 
 		$dhcpdv6conf .= "subnet6 {$subnetv6}/{$ifcfgsnv6}";
 
-		if ($dhcpv6ifconf['ddnsdomain']) {
+		if (isset($dhcpv6ifconf['ddnsupdate']) && $dhcpv6ifconf['ddnsdomain']) {
 			$newzone = array();
 			$newzone['domain-name'] = $dhcpv6ifconf['ddnsdomain'];
 			$newzone['dns-servers'][] = $dhcpv6ifconf['ddnsdomainprimary'];
 			$ddns_zones[] = $newzone;
-			$reversezone = array();
-			$unpacked = unpack('H*hex', inet_pton($subnetv6));
-			$reversezone['domain-name'] = implode('.', array_reverse(str_split(substr($unpacked['hex'], 0, 16)))).'.ip6.arpa';
-			$reversezone['dns-servers'][] = $dhcpv6ifconf['ddnsdomainprimary'];
-			$ddns_zones[] = $reversezone;
+			if (isset($dhcpv6ifconf['ddnsreverse'])) {
+				$reversezone = array();
+				$unpacked = unpack('H*hex', inet_pton($subnetv6));
+				$reversezone['domain-name'] = implode('.', array_reverse(str_split(substr($unpacked['hex'], 0, 16)))).'.ip6.arpa';
+				$reversezone['dns-servers'][] = $dhcpv6ifconf['ddnsdomainprimary'];
+				$ddns_zones[] = $reversezone;
+			}
 		}
 
 		$dhcpdv6conf .= " {\n";
@@ -1352,7 +1355,6 @@ EOD;
 		$dhcpdv6conf .= <<<EOD
 	range6 {$dhcpv6ifconf['range']['from']} {$dhcpv6ifconf['range']['to']};
 $dnscfgv6
-
 EOD;
 
 		if (is_ipaddrv6($dhcpv6ifconf['prefixrange']['from']) && is_ipaddrv6($dhcpv6ifconf['prefixrange']['to'])) {
@@ -1444,7 +1446,7 @@ EOD;
 			}
 		}
 
-		if ($dhcpv6ifconf['ddnsdomain']) {
+		if (isset($dhcpv6ifconf['ddnsupdate']) && $dhcpv6ifconf['ddnsdomain']) {
 			$dhcpdv6conf .= dhcpdkey($dhcpv6ifconf);
 			$dhcpdv6conf .= dhcpdzones($ddns_zones, $dhcpv6ifconf);
 		}

--- a/usr/local/www/services_dhcpv6.php
+++ b/usr/local/www/services_dhcpv6.php
@@ -113,6 +113,7 @@ if (is_array($config['dhcpdv6'][$if])){
 	if (empty($pconfig['ddnsclientupdates'])) {
 		$pconfig['ddnsclientupdates'] = 'allow';
 	}
+	$pconfig['ddnsreverse'] = isset($config['dhcpdv6'][$if]['ddnsreverse']);
 	$pconfig['ddnsupdate'] = isset($config['dhcpdv6'][$if]['ddnsupdate']);
 	list($pconfig['ntp1'],$pconfig['ntp2']) = $config['dhcpdv6'][$if]['ntpserver'];
 	$pconfig['tftp'] = $config['dhcpdv6'][$if]['tftp'];
@@ -309,6 +310,7 @@ if ($_POST) {
 		$config['dhcpdv6'][$if]['ddnsdomainkeyname'] = $_POST['ddnsdomainkeyname'];
 		$config['dhcpdv6'][$if]['ddnsdomainkey'] = $_POST['ddnsdomainkey'];
 		$config['dhcpdv6'][$if]['ddnsclientupdates'] = $_POST['ddnsclientupdates'];
+		$config['dhcpdv6'][$if]['ddnsreverse'] = ($_POST['ddnsreverse']) ? true : false;
 		$config['dhcpdv6'][$if]['ddnsupdate'] = ($_POST['ddnsupdate']) ? true : false;
 
 		unset($config['dhcpdv6'][$if]['ntpserver']);
@@ -347,8 +349,10 @@ if ($_POST) {
 			}
 		} else if (isset($config['unbound']['enable']) && isset($config['unbound']['regdhcpstatic'])) {
 			$retvaldns = services_unbound_configure();
-			if ($retvaldns == 0)
+			if ($retvaldns == 0) {
 				clear_subsystem_dirty('unbound');
+				clear_subsystem_dirty('staticmaps');
+			}
 		} else {
 			$retvaldhcp = services_dhcpd_configure();
 			if ($retvaldhcp == 0)
@@ -719,7 +723,9 @@ display_top_tabs($tab_array);
 					<input name="ddnsclientupdates" type="radio" class="formfld unknown" id="ddnsclientupdates" size="20" value="allow" <?php if($pconfig['ddnsclientupdates'] == 'allow') echo " checked=\"checked\""; ?> >Allow</input>
 					<input name="ddnsclientupdates" type="radio" class="formfld unknown" id="ddnsclientupdates" size="20" value="deny" <?php if($pconfig['ddnsclientupdates'] == 'deny') echo " checked=\"checked\""; ?> >Deny</input>
 					<input name="ddnsclientupdates" type="radio" class="formfld unknown" id="ddnsclientupdates" size="20" value="ignore" <?php if($pconfig['ddnsclientupdates'] == 'ignore') echo " checked=\"checked\""; ?> >Ignore</input><br />
-					<?=gettext("How Forward entries are handled when client indicates they wish to update DNS.  Allow prevents DHCP from updating Forward entries, Deny indicates that DHCP will do the updates and the client should not, Ignore specifies that DHCP will do the update and the client can also attempt the update usually using a different domain name.");?>
+					<?=gettext("How Forward entries are handled when client indicates they wish to update DNS.  Allow prevents DHCP from updating Forward entries, Deny indicates that DHCP will do the updates and the client should not, Ignore specifies that DHCP will do the update and the client can also attempt the update usually using a different domain name.");?><br />
+					<input style="vertical-align:middle" type="checkbox" name="ddnsreverse" id="ddnsreverse" <?php if($pconfig['ddnsreverse']) echo " checked=\"checked\""; ?> />&nbsp;
+					<?=gettext("Add reverse DNS entries.");?>
 					</p>
 				</div>
 			</td>

--- a/usr/local/www/services_dhcpv6.php
+++ b/usr/local/www/services_dhcpv6.php
@@ -109,6 +109,10 @@ if (is_array($config['dhcpdv6'][$if])){
 	$pconfig['ddnsdomainprimary'] = $config['dhcpdv6'][$if]['ddnsdomainprimary'];
 	$pconfig['ddnsdomainkeyname'] = $config['dhcpdv6'][$if]['ddnsdomainkeyname'];
 	$pconfig['ddnsdomainkey'] = $config['dhcpdv6'][$if]['ddnsdomainkey'];
+	$pconfig['ddnsclientupdates'] = $config['dhcpdv6'][$if]['ddnsclientupdates'];
+	if (empty($pconfig['ddnsclientupdates'])) {
+		$pconfig['ddnsclientupdates'] = 'allow';
+	}
 	$pconfig['ddnsupdate'] = isset($config['dhcpdv6'][$if]['ddnsupdate']);
 	list($pconfig['ntp1'],$pconfig['ntp2']) = $config['dhcpdv6'][$if]['ntpserver'];
 	$pconfig['tftp'] = $config['dhcpdv6'][$if]['tftp'];
@@ -304,6 +308,7 @@ if ($_POST) {
 		$config['dhcpdv6'][$if]['ddnsdomainprimary'] = $_POST['ddnsdomainprimary'];
 		$config['dhcpdv6'][$if]['ddnsdomainkeyname'] = $_POST['ddnsdomainkeyname'];
 		$config['dhcpdv6'][$if]['ddnsdomainkey'] = $_POST['ddnsdomainkey'];
+		$config['dhcpdv6'][$if]['ddnsclientupdates'] = $_POST['ddnsclientupdates'];
 		$config['dhcpdv6'][$if]['ddnsupdate'] = ($_POST['ddnsupdate']) ? true : false;
 
 		unset($config['dhcpdv6'][$if]['ntpserver']);
@@ -710,7 +715,11 @@ display_top_tabs($tab_array);
 					<input name="ddnsdomainkeyname" type="text" class="formfld unknown" id="ddnsdomainkeyname" size="20" value="<?=htmlspecialchars($pconfig['ddnsdomainkeyname']);?>" /><br />
 					<?=gettext("Enter the dynamic DNS domain key name which will be used to register client names in the DNS server.");?><br />
 					<input name="ddnsdomainkey" type="text" class="formfld unknown" id="ddnsdomainkey" size="20" value="<?=htmlspecialchars($pconfig['ddnsdomainkey']);?>" /><br />
-					<?=gettext("Enter the dynamic DNS domain key secret which will be used to register client names in the DNS server.");?>
+					<?=gettext("Enter the dynamic DNS domain key secret which will be used to register client names in the DNS server.");?><br />
+					<input name="ddnsclientupdates" type="radio" class="formfld unknown" id="ddnsclientupdates" size="20" value="allow" <?php if($pconfig['ddnsclientupdates'] == 'allow') echo " checked=\"checked\""; ?> >Allow</input>
+					<input name="ddnsclientupdates" type="radio" class="formfld unknown" id="ddnsclientupdates" size="20" value="deny" <?php if($pconfig['ddnsclientupdates'] == 'deny') echo " checked=\"checked\""; ?> >Deny</input>
+					<input name="ddnsclientupdates" type="radio" class="formfld unknown" id="ddnsclientupdates" size="20" value="ignore" <?php if($pconfig['ddnsclientupdates'] == 'ignore') echo " checked=\"checked\""; ?> >Ignore</input><br />
+					<?=gettext("How Forward entries are handled when client indicates they wish to update DNS.  Allow prevents DHCP from updating Forward entries, Deny indicates that DHCP will do the updates and the client should not, Ignore specifies that DHCP will do the update and the client can also attempt the update usually using a different domain name.");?>
 					</p>
 				</div>
 			</td>


### PR DESCRIPTION
There are three issues:
- The wrong domain was being used, domain instead of ddnsdomain.
- The option "deny client-updates" wasn't being set so forward entries weren't being added.
- No zone information was provided for reverse DNS.