### PR TITLE
Strip any \r when parsing URL table ports file

### DIFF
--- a/etc/inc/pfsense-utils.inc
+++ b/etc/inc/pfsense-utils.inc
@@ -2307,7 +2307,7 @@ function process_alias_urltable($name, $url, $freq, $forceupdate=false) {
 		if (download_file($url, $urltable_filename . ".tmp", $verify_ssl)) {
 			mwexec("/usr/bin/sed -E 's/\;.*//g; /^[[:space:]]*($|#)/d' ". escapeshellarg($urltable_filename . ".tmp") . " > " . escapeshellarg($urltable_filename));
 			if (alias_get_type($name) == "urltable_ports") {
-				$ports = explode("\n", file_get_contents($urltable_filename));
+				$ports = explode("\n", str_replace("\r", "", file_get_contents($urltable_filename)));
 				$ports = group_ports($ports);
 				file_put_contents($urltable_filename, implode("\n", $ports));
 			}


### PR DESCRIPTION
If the URL table ports file at the URL specified has lines separated by "\r\n" rather than just "\n", then the code here ends up with ports that look like "80\r" "443\r" ... and group_ports() does not match any of those and the final file ends up empty. That seems a shame just because the file was made in some editor that put "\r\n" line breaks. I messed about for a while trying to make my URL table ports alias work until I realized this.
This change first strips out any "\r" from the string, thus making it work with files that have either pure "\n" line breaks or "\r\n" line breaks.