### PR TITLE
Fix put static route destination in config change description

### DIFF
--- a/usr/local/www/system_routes.php
+++ b/usr/local/www/system_routes.php
@@ -144,11 +144,11 @@ if (isset($_POST['del_x'])) {
 	if ($a_routes[$_GET['id']]) {
 		if (isset($a_routes[$_GET['id']]['disabled'])) {
 			unset($a_routes[$_GET['id']]['disabled']);
-			$changedesc = $changedesc_prefix . gettext("enabled route to") . " " . $a_routes[$id]['network'];
+			$changedesc = $changedesc_prefix . gettext("enabled route to") . " " . $a_routes[$_GET['id']]['network'];
 		} else {
 			delete_static_route($_GET['id']);
 			$a_routes[$_GET['id']]['disabled'] = true;
-			$changedesc = $changedesc_prefix . gettext("disabled route to") . " " . $a_routes[$id]['network'];
+			$changedesc = $changedesc_prefix . gettext("disabled route to") . " " . $a_routes[$_GET['id']]['network'];
 		}
 
 		if (write_config($changedesc)) {


### PR DESCRIPTION
When enabling or disabling a route by using the enable/disable button on the Routes page, the destination network was not being put in the config change description, although the code intended it to be there.
This fixes it.