### PR TITLE
Really avoid error loading rules for numeric host name in alias

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -612,6 +612,7 @@ function filter_generate_nested_alias($name, $alias, &$aliasnesting, &$aliasaddr
 	$builtlist = "";
 	$urltable_nesting = "";
 	$aliasnesting[$name] = $name;
+	$alias_type = alias_get_type($name);
 	foreach ($addresses as $address) {
 		if (empty($address)) {
 			continue;
@@ -639,7 +640,7 @@ function filter_generate_nested_alias($name, $alias, &$aliasnesting, &$aliasaddr
 				$tmpline = filter_generate_nested_alias($name, $aliastable[$address], $aliasnesting, $aliasaddrnesting);
 			}
 		} else if (!isset($aliasaddrnesting[$address])) {
-			if (!is_ipaddr($address) && !is_subnet($address) && !is_port($address) && !is_portrange($address) && is_hostname($address)) {
+			if (!is_ipaddr($address) && !is_subnet($address) && !(($alias_type == 'port') && (is_port($address) || is_portrange($address))) && is_hostname($address)) {
 				if (!isset($filterdns["{$address}{$name}"])) {
 					$use_filterdns = true;
 					$filterdns["{$address}{$name}"] = "pf {$address} {$name}\n";


### PR DESCRIPTION
Create a host-type alias. Put just a number in "IP or FQDN" - e.g. I made alias name "Zqw" and a single host "23". The webGUI reports:
There were error(s) loading the rules: /tmp/rules.debug:44: syntax error - The line in question reads [44]: table { 23 }
and /tmp/rules.debug has:
table { 23 }
Zqw = ""
which pf does not cope with.
This change will differentiate between a number in the context of a port alias and a number that is_hostname.
This time I think it really works :) The call to alias_get_type() needed to send the alias name as parameter. alias_get_type() is a bit expensive - it scans through the whole list of aliases looking for a match on the name. So I made this code just call it once for the name and then use that $alias_type var each time as it loops through all the addresses in an alias.
I have tried this successfully with a few combinations of nested port/host/network aliases. But maybe there is some wacky combination of nested aliases possible that could still break this? I don't see how, but it needs testing on some configs that have all sorts of nested alias types.
Fixes Redmine #4844