### PR TITLE
Fix startingat var name typo in pkg.php

### DIFF
--- a/usr/local/www/pkg.php
+++ b/usr/local/www/pkg.php
@@ -473,7 +473,7 @@ if ($pkg['tabs'] <> "") {
 						if($startingat > -1) {
 							$final_footer .=  "<a href='pkg.php?xml=" . $_REQUEST['xml'] . "&amp;startdisplayingat={$startingat}&amp;display_maximum_rows={$display_maximum_rows}'>";
 						} else {
-							if($startingnat > 1) 
+							if($startingat > 1) 
 								$final_footer .=  "<a href='pkg.php?xml=" . $_REQUEST['xml'] . "&amp;startdisplayingat=0&amp;display_maximum_rows={$display_maximum_rows}'>";
 						}
 						$final_footer .=  "<font size='2'><< Previous page</font></a>";


### PR DESCRIPTION
Even with this fix, the code does not make sense. The first test is:
if ($startingat > -1)

if it gets into the else, then $startingat must be negative. But the test in the "else" tests for >1 ???

Someone who knows what it really is supposed to do could fix it!