### PR TITLE
Bug fix for #4065. After base64 encoding username/password, properly escape characters =,+,/ before submitting auth details

### DIFF
--- a/etc/inc/openvpn.auth-user.php
+++ b/etc/inc/openvpn.auth-user.php
@@ -84,8 +84,9 @@ openlog("openvpn", LOG_ODELAY, LOG_AUTH);
 
 if (isset($_GET['username'])) {
 	$authmodes = explode(",", $_GET['authcfg']);
-	$username = base64_decode(str_replace('%3D', '=', $_GET['username']));
-	$password = base64_decode(str_replace('%3D', '=', $_GET['password']));
+	/* Any string retrieved through $_GET is automatically urlDecoded */
+	$username = base64_decode($_GET['username']);
+	$password = base64_decode($_GET['password']);
 	$common_name = $_GET['cn'];
 	$modeid = $_GET['modeid'];
 	$strictusercn = $_GET['strictcn'] == "false" ? false : true;

--- a/usr/local/sbin/ovpn_auth_verify
+++ b/usr/local/sbin/ovpn_auth_verify
@@ -4,8 +4,9 @@ if [ "$1" = "tls" ]; then
 	RESULT=$(/usr/local/sbin/fcgicli -f /etc/inc/openvpn.tls-verify.php -d "servercn=$2&depth=$3&certdepth=$4&certsubject=$5")
 else
 	# Single quoting $password breaks getting the value from the variable.
-	password=$(echo -n "${password}" | openssl enc -base64 | sed -e 's/=/%3D/g')
-	username=$(echo -n "${username}" | openssl enc -base64 | sed -e 's/=/%3D/g')
+	# Base64 and urlEncode usernames and passwords
+	password=$(echo -n "${password}" | openssl enc -base64 | sed -e 's_=_%3D_g;s_+_%2B_g;s_/_%2F_g')
+	username=$(echo -n "${username}" | openssl enc -base64 | sed -e 's_=_%3D_g;s_+_%2B_g;s_/_%2F_g')
 	RESULT=$(/usr/local/sbin/fcgicli -f /etc/inc/openvpn.auth-user.php -d "username=$username&password=$password&cn=$common_name&strictcn=$3&authcfg=$2&modeid=$4")
 fi
 


### PR DESCRIPTION
For full details regarding the patch, please see: https://redmine.pfsense.org/issues/4605#note-1