### PR TITLE
Fix Bug #4853: Firewall - Aliases GUI inconsistencies when editing URL Table type aliases

### DIFF
--- a/usr/local/www/firewall_aliases_edit.php
+++ b/usr/local/www/firewall_aliases_edit.php
@@ -668,8 +668,8 @@ function update_box_type() {
 			typesel_change();
 			add_alias_control(this);
 		}
-		document.getElementById ("addressnetworkport").firstChild.data = "{$url_str}";
-		document.getElementById ("onecolumn").firstChild.data = "{$url_str}";
+		document.getElementById ("addressnetworkport").firstChild.data = "{$urltable_str}";
+		document.getElementById ("onecolumn").firstChild.data = "{$urltable_str}";
 		document.getElementById ("twocolumn").firstChild.data = "{$update_freq_str}";
 		document.getElementById ("threecolumn").firstChild.data = "";
 		document.getElementById ("threecolumn").style.display = 'none';
@@ -681,8 +681,8 @@ function update_box_type() {
 			typesel_change();
 			add_alias_control(this);
 		}
-		document.getElementById ("addressnetworkport").firstChild.data = "{$url_str}";
-		document.getElementById ("onecolumn").firstChild.data = "{$url_str}";
+		document.getElementById ("addressnetworkport").firstChild.data = "{$urltable_ports_str}";
+		document.getElementById ("onecolumn").firstChild.data = "{$urltable_ports_str}";
 		document.getElementById ("twocolumn").firstChild.data = "{$update_freq_str}";
 		document.getElementById ("threecolumn").firstChild.data = "";
 		document.getElementById ("threecolumn").style.display = 'none';


### PR DESCRIPTION
The GUI should show descriptions according to what's selected from the dropdown, but currently does not for URL Table (IPs) and URL Table (Ports) type of aliases.