### PR TITLE
More combinedfields and usecolspan2 fixes

### DIFF
--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -507,9 +507,12 @@ if ($pkg['tabs'] <> "") {
 		}
 
 		$size = "";
+		$colspan="";
 		if (isset($pkga['dontdisplayname'])) {
 			$input="";
-			if ($pkga['combinefields'] != "begin") {
+			// We do not want a separate tr tag pair for each field in a set of combined fields.
+			// The case of putting the first tr tag at the beginning of a combine-fields set is already handled above.
+			if (!isset($pkga['combinefields'])) {
 				$input .= "<tr valign='top' id='tr_{$pkga['fieldname']}'>";
 			}
 			if (isset($pkga['usecolspan2'])) {
@@ -529,7 +532,9 @@ if ($pkg['tabs'] <> "") {
 				$req = 'req';
 			}
 			$input="";
-			if ($pkga['combinefields'] != "begin") {
+			// We do not want a separate tr tag pair for each field in a set of combined fields.
+			// The case of putting the first tr tag at the beginning of a combine-fields set is already handled above.
+			if (!isset($pkga['combinefields'])) {
 				$input .= "<tr>";
 			}
 			$input .= "<td valign='top' width=\"22%\" class=\"vncell{$req}\">";
@@ -1001,13 +1006,16 @@ if ($pkg['tabs'] <> "") {
 		if ($pkga['typehint']) {
 			echo " " . $pkga['typehint'];
 		}
-		$input = "</td></tr>";
 		#check combinefields options
 		if (isset($pkga['combinefields'])) {
+			// At the end of each combined-fields field we just want to end a td tag.
+			$input = "</td>";
+			// The tr tag and... ends are only used to end the whole set of combined fields.
 			if ($pkga['combinefields']=="end") {
-				$input.="</table></td></tr>";
+				$input.="</tr></table></td></tr>";
 			}
 		} else {
+			$input = "</td></tr>";
 			if ($pkga['usecolspan2']) {
 				$input.= "</tr><br />";
 			}


### PR DESCRIPTION
Actually the "tr" tag needs to be a single tag-pair that encloses all of the set of fields with combinedfields specified - combinedfields=begin is where the "tr" tag starts and combinedfields=end is where the "tr" tag ends, enclosing a whole set of combined fields.
That allows usecolspan2 to work.
In the previous change I had made it enclose every field in its own "tr" tag-pair That caused usecolspan2 to be ineffective at spreading the combined fields across the display.
Also colspan needs to be initialised each time around the loop - it was getting applied to all fields further down the page after the first one it was used in.
This is the version for master.