### PR TITLE
simplify is_ipaddrv4() and fix zero-padding issue

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -615,18 +615,10 @@ function is_ipaddrv6($ipaddr) {
 
 /* returns true if $ipaddr is a valid dotted IPv4 address */
 function is_ipaddrv4($ipaddr) {
-	if (!is_string($ipaddr) || empty($ipaddr)) {
+	if (!is_string($ipaddr) || empty($ipaddr) || ip2long($ipaddr) === FALSE) {
 		return false;
 	}
-
-	$ip_long = ip2long($ipaddr);
-	$ip_reverse = long2ip32($ip_long);
-
-	if ($ipaddr == $ip_reverse) {
-		return true;
-	} else {
-		return false;
-	}
+	return true;
 }
 
 /* returns true if $ipaddr is a valid IPv6 linklocal address */


### PR DESCRIPTION
Fixes these two issues:  

1) The historical workaround of testing IPv4 for validity by (a) converting to long (b) converting back again, then (c) comparing to see if it's the same as the original, is redundant. The old issue with ip2long() was fixed in PHP 5.2.10 and invalid IPv4 can now be tested simply by ip2long() === FALSE.

2) The workaround didn't really work optimally anyway as it mis-reported otherwise valid IPs as invalid if any octet or the IP as a whole  was zero padded. Some IP lists or IP data sources users might use could be zero padded - an avoidable headache.