### PR TITLE
Pkg related cleanups and fixes

### DIFF
--- a/usr/local/www/pkg.php
+++ b/usr/local/www/pkg.php
@@ -73,11 +73,6 @@ if ($pkg['include_file'] != "") {
 	require_once($pkg['include_file']);
 }
 
-$package_name = $pkg['menu'][0]['name'];
-$section      = $pkg['menu'][0]['section'];
-$config_path  = $pkg['configpath'];
-$title	      = $pkg['title'];
-
 if ($_REQUEST['startdisplayingat']) {
 	$startdisplayingat = $_REQUEST['startdisplayingat'];
 }
@@ -154,7 +149,7 @@ if ($pkg['custom_php_command_before_form'] <> "") {
 	eval($pkg['custom_php_command_before_form']);
 }
 
-$pgtitle = array($title);
+$pgtitle = array($pkg['title']);
 include("head.inc");
 
 ?>
@@ -378,7 +373,6 @@ include("head.inc");
 				</tr>
 <?php
 	$i = 0;
-	$pagination_startingrow = 0;
 	$pagination_counter = 0;
 	if ($evaledvar) {
 		foreach ($evaledvar as $ip) {

--- a/usr/local/www/pkg.php
+++ b/usr/local/www/pkg.php
@@ -489,7 +489,7 @@ include("head.inc");
 			// Handle pagination and display_maximum_rows
 			if ($display_maximum_rows) {
 				if ($pagination_counter == ($display_maximum_rows-1) or
-					$i == (count($evaledvar)-1)) {
+				    $i == (count($evaledvar)-1)) {
 					$colcount = count($pkg['adddeleteeditpagefields']['columnitem']);
 					$final_footer = "";
 					$final_footer .= "<tr><td colspan='$colcount'>";

--- a/usr/local/www/pkg.php
+++ b/usr/local/www/pkg.php
@@ -489,7 +489,7 @@ include("head.inc");
 			// Handle pagination and display_maximum_rows
 			if ($display_maximum_rows) {
 				if ($pagination_counter == ($display_maximum_rows-1) or
-				    $i == (count($evaledvar)-1)) {
+					$i == (count($evaledvar)-1)) {
 					$colcount = count($pkg['adddeleteeditpagefields']['columnitem']);
 					$final_footer = "";
 					$final_footer .= "<tr><td colspan='$colcount'>";

--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -73,7 +73,7 @@ if ($_POST['xml']) {
 $xml_fullpath = realpath('/usr/local/pkg/' . $xml);
 
 if ($xml == "" || $xml_fullpath === false ||
-    substr($xml_fullpath, 0, strlen('/usr/local/pkg/')) != '/usr/local/pkg/') {
+	substr($xml_fullpath, 0, strlen('/usr/local/pkg/')) != '/usr/local/pkg/') {
 	print_info_box_np(gettext("ERROR: No valid package defined."));
 	die;
 } else {
@@ -117,7 +117,7 @@ if ($config['installedpackages'] && !is_array($config['installedpackages'][xml_s
 
 // If the first entry in the array is an empty <config/> tag, kill it.
 if ($config['installedpackages'] && (count($config['installedpackages'][xml_safe_fieldname($pkg['name'])]['config']) > 0)
-    && ($config['installedpackages'][xml_safe_fieldname($pkg['name'])]['config'][0] == "")) {
+	&& ($config['installedpackages'][xml_safe_fieldname($pkg['name'])]['config'][0] == "")) {
 	array_shift($config['installedpackages'][xml_safe_fieldname($pkg['name'])]['config']);
 }
 

--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -574,10 +574,12 @@ if ($pkg['tabs'] <> "") {
 				$value = implode(',', $value);
 			}
 		} else {
-			if (isset($id) && $a_pkg[$id]) {
+			if (isset($id) && isset($a_pkg[$id][$fieldname])) {
 				$value = $a_pkg[$id][$fieldname];
 			} else {
-				$value = $pkga['default_value'];
+				if (isset($pkga['default_value'])) {
+					$value = $pkga['default_value'];
+				}
 			}
 		}
 		switch ($pkga['type']) {

--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -90,13 +90,6 @@ if (!isset($pkg['adddeleteeditpagefields'])) {
 	$only_edit = false;
 }
 
-$package_name = $pkg['menu'][0]['name'];
-$section      = $pkg['menu'][0]['section'];
-$config_path  = $pkg['configpath'];
-$name         = $pkg['name'];
-$title        = $pkg['title'];
-$pgtitle      = $title;
-
 $id = $_GET['id'];
 if (isset($_POST['id'])) {
 	$id = htmlspecialchars($_POST['id']);
@@ -139,7 +132,6 @@ if ($pkg['custom_php_command_before_form'] <> "") {
 }
 
 if ($_POST) {
-	$firstfield = "";
 	$rows = 0;
 
 	$input_errors = array();
@@ -285,12 +277,10 @@ if ($_POST) {
 
 if ($pkg['title'] <> "") {
 	$edit = ($only_edit ? '' : ": " . gettext("Edit"));
-	$title = $pkg['title'] . $edit;
+	$pgtitle = $pkg['title'] . $edit;
 } else {
-	$title = gettext("Package Editor");
+	$pgtitle = gettext("Package Editor");
 }
-
-$pgtitle = $title;
 
 if ($pkg['custom_php_after_head_command']) {
 	$closehead = false;
@@ -963,13 +953,8 @@ if ($pkg['tabs'] <> "") {
 							if (isset($id) && $a_pkg[$id]) {
 								$value = $row[$fieldname];
 							}
-							$options = "";
 							$type = $rowhelper['type'];
-							$description = $rowhelper['description'];
 							$fieldname = $rowhelper['fieldname'];
-							if ($type == "option") {
-								$options = &$rowhelper['options']['option'];
-							}
 							if ($rowhelper['size']) {
 								$size = $rowhelper['size'];
 							} else if ($pkga['size']) {
@@ -1101,7 +1086,7 @@ if ($pkg['tabs'] <> "") {
  * ROW Helpers function
  */
 function display_row($trc, $value, $fieldname, $type, $rowhelper, $size) {
-	global $text, $config;
+	global $text;
 	echo "<td>\n";
 	switch ($type) {
 		case "input":
@@ -1202,13 +1187,11 @@ function fixup_string($string) {
  *  Parse templates if they are defined
  */
 function parse_package_templates() {
-	global $pkg, $config;
-	$rows = 0;
+	global $pkg;
 	if ($pkg['templates']['template'] <> "") {
 		foreach ($pkg['templates']['template'] as $pkg_template_row) {
 			$filename = $pkg_template_row['filename'];
 			$template_text = $pkg_template_row['templatecontents'];
-			$firstfield = "";
 			/* calculate total row helpers count and */
 			/* change fields defined as fieldname_fieldvalue to their value */
 			foreach ($pkg['fields']['field'] as $fields) {

--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -202,6 +202,7 @@ if ($_POST) {
 						$rowhelpername="row";
 						foreach ($fields['rowhelper']['rowhelperfield'] as $rowhelperfield) {
 							foreach ($_POST as $key => $value) {
+								$matches = array();
 								if (preg_match("/^{$rowhelperfield['fieldname']}(\d+)$/", $key, $matches)) {
 									$pkgarr[$rowhelpername][$matches[1]][$rowhelperfield['fieldname']] = $value;
 								}
@@ -471,6 +472,7 @@ if ($pkg['tabs'] <> "") {
 		$advanced = "<td>&nbsp;</td>";
 		$advanced .= "<tr><td colspan=\"2\" class=\"listtopic\">". gettext("Advanced features") . "<br /></td></tr>\n";
 	}
+	$js_array = array();
 	foreach ($pkg['fields']['field'] as $pkga) {
 		if ($pkga['type'] == "sorting") {
 			continue;

--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -73,7 +73,7 @@ if ($_POST['xml']) {
 $xml_fullpath = realpath('/usr/local/pkg/' . $xml);
 
 if ($xml == "" || $xml_fullpath === false ||
-	substr($xml_fullpath, 0, strlen('/usr/local/pkg/')) != '/usr/local/pkg/') {
+    substr($xml_fullpath, 0, strlen('/usr/local/pkg/')) != '/usr/local/pkg/') {
 	print_info_box_np(gettext("ERROR: No valid package defined."));
 	die;
 } else {
@@ -117,7 +117,7 @@ if ($config['installedpackages'] && !is_array($config['installedpackages'][xml_s
 
 // If the first entry in the array is an empty <config/> tag, kill it.
 if ($config['installedpackages'] && (count($config['installedpackages'][xml_safe_fieldname($pkg['name'])]['config']) > 0)
-	&& ($config['installedpackages'][xml_safe_fieldname($pkg['name'])]['config'][0] == "")) {
+    && ($config['installedpackages'][xml_safe_fieldname($pkg['name'])]['config'][0] == "")) {
 	array_shift($config['installedpackages'][xml_safe_fieldname($pkg['name'])]['config']);
 }
 


### PR DESCRIPTION
Removing some unused variables and initializing variables that are not being initialized. Also fixing issue with default value assignment. The code was only checking if $a_pkg[$id] existed instead of $a_pkg[$id][$fieldname] before assigning value when loading the form. This caused default value to never be displayed for any new fields added to the package xml.