### PR TITLE
Setup Wizard can result in invalid LAN DHCP pool calculation

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -440,13 +440,13 @@ function find_smallest_cidr_v4($number) {
 }
 
 /* Return the previous IP address before the given address */
-function ip_before($ip) {
-	return long2ip32(ip2long($ip)-1);
+function ip_before($ip, $offset = 1) {
+	return long2ip32(ip2long($ip) - $offset);
 }
 
 /* Return the next IP address after the given address */
-function ip_after($ip) {
-	return long2ip32(ip2long($ip)+1);
+function ip_after($ip, $offset = 1) {
+	return long2ip32(ip2long($ip) + $offset);
 }
 
 /* Return true if the first IP is 'before' the second */

--- a/usr/local/www/wizards/setup_wizard.xml
+++ b/usr/local/www/wizards/setup_wizard.xml
@@ -534,19 +534,52 @@
 			print_info_box_np("Invalid LAN IP Address. Please press back in your browser window and correct.");
 			die;
 		}
-		if ($_POST['subnetmask'] < 31 &&
-		    ($_POST['lanipaddress'] == gen_subnet($_POST['lanipaddress'], $_POST['subnetmask']) ||
-		     $_POST['lanipaddress'] == gen_subnet_max($_POST['lanipaddress'], $_POST['subnetmask']))) {
-			print_info_box_np("Invalid LAN IP Address. Please press back in your browser window and correct.");
+
+		$lowestip = gen_subnet($_POST['lanipaddress'], $_POST['subnetmask']);
+		$highestip = gen_subnet_max($_POST['lanipaddress'], $_POST['subnetmask']);
+
+		if ($_POST['subnetmask'] < 31) {
+			if ($_POST['lanipaddress'] == $lowestip) {
+				print_info_box_np("LAN IP Address equals subnet network address. This is not allowed. Please press back in your browser window and correct.");
+				die;
+			}
+			if ($_POST['lanipaddress'] == $highestip) {
+				print_info_box_np("LAN IP Address equals subnet broadcast address. This is not allowed. Please press back in your browser window and correct.");
+				die;
+			}
+		} else {
+			print_info_box_np("Invalid subnet mask, choose a mask less than 31. Please press back in your browser window and correct.");
 			die;
 		}
-		$ft = explode(".", $_POST['lanipaddress']);
-		$ft_ip = $ft[0] . "." . $ft[1] . "." . $ft[2] . ".";
-		$config['dhcpd']['lan']['range']['from'] = $ft_ip . "10";
-		$highestip = gen_subnet_max($_POST['lanipaddress'], $config['interfaces']['lan']['subnet']);
-		$hi = explode(".", $highestip);
-		$highestip = $hi[3]-10;
-		$config['dhcpd']['lan']['range']['to'] = $ft_ip . $highestip;
+
+		$ipaddresses_before = ip_range_size_v4($lowestip, $_POST['lanipaddress']);
+		$ipaddresses_after = ip_range_size_v4($_POST['lanipaddress'], $highestip);
+
+		if ($ipaddresses_after >= $ipaddresses_before) {
+			// The LAN IP is in the 1st half of the subnet, so put DHCP in the 2nd half.
+			if ($ipaddresses_after > 30) {
+				// There is reasonable space in the subnet, use a smaller chunk of the space for DHCP
+				// This case will work out like the old defaults if the user has specified the ".1" address.
+				// The range will be something like ".10" to ".245"
+				$config['dhcpd']['lan']['range']['from'] = ip_after($_POST['lanipaddress'], 9);
+				$config['dhcpd']['lan']['range']['to'] = ip_before($highestip, 10);
+			} else {
+				// There is not much space in the subnet, so allocate everything above the LAN IP to DHCP.
+				$config['dhcpd']['lan']['range']['from'] = ip_after($_POST['lanipaddress']);
+				$config['dhcpd']['lan']['range']['to'] = ip_before($highestip);
+			}
+		} else {
+			// The LAN IP is in the 2nd half of the subnet, so put DHCP in the 1st half.
+			if ($ipaddresses_before > 30) {
+				// There is reasonable space in the subnet, use a smaller chunk of the space for DHCP
+				$config['dhcpd']['lan']['range']['from'] = ip_after($lowestip, 10);
+				$config['dhcpd']['lan']['range']['to'] = ip_before($_POST['lanipaddress'], 9);
+			} else {
+				// There is not much space in the subnet, so allocate everything below the LAN IP to DHCP.
+				$config['dhcpd']['lan']['range']['from'] = ip_after($lowestip);
+				$config['dhcpd']['lan']['range']['to'] = ip_before($_POST['lanipaddress']);
+			}
+		}
 		]]>
 	</stepsubmitphpaction>
 </step>


### PR DESCRIPTION
Redmine #4738
1) consider where the LAN IP is in the subnet range and then purposely put the DHCP pool in the biggest remaining segment, either above or below.
2) Check the size of the available segment. If it is reasonably big then leave some space at either end of the segment, like the old code was doing. Otherwise give all the space to the pool.
3) Do not allow subnet mask 32 - I can't think of a use case for LAN to have a /32 subnet mask, it kind of breaks the whole concept of LAN.
4) Provide more detailed separate messages if the user tries to use the
network address or broadcast address as the LAN IP.