### PR TITLE
Firewall Rules Edit missing slash

### DIFF
--- a/usr/local/www/firewall_rules_edit.php
+++ b/usr/local/www/firewall_rules_edit.php
@@ -965,7 +965,7 @@ include("head.inc");
 				</select>
 				<input type="hidden" id="floating" name="floating" value="floating" />
 			</td>
-		<tr>
+		</tr>
 <?php endif; ?>
 		<tr>
 			<td width="22%" valign="top" class="vncellreq"><?=gettext("TCP/IP Version");?></td>


### PR DESCRIPTION
This should be the end of a "tr" here.
Browsers seem to be forgiving of this stuff - I don't see any difference in rendering in Firefox before or after this change.