### PR TITLE
Fix typo 

### DIFF
--- a/etc/inc/shaper.inc
+++ b/etc/inc/shaper.inc
@@ -491,7 +491,7 @@ class altq_root_queue {
 					$myBw = $this->GetAvailableBandwidth() * $queue['bandwidth'] / 100;
 					break;
 				default:
-					$myBw = $queue['bandwidth'] * get_bandwidthtype_scale($queue['bandwdithtype']);
+					$myBw = $queue['bandwidth'] * get_bandwidthtype_scale($queue['bandwidthtype']);
 					break;
 			}
 		}


### PR DESCRIPTION
It looks like get_bandwidthtype_scale can only return default of "1", being that queue[bandwidthtype] will not return b, Kb, Gb, etc.
