### PR TITLE
Supply current WAN gateway name to wizard

### DIFF
--- a/usr/local/www/wizards/setup_wizard.xml
+++ b/usr/local/www/wizards/setup_wizard.xml
@@ -410,9 +410,14 @@
 	</fields>
 	<stepbeforeformdisplay>
 		<![CDATA[
+		if (empty($config['interfaces']['wan']['gateway'])) {
+			$wangw_name = "WANGW";
+		} else {
+			$wangw_name = $config['interfaces']['wan']['gateway'];
+		}
 		if (is_array($config['gateways']['gateway_item']))
 			foreach ($config['gateways']['gateway_item'] as $gw)
-				if ($gw['name'] == 'WANGW' || (!empty($config['wizardtemp']['wangateway']) && $gw['gateway'] == $config['wizardtemp']['wangateway']))
+				if ($gw['name'] == $wangw_name || (!empty($config['wizardtemp']['wangateway']) && $gw['gateway'] == $config['wizardtemp']['wangateway']))
 					$config['wizardtemp']['wangateway'] = $gw['gateway'];
 		]]>
 	</stepbeforeformdisplay>


### PR DESCRIPTION
As the name of the WAN gateway is not always WANGW.
Should fix redmine #4713