### PR TITLE
default config.xml: Remove track6-interface and track6-prefix-id from interfaces->lan

### DIFF
--- a/conf.default/config.xml
+++ b/conf.default/config.xml
@@ -80,8 +80,6 @@
 			<subnetv6>64</subnetv6>
 			<media/>
 			<mediaopt/>
-			<track6-interface>wan</track6-interface>
-			<track6-prefix-id>0</track6-prefix-id>
 		</lan>
 	</interfaces>
 	<staticroutes/>


### PR DESCRIPTION
1. &lt;track6-interface&gt;wan&lt;/track6-interface&gt; and &lt;track6-prefix-id&gt;0&lt;/track6-prefix-id&gt; of interfaces-&gt;lan from /conf.default/config.xml will get copied over to /cf/conf/config.xml

2. Without going to the LAN interface configuration page to click "Save" at least once, those 2 entries will stay there (even after going through the first run wizard).

3. In the services_radvd_configure function in /etc/inc/services.inc, the existence of those 2 entries will cause /var/etc/radvd.conf to be written with "AdvSendAdvert on;" for the LAN interface

4. Hence, IPv6 router advertisements will be periodically sent even if IPv6 is never enabled for the network.