### PR TITLE
Firewall Aliases Import display error message for invalid alias name

### DIFF
--- a/usr/local/www/firewall_aliases_import.php
+++ b/usr/local/www/firewall_aliases_import.php
@@ -66,7 +66,7 @@ if (!is_array($config['aliases']['alias'])) {
 }
 $a_aliases = &$config['aliases']['alias'];
 
-if ($_POST['aliasimport'] <> "") {
+if ($_POST) {
 	$reqdfields = explode(" ", "name aliasimport");
 	$reqdfieldsn = array(gettext("Name"), gettext("Aliases"));
 


### PR DESCRIPTION
If you open firewall_aliases_import and enter just an invalid Alias Name (e.g. a$b) and press save or press save with all fields empty, then the screen redraws but the input error(s) is not displayed.
This fixes it.