### PR TITLE
test unbound.conf is valid before overwriting new options

### DIFF
--- a/etc/inc/unbound.inc
+++ b/etc/inc/unbound.inc
@@ -103,7 +103,8 @@ function unbound_optimization() {
 
 }
 
-function unbound_generate_config() {
+/* call with $testonly=true to generate, validate and return (1 = error) */
+function unbound_generate_config($testonly = false) {
 	global $config, $g;
 
 	// Setup optimization
@@ -356,7 +357,18 @@ include: {$g['unbound_chroot_path']}/remotecontrol.conf
 
 EOD;
 
+	// config generated, either test it or save it
 	create_unbound_chroot_path();
+	if ($testonly) {
+		$fname = "{$g['unbound_chroot_path']}/unbound.test.conf";
+		file_put_contents($fname, $unboundconf);
+		return mwexec("/usr/local/sbin/unbound-checkconf {$fname}");
+	} else {
+		file_put_contents("{$g['unbound_chroot_path']}/unbound.conf", $unboundconf);
+		return 0;
+	}
+
+
 	file_put_contents("{$g['unbound_chroot_path']}/unbound.conf", $unboundconf);
 
 	return 0;

--- a/usr/local/www/services_unbound.php
+++ b/usr/local/www/services_unbound.php
@@ -387,15 +387,15 @@ function show_advanced_dns() {
 								</td>
 							</tr>
 							<tr>
-								<td width="22%" valign="top" class="vncellreq"><?=gettext("Advanced");?></td>
+								<td width="22%" valign="top" class="vncellreq"><?=gettext("Custom options");?></td>
 								<td width="78%" class="vtable">
 									<div id="showadvbox" <?php if ($pconfig['custom_options']) echo "style='display:none'"; ?>>
-										<input type="button" onclick="show_advanced_dns()" value="<?=gettext("Advanced"); ?>" /> - <?=gettext("Show advanced option");?>
+										<input type="button" onclick="show_advanced_dns()" value="<?=gettext("Custom options"); ?>" /> - <?=gettext("Show custom options");?>
 									</div>
 									<div id="showadv" <?php if (empty($pconfig['custom_options'])) echo "style='display:none'"; ?>>
-										<strong><?=gettext("Advanced");?><br /></strong>
+										<strong><?=gettext("Custom options");?><br /></strong>
 										<textarea rows="6" cols="78" name="custom_options" id="custom_options"><?=htmlspecialchars($pconfig['custom_options']);?></textarea><br />
-										<?=gettext("Enter any additional configuration parameters to add to the DNS Resolver configuration here, separated by a newline"); ?><br />
+										<?=gettext("Enter any additional configuration parameters to add to the DNS Resolver configuration here. Separate options by a newline"); ?><br />
 									</div>
 								</td>
 							</tr>


### PR DESCRIPTION
Currently the only way bad unbound.conf custom options can be detected is to save them, but when this is done, no error detection occurs: - new options are saved, but unbound fails to restart and the old config has been overwritten already and can't so easily be reverted.

This PR contains 3 separate changes:

1) Modify unbound_generate_config() to allow testing-only of $config['unbound']

2) Validate proposed $config['unbound'] changes before irrevocably overwriting the current unbound.conf, and notify the user if it won't work (eg if they had an error in their custom options).

3) GUI textual change: it's odd to have an "Advanced" input box on the 1st tab when there is also separately a second tab, also called "Advanced". So I changed this to "Custom options" which is both more accurate and avoids the confusion.

The effect of these changes is that a non-valid new config won't so easily overwrite the current config, the resolver won't be told to resync until the new conf is valid, and in the event that the error is purely in the custom options this will be detected and the user told. So the resolver and config changes to it, should be less easily upset by accidental bad input.

**** NOTES ****

(1) - "unbound-checkconf" utility doesn't specify any errors found, so if an error is returned, we have to find what it was ourselves. To be somewhat helpful the code re-tries it without the custom options changes, on the basis that the most helpful thing is to identify whether the freeform input was the apparent sole problem. Again this could be done better but for now it's at least somewhat helpful.

(2) - I've tagged one part of the code change as FIXME due to ugliness in original code:

The problem is that the current codebase changes $config, then "crosses fingers" and hopes it will work when the service is restarted.  Currently it builds a new unbound.conf uses data from $config itself, but the proposed conf can't be validated until constructed so it should really use a temp array until it's known to be good data, not saving changes into $config and just "hoping" they are okay. 

Given this current code, the simplest way to improve validation of config input changes is to allow the config to be changed, then change it back if it doesn't validate. That's bad coding and ugly. What *should* happen is to construct the new (proposed) $config['unbound'] in a temporary array, pass it to a validating function, and only overwrite $config if validation *succeeded*, which would be better. I've done this to avoid too-extensive changes to the codebase. It's not hard to fix, so I'll fix that bit quickly if asked.