### PR TITLE
Interfaces GRE Edit fix required fields text

### DIFF
--- a/usr/local/www/interfaces_gre_edit.php
+++ b/usr/local/www/interfaces_gre_edit.php
@@ -76,8 +76,8 @@ if ($_POST) {
 	$pconfig = $_POST;
 
 	/* input validation */
-	$reqdfields = explode(" ", "if tunnel-remote-addr tunnel-remote-net tunnel-local-addr");
-	$reqdfieldsn = array(gettext("Parent interface"), gettext("Local address"), gettext("Remote tunnel address"), gettext("Remote tunnel network"), gettext("Local tunnel address"));
+	$reqdfields = explode(" ", "if remote-addr tunnel-local-addr tunnel-remote-addr tunnel-remote-net");
+	$reqdfieldsn = array(gettext("Parent interface"), gettext("Remote tunnel endpoint IP address"), gettext("Local tunnel IP address"), gettext("Remote tunnel IP address"), gettext("Remote tunnel network"));
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 


### PR DESCRIPTION
The reqdfields had only 4 entries but reqdfieldsn has 5 entries and the field names to text descriptions did not match up.
Fixed it.