### PR TITLE
Be smarter about combinations of combinedfields and usecolspan2

### DIFF
--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -510,9 +510,12 @@ if ($pkg['tabs'] <> "") {
 		$colspan="";
 		if (isset($pkga['dontdisplayname'])) {
 			$input="";
-			// We do not want a separate tr tag pair for each field in a set of combined fields.
-			// The case of putting the first tr tag at the beginning of a combine-fields set is already handled above.
-			if (!isset($pkga['combinefields'])) {
+			// If this is in a set of combined fields and;
+			// - it is a "begin" (case already handled above) or
+			// - usecolspan2 is in effect (so we want to spread all the combined fields horizontally)
+			// then we do not want this "tr" to be inserted.
+			// Thus only insert the "tr" if the not (!) of the above condition.
+			if (!((isset($pkga['combinefields'])) && (($pkga['combinefields'] == "begin") || (isset($pkga['usecolspan2']))))) {
 				$input .= "<tr valign='top' id='tr_{$pkga['fieldname']}'>";
 			}
 			if (isset($pkga['usecolspan2'])) {
@@ -532,9 +535,12 @@ if ($pkg['tabs'] <> "") {
 				$req = 'req';
 			}
 			$input="";
-			// We do not want a separate tr tag pair for each field in a set of combined fields.
-			// The case of putting the first tr tag at the beginning of a combine-fields set is already handled above.
-			if (!isset($pkga['combinefields'])) {
+			// If this is in a set of combined fields and;
+			// - it is a "begin" (case already handled above) or
+			// - usecolspan2 is in effect (so we want to spread all the combined fields horizontally)
+			// then we do not want this "tr" to be inserted.
+			// Thus only insert the "tr" if the not (!) of the above condition.
+			if (!((isset($pkga['combinefields'])) && (($pkga['combinefields'] == "begin") || (isset($pkga['usecolspan2']))))) {
 				$input .= "<tr>";
 			}
 			$input .= "<td valign='top' width=\"22%\" class=\"vncell{$req}\">";
@@ -1008,11 +1014,16 @@ if ($pkg['tabs'] <> "") {
 		}
 		#check combinefields options
 		if (isset($pkga['combinefields'])) {
-			// At the end of each combined-fields field we just want to end a td tag.
+			// At the end of each combined-fields field we always want to end a td tag.
 			$input = "</td>";
-			// The tr tag and... ends are only used to end the whole set of combined fields.
-			if ($pkga['combinefields']=="end") {
-				$input.="</tr></table></td></tr>";
+			// The tr tag end is used to end the whole set of combined fields,
+			// but also if usecolspan2 is not in effect then we also put each combined field in its own tr.
+			if (($pkga['combinefields'] == "end") || (!isset($pkga['usecolspan2']))) {
+				$input.="</tr>";
+			}
+			// At the end of the combined fields we finish up the table that encloses the combined fields...
+			if ($pkga['combinefields'] == "end") {
+				$input.="</table></td></tr>";
 			}
 		} else {
 			$input = "</td></tr>";


### PR DESCRIPTION
a) When we are doing combined fields and usecolspan2 is in effect, then usecolspan2 is also a signal that we want to spread the combined fields horizontally in a single row. In that case we want the combined fields to all be in a single "tr" tag enclosing them all. That was already working in that way.
b) But if usecolspan2 is NOT in effect, then we want the combined fields to still run "together" but vertically under each other. In this case we want each field to be in its own "tr" tag.

This change makes (b) happen.

If combinedfields is not set, then each of the "if" tests here still follows the same path it did previously, so there should be no effect on the HTML output for any ordinary package fields.

These are changes for master that correspond to https://github.com/pfsense/pfsense/pull/1672 on RELENG_2_2.