### PR TITLE
Backup IPsec: MSS clamping. Wrong group location used.

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -554,10 +554,10 @@ function filter_generate_scrubing() {
 	global $config, $FilterIflist;
 	$scrubrules = "";
 
-	if (isset($config['system']['maxmss_enable'])) {
+	if (isset($config['ipsec']['maxmss_enable'])) {
 		$maxmss = 1400;
-		if (!empty($config['system']['maxmss'])) {
-			$maxmss = $config['system']['maxmss'];
+		if (!empty($config['ipsec']['maxmss'])) {
+			$maxmss = $config['ipsec']['maxmss'];
 		}
 
 		$scrubrules .= "scrub from any to <vpn_networks> max-mss {$maxmss}\n";

--- a/etc/inc/upgrade_config.inc
+++ b/etc/inc/upgrade_config.inc
@@ -3767,5 +3767,17 @@ function upgrade_117_to_118() {
 		unset($miniupnpd["permuser{$i}"]);
 	}
 }
+
+function upgrade_118_to_119() {
+	global $config;
+
+	if (isset($config['system']['maxmss_enable']) && isset($config['system']['maxmss'])) {
+		$config['ipsec']['maxmss_enable'] = $config['system']['maxmss_enable'];
+		$config['ipsec']['maxmss'] = $config['system']['maxmss'];
+		unset($config['system']['maxmss_enable']);
+		unset($config['system']['maxmss']);
+	}
+}
+
 ?>
 

--- a/usr/local/www/vpn_ipsec_settings.php
+++ b/usr/local/www/vpn_ipsec_settings.php
@@ -51,8 +51,8 @@ $pconfig['noshuntlaninterfaces'] = isset($config['ipsec']['noshuntlaninterfaces'
 $pconfig['compression'] = isset($config['ipsec']['compression']);
 $pconfig['enableinterfacesuse'] = isset($config['ipsec']['enableinterfacesuse']);
 $pconfig['acceptunencryptedmainmode'] = isset($config['ipsec']['acceptunencryptedmainmode']);
-$pconfig['maxmss_enable'] = isset($config['system']['maxmss_enable']);
-$pconfig['maxmss'] = $config['system']['maxmss'];
+$pconfig['maxmss_enable'] = isset($config['ipsec']['maxmss_enable']);
+$pconfig['maxmss'] = $config['ipsec']['maxmss'];
 $pconfig['uniqueids'] = $config['ipsec']['uniqueids'];
 
 if ($_POST) {
@@ -185,11 +185,11 @@ if ($_POST) {
 		}
 
 		if($_POST['maxmss_enable'] == "yes") {
-			$config['system']['maxmss_enable'] = true;
-			$config['system']['maxmss'] = $_POST['maxmss'];
+			$config['ipsec']['maxmss_enable'] = true;
+			$config['ipsec']['maxmss'] = $_POST['maxmss'];
 		} else {
-			unset($config['system']['maxmss_enable']);
-			unset($config['system']['maxmss']);
+			unset($config['ipsec']['maxmss_enable']);
+			unset($config['ipsec']['maxmss']);
 		}
 
 		write_config();


### PR DESCRIPTION
MSS value of IPsec isn't backed up when selecting IPsec, because its in the wrong config group.

Now uses "IPsec" instead of "System" group.

Signed-off by: Lars Alex Pedersen <thacaleb@gmail.com>