### PR TITLE
Handle multiple notices in the same second

### DIFF
--- a/etc/inc/notices.inc
+++ b/etc/inc/notices.inc
@@ -80,6 +80,9 @@ function file_notice($id, $notice, $category = "General", $url = "", $priority =
 				'category'	=> $category,
 				'priority'	=> $priority,
 			);
+	while (isset($queue[$queuekey])) {
+		$queuekey++;
+	}
 	$queue[$queuekey] = $toqueue;
 	$queueout = fopen($notice_path, "w");
 	if (!$queueout) {


### PR DESCRIPTION
The notices are currently keyed by the Unix time stamp second. If file_notice() is called more than once in the same second, then the previous notice is overwritten. Only the last notice in any second actually ends up in /tmp/notices and thus on the webGUI flashing display.

The $queuekey value seems to be used to work out the actual time of the event for display, so it is a bit tricky to change that to a finer-grained key - callers of these functions are expecting an array key that is the Unix time in seconds, so all calls to this stuff would have to be examined and adjusted...

The workaround here is to increment the key if the existing key is already in use. This allows all notices in the same second to be saved, but the time of each one will be an incrementing seconds counter, even though the events all happened in the same second. Maybe that is a reasonable/practical workaround for now? Given that there should not be too many notices filed at the same second.