### PR TITLE
Set correct noshuntlaninterfaces boolean after save

### DIFF
--- a/usr/local/www/vpn_ipsec_settings.php
+++ b/usr/local/www/vpn_ipsec_settings.php
@@ -216,6 +216,14 @@ if ($_POST) {
 //		header("Location: vpn_ipsec_settings.php");
 //		return;
 	}
+
+	// The logic value sent by $POST is opposite to the way it is stored in the config.
+	// Reset the $pconfig value so it reflects the opposite of what was $POSTed.
+	if ($_POST['noshuntlaninterfaces'] == "yes") {
+		$pconfig['noshuntlaninterfaces'] = false;
+	} else {
+		$pconfig['noshuntlaninterfaces'] = true;
+	}
 }
 
 $pgtitle = array(gettext("VPN"), gettext("IPsec"), gettext("Settings"));


### PR DESCRIPTION
The truth value of noshuntlaninterfaces is displayed the opposite to what is actually stored in the config - a bit tricky, but it should work. The logic is:
1) read value from config into $pconfig array
2) if $pconfig value false then display box checked, otherwise display box unchecked
3) when saving, if $POST value (from checkbox state) is true then unset noshuntlaninterfaces in config, otherwise set it. (change/fix by Ermal just a few hours ago)

The remaining problem here is that the display code uses the value in $pconfig array to decide what to display in the checkbox. During the $POST processing, $pconfig array is getting set to what was sent in $POST. So after a save the checkbox was getting displayed in the wrong state. A full refresh of the page would display it correctly based on the "opposite of what is in $config".
For most settings the $POST value is the same as what ends up in $config so it works. But for noshuntlaninterfaces the value in $POST is the opposite of what goes into $config.

Solution: when processing the $POST (and save if no input_errors...) set the $pconfig value based on the opposite of what was in $POST.
I take from $POST rather than $config because this preserves whatever the user might have changed the checkbox too, for redisplay, particularly in the case of input_errors (from other inputs).