### PR TITLE
Consider url_port alias type when checking port-type aliases V2

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -601,7 +601,7 @@ function filter_generate_nested_alias($name, $alias, &$aliasnesting, &$aliasaddr
 			else if(!isset($aliasnesting[$address]))
 				$tmpline = filter_generate_nested_alias($name, $aliastable[$address], $aliasnesting, $aliasaddrnesting);
 		} else if(!isset($aliasaddrnesting[$address])) {
-			if (!is_ipaddr($address) && !is_subnet($address) && !(($alias_type == 'port') && (is_port($address) || is_portrange($address))) && is_hostname($address)) {
+			if (!is_ipaddr($address) && !is_subnet($address) && !((($alias_type == 'port') || ($alias_type == 'url_ports')) && (is_port($address) || is_portrange($address))) && is_hostname($address)) {
 				if (!isset($filterdns["{$address}{$name}"])) {
 					$use_filterdns = true;
 					$filterdns["{$address}{$name}"] = "pf {$address} {$name}\n";


### PR DESCRIPTION
This time I have typed url_ports correctly.
Hopefully will fix forum thread https://forum.pfsense.org/index.php?topic=97101.0
This is the version for RELENG_2_2
Redmine bug logged https://redmine.pfsense.org/issues/4888