### PR TITLE
changes to allow a new user to login on the same computer

### DIFF
--- a/etc/inc/captiveportal.inc
+++ b/etc/inc/captiveportal.inc
@@ -1913,7 +1913,13 @@ function portal_allow($clientip,$clientmac,$username,$password = null, $attribut
 		}
 		/* on the same ip */
 		if ($cpentry[2] == $clientip) {
-			if (isset($config['captiveportal'][$cpzone]['nomacfilter']) || $cpentry[3] == $clientmac)
+			if(isset($config['captiveportal'][$cpzone]['newloginwins']) && strcasecmp($cpentry[4], $username) != 0) {
+				//delete the previous user because we have a new user trying to login on the same ip address
+				captiveportal_disconnect($cpentry, $radiusservers[$cpentry[11]], 13);
+				captiveportal_logportalauth($cpentry[4], $cpentry[3], $cpentry[2], "NEW LOGIN ON SAME IP ADDRESS - TERMINATING OLD SESSION");
+				$unsetindexes[] = $cpentry[5];
+				break;
+			} elseif (isset($config['captiveportal'][$cpzone]['nomacfilter']) || $cpentry[3] == $clientmac)
 				captiveportal_logportalauth($cpentry[4],$cpentry[3],$cpentry[2],"CONCURRENT LOGIN - REUSING OLD SESSION");
 			else
 				captiveportal_logportalauth($cpentry[4],$cpentry[3],$cpentry[2],"CONCURRENT LOGIN - REUSING IP {$cpentry[2]} WITH DIFFERENT MAC ADDRESS {$cpentry[3]}");

--- a/usr/local/www/services_captiveportal.php
+++ b/usr/local/www/services_captiveportal.php
@@ -168,6 +168,7 @@ if ($a_cp[$cpzone]) {
 	$pconfig['bwdefaultup'] = $a_cp[$cpzone]['bwdefaultup'];
 	$pconfig['nomacfilter'] = isset($a_cp[$cpzone]['nomacfilter']);
 	$pconfig['noconcurrentlogins'] = isset($a_cp[$cpzone]['noconcurrentlogins']);
+	$pconfig['newloginwins'] = isset($a_cp[$cpzone]['newloginwins']);
 	$pconfig['radius_protocol'] = $a_cp[$cpzone]['radius_protocol'];
 	$pconfig['redirurl'] = $a_cp[$cpzone]['redirurl'];
 	$pconfig['radiusip'] = $a_cp[$cpzone]['radiusip'];
@@ -359,6 +360,7 @@ if ($_POST) {
 		$newcp['logoutwin_enable'] = $_POST['logoutwin_enable'] ? true : false;
 		$newcp['nomacfilter'] = $_POST['nomacfilter'] ? true : false;
 		$newcp['noconcurrentlogins'] = $_POST['noconcurrentlogins'] ? true : false;
+		$newcp['newloginwins'] = $_POST['newloginwins'] ? true : false;
 		$newcp['radius_protocol'] = $_POST['radius_protocol'];
 		$newcp['redirurl'] = $_POST['redirurl'];
 		if (isset($_POST['radiusip']))
@@ -485,6 +487,7 @@ function enable_change(enable_change) {
 	document.iform.logoutwin_enable.disabled = endis;
 	document.iform.nomacfilter.disabled = endis;
 	document.iform.noconcurrentlogins.disabled = endis;
+	document.iform.newloginwins.disabled = endis;
 	document.iform.radiusvendor.disabled = radius_endis;
 	document.iform.radiussession_timeout.disabled = radius_endis;
 	document.iform.radiussrcip_attribute.disabled = radius_endis;
@@ -629,6 +632,13 @@ function enable_change(enable_change) {
 	<input name="noconcurrentlogins" type="checkbox" class="formfld" id="noconcurrentlogins" value="yes" <?php if ($pconfig['noconcurrentlogins']) echo "checked=\"checked\""; ?> />
 	<strong><?=gettext("Disable concurrent logins"); ?></strong><br />
 	<?=gettext("If this option is set, only the most recent login per username will be active. Subsequent logins will cause machines previously logged in with the same username to be disconnected."); ?></td>
+	</tr>
+	<tr>
+      <td valign="top" class="vncell"><?=gettext("Allow new login on same IP address"); ?></td>
+      <td class="vtable">
+	<input name="newloginwins" type="checkbox" class="formfld" id="newloginwins" value="yes" <?php if ($pconfig['newloginwins']) echo "checked=\"checked\""; ?> />
+	<strong><?=gettext("Allow new user to login on same IP address"); ?></strong><br />
+	<?=gettext("If this option is set, a new user logging in from a computer that already has an existing connection will disconnect the old session and login as themselves.  When this option is unset, the existing session is reused and the username is not changed."); ?></td>
 	</tr>
 	<tr>
       <td valign="top" class="vncell"><?=gettext("MAC filtering"); ?> </td>


### PR DESCRIPTION
I'm not clear on what the ramifications of tearing down a connection and creating a new connection are, so I made this an option so that my fix doesn't break existing functionality.  I suspect that my usage scenario is different from that of the hotels and coffee shops that are trying to make sure that a user doesn't cheat by logging in as a different user from the same computer.

In my scenario, I don't care about usage caps, but I do need to have an accurate accounting of who is actually logged in.  In a school setting, if a shared computer is checked out to a student, that student should be able to log in using his/her own credentials even if someone else is already logged in.  In most situations the fact that the previous user's session is retained probably goes unnoticed, but in my case I am relying on the pfsense captive portal to tell me the user/ip address mapping so that I can filter traffic appropriately in dansguardian.  I imagine others would at least want the database to reflect who is actually logged in.  The fact that the user's attempt to login fails silently sounds like a bug to me.

This is my first pull request, so please let me know if I haven't done this correctly.  In order to have the patch work for my production box I had to branch off of RELENG_2_2.  I apologize if the standard is to branch from master.

Thanks.

Neil

