### PR TITLE
Make Cancel button work after input error

### DIFF
--- a/usr/local/www/system_routes_edit.php
+++ b/usr/local/www/system_routes_edit.php
@@ -45,7 +45,11 @@ require_once("filter.inc");
 require_once("util.inc");
 require_once("gwlb.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_routes.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_routes.php');
+}
 
 if (!is_array($config['staticroutes']['route'])) {
 	$config['staticroutes']['route'] = array();
@@ -354,6 +358,7 @@ include("head.inc");
 					<?php if (isset($id) && $a_routes[$id]): ?>
 						<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 					<?php endif; ?>
+					<input name="referer" type="hidden" value="<?=$referer;?>" />
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
If you add or edit a route, input some invalid data, click Save, then you get presented with the input error message/s and the input screen again, then if you click Cancel you are taken to an empty System Routes Edit screen.
The problem is that after first clicking Save, the form is submitted and (if there are input errors) the new form sees the old System Routes Edit as HTTP_REFERER.
This seems to be a generic issue across the current GUI - e.g. it happens in System GW Groups Edit also and... If the data has input errors then after display of the input errors the Cancel button becomes wrong, pointing to the existing page, not to where the user really came from.
With the new "bootstrapped" webGUI coming, maybe this will all be handled correctly anyway, so maybe nobody will care to fix the existing GUI.
Anyway, I got bugged by this just now so thought it worth pointing out the issue and 1 way to fix it. If you think it is worth fixing then let me know if you agree with the method here, or... and I am happy to find and fix the various webGUI edit screens that have this Cancel button issue.