### PR TITLE
Interfaces GIF Edit fix do_input_validation

### DIFF
--- a/usr/local/www/interfaces_gif_edit.php
+++ b/usr/local/www/interfaces_gif_edit.php
@@ -77,8 +77,8 @@ if ($_POST) {
 	$pconfig = $_POST;
 
 	/* input validation */
-	$reqdfields = explode(" ", "if tunnel-remote-addr tunnel-remote-net tunnel-local-addr");
-	$reqdfieldsn = array(gettext("Parent interface,Local address, Remote tunnel address, Remote tunnel network, Local tunnel address"));
+	$reqdfields = explode(" ", "if remote-addr tunnel-local-addr tunnel-remote-addr tunnel-remote-net");
+	$reqdfieldsn = array(gettext("Parent interface"), gettext("gif remote address"), gettext("gif tunnel local address"), gettext("gif tunnel remote address"), gettext("gif tunnel remote netmask"));
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 


### PR DESCRIPTION
Make the required fields be correct and match their text names, which should each have their own gettext() call so as to build a proper array at line 81. Basically it was all broken and the errors displayed when field/s were left empty were rubbish.