### PR TITLE
Fix uniqeness 

### DIFF
--- a/usr/local/www/services_dhcp_edit.php
+++ b/usr/local/www/services_dhcp_edit.php
@@ -187,19 +187,19 @@ if ($_POST) {
 	}
 
 	/* check for overlaps */
-  foreach ($a_maps as $mapent) {
-    if (isset($id) && ($a_maps[$id]) && ($a_maps[$id] === $mapent))
-      continue;
-      /* The fully qualified hostname (hostname + '.' + domainname) must be unique.
-        The unqualified hostname does not have to be unique as long as the fully
-        qualified hostname is unique. */
+	foreach ($a_maps as $mapent) {
+		if (isset($id) && ($a_maps[$id]) && ($a_maps[$id] === $mapent))
+			continue;
+		/* The fully qualified hostname (hostname + '.' + domainname) must be unique.
+		 * The unqualified hostname does not have to be unique as long as the fully
+		 * qualified hostname is unique. */
 		$existingFqn = "{$mapent['hostname']}.{$mapent['domain']}";
-    $candidateFqn = "{$_POST['hostname']}.{$_POST['domain']}";
-    if ((($existingFqn == $candidateFqn) && $mapent['hostname']) || (($mapent['mac'] == $_POST['mac']) && $mapent['mac']) || (($mapent['ipaddr'] == $_POST['ipaddr']) && $mapent['ipaddr'] ) || (($mapent['cid'] == $_POST['cid']) && $mapent['cid'])) {
-      $input_errors[] = gettext("This fully qualified hostname (Hostname + Domainname), IP, MAC address or Client identifier already exists.");
-      break;
-    }
-  }
+		$candidateFqn = "{$_POST['hostname']}.{$_POST['domain']}";
+		if ((($existingFqn == $candidateFqn) && $mapent['hostname']) || (($mapent['mac'] == $_POST['mac']) && $mapent['mac']) || (($mapent['ipaddr'] == $_POST['ipaddr']) && $mapent['ipaddr'] ) || (($mapent['cid'] == $_POST['cid']) && $mapent['cid'])) {
+			$input_errors[] = gettext("This fully qualified hostname (Hostname + Domainname), IP, MAC address or Client identifier already exists.");
+			break;
+		}
+	}
 
 	/* make sure it's not within the dynamic subnet */
 	if ($_POST['ipaddr']) {

--- a/usr/local/www/services_dhcp_edit.php
+++ b/usr/local/www/services_dhcp_edit.php
@@ -187,15 +187,19 @@ if ($_POST) {
 	}
 
 	/* check for overlaps */
-	foreach ($a_maps as $mapent) {
-		if (isset($id) && ($a_maps[$id]) && ($a_maps[$id] === $mapent))
-			continue;
-
-		if ((($mapent['hostname'] == $_POST['hostname']) && $mapent['hostname'])  || (($mapent['mac'] == $_POST['mac']) && $mapent['mac']) || (($mapent['ipaddr'] == $_POST['ipaddr']) && $mapent['ipaddr'] ) || (($mapent['cid'] == $_POST['cid']) && $mapent['cid'])) {
-			$input_errors[] = gettext("This Hostname, IP, MAC address or Client identifier already exists.");
-			break;
-		}
-	}
+  foreach ($a_maps as $mapent) {
+    if (isset($id) && ($a_maps[$id]) && ($a_maps[$id] === $mapent))
+      continue;
+      /* The fully qualified hostname (hostname + '.' + domainname) must be unique.
+        The unqualified hostname does not have to be unique as long as the fully
+        qualified hostname is unique. */
+		$existingFqn = "{$mapent['hostname']}.{$mapent['domain']}";
+    $candidateFqn = "{$_POST['hostname']}.{$_POST['domain']}";
+    if ((($existingFqn == $candidateFqn) && $mapent['hostname']) || (($mapent['mac'] == $_POST['mac']) && $mapent['mac']) || (($mapent['ipaddr'] == $_POST['ipaddr']) && $mapent['ipaddr'] ) || (($mapent['cid'] == $_POST['cid']) && $mapent['cid'])) {
+      $input_errors[] = gettext("This fully qualified hostname (Hostname + Domainname), IP, MAC address or Client identifier already exists.");
+      break;
+    }
+  }
 
 	/* make sure it's not within the dynamic subnet */
 	if ($_POST['ipaddr']) {


### PR DESCRIPTION
Currently pfsense enforces unique unqualified hostnames for static dhcp leases, which is not correct as only the fully qualified hostname (hostname + domainname) must be unique. With this commit the old validation logic for uniqeness is modified such that hostnames no longer need to be unique and at the same time the fully qualified hostname hast to be unique.

This change makes it possible to have host with identical hostnames in different (sub)domains. For example myhost.sales.acme.com and myhost.support.acme.com will now be possible.