### PR TITLE
system_advanced_network small grammar changes

### DIFF
--- a/usr/local/www/system_advanced_network.php
+++ b/usr/local/www/system_advanced_network.php
@@ -226,9 +226,9 @@ function enable_change(enable_over) {
 									<input name="ipv6nat_enable" type="checkbox" id="ipv6nat_enable" value="yes" <?php if ($pconfig['ipv6nat_enable']) echo "checked=\"checked\""; ?> onclick="enable_change(false)" />
 									<strong><?=gettext("Enable IPv4 NAT encapsulation of IPv6 packets"); ?></strong><br />
 									<?=gettext("This provides an RFC 2893 compatibility mechanism ".
-									"that can be used to tunneling IPv6 packets over IPv4 ".
-									"routing infrastructures. If enabled, don't forget to ".
-									"add a firewall rule to permit IPv6 packets."); ?><br />
+										"that can be used to tunnel IPv6 packets over IPv4 ".
+										"routing infrastructures. If enabled, don't forget to ".
+										"add a firewall rule to permit IPv6 packets."); ?><br />
 									<br />
 									<?=gettext("IP address"); ?>&nbsp;:&nbsp;
 									<input name="ipv6nat_ipaddr" type="text" class="formfld unknown" id="ipv6nat_ipaddr" size="20" value="<?=htmlspecialchars($pconfig['ipv6nat_ipaddr']);?>" />
@@ -239,9 +239,8 @@ function enable_change(enable_over) {
 								<td width="78%" class="vtable">
 									<input name="prefer_ipv4" type="checkbox" id="prefer_ipv4" value="yes" <?php if ($pconfig['prefer_ipv4']) echo "checked=\"checked\""; ?> />
 									<strong><?=gettext("Prefer to use IPv4 even if IPv6 is available"); ?></strong><br />
-									<?=gettext("By default, if a hostname resolves IPv6 and IPv4 addresses ".
-									"IPv6 will be used, if you check this option, IPv4 will be " .
-									"used instead of IPv6."); ?><br />
+									<?=gettext("By default, if a hostname resolves IPv6 and IPv4 addresses IPv6 will be used. " .
+										"If you check this option, IPv4 will be used instead of IPv6."); ?><br />
 								</td>
 							</tr>
 							<tr>


### PR DESCRIPTION
"to tunnel" instead of "to tunneling"
Text for "prefer IPv4" reads better as 2 sentences.