### PR TITLE
Pkg install error handling and connect timeout RELENG_2_2

### DIFF
--- a/etc/inc/pkg-utils.inc
+++ b/etc/inc/pkg-utils.inc
@@ -87,6 +87,11 @@ if(!is_dir("/usr/local/pkg") or !is_dir("/usr/local/pkg/pf")) {
 	conf_mount_ro();
 }
 
+// Use a longer (30 second) connect timeout when trying to download each package file.
+// Package installs are not holding up general boot and routing/firewall functionality,
+// so it is nicer to wait a while if necessary rather than abort.
+define('PKG_FILE_DOWNLOAD_CONNECT_TIMEOUT', '30');
+
 /****f* pkg-utils/remove_package
  * NAME
  *   remove_package - Removes package from FreeBSD if it exists
@@ -497,8 +502,8 @@ function pkg_fetch_recursive($pkgname, $filename, $dependlevel = 0, $base_url = 
 			$base_url = substr($base_url, 0, -1);
 		$fetchto = "{$fetchdir}/apkg_{$filename}";
 		$static_output .= "\n" . str_repeat(" ", $dependlevel * 2 + 1) . "Downloading {$base_url}/{$filename} ... ";
-		if (download_file_with_progress_bar("{$base_url}/{$filename}", $fetchto) !== true) {
-			if ($base_url != $priv_url && download_file_with_progress_bar("{$priv_url}/{$filename}", $fetchto) !== true) {
+		if (download_file_with_progress_bar("{$base_url}/{$filename}", $fetchto, "read_body", PKG_FILE_DOWNLOAD_CONNECT_TIMEOUT) !== true) {
+			if ($base_url != $priv_url && download_file_with_progress_bar("{$priv_url}/{$filename}", $fetchto, "read_body", PKG_FILE_DOWNLOAD_CONNECT_TIMEOUT) !== true) {
 				$static_output .= " could not download from there or {$priv_url}/{$filename}.\n";
 				update_output_window($static_output);
 				return false;
@@ -770,7 +775,9 @@ function install_package_xml($pkg) {
 			update_output_window($static_output);
 		}
 
-		pkg_fetch_additional_files($pkg, $pkg_info);
+		if (!pkg_fetch_additional_files($pkg, $pkg_info)) {
+			return false;
+		}
 
 		/*   if a require exists, include it.  this will
 		 *   show us where an error exists in a package
@@ -1448,8 +1455,7 @@ function pkg_fetch_config_file($package, $pkg_info = "") {
 		update_output_window($static_output);
 		pkg_debug(gettext("Downloading package configuration file...") . "\n");
 		$fetchto = substr(strrchr($pkg_info['config_file'], '/'), 1);
-		download_file_with_progress_bar($pkg_info['config_file'], '/usr/local/pkg/' . $fetchto);
-		if(!file_exists('/usr/local/pkg/' . $fetchto)) {
+		if (download_file_with_progress_bar($pkg_info['config_file'], '/usr/local/pkg/' . $fetchto, "read_body", PKG_FILE_DOWNLOAD_CONNECT_TIMEOUT) !== true) {
 			pkg_debug(gettext("ERROR! Unable to fetch package configuration file. Aborting installation.") . "\n");
 			if($pkg_interface == "console")
 				print "\n" . gettext("ERROR! Unable to fetch package configuration file. Aborting package installation.") . "\n";
@@ -1510,7 +1516,7 @@ function pkg_fetch_additional_files($package, $pkg_info = "") {
 					safe_mkdir($prefix);
 				$static_output .= $filename . " ";
 				update_output_window($static_output);
-				if (download_file_with_progress_bar($afn['item'][0], $prefix . $filename) !== true) {
+				if (download_file_with_progress_bar($afn['item'][0], $prefix . $filename, "read_body", PKG_FILE_DOWNLOAD_CONNECT_TIMEOUT) !== true) {
 					$static_output .= "failed.\n";
 					@unlink($prefix . $filename);
 					update_output_window($static_output);


### PR DESCRIPTION
Fixes Redmine #4884
1) Line 778-780 - If the fetch of any of the package additional files fails then bail out. This prevents half-installed packages that look like they had a successful install.
2) Line 1458 - use the return boolean value from download_file_with_progress_bar() to determine success or failure here, like is done in the other places in this file. I had a case of installing a package with an error (timeout) and the download (I presume it was the download code) had left an empty file /usr/local/pkg/autoconfigbackup.xml - it passed the file_exists() check and the rest of the code went on to happily install the "nothing" in the package and then claim the package was successfully installed :(
After the above 2 changes I could get reliable indication of success/failure of the package install and the code would abort nicely if a download went wrong.
3) Package installs happen either:
i) On the end of a boot after upgrade or config restore, or;
ii) Online while the main system is running (happily)
Therefore there is no need to rush to abort if the download of a package file is taking some time to get started. It seems better to me to wait a decent amount of time rather than abort.
Thus I have increased the connect timeout for this from the default (5) to 30 seconds.
This makes my crap sites load packages much better :)
I will make a version for master also.