### PR TITLE
Handle IPsec Advanced Settings save before IPsec is enabled

### DIFF
--- a/usr/local/www/vpn_ipsec_settings.php
+++ b/usr/local/www/vpn_ipsec_settings.php
@@ -120,15 +120,13 @@ if ($_POST) {
 
 	if (!$input_errors) {
 
-		if (is_array($config['ipsec'])) {
-			foreach ($ipsec_loglevels as $lkey => $ldescr) {
-				if (empty($_POST["ipsec_{$lkey}"])) {
-					if (isset($config['ipsec']["ipsec_{$lkey}"])) {
-						unset($config['ipsec']["ipsec_{$lkey}"]);
-					}
-				} else {
-					$config['ipsec']["ipsec_{$lkey}"] = $_POST["ipsec_{$lkey}"];
+		foreach ($ipsec_loglevels as $lkey => $ldescr) {
+			if (empty($_POST["ipsec_{$lkey}"])) {
+				if (isset($config['ipsec']["ipsec_{$lkey}"])) {
+					unset($config['ipsec']["ipsec_{$lkey}"]);
 				}
+			} else {
+				$config['ipsec']["ipsec_{$lkey}"] = $_POST["ipsec_{$lkey}"];
 			}
 		}
 
@@ -171,7 +169,9 @@ if ($_POST) {
 		}
 
 		if ($_POST['noshuntlaninterfaces'] == "yes") {
-			unset($config['ipsec']['noshuntlaninterfaces']);
+			if (isset($config['ipsec']['noshuntlaninterfaces'])) {
+				unset($config['ipsec']['noshuntlaninterfaces']);
+			}
 		} else {
 			$config['ipsec']['noshuntlaninterfaces'] = true;
 		}
@@ -188,7 +188,7 @@ if ($_POST) {
 
 		if (!empty($_POST['uniqueids'])) {
 			$config['ipsec']['uniqueids'] = $_POST['uniqueids'];
-		} else {
+		} else if (isset($config['ipsec']['uniqueids'])) {
 			unset($config['ipsec']['uniqueids']);
 		}
 
@@ -196,8 +196,12 @@ if ($_POST) {
 			$config['system']['maxmss_enable'] = true;
 			$config['system']['maxmss'] = $_POST['maxmss'];
 		} else {
-			unset($config['system']['maxmss_enable']);
-			unset($config['system']['maxmss']);
+			if (isset($config['system']['maxmss_enable'])) {
+				unset($config['system']['maxmss_enable']);
+			}
+			if (isset($config['system']['maxmss'])) {
+				unset($config['system']['maxmss']);
+			}
 		}
 
 		write_config();


### PR DESCRIPTION
If the Advanced Settings are saved before any other IPsec is set up then $config['ipsec'] can be just the empty string. As a result you can get:
a) If you select some debug settings then those are not saved. The code to save those settings was only executed when $config['ipsec'] was already an array. Actually the code already did the necessary "if isset() then unset()" stuff. So I just took the the "if is_array()" away from the code block and it saves fine the first time.

b) Some potential unset() can go wrong with errors like:
Fatal error: Cannot unset string offsets in /usr/local/www/vpn_ipsec_settings.php on line 168
This is corrected by adding more "if (isset())" checks.

Fixes Redmine #4865