### PR TITLE
Captive Portal zoneid upgrade fix var name typo

### DIFF
--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -3438,7 +3438,7 @@ function upgrade_104_to_105() {
 	if (is_array($config['captiveportal'])) {
 		$zoneid = 2;
 		foreach ($config['captiveportal'] as $cpzone => $cpcfg) {
-			if (empty($cpfg['zoneid'])) {
+			if (empty($cpcfg['zoneid'])) {
 				$config['captiveportal'][$cpzone]['zoneid'] = $zoneid;
 				$zoneid += 2;
 			} else if ($cpcfg['zoneid'] > 4000) {


### PR DESCRIPTION
With the typo, this empty() test would always have been true. So maybe on upgrade some existing captive portal zoneid values have been getting overwritten by this even number counter? Or?