### PR TITLE
Tighten is_linklocal() [rebase of PR #973]

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -406,9 +406,11 @@ function long2ip32($ip) {
 	return long2ip($ip & 0xFFFFFFFF);
 }
 
-/* Convert IP address to long int, truncated to 32-bits to avoid sign extension on 64-bit platforms. */
+/* Convert IP address to long int, truncated to 32-bits to avoid sign extension on 64-bit platforms.
+   Returns '' (not numeric) if not valid IPv4. */
 function ip2long32($ip) {
-	return (ip2long($ip) & 0xFFFFFFFF);
+	$a = ip2long($ip);
+	return ($a === False ? '' : $a & 0xFFFFFFFF);
 }
 
 /* Convert IP address to unsigned long int. */
@@ -621,9 +623,27 @@ function is_ipaddrv4($ipaddr) {
 	return true;
 }
 
-/* returns true if $ipaddr is a valid IPv6 linklocal address */
+/* returns 4 or 6 respectively (== TRUE) if $ipaddr is a valid IPv4 or IPv6 linklocal address
+   returns '' if not a valid linklocal address
+   TODO: does not attempt to validate any IPv6 %scope (if present) other than to check [0-9a-z] and non-pathological max length 64 */
 function is_linklocal($ipaddr) {
-	return (strtolower(substr($ipaddr, 0, 5)) == "fe80:");
+	if (!is_string($ipaddr))
+		return '';
+	$ip4 = ip2long32($ipaddr);
+	if ($ip4 !== false) {
+		// IPv4: test whether 169.254.1.0 - 169.254.254.255 per rfc3927 2.1
+		list($local4lo, $local4hi) = array(ip2long32('169.254.1.0'), ip2long32('169.254.254.255');)
+		if ($ip4 >= $local4lo && $ip4 <= $local4hi)
+			return 4;
+	} elseif (preg_match('/^([0-9a-f:]{2,39})(%([0-9a-z]{1,64}))?$/i', $ipaddr, $ip6)) {
+		// IPv6: test whether valid IPv6 and first 64 bits are '1111111010' + 54 zero bits (fe80::) per rfc4291 2.5.6
+		// we don't attempt any validation on scope data captured in $ip6[3] (if any) so long as plausible
+		// Net_IPv6::_Ip2Bin() can return a shorter binary string for non-IPv6 or other bad data so also test we got 128 bits returned
+		$ipbin = Net_IPv6::_Ip2Bin($ip6[1]);
+		if (strlen($ipbin) == 128 && substr($ipbin,0,64) == '1111111010' . str_repeat('0',54))
+			return 6;
+	}
+	return '';
 }
 
 /* returns scope of a linklocal address */


### PR DESCRIPTION
As requested by @rbgarga, rebase/resubmit of PR #973 which is superseded.

ORIGINAL DESCRIPTION AT #973:



is_linklocal has a few issues, including validating as linklocal, addresses that aren't linklocal according to RFC 4291, and doing no validation of reasonableness on any %(scope/interface) present, allowing this to contain arbitrary text.

1) IPv4/6 agnostic: while IPv4 linklocal testing isn't much needed, it should probably be recognised because some code handling linklocal may reasonably expect is_linklocal() to be IPv4/IPv6 agnostic.

2) For IPv6, it tests at least, that the purported scope/interface is [0-9a-z]+ otherwise user input or other text such as "fe80::%\n;ARBIRARYTEXT;" would be validated as a linklocal address and inserted into pf and perhaps other places without further detection, leading to possible vulnerabilities. But it doesn't test more than this (and probably should test for valid scope/interface if present).

3) Follows RFC 4291 exactly: IPv6 linklocal isn't just "fe80::", it requires the rest of the first 64 bits to be zero too. The RFC defines it as '1111111010' + 54 zeros (Ref: https://tools.ietf.org/html/rfc4291#section-2.5.6 )

4) Returns 4 or 6 to give a more exact response to the calling function as to whether the match was an IPv4 linklocal or IPv6 linklocal address (both evaluate to True for Boolean test purposes such as "if (is_linklocal(...))")

To which I add: 
- ip2long32() now a bit more robust:  this now returns FALSE for non-valid IPv4
- scope/interface part still not tested other than [0-9a-z], but a non-pathological max length of 64 has been added "just in case"
- Net_IPv6::_Ip2Bin() can return shorter binary strings for IPv4 or "junk" input. So this resubmit tests at lines 642-643 that it returned a 128 bit length, which should be sufficient for input sanitising that it was meaningful for IPv6.