### PR TITLE
Standardize widget iform and submit names

### DIFF
--- a/usr/local/www/widgets/javascript/traffic_graph.js
+++ b/usr/local/www/widgets/javascript/traffic_graph.js
@@ -12,7 +12,7 @@ function trafficshowDiv(incDiv,swapButtons) {
 		textlink = d.getElementById(selectIntLink);
 		textlink.style.display = "none";
 	}
-	document.iform["shown[" + incDiv + "]"].value = "show";
+	document.traffic_graphs_widget_iform["shown[" + incDiv + "]"].value = "show";
 }
 
 function  trafficminimizeDiv(incDiv,swapButtons) {
@@ -29,6 +29,6 @@ function  trafficminimizeDiv(incDiv,swapButtons) {
 		textlink = d.getElementById(selectIntLink);
 		textlink.style.display = "none";
 	}
-	document.iform["shown[" + incDiv + "]"].value = "hide";
+	document.traffic_graphs_widget_iform["shown[" + incDiv + "]"].value = "hide";
 }
 

--- a/usr/local/www/widgets/widgets/log.widget.php
+++ b/usr/local/www/widgets/widgets/log.widget.php
@@ -162,7 +162,7 @@ function format_log_line(row) {
 <input type="hidden" id="log-config" name="log-config" value="" />
 
 <div id="log-settings" class="widgetconfigdiv" style="display:none;">
-	<form action="/widgets/widgets/log.widget.php" method="post" name="iforma">
+	<form action="/widgets/widgets/log.widget.php" method="post" name="log_widget_iform">
 		Number of lines to display:
 		<select name="filterlogentries" class="formfld unknown" id="filterlogentries">
 		<?php for ($i = 1; $i <= 20; $i++) { ?>
@@ -197,7 +197,7 @@ function format_log_line(row) {
 ?>
 		</select>
 
-		<input id="submita" name="submita" type="submit" class="formbtn" value="Save" />
+		<input id="log_widget_submit" name="log_widget_submit" type="submit" class="formbtn" value="Save" />
 	</form>
 </div>
 

--- a/usr/local/www/widgets/widgets/picture.widget.php
+++ b/usr/local/www/widgets/widgets/picture.widget.php
@@ -74,9 +74,9 @@ if ($_POST) {
 <input type="hidden" id="picture-config" name="picture-config" value="" />
 
 <div id="picture-settings" class="widgetconfigdiv" style="display:none;">
-	<form action="/widgets/widgets/picture.widget.php" method="post" name="iforma" enctype="multipart/form-data">
+	<form action="/widgets/widgets/picture.widget.php" method="post" name="picture_widget_iform" enctype="multipart/form-data">
 		<input name="pictfile" type="file" class="formbtn" id="pictfile" size="20" />
-		<input id="submita" name="submita" type="submit" class="formbtn" value="Upload" />
+		<input id="picture_widget_submit" name="picture_widget_submit" type="submit" class="formbtn" value="Upload" />
 	</form>
 </div>
 

--- a/usr/local/www/widgets/widgets/rss.widget.php
+++ b/usr/local/www/widgets/widgets/rss.widget.php
@@ -89,7 +89,7 @@ if ($config['widgets']['rssfeed']) {
 <input type="hidden" id="rss-config" name="rss-config" value="" />
 
 <div id="rss-settings" class="widgetconfigdiv" style="display:none;">
-	<form action="/widgets/widgets/rss.widget.php" method="post" name="iformc">
+	<form action="/widgets/widgets/rss.widget.php" method="post" name="rss_widget_iform">
 		<textarea name="rssfeed" class="formfld unknown textarea_widget" id="rssfeed" cols="40" rows="3"><?=$textarea_txt;?></textarea>
 		<br />
 		<table summary="rss widget">
@@ -143,7 +143,7 @@ if ($config['widgets']['rssfeed']) {
 					&nbsp;
 				</td>
 				<td>
-					<input id="submitc" name="submitc" type="submit" class="formbtn" value="Save" />
+					<input id="rss_widget_submit" name="rss_widget_submit" type="submit" class="formbtn" value="Save" />
 				</td>
 			</tr>
 		</table>

--- a/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/usr/local/www/widgets/widgets/services_status.widget.php
@@ -50,10 +50,10 @@ if (isset($_POST['servicestatusfilter'])) {
 ?>
 <input type="hidden" id="services_status-config" name="services_status-config" value="" />
 <div id="services_status-settings" class="widgetconfigdiv" style="display:none;">
-	<form action="/widgets/widgets/services_status.widget.php" method="post" name="iformd">
+	<form action="/widgets/widgets/services_status.widget.php" method="post" name="services_status_widget_iform">
 		Comma separated list of services to NOT display in the widget<br />
 		<input type="text" size="30" name="servicestatusfilter" class="formfld unknown" id="servicestatusfilter" value="<?= $config['widgets']['servicestatusfilter'] ?>" />
-		<input id="submitd" name="submitd" type="submit" class="formbtn" value="Save" />
+		<input id="services_status_widget_submit" name="services_status_widget_submit" type="submit" class="formbtn" value="Save" />
     </form>
 </div>
 

--- a/usr/local/www/widgets/widgets/thermal_sensors.widget.php
+++ b/usr/local/www/widgets/widgets/thermal_sensors.widget.php
@@ -167,7 +167,7 @@ function getBoolValueFromConfig(&$configArray, $valueKey, $defaultValue) {
 
 <input type="hidden" id="thermal_sensors-config" name="thermal_sensors-config" value="" />
 <div id="thermal_sensors-settings" class="widgetconfigdiv" style="display:none;">
-	<form action="/widgets/widgets/thermal_sensors.widget.php" method="post" id="iform_thermal_sensors_settings" name="iform_thermal_sensors_settings">
+	<form action="/widgets/widgets/thermal_sensors.widget.php" method="post" id="thermal_sensors_widget_iform" name="thermal_sensors_widget_iform">
 	<table width="100%" border="0" summary="thermal sensors widget">
 		<tr>
 			<td align="left" colspan="2">

--- a/usr/local/www/widgets/widgets/traffic_graphs.widget.php
+++ b/usr/local/www/widgets/widgets/traffic_graphs.widget.php
@@ -102,7 +102,7 @@ if (isset($a_config["scale_type"])) {
 <input type="hidden" id="traffic_graphs-config" name="traffic_graphs-config" value="" />
 
 <div id="traffic_graphs-settings" class="widgetconfigdiv" style="display:none;">
-<form action="/widgets/widgets/traffic_graphs.widget.php" method="post" name="iform" id="iform">
+<form action="/widgets/widgets/traffic_graphs.widget.php" method="post" name="traffic_graphs_widget_iform" id="traffic_graphs_widget_iform">
 	<?php foreach ($ifdescrs as $ifname => $ifdescr) { ?>
 		<input type="hidden" name="shown[<?= $ifname ?>]" value="<?= $shown[$ifname] ? "show" : "hide" ?>" />
 	<?php } ?>
@@ -129,7 +129,7 @@ if (isset($a_config["scale_type"])) {
 			<option value="<?= $i ?>" <?php if ($refreshinterval == $i) echo "selected=\"selected\"";?>><?= $i ?></option>
 		<?php } ?>
 	</select>&nbsp; Seconds<br />&nbsp; &nbsp; &nbsp; <b>Note:</b> changing this setting will increase CPU utilization<br /><br />
-	<input id="submit_settings" name="submit_settings" type="submit" onclick="return updatePref();" class="formbtn" value="Save Settings" />
+	<input id="traffic_graphs_widget_submit" name="traffic_graphs_widget_submit" type="submit" onclick="return updatePref();" class="formbtn" value="Save Settings" />
 </form>
 </div>
 


### PR DESCRIPTION
The log and picture widgets were both using "iforma" and "submita".
Actually it did not break anything because it was only the form name
repeated, not id. And nothing was using these names.
Traffic Graphs widget was using just "iform". That is a bit dangerous
for the future. I got tricked when cut-pasting some code to make some
settings options for the Gateways widget. I kept "iform" and then
wondered for a while why my Traffic Graphs widget show-hide settings
would not save. There was traffic graph JS that referred to just "iform"
and that started modifying the "iform" in my new Gateways widget code.
Rather than having names "iforma", "iformb"... "submita", "submitb"...
it seems much less risk of accidental duplication if these are named
like:
name_of_widget_iform
name_of_widget_submit

I don't think there is any user-visible bug in 2.2.* - so this
standardization could just go into 2.3