### PR TITLE
Unmatched td in firewall_nat

### DIFF
--- a/usr/local/www/firewall_nat.php
+++ b/usr/local/www/firewall_nat.php
@@ -328,6 +328,7 @@ echo "<script type=\"text/javascript\" src=\"/javascript/domTT/fadomatic.js\"></
 			<td><a href="firewall_nat_edit.php?dup=<?=$i;?>"><img src="/themes/<?= $g['theme']; ?>/images/icons/icon_plus.gif" title="<?=gettext("add a new NAT based on this one");?>" width="17" height="17" border="0" alt="add" /></a></td>
                       </tr>
                     </table>
+			</td>
 		</tr>
   	     <?php $i++; $nnats++; endforeach; ?>
                 <tr>


### PR DESCRIPTION
This file seems to have an unmatched "td" ending. Adding the line here matches the "td" at line 320 and this embraces the little table that has the 4 icons in it in a square that comes at the right hand end of each port-forward entry in the main table.
I can't see any difference in the rendering of the page, at least on Firefox, with and without this fix.
The tabbing of this file is woeful. I am fixing that up with a code-style review. But thought I should do a separate pull request for this kind-of-functional fix.