### PR TITLE
Ignore DHCP pools that are out of range

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -729,6 +729,14 @@ EOPP;
 
 		// Setup pool options
 		foreach ($all_pools as $poolconf) {
+			if (!(ip_in_subnet($poolconf['range']['from'], "{$subnet}/{$ifcfgsn}") && ip_in_subnet($poolconf['range']['to'], "{$subnet}/{$ifcfgsn}"))) {
+				// If the user has changed the subnet from the interfaces page and applied,
+				// but has not updated the DHCP range, then the range to/from of the pool can be outside the subnet.
+				// In that case, ignore the pool and post an error.
+				$error_msg = sprintf(gettext("Invalid DHCP pool %s - %s for %s subnet %s/%s detected. Please correct the settings in Services, DHCP Server"), $poolconf['range']['from'], $poolconf['range']['to'], convert_real_interface_to_friendly_descr($dhcpif), $subnet, $ifcfgsn);
+				file_notice("DHCP", $error_msg);
+				continue;
+			}
 			$dhcpdconf .= "	pool {\n";
 			/* is failover dns setup? */
 			if (is_array($poolconf['dnsserver']) && $poolconf['dnsserver'][0] <> "") {


### PR DESCRIPTION
If the user changes the subnet of an interface then applies without adjusting the DHCP pool range/s to be in the new subnet, then an invalid dhcpd.conf is generated. The DHCP server complains about it and exits. If you have only 1 LAN with DHCP then it does not make a difference - you are not going to get DHCP whatever happens because there is no valid pool data. But if there are multiple LAN-style interfaces with DHCP then you can cause no DHCP-service on LAN when you are messing with settings on OPT1/OPT2...

I did this to myself last night, and even after rebooting got no DHCP for either my LAN or OPT1, just because the OPT1 pool settings were bad.

This change checks that the pool ranges are in the interface subnet. If they are not, then they are excluded from dhcpd.conf and a notice os filed. The user gets the flashing notice stuff on the webGUI to tell them what is wrong. And any other good DHCP interfaces+pools continue to work.