### PR TITLE
XHTML Compliance - Diagnostics Tables

### DIFF
--- a/usr/local/www/diag_tables.php
+++ b/usr/local/www/diag_tables.php
@@ -114,7 +114,8 @@ include("head.inc");
 			if (200 == response.status) {
 				// Escape all dots to not confuse jQuery selectors
 				name = response.responseText.replace(/\./g,'\\.');
-				name = name.replace(/\//g,'\\/');
+				name = name.replace(/\//g,'\\-');
+				name = "entry_" + name;
 				jQuery('#' + name).fadeOut(1000);
 			}
 		}
@@ -147,7 +148,7 @@ include("head.inc");
 	foreach ($entries as $entryA):
 		$entry = trim($entryA);
 ?>
-	<tr id="entry_<?=str_replace("/", "-", $entry)?>">
+	<tr id="entry_<?=str_replace("/", "-", $entry);?>">
 		<td>
 			<?php echo $entry; ?>
 		</td>

--- a/usr/local/www/diag_tables.php
+++ b/usr/local/www/diag_tables.php
@@ -147,7 +147,7 @@ include("head.inc");
 	foreach ($entries as $entryA):
 		$entry = trim($entryA);
 ?>
-	<tr id="<?=$entry?>">
+	<tr id="entry_<?=str_replace("/", "-", $entry)?>">
 		<td>
 			<?php echo $entry; ?>
 		</td>


### PR DESCRIPTION
html id's not permitted to begin with a number.
html id's not permitted to contain '/'
add prefix (entry_) and replace slash with hyphen.
table entry id format becomes: entry_<ip address>-<cidr>
replacing the format: <ip address>/<cidr>
does not change the displayed format.