### PR TITLE
Fixing PD size selection for HughesNet

### DIFF
--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -2507,7 +2507,7 @@ $types6 = array("none" => gettext("None"), "staticv6" => gettext("Static IPv6"),
 										<td width="78%" class="vtable">
 											<select name="dhcp6-ia-pd-len" class="formselect" id="dhcp6-ia-pd-len">
 												<?php
-												$sizes = array("none" => "None", 16 => "48", 12 => "52", 8 => "56", 4 => "60", 2 => "62", 1 => "63", 0 => "64");
+												$sizes = array("none" => "None", 16 => "48", 12 => "52", 8 => "56", 4 => "60", 3 => "61",  2 => "62", 1 => "63", 0 => "64");
 												foreach ($sizes as $bits => $length) {
 													echo "<option value=\"{$bits}\" ";
 													if (is_numeric($pconfig['dhcp6-ia-pd-len']) && ($bits == $pconfig['dhcp6-ia-pd-len'])) {


### PR DESCRIPTION
HughesNet, a popular US satellite Internet provider, provides native IPv6 via DHCPv6 prefix delegation. They provide a /61 prefix, which pfSense does not currently support. Using an incorrect prefix size will result in intermittent IPv6 connectivity as the prefix delegation changes with time. I've forced a prefix size of 3 for the /61 using Firefox's developer tools. This PR integrates that change, it's just another key => value pair for the select list.