### PR TITLE
Cleanup code logic status_upnp

### DIFF
--- a/usr/local/www/status_upnp.php
+++ b/usr/local/www/status_upnp.php
@@ -90,14 +90,15 @@ if(!$config['installedpackages'] || !$config['installedpackages']['miniupnpd']['
           <td width="10%" class="listhdrr"><?=gettext("Int. Port");?></td>
           <td width="50%" class="listhdr"><?=gettext("Description");?></td>
 		</tr>
-		<?php $i = 0; foreach ($rdr_entries as $rdr_entry) {
-			if (preg_match("/on (.*) inet proto (.*) from any to any port = (.*) keep state label \"(.*)\" rtable [0-9] -> (.*) port (.*)/", $rdr_entry, $matches))
+<?php
+	foreach ($rdr_entries as $rdr_entry) {
+		if (preg_match("/on (.*) inet proto (.*) from any to any port = (.*) keep state label \"(.*)\" rtable [0-9] -> (.*) port (.*)/", $rdr_entry, $matches)) {
 			$rdr_proto = $matches[2];
 			$rdr_port = $matches[3];
 			$rdr_label =$matches[4];
 			$rdr_ip = $matches[5];
 			$rdr_iport = $matches[6];
-		?>
+?>
         <tr>
           <td class="listlr">
 		<?php print $rdr_port;?>
@@ -115,7 +116,10 @@ if(!$config['installedpackages'] || !$config['installedpackages']['miniupnpd']['
 		<?php print $rdr_label;?>
           </td>
         </tr>
-        <?php $i++; }?>
+<?php
+		}
+	}
+?>
       </table>
      </td>
     </tr>


### PR DESCRIPTION
1) Variable $i is was set, incremented and not used.
2) "if preg_match" at line 94 had no curlies after it, so it was only applying to the first line after it ($rdr_proto = ...) It really looks like "if preg_match"should apply to the whole code chunk - setting the various "rdr*" vars and then spitting out the "tr" with the various matches values in the row.
Somebody with some various UPnP enabled and running should test this to see if the status page works (better) with this change.
I think it only makes a difference if $rdr_entries has some lines in it that do not match the regex - in that case the old code might have displayed some rubbish or (almost?) duplicated rows.