### PR TITLE
Interfaces widget use more obscure separator

### DIFF
--- a/usr/local/www/includes/functions.inc.php
+++ b/usr/local/www/includes/functions.inc.php
@@ -377,7 +377,7 @@ function get_interfacestatus() {
 
 	foreach ($ifdescrs as $ifdescr => $ifname) {
 		$ifinfo = get_interface_info($ifdescr);
-		$data .= $ifname . ",";
+		$data .= $ifname . "^";
 		if ($ifinfo['status'] == "up" || $ifinfo['status'] == "associated") {
 			$data .= "up";
 		} else if ($ifinfo['status'] == "no carrier") {
@@ -385,15 +385,15 @@ function get_interfacestatus() {
 		} else if ($ifinfo['status'] == "down") {
 			$data .= "block";
 		}
-		$data .= ",";
+		$data .= "^";
 		if ($ifinfo['ipaddr']) {
 			$data .= "<strong>" . htmlspecialchars($ifinfo['ipaddr']) . "</strong>";
 		}
-		$data .= ",";
+		$data .= "^";
 		if ($ifinfo['ipaddrv6']) {
 			$data .= "<strong>" . htmlspecialchars($ifinfo['ipaddrv6']) . "</strong>";
 		}
-		$data .= ",";
+		$data .= "^";
 		if ($ifinfo['status'] != "down") {
 			$data .= htmlspecialchars($ifinfo['media']);
 		}

--- a/usr/local/www/javascript/index/ajax.js
+++ b/usr/local/www/javascript/index/ajax.js
@@ -149,7 +149,7 @@ function updateInterfaces(x){
 	if (widgetActive("interfaces")){
 		interfaces_split = x.split("~");
 		interfaces_split.each(function(iface){
-			details = iface.split(",");
+			details = iface.split("^");
 			if (details[2] == '')
 				ipv4_details = '';
 			else


### PR DESCRIPTION
when acquiring the interface data. In particular the media information
can have commas in it already as reported in Redmine bug #4859
Note that get_interfacestatus() is already using "~" to separate the data for each interface. Then get_stats() puts together the data for various common widgets and separates them with "|" for return by getstats.php. So neither of those characters can be used here. "^" seems the next least likely to actually appear in the data.