### PR TITLE
Allocate dnpipe and dnqueue numbers even if no filter rules

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -3053,9 +3053,6 @@ function upgrade_085_to_086() {
 function upgrade_086_to_087() {
 	global $config, $dummynet_pipe_list;
 
-	if (!is_array($config['filter']) || !is_array($config['filter']['rule'])) {
-		return;
-	}
 	if (!is_array($config['dnshaper']) || !is_array($config['dnshaper']['queue'])) {
 		return;
 	}
@@ -3075,6 +3072,10 @@ function upgrade_086_to_087() {
 	}
 
 	unset($dnqueue_number, $dnpipe_number, $qidx, $idx, $dnpipe, $dnqueue);
+
+	if (!is_array($config['filter']) || !is_array($config['filter']['rule'])) {
+		return;
+	}
 
 	require_once("shaper.inc");
 	read_dummynet_config();


### PR DESCRIPTION
It would be quite unusual to have no filter rules array, but if that is indeed the case then the first part of this code that sets dnpipe and dnqueue numbers should execute anyway.