### PR TITLE
mwexec_bg() and mwexec() -  transparent change

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -1420,58 +1420,43 @@ function exec_command($command) {
 	return(implode("\n", $output));
 }
 
-/* wrapper for exec() */
-function mwexec($command, $mute = false, $clearsigmask = false) {
+/* wrapper for exec() 
+   Executes in background or foreground.
+   For background execution, returns PID of background process to allow calling code control */
+function mwexec($command, $nologentry = false, $clearsigmask = false, $background = false) {
 	global $g;
-
+	$outputarray = array();
+	$retval = 0;
+	
 	if ($g['debug']) {
 		if (!$_SERVER['REMOTE_ADDR']) {
-			echo "mwexec(): $command\n";
+			echo "mwexec(): $command" . ($background ? " [BG]":"") . "\n";
 		}
 	}
-	$oarr = array();
-	$retval = 0;
-
 	if ($clearsigmask) {
 		$oldset = array();
 		pcntl_sigprocmask(SIG_SETMASK, array(), $oldset);
 	}
-	$garbage = exec("$command 2>&1", $oarr, $retval);
+
+	if ($background)
+		$retval = exec("/usr/bin/nohup $command > /dev/null 2>&1 & echo $!");    // start background process and return PID
+	else {
+		exec("$command 2>&1", $outputarray, $retval);
+		$output = implode(" ", $outputarray);
+		if (($retval <> 0) && (!$nologentry || isset($config['system']['developerspew'])))
+			log_error(sprintf(gettext("The command '%1\$s' returned exit code '%2\$d', the output was '%3\$s' "), $command, $retval, $output));
+	}
+
 	if ($clearsigmask) {
 		pcntl_sigprocmask(SIG_SETMASK, $oldset);
 	}
 
-	if (isset($config['system']['developerspew'])) {
-		$mute = false;
-	}
-	if (($retval <> 0) && ($mute === false)) {
-		$output = implode(" ", $oarr);
-		log_error(sprintf(gettext("The command '%1\$s' returned exit code '%2\$d', the output was '%3\$s' "), $command, $retval, $output));
-		unset($output);
-	}
-	unset($oarr);
 	return $retval;
 }
 
 /* wrapper for exec() in background */
 function mwexec_bg($command, $clearsigmask = false) {
-	global $g;
-
-	if ($g['debug']) {
-		if (!$_SERVER['REMOTE_ADDR']) {
-			echo "mwexec(): $command\n";
-		}
-	}
-
-	if ($clearsigmask) {
-		$oldset = array();
-		pcntl_sigprocmask(SIG_SETMASK, array(), $oldset);
-	}
-	$_gb = exec("/usr/bin/nohup $command > /dev/null 2>&1 &");
-	if ($clearsigmask) {
-		pcntl_sigprocmask(SIG_SETMASK, $oldset);
-	}
-	unset($_gb);
+	return mwexec($command, false, $clearsigmask, true);
 }
 
 /* unlink a file, if it exists */

--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -1444,9 +1444,8 @@ function mwexec($command, $nologentry = false, $clearsigmask = false, $backgroun
 		// run in foreground, and (optionally) log if nonzero return
 		$outputarray = array();
 		exec("$command 2>&1", $outputarray, $retval);
-		$output = implode(" ", $outputarray);
 		if (($retval <> 0) && (!$nologentry || isset($config['system']['developerspew'])))
-			log_error(sprintf(gettext("The command '%1\$s' returned exit code '%2\$d', the output was '%3\$s' "), $command, $retval, $output));
+			log_error(sprintf(gettext("The command '%1\$s' returned exit code '%2\$d', the output was '%3\$s' "), $command, $retval, implode(" ", $outputarray)));
 	}
 
 	if ($clearsigmask) {

--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -1425,7 +1425,6 @@ function exec_command($command) {
    For background execution, returns PID of background process to allow calling code control */
 function mwexec($command, $nologentry = false, $clearsigmask = false, $background = false) {
 	global $g;
-	$outputarray = array();
 	$retval = 0;
 	
 	if ($g['debug']) {
@@ -1438,9 +1437,12 @@ function mwexec($command, $nologentry = false, $clearsigmask = false, $backgroun
 		pcntl_sigprocmask(SIG_SETMASK, array(), $oldset);
 	}
 
-	if ($background)
-		$retval = exec("/usr/bin/nohup $command > /dev/null 2>&1 & echo $!");    // start background process and return PID
-	else {
+	if ($background) {
+		// start background process and return PID
+		$retval = exec("/usr/bin/nohup $command > /dev/null 2>&1 & echo $!");
+	} else {
+		// run in foreground, and (optionally) log if nonzero return
+		$outputarray = array();
 		exec("$command 2>&1", $outputarray, $retval);
 		$output = implode(" ", $outputarray);
 		if (($retval <> 0) && (!$nologentry || isset($config['system']['developerspew'])))


### PR DESCRIPTION
Slight cleanup with two effects:
1) a bit easier to follow
2) background execution returns PID of started process, which may be very helpful to the calling code if it has to track and control it (eg started processes or "wait....." screens displayed in the graphical UI).

No external effects (totally transparent change with no effect on wider platform code)

This is prompted by (and needed for) work I'm doing on the packet capture page, where it becomes important to track the PID of the background tcpdump (as "ps -axx | grep" used at present won't be sufficient). Since background processes started with mwexec_bg() aren't currently expected to return a value, this doesn't have any wider impact or change anything else, but this change will enable the started process pid to be tracked by calling code in future, when it's useful to do so. 

Also cleans up some artifacts:  explicit unset() of local variables (usually) isn't needed prior to return, and it doesn't need the redundant $_gb = exec(...) or $garbage = exec(...) as exec() can be run as a statement without using its return value.