### PR TITLE
Avoid error loading rules for numeric host name in alias

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -639,7 +639,7 @@ function filter_generate_nested_alias($name, $alias, &$aliasnesting, &$aliasaddr
 				$tmpline = filter_generate_nested_alias($name, $aliastable[$address], $aliasnesting, $aliasaddrnesting);
 			}
 		} else if (!isset($aliasaddrnesting[$address])) {
-			if (!is_ipaddr($address) && !is_subnet($address) && !is_port($address) && !is_portrange($address) && is_hostname($address)) {
+			if (!is_ipaddr($address) && !is_subnet($address) && !((alias_get_type($address) == 'port') && (is_port($address) || is_portrange($address))) && is_hostname($address)) {
 				if (!isset($filterdns["{$address}{$name}"])) {
 					$use_filterdns = true;
 					$filterdns["{$address}{$name}"] = "pf {$address} {$name}\n";


### PR DESCRIPTION
Create a host-type alias. Put just a number in "IP or FQDN" - e.g. I made alias name "Zqw" and a single host "23". The webGUI reports:
There were error(s) loading the rules: /tmp/rules.debug:44: syntax error - The line in question reads [44]: table { 23 }
and /tmp/rules.debug has:
table <Zqw> {   23 } 
Zqw = "<Zqw>"
which pf does not cope with.
It is possible to have a host name that is a number, and end up with a domain name like 23.mycompany.com - unfortunately some Wally allowed such things in standards many years ago, so it can be rather difficult to tell the difference between a number and a host name.
This change improves the check when looking through alias entries and deciding if they are meant to be a name or a "bottom-level" value (address, subnet, port, port range). Anything that ends up looking like a host name gets given to filterdns to sort out. "Names" like "23" now get given to filterdns instead of being put directly into the table in pf. This makes things happier. Even if filterdns cannot resolve "23", at least it tries and nothing barfs.