### PR TITLE
fix checking for overlaps of NAT destination port

### DIFF
--- a/usr/local/www/firewall_nat_edit.php
+++ b/usr/local/www/firewall_nat_edit.php
@@ -337,8 +337,8 @@ if ($_POST) {
 			$endp = $begp;
 		}
 
-		if (!((($_POST['beginport'] < $begp) && ($_POST['endport'] < $begp)) ||
-		     (($_POST['beginport'] > $endp) && ($_POST['endport'] > $endp)))) {
+		if (!((($_POST['dstbeginport'] < $begp) && ($_POST['dstendport'] < $begp)) ||
+		     (($_POST['dstbeginport'] > $endp) && ($_POST['dstendport'] > $endp)))) {
 			$input_errors[] = gettext("The destination port range overlaps with an existing entry.");
 			break;
 		}


### PR DESCRIPTION
Fixed the POST index name for checking of the NAT destination port and avoid overlap of the existents rules.