### PR TITLE
Allow wildcard domains in SAN fields in certificate manager

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -838,12 +838,12 @@ function is_unqualified_hostname($hostname) {
 }
 
 /* returns true if $hostname is a valid hostname, with or without being a fully-qualified domain name. */
-function is_hostname($hostname) {
+function is_hostname($hostname, $allow_wildcard=false) {
 	if (!is_string($hostname)) {
 		return false;
 	}
 
-	if (is_domain($hostname)) {
+	if (is_domain($hostname, $allow_wildcard)) {
 		if ((substr_count($hostname, ".") == 1) && ($hostname[strlen($hostname)-1] == ".")) {
 			/* Only a single dot at the end like "test." - hosts cannot be directly in the root domain. */
 			return false;
@@ -856,12 +856,14 @@ function is_hostname($hostname) {
 }
 
 /* returns true if $domain is a valid domain name */
-function is_domain($domain) {
+function is_domain($domain, $allow_wildcard=false) {
 	if (!is_string($domain)) {
 		return false;
 	}
 
-	if (preg_match('/^(?:(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i', $domain)) {
+	$domain_regex = ($allow_wildcard) ? '/^(?:(?:[a-z_0-9\*]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i' : '/^(?:(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i';
+
+	if (preg_match($domain_regex, $domain)) {
 		return true;
 	} else {
 		return false;

--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -861,7 +861,11 @@ function is_domain($domain, $allow_wildcard=false) {
 		return false;
 	}
 
-	$domain_regex = ($allow_wildcard) ? '/^(?:(?:[a-z_0-9\*]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i' : '/^(?:(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i';
+	if ($allow_wildcard) {
+		$domain_regex = '/^(?:(?:[a-z_0-9\*]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i';
+	} else {
+		$domain_regex = '/^(?:(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i';
+	}
 
 	if (preg_match($domain_regex, $domain)) {
 		return true;

--- a/usr/local/www/system_certmanager.php
+++ b/usr/local/www/system_certmanager.php
@@ -285,8 +285,8 @@ if ($_POST) {
 			foreach ($altnames as $idx => $altname) {
 				switch ($altname['type']) {
 					case "DNS":
-						if (!is_hostname($altname['value'])) {
-							array_push($input_errors, "DNS subjectAltName values must be valid hostnames or FQDNs");
+						if (!is_hostname($altname['value'], true)) {
+							array_push($input_errors, "DNS subjectAltName values must be valid hostnames, FQDNs or wildcard domains.");
 						}
 						break;
 					case "IP":


### PR DESCRIPTION
This is a bug fix for #3733 (https://redmine.pfsense.org/issues/3733)

This fix now allows the administrator to specify additional wildcard domains in the subjectAlternativeName fields when issuing a new certificate.

This would normally have caused the error message

    DNS subjectAltName values must be valid hostnames or FQDNs

although it is valid to place wildcard domains as the subjectAlternativeName extension.