### PR TITLE
Make serial ports glob cope with many more possibilities

### DIFF
--- a/usr/local/www/interfaces_ppps_edit.php
+++ b/usr/local/www/interfaces_ppps_edit.php
@@ -493,9 +493,9 @@ $types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE"
 				// Match files in /dev starting with "cua" then:
 				// ? = any single character e.g. like "cuau"
 				// [0-9] = a digit from 0 to 9
-				// {,[0-9]} = nothing (the empty before the comma) or a digit from 0 to 9
-				// This supports up to 100 devices (0 to 99), e.g. cuau0 cuau1 ... cuau10 cuau11 ... cuau99
-				$serialports = glob("/dev/cua?[0-9]{,[0-9]}", GLOB_BRACE);
+				// stuff in {} = the various possible digit and dot combinations to allow an optional 2nd digit, dot, followed by 1 or 2 optional digits
+				// This supports up to 100 devices (0 to 99), e.g. cuau0 cuau1 ... cuau10 cuau11 ... cuau99 and also possibilities like cuau1.1 cuau1.11 cuau11.1 cuau11.11
+				$serialports = glob("/dev/cua?[0-9]{,.[0-9],.[0-9][0-9],[0-9],[0-9].[0-9],[0-9].[0-9][0-9]}", GLOB_BRACE);
 				$serport_count = 0;
 				foreach ($serialports as $port) {
 					$serport_count++;

--- a/usr/local/www/interfaces_ppps_edit.php
+++ b/usr/local/www/interfaces_ppps_edit.php
@@ -491,11 +491,11 @@ $types = array("select" => gettext("Select"), "ppp" => "PPP", "pppoe" => "PPPoE"
 				}
 				// $serialports = pfSense_get_modem_devices();
 				// Match files in /dev starting with "cua" then:
-				// ? = any single character e.g. like "cuau"
+				// [a-zA-Z] = any single alpha character e.g. like "cuau"
 				// [0-9] = a digit from 0 to 9
 				// stuff in {} = the various possible digit and dot combinations to allow an optional 2nd digit, dot, followed by 1 or 2 optional digits
-				// This supports up to 100 devices (0 to 99), e.g. cuau0 cuau1 ... cuau10 cuau11 ... cuau99 and also possibilities like cuau1.1 cuau1.11 cuau11.1 cuau11.11
-				$serialports = glob("/dev/cua?[0-9]{,.[0-9],.[0-9][0-9],[0-9],[0-9].[0-9],[0-9].[0-9][0-9]}", GLOB_BRACE);
+				// This supports up to 100 device numbers (0 to 99), e.g. cuau0 cuau1 ... cuau10 cuau11 ... cuau99 and also possibilities like cuau1.1 cuau1.11 cuau11.1 cuau11.11
+				$serialports = glob("/dev/cua[a-zA-Z][0-9]{,.[0-9],.[0-9][0-9],[0-9],[0-9].[0-9],[0-9].[0-9][0-9]}", GLOB_BRACE);
 				$serport_count = 0;
 				foreach ($serialports as $port) {
 					$serport_count++;


### PR DESCRIPTION
It originally coped with things like cuau1 cuau1.1
Then I made it cope with things like cuau1 cuau11 but it stopped working for cuau1.1
This one copes with:
cuau1
cuau1.1
cuau1.11
cuau11
cuau11.1
cuau11.11
That should allow for all sorts of reasonable device name files without matching other stuff in /dev (like cuau1.init cuau1.lock) that we need to ignore.
Please think if I have covered the bases here.