### PR TITLE
Why is break missing for reinstallxml

### DIFF
--- a/usr/local/www/pkg_mgr_install.php
+++ b/usr/local/www/pkg_mgr_install.php
@@ -238,6 +238,7 @@ if ($_GET) {
 		case 'reinstallxml':
 			pkg_fetch_config_file($pkgid);
 			pkg_fetch_additional_files($pkgid);
+			break;
 		case 'reinstallpkg':
 			delete_package_xml($pkgid);
 			if (install_package($pkgid) < 0) {


### PR DESCRIPTION
I thought that "reinstallxml" should do less than "reinstallpkg" but actually it was getting stuff here, then falling through "reinstalpkg" which did delete_package_xml and then install_pkg, which got the files a 2nd time and...
Maybe that was supposed to happen?
Anyway, I thought I would point this out and someone can either commit this pull request if the "break" should be there, or explain to me why "reinstallxml" is supposed to fall through executing all this code.