### PR TITLE
Simplify is_literalipaddrv6 & is_hostnamewithport (resubmit/rebase of PR #962)

### DIFF
--- a/etc/inc/util.inc
+++ b/etc/inc/util.inc
@@ -637,16 +637,14 @@ function get_ll_scope($addr) {
 
 /* returns true if $ipaddr is a valid literal IPv6 address */
 function is_literalipaddrv6($ipaddr) {
-	if (preg_match("/\[([0-9a-f:]+)\]/i", $ipaddr, $match)) {
-		$ipaddr = $match[1];
-	} else {
-		return false;
+	if (substr($ipaddr,0,1) == '[' && substr($ipaddr,-1,1) == ']') {
+		// if it's data wrapped in "[ ... ]" then test if middle part is valid IPv6
+		return is_ipaddrv6(substr($ipaddr,1,-1));
 	}
-
-	return is_ipaddrv6($ipaddr);
+	return false;
 }
 
-/* returns true if $iport is a valid IPv4/IPv6 address + port
+/* returns true if $iport is a valid IPv4:port or [Literal IPv6]:port
 	false - not valid
 	true (numeric 4 or 6) - if valid, gives type of address */
 function is_ipaddrwithport($ipport) {
@@ -671,12 +669,11 @@ function is_ipaddrwithport($ipport) {
 
 function is_hostnamewithport($hostport) {
 	$parts = explode(":", $hostport);
-	$port = array_pop($parts);
-	if (count($parts) == 1) {
-		return is_hostname($parts[0]) && is_port($port);
-	} else {
-		return false;
+	// no need to validate with is_string(); if it's not a string then explode won't return 2 parts anyway
+	if (count($parts) == 2) {
+		return is_hostname($parts[0]) && is_port($parts[1]);
 	}
+	return false;
 }
 
 /* returns true if $ipaddr is a valid dotted IPv4 address or an alias thereof */


### PR DESCRIPTION
rbgarga asked for PR #962 to be rebased/resubmitted.

On doing so I find that 
- is_ipaddrwithport() has been sorted out effectively already, so that part is redundant
- is_hostnamewithport() can be simplified (we don't need to pop() or assign a new variable just to test 2nd member of the array)
- is_literalipaddrv6() can be much simplified - we don't need an expensive preg_match() to test if it's a valid IPv6 wrapped in "[" ... "]"

If this is ok then the original PR can be closed as it's superseded.