### PR TITLE
Cancel button after input error

### DIFF
--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -52,7 +52,11 @@ require_once("shaper.inc");
 
 $pgtitle = array(gettext("Firewall"), gettext("Aliases"), gettext("Edit"));
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_aliases.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_aliases.php');
+}
 
 // Keywords not allowed in names
 $reserved_keywords = array("all", "pass", "block", "out", "queue", "max", "min", "pptp", "pppoe", "L2TP", "OpenVPN", "IPsec");
@@ -851,6 +855,7 @@ if (empty($tab)) {
 		<td width="78%">
 			<input id="submit" name="submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 			<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+			<input name="referer" type="hidden" value="<?=$referer;?>" />
 		</td>
 	</tr>
 </table>

--- a/usr/local/www/firewall_aliases_import.php
+++ b/usr/local/www/firewall_aliases_import.php
@@ -49,7 +49,11 @@ require("shaper.inc");
 
 $pgtitle = array(gettext("Firewall"), gettext("Aliases"), gettext("Bulk import"));
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_aliases.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_aliases.php');
+}
 
 // Add all Load balance names to reserved_keywords
 if (is_array($config['load_balancer']['lbpool'])) {
@@ -220,6 +224,7 @@ include("head.inc");
 		<td width="78%">
 			<input id="submit" name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 			<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+			<input name="referer" type="hidden" value="<?=$referer;?>" />
 		</td>
 	</tr>
 </table>

--- a/usr/local/www/firewall_nat_1to1_edit.php
+++ b/usr/local/www/firewall_nat_1to1_edit.php
@@ -46,7 +46,11 @@ require_once("interfaces.inc");
 require_once("filter.inc");
 require("shaper.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat_1to1.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat_1to1.php');
+}
 
 $specialsrcdst = explode(" ", "any pptp pppoe l2tp openvpn");
 $ifdisp = get_configured_interface_with_descr();
@@ -564,6 +568,7 @@ if ($input_errors) {
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_1to1[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/firewall_nat_edit.php
+++ b/usr/local/www/firewall_nat_edit.php
@@ -46,7 +46,11 @@ require_once("itemid.inc");
 require_once("filter.inc");
 require("shaper.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat.php');
+}
 
 $specialsrcdst = explode(" ", "any (self) pptp pppoe l2tp openvpn");
 $ifdisp = get_configured_interface_with_descr();
@@ -970,6 +974,7 @@ include("fbegin.inc"); ?>
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_nat[$id]): ?>
 					<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/firewall_nat_npt_edit.php
+++ b/usr/local/www/firewall_nat_npt_edit.php
@@ -59,7 +59,11 @@ require_once("interfaces.inc");
 require_once("filter.inc");
 require("shaper.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat_npt.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat_npt.php');
+}
 
 $ifdisp = get_configured_interface_with_descr();
 foreach ($ifdisp as $kif => $kdescr) {
@@ -294,6 +298,7 @@ include("head.inc");
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_npt[$id]): ?>
 					<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/firewall_nat_out_edit.php
+++ b/usr/local/www/firewall_nat_out_edit.php
@@ -46,7 +46,11 @@ require("guiconfig.inc");
 require_once("filter.inc");
 require("shaper.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat_out.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat_out.php');
+}
 
 if (!is_array($config['nat']['outbound'])) {
 	$config['nat']['outbound'] = array();
@@ -865,6 +869,7 @@ function poolopts_change() {
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 <?php
 			if (isset($id) && $a_out[$id]):
 ?>

--- a/usr/local/www/firewall_rules_edit.php
+++ b/usr/local/www/firewall_rules_edit.php
@@ -46,7 +46,11 @@ require("guiconfig.inc");
 require_once("filter.inc");
 require("shaper.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_rules.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_rules.php');
+}
 
 function is_posnumericint($arg) {
 	// Note that to be safe we do not allow any leading zero - "01", "007"
@@ -1907,6 +1911,7 @@ $has_updated_time = (isset($a_filter[$id]['updated']) && is_array($a_filter[$id]
 				&nbsp;<br />&nbsp;
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 <?php			if (isset($id) && $a_filter[$id]): ?>
 					<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 					<input name="tracker" type="hidden" value="<?=htmlspecialchars($pconfig['tracker']);?>">

--- a/usr/local/www/firewall_schedule_edit.php
+++ b/usr/local/www/firewall_schedule_edit.php
@@ -62,7 +62,11 @@ require_once("shaper.inc");
 
 $pgtitle = array(gettext("Firewall"), gettext("Schedules"), gettext("Edit"));
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_schedule.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_schedule.php');
+}
 
 $dayArray = array (gettext('Mon'), gettext('Tues'), gettext('Wed'), gettext('Thur'), gettext('Fri'), gettext('Sat'), gettext('Sun'));
 $monthArray = array (gettext('January'), gettext('February'), gettext('March'), gettext('April'), gettext('May'), gettext('June'), gettext('July'), gettext('August'), gettext('September'), gettext('October'), gettext('November'), gettext('December'));
@@ -1131,6 +1135,7 @@ EOD;
 						<td width="85%">
 							<input id="submit" name="submit" type="submit" onclick="return checkForRanges();" class="formbtn" value="<?=gettext("Save"); ?>" />
 							<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+							<input name="referer" type="hidden" value="<?=$referer;?>" />
 							<?php if (isset($id) && $a_schedules[$id]): ?>
 							<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 							<?php endif; ?>

--- a/usr/local/www/firewall_virtual_ip_edit.php
+++ b/usr/local/www/firewall_virtual_ip_edit.php
@@ -55,7 +55,11 @@ require("guiconfig.inc");
 require_once("filter.inc");
 require("shaper.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_virtual_ip.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_virtual_ip.php');
+}
 
 if (!is_array($config['virtualip']['vip'])) {
 		$config['virtualip']['vip'] = array();
@@ -538,6 +542,7 @@ function typesel_change() {
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_vip[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/interfaces.php
+++ b/usr/local/www/interfaces.php
@@ -55,7 +55,11 @@ require_once("rrd.inc");
 require_once("vpn.inc");
 require_once("xmlparse_attr.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces.php');
+}
 
 // Get configured interface list
 $ifdescrs = get_configured_interface_with_descr(false, true);
@@ -3696,6 +3700,7 @@ $types6 = array("none" => gettext("None"), "staticv6" => gettext("Static IPv6"),
 								<br />
 								<input id="save" name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 								<input id="cancel" type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+								<input name="referer" type="hidden" value="<?=$referer;?>" />
 								<input name="if" type="hidden" id="if" value="<?=htmlspecialchars($if);?>" />
 								<?php if ($wancfg['if'] == $a_ppps[$pppid]['if']) : ?>
 								<input name="ppp_port" type="hidden" value="<?=htmlspecialchars($pconfig['port']);?>" />

--- a/usr/local/www/interfaces_bridge_edit.php
+++ b/usr/local/www/interfaces_bridge_edit.php
@@ -41,7 +41,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_bridge.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_bridge.php');
+}
 
 if (!is_array($config['bridges']['bridged'])) {
 	$config['bridges']['bridged'] = array();
@@ -691,6 +695,7 @@ function show_source_port_range() {
 				<input type="hidden" name="bridgeif" value="<?=htmlspecialchars($pconfig['bridgeif']); ?>" />
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_bridges[$id]): ?>
 					<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/interfaces_gif_edit.php
+++ b/usr/local/www/interfaces_gif_edit.php
@@ -41,7 +41,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_gif.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_gif.php');
+}
 
 if (!is_array($config['gifs']['gif'])) {
 	$config['gifs']['gif'] = array();
@@ -255,6 +259,7 @@ include("head.inc");
 				<input type="hidden" name="gifif" value="<?=htmlspecialchars($pconfig['gifif']); ?>" />
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_gifs[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/interfaces_gre_edit.php
+++ b/usr/local/www/interfaces_gre_edit.php
@@ -42,7 +42,11 @@
 require("guiconfig.inc");
 require_once("functions.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_gre.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_gre.php');
+}
 
 if (!is_array($config['gres']['gre'])) {
 	$config['gres']['gre'] = array();
@@ -245,6 +249,7 @@ include("head.inc");
 				<input type="hidden" name="greif" value="<?=htmlspecialchars($pconfig['greif']); ?>" />
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 			<?php if (isset($id) && $a_gres[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 			<?php endif; ?>

--- a/usr/local/www/interfaces_lagg_edit.php
+++ b/usr/local/www/interfaces_lagg_edit.php
@@ -41,7 +41,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_lagg.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_lagg.php');
+}
 
 if (!is_array($config['laggs']['lagg'])) {
 	$config['laggs']['lagg'] = array();
@@ -261,6 +265,7 @@ include("head.inc");
 				<input type="hidden" name="laggif" value="<?=htmlspecialchars($pconfig['laggif']); ?>" />
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 			<?php if (isset($id) && $a_laggs[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 			<?php endif; ?>

--- a/usr/local/www/interfaces_ppps_edit.php
+++ b/usr/local/www/interfaces_ppps_edit.php
@@ -46,7 +46,11 @@
 require("guiconfig.inc");
 require("functions.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_ppps.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_ppps.php');
+}
 
 define("CRON_MONTHLY_PATTERN", "0 0 1 * *");
 define("CRON_WEEKLY_PATTERN", "0 0 * * 0");
@@ -878,6 +882,7 @@ $types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE"
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<input name="ptpid" type="hidden" value="<?=htmlspecialchars($pconfig['ptpid']);?>" />
 				<?php if (isset($id) && $a_ppps[$id]): ?>
 					<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />

--- a/usr/local/www/interfaces_vlan_edit.php
+++ b/usr/local/www/interfaces_vlan_edit.php
@@ -42,7 +42,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_vlan.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_vlan.php');
+}
 
 if (!is_array($config['vlans']['vlan'])) {
 	$config['vlans']['vlan'] = array();
@@ -219,6 +223,7 @@ include("head.inc");
 				<input type="hidden" name="vlanif" value="<?=htmlspecialchars($pconfig['vlanif']); ?>" />
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_vlans[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/interfaces_wireless_edit.php
+++ b/usr/local/www/interfaces_wireless_edit.php
@@ -41,7 +41,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_wireless.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/interfaces_wireless.php');
+}
 
 if (!is_array($config['wireless'])) {
 	$config['wireless'] = array();
@@ -213,6 +217,7 @@ include("head.inc");
 				<input type="hidden" name="cloneif" value="<?=htmlspecialchars($pconfig['cloneif']); ?>" />
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_clones[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/load_balancer_monitor_edit.php
+++ b/usr/local/www/load_balancer_monitor_edit.php
@@ -42,7 +42,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/load_balancer_monitor.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/load_balancer_monitor.php');
+}
 
 if (!is_array($config['load_balancer']['monitor_type'])) {
 	$config['load_balancer']['monitor_type'] = array();
@@ -372,6 +376,7 @@ function updateType(t) {
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_monitor[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/load_balancer_pool_edit.php
+++ b/usr/local/www/load_balancer_pool_edit.php
@@ -44,7 +44,11 @@ require("guiconfig.inc");
 require_once("filter.inc");
 require_once("util.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/load_balancer_pool.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/load_balancer_pool.php');
+}
 
 if (!is_array($config['load_balancer']['lbpool'])) {
 	$config['load_balancer']['lbpool'] = array();
@@ -350,6 +354,7 @@ function clearcombo() {
 				<br />
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" onclick="AllServers('serversSelect', true); AllServers('serversDisabledSelect', true);" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_pool[$id] && $_GET['act'] != 'dup'): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/load_balancer_virtual_server_edit.php
+++ b/usr/local/www/load_balancer_virtual_server_edit.php
@@ -43,7 +43,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/load_balancer_virtual_server.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/load_balancer_virtual_server.php');
+}
 
 if (!is_array($config['load_balancer']['virtual_server'])) {
 	$config['load_balancer']['virtual_server'] = array();
@@ -296,6 +300,7 @@ include("head.inc");
 			<td align="left" valign="bottom" width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Submit"); ?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_vs[$id] && $_GET['act'] != 'dup'): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/services_captiveportal_vouchers.php
+++ b/usr/local/www/services_captiveportal_vouchers.php
@@ -50,7 +50,11 @@ require("shaper.inc");
 require("captiveportal.inc");
 require_once("voucher.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_captiveportal_vouchers.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_captiveportal_vouchers.php');
+}
 
 $cpzone = $_GET['zone'];
 if (isset($_POST['zone'])) {
@@ -683,6 +687,7 @@ function enable_change(enable_change) {
 						<input type="hidden" name="exponent" id="exponent" value="<?=$pconfig['exponent'];?>" />
 						<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" onclick="enable_change(true); before_save();" />
 						<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+						<input name="referer" type="hidden" value="<?=$referer;?>" />
 					</td>
 				</tr>
 				<tr>

--- a/usr/local/www/services_dhcp_edit.php
+++ b/usr/local/www/services_dhcp_edit.php
@@ -60,7 +60,11 @@ if (!$g['services_dhcp_server_enable']) {
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_dhcp.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_dhcp.php');
+}
 
 $if = $_GET['if'];
 if ($_POST['if']) {
@@ -607,6 +611,7 @@ include("head.inc");
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_maps[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/services_dhcpv6_edit.php
+++ b/usr/local/www/services_dhcpv6_edit.php
@@ -54,7 +54,11 @@ function staticmaps_sort($ifgui) {
 
 require_once('globals.inc');
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_dhcpv6.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_dhcpv6.php');
+}
 
 if (!$g['services_dhcp_server_enable']) {
 	header("Location: /");
@@ -267,6 +271,7 @@ include("head.inc");
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_maps[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/services_dnsmasq_domainoverride_edit.php
+++ b/usr/local/www/services_dnsmasq_domainoverride_edit.php
@@ -41,7 +41,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_dnsmasq.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_dnsmasq.php');
+}
 
 if (!is_array($config['dnsmasq']['domainoverrides'])) {
 	$config['dnsmasq']['domainoverrides'] = array();
@@ -180,6 +184,7 @@ include("head.inc");
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_domainOverrides[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/services_dnsmasq_edit.php
+++ b/usr/local/www/services_dnsmasq_edit.php
@@ -56,7 +56,11 @@ function hosts_sort() {
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_dnsmasq.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_dnsmasq.php');
+}
 
 if (!is_array($config['dnsmasq']['hosts'])) {
 	$config['dnsmasq']['hosts'] = array();
@@ -328,6 +332,7 @@ include("head.inc");
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_hosts[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/services_unbound_acls.php
+++ b/usr/local/www/services_unbound_acls.php
@@ -33,7 +33,11 @@
 require("guiconfig.inc");
 require("unbound.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_unbound_acls.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_unbound_acls.php');
+}
 
 if (!is_array($config['unbound']['acls'])) {
 	$config['unbound']['acls'] = array();
@@ -323,6 +327,7 @@ include("head.inc");
 								&nbsp;<br />&nbsp;
 								<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 								<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+								<input name="referer" type="hidden" value="<?=$referer;?>" />
 							</td>
 						</tr>
 					</table>

--- a/usr/local/www/services_unbound_domainoverride_edit.php
+++ b/usr/local/www/services_unbound_domainoverride_edit.php
@@ -43,7 +43,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_unbound.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_unbound.php');
+}
 
 if (!is_array($config['unbound']['domainoverrides'])) {
 	$config['unbound']['domainoverrides'] = array();
@@ -166,6 +170,7 @@ include("head.inc");
 				<td width="78%">
 					<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 					<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+					<input name="referer" type="hidden" value="<?=$referer;?>" />
 					<?php if (isset($id) && $a_domainOverrides[$id]): ?>
 					<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 					<?php endif; ?>

--- a/usr/local/www/services_unbound_host_edit.php
+++ b/usr/local/www/services_unbound_host_edit.php
@@ -42,7 +42,11 @@
 ##|*MATCH=services_unbound_host_edit.php*
 ##|-PRIV
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_unbound.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_unbound.php');
+}
 
 function hostcmp($a, $b) {
 	return strcasecmp($a['host'], $b['host']);
@@ -320,6 +324,7 @@ include("head.inc");
 				<td width="78%">
 					<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 					<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+					<input name="referer" type="hidden" value="<?=$referer;?>" />
 					<?php if (isset($id) && $a_hosts[$id]): ?>
 					<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 					<?php endif; ?>

--- a/usr/local/www/services_wol_edit.php
+++ b/usr/local/www/services_wol_edit.php
@@ -52,7 +52,11 @@ function wol_sort() {
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_wol.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/services_wol.php');
+}
 
 if (!is_array($config['wol']['wolentry'])) {
 	$config['wol']['wolentry'] = array();
@@ -163,6 +167,7 @@ include("head.inc");
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_wol[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/system_advanced_sysctl.php
+++ b/usr/local/www/system_advanced_sysctl.php
@@ -45,7 +45,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_advanced_sysctl.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_advanced_sysctl.php');
+}
 
 if (!is_array($config['sysctl'])) {
 	$config['sysctl'] = array();
@@ -283,6 +287,7 @@ include("head.inc");
 								<td width="78%">
 									<input id="submit" name="Submit" type="submit" class="formbtn" value="<?=gettext("Save"); ?>" />
 									<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+									<input name="referer" type="hidden" value="<?=$referer;?>" />
 									<?php if (isset($id) && $a_tunable[$id]): ?>
 									<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 									<?php endif; ?>

--- a/usr/local/www/system_gateway_groups_edit.php
+++ b/usr/local/www/system_gateway_groups_edit.php
@@ -44,7 +44,11 @@ require("guiconfig.inc");
 require_once("ipsec.inc");
 require_once("vpn.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_gateway_groups.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_gateway_groups.php');
+}
 
 if (!is_array($config['gateways']['gateway_group'])) {
 	$config['gateways']['gateway_group'] = array();
@@ -361,6 +365,7 @@ jQuery(function ($) {
 			<td width="78%">
 				<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" />
 				<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+				<input name="referer" type="hidden" value="<?=$referer;?>" />
 				<?php if (isset($id) && $a_gateway_groups[$id]): ?>
 				<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 				<?php endif; ?>

--- a/usr/local/www/system_gateways_edit.php
+++ b/usr/local/www/system_gateways_edit.php
@@ -43,7 +43,11 @@
 require("guiconfig.inc");
 require("pkg-utils.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_gateways.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_gateways.php');
+}
 
 $a_gateways = return_gateways_array(true, false, true);
 $a_gateways_arr = array();
@@ -902,6 +906,7 @@ function enable_change() {
 				<td width="78%">
 					<input name="Submit" type="submit" class="formbtn" value="<?=gettext("Save");?>" onclick="enable_change()" />
 					<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+					<input name="referer" type="hidden" value="<?=$referer;?>" />
 					<?php if (isset($id) && $a_gateways[$id]): ?>
 					<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 					<?php endif; ?>

--- a/usr/local/www/system_hasync.php
+++ b/usr/local/www/system_hasync.php
@@ -42,7 +42,11 @@
 
 require("guiconfig.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_hasync.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_hasync.php');
+}
 
 if (!is_array($config['hasync'])) {
 	$config['hasync'] = array();
@@ -347,6 +351,7 @@ include("head.inc");
 						<input name="id" type="hidden" value="0" />
 						<input name="Submit" type="submit" class="formbtn" value="Save" />
 						<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+						<input name="referer" type="hidden" value="<?=$referer;?>" />
 					</td>
 				</tr>
 			</table>

--- a/usr/local/www/system_routes_edit.php
+++ b/usr/local/www/system_routes_edit.php
@@ -45,7 +45,11 @@ require_once("filter.inc");
 require_once("util.inc");
 require_once("gwlb.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_routes.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/system_routes.php');
+}
 
 if (!is_array($config['staticroutes']['route'])) {
 	$config['staticroutes']['route'] = array();
@@ -354,6 +358,7 @@ include("head.inc");
 					<?php if (isset($id) && $a_routes[$id]): ?>
 						<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 					<?php endif; ?>
+					<input name="referer" type="hidden" value="<?=$referer;?>" />
 				</td>
 			</tr>
 		</table>

--- a/usr/local/www/vpn_l2tp_users_edit.php
+++ b/usr/local/www/vpn_l2tp_users_edit.php
@@ -56,7 +56,11 @@ function l2tp_users_sort() {
 require("guiconfig.inc");
 require_once("vpn.inc");
 
-$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/vpn_l2tp_users.php');
+if (isset($_POST['referer'])) {
+	$referer = $_POST['referer'];
+} else {
+	$referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/vpn_l2tp_users.php');
+}
 
 if (!is_array($config['l2tp']['user'])) {
 	$config['l2tp']['user'] = array();
@@ -193,6 +197,7 @@ include("head.inc");
 				<td width="78%">
 					<input id="submit" name="Submit" type="submit" class="formbtn" value="<?=gettext('Save');?>" />
 					<input type="button" class="formbtn" value="<?=gettext("Cancel");?>" onclick="window.location.href='<?=$referer;?>'" />
+					<input name="referer" type="hidden" value="<?=$referer;?>" />
 					<?php if (isset($id) && $a_secret[$id]): ?>
 					<input name="id" type="hidden" value="<?=htmlspecialchars($id);?>" />
 					<?php endif; ?>


### PR DESCRIPTION
If there is an input error then the edit page is redrawn showing the
input errors. The HTTP_REFERER becomes the current page, rather than the
true original referer. Then if you click Cancel the current page is just
redrawn.
This change makes the code remember the original referer, so if the user
enters some invalid data, presses Save, reads the input error messages
then presses Cancel they are taken back out to the original page - the
same as if Cancel was used before Save.