### PR TITLE
Unset old CA and Cert in system config

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -3754,6 +3754,14 @@ function upgrade_116_to_117() {
 function upgrade_117_to_118() {
 	global $config;
 
+	// Unset any old CA and Cert in the system section that might still be there from when upgrade_066_to_067 did not unset them.
+	if (isset($config['system']['ca'])) {
+		unset($config['system']['ca']);
+	}
+	if (isset($config['system']['cert'])) {
+		unset($config['system']['cert']);
+	}
+
 	if (!isset($config['ipsec']['phase1'])) {
 		return;
 	}

--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -2547,9 +2547,11 @@ function upgrade_066_to_067() {
 	global $config;
 	if (isset($config['system']['ca'])) {
 		$config['ca'] = $config['system']['ca'];
+		unset($config['system']['ca']);
 	}
 	if (isset($config['system']['cert'])) {
 		$config['cert'] = $config['system']['cert'];
+		unset($config['system']['cert']);
 	}
 }
 


### PR DESCRIPTION
This looked odd. Why would we leave behind the old "ca" and "cert" section in $config["system"]?
I guess it would do no harm, but seems confusing for the future to have some unused entries like this remaining in the config.
Should a piece of code be put into the latest upgrade function to clean out these in any current config?