### PR TITLE
Provide separate checkboxes for tmp and var RAM disks

### DIFF
--- a/etc/inc/rrd.inc
+++ b/etc/inc/rrd.inc
@@ -55,7 +55,7 @@ function restore_rrd() {
 
 	$rrdrestore = "";
 	$rrdreturn = "";
-	if (file_exists("{$g['cf_conf_path']}/rrd.tgz") && (isset($config['system']['use_mfs_tmpvar']) || $g['platform'] != "pfSense")) {
+	if (file_exists("{$g['cf_conf_path']}/rrd.tgz") && (isset($config['system']['use_mfs_var']) || $g['platform'] != "pfSense")) {
 		foreach (glob("{$rrddbpath}/*.xml") as $xml_file) {
 			@unlink($xml_file);
 		}
@@ -87,7 +87,7 @@ function restore_rrd() {
 		unset($rrdrestore);
 		@unlink("{$g['tmp_path']}/rrd_restore");
 		/* If this backup is still there on a full install, but we aren't going to use ram disks, remove the archive since this is a transition. */
-		if (($g['platform'] == "pfSense") && !isset($config['system']['use_mfs_tmpvar'])) {
+		if (($g['platform'] == "pfSense") && !isset($config['system']['use_mfs_var'])) {
 			unlink_if_exists("{$g['cf_conf_path']}/rrd.tgz");
 		}
 		return true;

--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -475,7 +475,7 @@ function services_dhcpdv4_configure() {
 			}
 		}
 		/* If this backup is still there on a full install, but we aren't going to use ram disks, remove the archive since this is a transition. */
-		if (($g['platform'] == "pfSense") && !isset($config['system']['use_mfs_tmpvar'])) {
+		if (($g['platform'] == "pfSense") && !isset($config['system']['use_mfs_var'])) {
 			unlink_if_exists("{$g['cf_conf_path']}/dhcpleases.tgz");
 		}
 	}

--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -3787,6 +3787,12 @@ function upgrade_118_to_119() {
 		}
 		unset($miniupnpd["permuser{$i}"]);
 	}
+
+	if (isset($config['system']['use_mfs_tmpvar'])) {
+		$config['system']['use_mfs_tmp'] = true;
+		$config['system']['use_mfs_var'] = true;
+		unset($config['system']['use_mfs_tmpvar']);
+	}
 }
 
 ?>

--- a/etc/rc
+++ b/etc/rc
@@ -91,8 +91,9 @@ if [ ! "${PLATFORM}" = "cdrom" ]; then
 		fi
 	fi
 
-	USE_MFS_TMPVAR=`/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml`
-	if [ "${PLATFORM}" = "nanobsd" ] || [ ${USE_MFS_TMPVAR} -gt 0 ]; then
+	USE_MFS_TMP=`/usr/bin/grep -c use_mfs_tmp /cf/conf/config.xml`
+	USE_MFS_VAR=`/usr/bin/grep -c use_mfs_var /cf/conf/config.xml`
+	if [ "${PLATFORM}" = "nanobsd" ] || [ ${USE_MFS_TMP} -gt 0 ] || [ ${USE_MFS_VAR} -gt 0 ]; then
 		/etc/rc.embedded
 	fi
 fi
@@ -140,7 +141,7 @@ product=`/usr/bin/grep product_name /etc/inc/globals.inc | /usr/bin/cut -d'"' -f
 hideplatform=`/usr/bin/grep hideplatform /etc/inc/globals.inc | /usr/bin/wc -l`
 varrunpath=`/usr/bin/grep varrun_path /etc/inc/globals.inc | /usr/bin/cut -d'"' -f4`
 
-if [ "$PLATFORM" = "pfSense" ] && [ ${USE_MFS_TMPVAR} -eq 0 ]; then
+if [ "$PLATFORM" = "pfSense" ] && [ ${USE_MFS_VAR} -eq 0 ]; then
 	/sbin/mdmfs -S -M -s 4m md $varrunpath
 fi
 
@@ -164,7 +165,7 @@ fi
 
 if [ "$PLATFORM" = "cdrom" ] ; then
 	# do nothing for cdrom platform
-elif [ "$PLATFORM" = "nanobsd" ] || [ ${USE_MFS_TMPVAR} -gt 0 ]; then
+elif [ "$PLATFORM" = "nanobsd" ] || [ ${USE_MFS_VAR} -gt 0 ]; then
 	# Ensure that old-style PKG packages can be persistent across reboots
 	/bin/mkdir -p /root/var/db/pkg
 	/bin/rm -rf /var/db/pkg

--- a/etc/rc.embedded
+++ b/etc/rc.embedded
@@ -3,6 +3,9 @@
 # rc.embedded - embedded system specific startup information
 # For pfSense
 
+# Set our operating platform
+PLATFORM=`/bin/cat /etc/platform`
+
 # Size of /tmp
 USE_MFS_TMP_SIZE=`/usr/bin/grep use_mfs_tmp_size /cf/conf/config.xml | /usr/bin/cut -f2 -d'>' | /usr/bin/cut -f1 -d'<'`
 if [ ! -z ${USE_MFS_TMP_SIZE} ] && [ ${USE_MFS_TMP_SIZE} -gt 0 ]; then
@@ -23,13 +26,21 @@ fi
 [ -f /etc/rc.d/uzip ] && /etc/rc.d/uzip start
 
 echo -n "Setting up memory disks..."
-mdmfs -S -M -s ${tmpsize} md /tmp
-mdmfs -S -M -s ${varsize} md /var
+USE_MFS_TMP=`/usr/bin/grep -c use_mfs_tmp /cf/conf/config.xml`
+if [ "${PLATFORM}" = "nanobsd" ] || [ ${USE_MFS_TMP} -gt 0 ]; then
+	mdmfs -S -M -s ${tmpsize} md /tmp
+fi
 
-# Create some needed directories
-/bin/mkdir -p /var/db /var/spool/lock
-/usr/sbin/chown uucp:dialer /var/spool/lock
+USE_MFS_VAR=`/usr/bin/grep -c use_mfs_var /cf/conf/config.xml`
+if [ "${PLATFORM}" = "nanobsd" ] || [ ${USE_MFS_VAR} -gt 0 ]; then
+	mdmfs -S -M -s ${varsize} md /var
 
-# Ensure vi's recover directory is present
-/bin/mkdir -p /var/tmp/vi.recover/
+	# Create some needed directories
+	/bin/mkdir -p /var/db /var/spool/lock
+	/usr/sbin/chown uucp:dialer /var/spool/lock
+
+	# Ensure vi's recover directory is present
+	/bin/mkdir -p /var/tmp/vi.recover/
+fi
+
 echo " done."

--- a/etc/rc.reboot
+++ b/etc/rc.reboot
@@ -16,11 +16,11 @@ if [ "$PLATFORM" = "pfSense" ]; then
 	rm -rf /tmp/*
 fi
 
-USE_MFS_TMPVAR=`/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml`
+USE_MFS_VAR=`/usr/bin/grep -c use_mfs_var /cf/conf/config.xml`
 DISK_NAME=`/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}'`
 DISK_TYPE=`/usr/bin/basename ${DISK_NAME} | /usr/bin/cut -c1-2`
 # If we are not on a full install, or if the full install wants RAM disks, or if the full install _was_ using RAM disks, but isn't for the next boot...
-if [ "${PLATFORM}" != "pfSense" ] || [ ${USE_MFS_TMPVAR} -gt 0 ] || [ "${DISK_TYPE}" = "md" ]; then
+if [ "${PLATFORM}" != "pfSense" ] || [ ${USE_MFS_VAR} -gt 0 ] || [ "${DISK_TYPE}" = "md" ]; then
 	/etc/rc.backup_rrd.sh
 	/etc/rc.backup_dhcpleases.sh
 fi

--- a/etc/rc.shutdown
+++ b/etc/rc.shutdown
@@ -27,11 +27,11 @@ if [ "$PLATFORM" = "pfSense" ]; then
 	find -x /tmp/* -type f -exec rm -f {} \; >/dev/null 2>&1
 fi
 
-USE_MFS_TMPVAR=`/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml`
+USE_MFS_VAR=`/usr/bin/grep -c use_mfs_var /cf/conf/config.xml`
 DISK_NAME=`/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}'`
 DISK_TYPE=`/usr/bin/basename ${DISK_NAME} | /usr/bin/cut -c1-2`
 # If we are not on a full install, or if the full install wants RAM disks, or if the full install _was_ using RAM disks, but isn't for the next boot...
-if [ "${PLATFORM}" != "pfSense" ] || [ ${USE_MFS_TMPVAR} -gt 0 ] || [ "${DISK_TYPE}" = "md" ]; then
+if [ "${PLATFORM}" != "pfSense" ] || [ ${USE_MFS_VAR} -gt 0 ] || [ "${DISK_TYPE}" = "md" ]; then
 	/etc/rc.backup_rrd.sh
 	/etc/rc.backup_dhcpleases.sh
 fi

--- a/usr/local/www/system_advanced_misc.php
+++ b/usr/local/www/system_advanced_misc.php
@@ -65,7 +65,8 @@ $pconfig['schedule_states'] = isset($config['system']['schedule_states']);
 $pconfig['kill_states'] = isset($config['system']['kill_states']);
 $pconfig['skip_rules_gw_down'] = isset($config['system']['skip_rules_gw_down']);
 $pconfig['apinger_debug'] = isset($config['system']['apinger_debug']);
-$pconfig['use_mfs_tmpvar'] = isset($config['system']['use_mfs_tmpvar']);
+$pconfig['use_mfs_tmp'] = isset($config['system']['use_mfs_tmp']);
+$pconfig['use_mfs_var'] = isset($config['system']['use_mfs_var']);
 $pconfig['use_mfs_tmp_size'] = $config['system']['use_mfs_tmp_size'];
 $pconfig['use_mfs_var_size'] = $config['system']['use_mfs_var_size'];
 $pconfig['pkg_nochecksig'] = isset($config['system']['pkg_nochecksig']);
@@ -251,10 +252,16 @@ if ($_POST) {
 			unset($config['system']['apinger_debug']);
 		}
 
-		if ($_POST['use_mfs_tmpvar'] == "yes") {
-			$config['system']['use_mfs_tmpvar'] = true;
+		if ($_POST['use_mfs_tmp'] == "yes") {
+			$config['system']['use_mfs_tmp'] = true;
 		} else {
-			unset($config['system']['use_mfs_tmpvar']);
+			unset($config['system']['use_mfs_tmp']);
+		}
+
+		if ($_POST['use_mfs_var'] == "yes") {
+			$config['system']['use_mfs_var'] = true;
+		} else {
+			unset($config['system']['use_mfs_var']);
 		}
 
 		$config['system']['use_mfs_tmp_size'] = $_POST['use_mfs_tmp_size'];
@@ -316,14 +323,19 @@ function sticky_checked(obj) {
 		jQuery('#srctrack').attr('disabled', 'true');
 	}
 }
-function tmpvar_checked(obj) {
+function tmp_checked(obj) {
 	if (obj.checked) {
 		jQuery('#use_mfs_tmp_size').attr('disabled', false);
+	} else {
+		jQuery('#use_mfs_tmp_size').attr('disabled', 'true');
+	}
+}
+function var_checked(obj) {
+	if (obj.checked) {
 		jQuery('#use_mfs_var_size').attr('disabled', false);
 		jQuery('#rrdbackup').attr('disabled', false);
 		jQuery('#dhcpbackup').attr('disabled', false);
 	} else {
-		jQuery('#use_mfs_tmp_size').attr('disabled', 'true');
 		jQuery('#use_mfs_var_size').attr('disabled', 'true');
 		jQuery('#rrdbackup').attr('disabled', 'true');
 		jQuery('#dhcpbackup').attr('disabled', 'true');
@@ -605,19 +617,28 @@ function tmpvar_checked(obj) {
 							</tr>
 							<?php if ($g['platform'] == "pfSense"): ?>
 							<tr>
-								<td width="22%" valign="top" class="vncell"><?=gettext("Use RAM Disks"); ?></td>
+								<td width="22%" valign="top" class="vncell"><?=gettext("Use RAM Disk for /tmp"); ?></td>
 								<td width="78%" class="vtable">
-									<input name="use_mfs_tmpvar" type="checkbox" id="use_mfs_tmpvar" value="yes" <?php if ($pconfig['use_mfs_tmpvar']) echo "checked=\"checked\""; ?> onclick="tmpvar_checked(this)" />
-									<strong><?=gettext("Use memory file system for /tmp and /var"); ?></strong><br />
-									<?=gettext("Set this if you wish to use /tmp and /var as RAM disks (memory file system disks) on a full install " .
-										"rather than use the hard disk. Setting this will cause the data in /tmp and /var to be lost at reboot, including log data. RRD and DHCP Leases will be retained."); ?>
+									<input name="use_mfs_tmp" type="checkbox" id="use_mfs_tmp" value="yes" <?php if ($pconfig['use_mfs_tmp']) echo "checked=\"checked\""; ?> onclick="tmp_checked(this)" />
+									<strong><?=gettext("Use memory file system for /tmp"); ?></strong><br />
+									<?=gettext("Set this if you wish to use /tmp as a RAM disk (memory file system disk) on a full install rather than use the hard disk. " .
+										"Setting this will cause the data in /tmp to be lost at reboot."); ?>
+								</td>
+							</tr>
+							<tr>
+								<td width="22%" valign="top" class="vncell"><?=gettext("Use RAM Disk for /var"); ?></td>
+								<td width="78%" class="vtable">
+									<input name="use_mfs_var" type="checkbox" id="use_mfs_var" value="yes" <?php if ($pconfig['use_mfs_var']) echo "checked=\"checked\""; ?> onclick="var_checked(this)" />
+									<strong><?=gettext("Use memory file system for /var"); ?></strong><br />
+									<?=gettext("Set this if you wish to use /var as a RAM disk (memory file system disk) on a full install rather than use the hard disk. " .
+										"Setting this will cause the data in /var to be lost at reboot, including log data. RRD and DHCP Leases will be retained."); ?>
 								</td>
 							</tr>
 							<?php endif; ?>
 							<tr>
 								<td width="22%" valign="top" class="vncell"><?=gettext("/tmp RAM Disk Size"); ?></td>
 								<td width="78%" class="vtable">
-									<input name="use_mfs_tmp_size" id="use_mfs_tmp_size" value="<?php if ($pconfig['use_mfs_tmp_size'] <> "") echo htmlspecialchars($pconfig['use_mfs_tmp_size']); ?>" class="formfld unknown" <?php if (($g['platform'] == "pfSense") && ($pconfig['use_mfs_tmpvar'] == false)) echo "disabled=\"disabled\""; ?> /> MB
+									<input name="use_mfs_tmp_size" id="use_mfs_tmp_size" value="<?php if ($pconfig['use_mfs_tmp_size'] <> "") echo htmlspecialchars($pconfig['use_mfs_tmp_size']); ?>" class="formfld unknown" <?php if (($g['platform'] == "pfSense") && ($pconfig['use_mfs_tmp'] == false)) echo "disabled=\"disabled\""; ?> /> MB
 									<br />
 									<?=gettext("Set the size, in MB, for the /tmp RAM disk. " .
 										"Leave blank for 40MB. Do not set lower than 40."); ?>
@@ -626,7 +647,7 @@ function tmpvar_checked(obj) {
 							<tr>
 								<td width="22%" valign="top" class="vncell"><?=gettext("/var RAM Disk Size"); ?></td>
 								<td width="78%" class="vtable">
-									<input name="use_mfs_var_size" id="use_mfs_var_size" value="<?php if ($pconfig['use_mfs_var_size'] <> "") echo htmlspecialchars($pconfig['use_mfs_var_size']); ?>" class="formfld unknown" <?php if (($g['platform'] == "pfSense") && ($pconfig['use_mfs_tmpvar'] == false)) echo "disabled=\"disabled\""; ?> /> MB
+									<input name="use_mfs_var_size" id="use_mfs_var_size" value="<?php if ($pconfig['use_mfs_var_size'] <> "") echo htmlspecialchars($pconfig['use_mfs_var_size']); ?>" class="formfld unknown" <?php if (($g['platform'] == "pfSense") && ($pconfig['use_mfs_var'] == false)) echo "disabled=\"disabled\""; ?> /> MB
 									<br />
 									<?=gettext("Set the size, in MB, for the /var RAM disk. " .
 										"Leave blank for 60MB. Do not set lower than 60."); ?>
@@ -636,7 +657,7 @@ function tmpvar_checked(obj) {
 								<td width="22%" valign="top" class="vncell"><?=gettext("Periodic RRD Backup");?></td>
 								<td width="78%" class="vtable">
 									<?=gettext("Frequency:");?>
-									<select name="rrdbackup" id="rrdbackup" <?php if (($g['platform'] == "pfSense") && ($pconfig['use_mfs_tmpvar'] == false)) echo "disabled=\"disabled\""; ?> >
+									<select name="rrdbackup" id="rrdbackup" <?php if (($g['platform'] == "pfSense") && ($pconfig['use_mfs_var'] == false)) echo "disabled=\"disabled\""; ?> >
 										<option value='0' <?php if (!isset($config['system']['rrdbackup']) || ($config['system']['rrdbackup'] == 0)) echo "selected='selected'"; ?>><?=gettext("Disable"); ?></option>
 									<?php for ($x=1; $x<=24; $x++) { ?>
 										<option value='<?= $x ?>' <?php if ($config['system']['rrdbackup'] == $x) echo "selected='selected'"; ?>><?= $x ?> <?=gettext("hour"); ?><?php if ($x>1) echo "s"; ?></option>
@@ -652,7 +673,7 @@ function tmpvar_checked(obj) {
 								<td width="22%" valign="top" class="vncell"><?=gettext("Periodic DHCP Leases Backup");?></td>
 								<td width="78%" class="vtable">
 									<?=gettext("Frequency:");?>
-									<select name="dhcpbackup" id="dhcpbackup" <?php if (($g['platform'] == "pfSense") && ($pconfig['use_mfs_tmpvar'] == false)) echo "disabled=\"disabled\""; ?> >
+									<select name="dhcpbackup" id="dhcpbackup" <?php if (($g['platform'] == "pfSense") && ($pconfig['use_mfs_var'] == false)) echo "disabled=\"disabled\""; ?> >
 										<option value='0' <?php if (!isset($config['system']['dhcpbackup']) || ($config['system']['dhcpbackup'] == 0)) echo "selected='selected'"; ?>><?=gettext("Disable"); ?></option>
 									<?php for ($x=1; $x<=24; $x++) { ?>
 										<option value='<?= $x ?>' <?php if ($config['system']['dhcpbackup'] == $x) echo "selected='selected'"; ?>><?= $x ?> <?=gettext("hour"); ?><?php if ($x>1) echo "s"; ?></option>


### PR DESCRIPTION
As suggested in forum: https://forum.pfsense.org/index.php?topic=96705.0
It is not hard to do - so here it is if someone thinks it is worth having. e.g. on my SG-2440 full install that has plenty of free RAM I could enable just /tmp memory disk and leave /var where it is on the eMMC.