### PR TITLE
Minor changes to firewall_shaper_layer7

### DIFF
--- a/usr/local/www/firewall_shaper_layer7.php
+++ b/usr/local/www/firewall_shaper_layer7.php
@@ -220,9 +220,6 @@ if (is_array($layer7_rules_list)) {
         }
 }
 $tree .= "</ul>";
-
-$output = "<table summary=\"output form\">";
-$output .= $output_form;
 $closehead = false;
 include("head.inc");
 ?>
@@ -435,8 +432,9 @@ function removeRow(tbl,row) {
 			</td>
 			<td width="75%" valign="top" align="center">
 			<div id="shaperarea" style="position:relative">
+			<table summary="output form">
 			<?php
-				echo $output;
+				echo $output_form;
 			?>
 
 			<!-- Layer 7 rules form -->
@@ -524,20 +522,18 @@ function removeRow(tbl,row) {
 								<?php foreach($avail_behaviours_action as $behaviour): ?>
 								<option value="<?=$behaviour ?>" <?php if ($behaviour == $l7rule->GetRBehaviour()) echo "selected=\"selected\""; ?>><?=$behaviour;?></option>
 								<?php endforeach; ?>
-								</select>
 							<?php endif; ?>
 							<?php if($l7rule->GetRStructure() == "queue"): ?>
 								<?php foreach($avail_behaviours_altq as $behaviour): ?>
 								<option value="<?=$behaviour ?>" <?php if ($behaviour == $l7rule->GetRBehaviour()) echo "selected=\"selected\""; ?>><?=$behaviour;?></option>
 								<?php endforeach; ?>
-								</select>
 							<?php endif; ?>
 							<?php if($l7rule->GetRStructure() == "limiter"): ?>
 								<?php foreach($avail_behaviours_limiter as $behaviour): ?>
 								<option value="<?=$behaviour ?>" <?php if ($behaviour == $l7rule->GetRBehaviour()) echo "selected=\"selected\""; ?>><?=$behaviour;?></option>
 								<?php endforeach; ?>
-								</select>
 							<?php endif; ?>
+							</select>
 						</td>
 						<td>
 							<a onclick="removeRow('maintable',this.parentNode.parentNode); return false;" href="#"><img border="0" src="/themes/<?=$g['theme'];?>/images/icons/icon_x.gif" alt="x" /></a>


### PR DESCRIPTION
The tabbing of this code is not so good, so it is difficult to see what is going on. I will format that in a later pull request.
These things look unbalanced but actually were not at run time. These changes make it easier to check the code in an editor that can show the balanced "table" "/table", "selected" "/selected".
1) Take the "table" start declaration out of the output form var that has been built up. Put it in-line in the code so it can be seen to match the "/table" now at line 575. $output var is no longer needed.
2) Remove 3 "/select" that were each inside an "if" statement. Put a single "/select" at the end. This makes it easy to see the matching "select" and "/select" and also ensures there will always be a "/select" written.

I thought these things were worth doing separate to code-style, as they are "real" changes. The L7 form still works in my testing.