### PR TITLE
Firewall Aliases Edit ensure input_addresses array exists

### DIFF
--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -273,6 +273,7 @@ if ($_POST) {
 		$wrongaliases = "";
 		$desc_fmt_err_found = false;
 		$alias_address_count = 0;
+		$input_addresses = array();
 
 		// First trim and expand the input data.
 		// Users can paste strings like "10.1.2.0/24 10.3.0.0/16 9.10.11.0/24" into an address box.


### PR DESCRIPTION
If you click "+" to add an alias, then press Save without entering anything, you get:
Warning: Invalid argument supplied for foreach() in /usr/local/www/firewall_aliases_edit.php on line 402
as well as the various messages related to $input_errors.
This change ensures that $input_addresses array always exists (even if it has no real entries) so that the foreach() warning does not happen.