### PR TITLE
Fix references to Load Balancer Virtual Server redirect_mode

### DIFF
--- a/usr/local/www/load_balancer_virtual_server_edit.php
+++ b/usr/local/www/load_balancer_virtual_server_edit.php
@@ -61,7 +61,7 @@ if (isset($id) && $a_vs[$id]) {
   $pconfig = $a_vs[$id];
 } else {
   // Sane defaults
-  $pconfig['mode'] = 'redirect';
+  $pconfig['mode'] = 'redirect_mode';
 }
 
 $changedesc = gettext("Load Balancer: Virtual Server:") . " ";
@@ -73,14 +73,14 @@ if ($_POST) {
 
 	/* input validation */
 	switch ($pconfig['mode']) {
-		case "redirect": {
+		case "redirect_mode": {
 			$reqdfields = explode(" ", "ipaddr name mode");
 			$reqdfieldsn = array(gettext("IP Address"), gettext("Name"), gettext("Mode"));
 			break;
 		}
-		case "relay": {
+		case "relay_mode": {
 			$reqdfields = explode(" ", "ipaddr name mode relay_protocol");
-			$reqdfieldsn = array(gettext("IP Address"), gettext("Name"), gettext("Relay Protocol"));
+			$reqdfieldsn = array(gettext("IP Address"), gettext("Name"), gettext("Mode"), gettext("Relay Protocol"));
 			break;
 		}
 	}


### PR DESCRIPTION
When adding a Virtual Server, if you press Save with blank fields, the validation does not show. That was because the switch statement selecting the fields to validate had wrong case values. Actually the "mode" here is locked to "redirect_mode" (later code to allow the mode to be selected by the user is commented out - not implemented.
I fixed the reqdfieldsn array also for relay_mode case, even though it is never used. It looked dodgy the way it was.