### PR TITLE
Add description as a display option on Traffic Graph

### DIFF
--- a/usr/local/www/status_graph.php
+++ b/usr/local/www/status_graph.php
@@ -233,6 +233,7 @@ if (isset($config['ipsec']['enable']) || isset($config['ipsec']['client']['enabl
 	<select id="hostipformat" name="hostipformat" class="formselect" style="z-index: -10;" onchange="document.form1.submit()">
 		<option value="">IP Address</option>
 		<option value="hostname"<?php if ($curhostipformat == "hostname") echo " selected";?>>Host Name</option>
+		<option value="descr"<?php if ($curhostipformat == "descr") echo " selected=\"selected\"";?>>Description</option>
 		<option value="fqdn"<?php if ($curhostipformat == "fqdn") echo " selected=\"selected\"";?>>FQDN</option>
 	</select>
 </form>


### PR DESCRIPTION
This is handy at sites where lots of the LAN clients have static-mapped
DHCP IP addresses. Depending on the site host naming conventions, host
names can be a bit obtuse - may not tell you where the client device
might actually be in the building. We put other useful stuff in the
description - "Jane Doe - Reception".
This enhancement allows the user of Traffic Graph to select
"Description" in the "Display" dropdown. Then, for IP addresses that are
static mapped, the description from the config is shown, rather than the
host name. For non-static-mapped IPs it will show the hostname from a reverse lookup or the IP address if no reverse lookup name is found.
When a client device is noticed hogging bandwidth, it is easy to go
straight to "Jane Doe - Reception" and ask why they are doing some huge
download.
Might be useful for others?