### PR TITLE
status_queues missing semi-colon

### DIFF
--- a/usr/local/www/status_queues.php
+++ b/usr/local/www/status_queues.php
@@ -187,7 +187,7 @@ if (!is_array($config['shaper']['queue']) || count($config['shaper']['queue']) <
 	</tr>
 <?php
 	$if_queue_list = get_configured_interface_list_by_realif(false, true);
-	processQueues($altqstats, 0, "")
+	processQueues($altqstats, 0, "");
 ?>
 <?php endif; ?>
 </table>


### PR DESCRIPTION
This really looks like it should have a semi-colon. Somehow the PHP interpreter is not being fussy about it in this context, I guess being followed by the "endif;" keyword the interpreter guesses the previous statement must be done.