### PR TITLE
Fix var name typo in shaper.inc

### DIFF
--- a/etc/inc/shaper.inc
+++ b/etc/inc/shaper.inc
@@ -491,7 +491,7 @@ class altq_root_queue {
 					$myBw = $this->GetAvailableBandwidth() * $queue['bandwidth'] / 100;
 					break;
 				default:
-					$myBw = $queue['bandwidth'] * get_bandwidthtype_scale($queue['bandwdithtype']);
+					$myBw = $queue['bandwidth'] * get_bandwidthtype_scale($queue['bandwidthtype']);
 					break;
 			}
 		}


### PR DESCRIPTION
Fix typo so get_bandwidthtype_scale will return more than exclusively the default "1", because of a non-existant var that will not return the expected 'b, Kb, Gb, %'.