### PR TITLE
Fix tr use for combinedfields in pkg xml

### DIFF
--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -509,7 +509,7 @@ if ($pkg['tabs'] <> "") {
 		$size = "";
 		if (isset($pkga['dontdisplayname'])) {
 			$input="";
-			if (!isset($pkga['combinefields'])) {
+			if ($pkga['combinefields'] != "begin") {
 				$input .= "<tr valign='top' id='tr_{$pkga['fieldname']}'>";
 			}
 			if (isset($pkga['usecolspan2'])) {
@@ -528,7 +528,11 @@ if ($pkg['tabs'] <> "") {
 			if (isset($pkga['required'])) {
 				$req = 'req';
 			}
-			$input= "<tr><td valign='top' width=\"22%\" class=\"vncell{$req}\">";
+			$input="";
+			if ($pkga['combinefields'] != "begin") {
+				$input .= "<tr>";
+			}
+			$input .= "<td valign='top' width=\"22%\" class=\"vncell{$req}\">";
 			$input .= fixup_string($pkga['fielddescr']);
 			$input .= "</td>";
 			if (isset($pkga['advancedfield']) && isset($adv_filed_count)) {
@@ -539,7 +543,7 @@ if ($pkg['tabs'] <> "") {
 			}
 		}
 		if ($pkga['combinefields']=="begin") {
-			$input="<td class=\"vncell\"><table summary=\"advanced\">";
+			$input="<td class=\"vncell\"><table summary=\"advanced\"><tr>";
 			if (isset($pkga['advancedfield']) && isset($adv_filed_count)) {
 				$advanced .= $input;
 			} else {
@@ -997,14 +1001,13 @@ if ($pkg['tabs'] <> "") {
 		if ($pkga['typehint']) {
 			echo " " . $pkga['typehint'];
 		}
+		$input = "</td></tr>";
 		#check combinefields options
 		if (isset($pkga['combinefields'])) {
-			$input="</td>";
 			if ($pkga['combinefields']=="end") {
 				$input.="</table></td></tr>";
 			}
 		} else {
-			$input= "</td></tr>";
 			if ($pkga['usecolspan2']) {
 				$input.= "</tr><br />";
 			}


### PR DESCRIPTION
When specifying combinedfields begin and end in a package XML file, IE reports some unexpected start tag messages. This is because some "td" tags are not enclosed in "tr" tags in these cases, both at the begin and end of the combinedfields table that is generated. Firefox seems to be forgiving of this.
This has been investigated because BBscan177 who is developing pfBlockerNG is trying to use the combinedfields feature and it was not working so well. I will ask him to try these changes for RELENG_2_2 and confirm that they work.
When combinedfields is not set, then the code path with this change results in the same HTML being output as previously, so it should not change the HTML generated for packages that do not use combinedfields - i.e. I claim not to have broken anything else :)