### PR TITLE
Improve setup wizard host name check

### DIFF
--- a/usr/local/www/wizards/setup_wizard.xml
+++ b/usr/local/www/wizards/setup_wizard.xml
@@ -71,7 +71,7 @@
 			<type>input</type>
 			<bindstofield>wizardtemp->system->hostname</bindstofield>
 			<description>EXAMPLE: myserver</description>
-			<validate>^[a-z0-9.|-]+$</validate>
+			<validate>^[a-zA-Z0-9-]+$</validate>
 			<message>Invalid Hostname</message>
 		</field>
 		<field>
@@ -79,7 +79,7 @@
 			<type>input</type>
 			<bindstofield>wizardtemp->system->domain</bindstofield>
 			<description>EXAMPLE: mydomain.com</description>
-			<validate>^[a-z0-9.|-]+$</validate>
+			<validate>^[a-zA-Z0-9.-]+$</validate>
 			<message>Domain name field is invalid</message>
 		</field>
 		<field>


### PR DESCRIPTION
Redmine #4712
It seems good enough to make the regex strings here be "reasonable". The full checks are done after pressing Next and the correct routines are called that do an exhaustive check. There seems not much point in trying to re-engineer all that here also.
Odd things like "-hostname" and "hostname-" would be allowed through here but are caught by the full validation check.
"." and "|" were being allowed in this regex - no idea why!