### PR TITLE
Say what is happening when reinstalling package GUI XML

### DIFF
--- a/usr/local/www/pkg_mgr_install.php
+++ b/usr/local/www/pkg_mgr_install.php
@@ -115,12 +115,14 @@ if ((empty($_GET['mode']) && $_GET['id']) || (!empty($_GET['mode']) && (!empty($
 	} else if ($_GET['mode'] == 'reinstallall') {
 		$pkgmode = 'reinstallall';
 	}
+	$pkg_gui_xml_text = "";
 	switch ($pkgmode) {
 		case 'reinstallall':
 			$pkgname = 'All packages';
 			$pkgtxt = 'reinstalled';
 			break;
 		case 'reinstallxml':
+			$pkg_gui_xml_text = " GUI XML components";
 		case 'reinstallpkg':
 			$pkgtxt = 'reinstalled';
 			break;
@@ -136,7 +138,7 @@ if ((empty($_GET['mode']) && $_GET['id']) || (!empty($_GET['mode']) && (!empty($
 					<td class="tabcont" align="center">
 						<table style="height:15;colspacing:0" width="420" border="0" cellpadding="0" cellspacing="0" summary="images">
 							<tr>
-								<td class="tabcont" align="center">Package: <b><?=$pkgname;?></b> will be <?=$pkgtxt;?>.<br/>
+								<td class="tabcont" align="center">Package: <b><?=$pkgname;?></b><?=$pkg_gui_xml_text;?> will be <?=$pkgtxt;?>.<br/>
 									Please confirm the action.<br/>
 								</td>
 								<td class="tabcont" align="center">


### PR DESCRIPTION
At the confirmation dialog after pressing the "Reinstall XML" button, the text does not distinguish between having pressed "Reinstall the whole package" and "Reinstall the GUI/XML". It would be nice if the text of this confirmation allowed the user to be confident about which button they had just pushed, before confirming the action.
Note: This stuff has no gettext() wrappers - but that can be fixed later, not get mixed up in this.