### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*.php]
+indent_style = tab
+tab_width = 8
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@
 
 root = true
 
-[*.php]
+[*.{inc,php}]
 indent_style = tab
 tab_width = 8
 end_of_line = lf


### PR DESCRIPTION
To start with just `.php` files. According to the [Developer Style Guide](https://doc.pfsense.org/index.php/Developer_Style_Guide):

- Use tabs for indentation (not spaces or a mixture of both)
- Use a tab stop of 8, rather than 4
- Ensure there is NO trailing whitespace at the end of a line, for example spaces or tabs when there is no more text afterward
- Ensure there is NO whitespace on empty lines. For example, a line must not contain only spaces or only tabs

Additionally, I've added:

- UTF-8 character encoding
- LF line endings
- Final newline

Proposed `.editorconfig` file (`.php` files for now):

```ini
; This file is for unifying the coding style for different editors and IDEs.
; More information at http://editorconfig.org

root = true

[*.php]
indent_style = tab
tab_width = 8
end_of_line = lf
charset = utf-8
trim_trailing_whitespace = true
insert_final_newline = true
```

GitHub will also read and apply this style to the repo.

See #1664.