### PR TITLE
GratisDNS support for hosts without subdomains

### DIFF
--- a/etc/inc/dyndns.class
+++ b/etc/inc/dyndns.class
@@ -695,8 +695,14 @@
 						log_error("GratisDNS.dk ({$this->_dnsHost}): DNS update() starting.");
 					}
 					$server = "https://ssl.gratisdns.dk/ddns.phtml";
-					list($hostname, $domain) = explode(".", $this->_dnsHost, 2);
-					curl_setopt($ch, CURLOPT_URL, $server . '?u=' . $this->_dnsUser . '&p=' . $this->_dnsPass . '&h=' . $this->_dnsHost . '&d=' . $domain . '&i=' . $this->_dnsIP);
+					$host = trim($this->_dnsHost);
+					$hostnames = explode(".", $host);
+					$hostnames_count = count($hostnames);
+					if ($hostnames_count > 1)
+						$domain = $hostnames[$hostnames_count-2] . "." . $hostnames[$hostnames_count-1];
+					else
+						$domain = $host;
+					curl_setopt($ch, CURLOPT_URL, $server . '?u=' . $this->_dnsUser . '&p=' . $this->_dnsPass . '&h=' . $host . '&d=' . $domain . '&i=' . $this->_dnsIP);
 					break;
 				case 'ovh-dynhost':
 					$needsIP = FALSE;

--- a/etc/inc/dyndns.class
+++ b/etc/inc/dyndns.class
@@ -698,7 +698,7 @@
 					$host = trim($this->_dnsHost);
 					$hostnames = explode(".", $host);
 					$hostnames_count = count($hostnames);
-					if ($hostnames_count > 1)
+					if ($hostnames_count > 2)
 						$domain = $hostnames[$hostnames_count-2] . "." . $hostnames[$hostnames_count-1];
 					else
 						$domain = $host;


### PR DESCRIPTION
Previous GratisDNS implementation did not work with hosts without subdomains (www.bob.dk works, bob.dk does not).