### PR TITLE
Allow packages to request syslogd log socket to be created inside chroot

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -836,7 +836,7 @@ function system_syslogd_start() {
 		$syslogconf = "";
 		if ($config['installedpackages']['package']) {
 			foreach ($config['installedpackages']['package'] as $package) {
-				if ($package['logging']) {
+				if (isset($package['logging']['facilityname']) && isset($package['logging']['logfilename'])) {
 					array_push($separatelogfacilities, $package['logging']['facilityname']);
 					if (!is_file($g['varlog_path'].'/'.$package['logging']['logfilename'])) {
 						mwexec("{$log_create_directive} {$log_size} {$g['varlog_path']}/{$package['logging']['logfilename']}");
@@ -1013,6 +1013,23 @@ EOD;
 		$syslogd_extra = "-f {$g['varetc_path']}/syslog.conf {$sourceip}";
 	}
 
+	$log_sockets = array();
+	$log_sockets[] = "{$g['dhcpd_chroot_path']}/var/run/log";
+
+	if (isset($config['installedpackages']['package'])) {
+		foreach ($config['installedpackages']['package'] as $package) {
+			if (isset($package['logging']['logsocket']) && '' != $package['logging']['logsocket'] &&
+			    is_dir(pathinfo($package['logging']['logsocket'], PATHINFO_DIRNAME)) && !in_array($package['logging']['logsocket'], $log_sockets)) {
+				$log_sockets[] = $package['logging']['logsocket'];
+			}
+		}
+	}
+
+	$syslogd_sockets = "";
+	foreach ($log_sockets as $log_socket) {
+		$syslogd_sockets .= " -l {$log_socket}";
+	}
+
 	if (isvalidpid("{$g['varrun_path']}/syslog.pid")) {
 		sigkillbypid("{$g['varrun_path']}/syslog.pid", "TERM");
 		usleep(100000); // syslogd often doesn't respond to a TERM quickly enough for the starting of syslogd below to be successful
@@ -1025,7 +1042,7 @@ EOD;
 	}
 
 
-	$retval = mwexec_bg("/usr/sbin/syslogd -s -c -c -l {$g['dhcpd_chroot_path']}/var/run/log -P {$g['varrun_path']}/syslog.pid {$syslogd_extra}");
+	$retval = mwexec_bg("/usr/sbin/syslogd -s -c -c {$syslogd_sockets} -P {$g['varrun_path']}/syslog.pid {$syslogd_extra}");
 
 	if (platform_booting()) {
 		echo gettext("done.") . "\n";

--- a/usr/local/www/diag_pkglogs.php
+++ b/usr/local/www/diag_pkglogs.php
@@ -66,9 +66,9 @@ $i = 0;
 $pkgwithlogging = false;
 $apkg = $_GET['pkg'];
 if (!$apkg) { // If we aren't looking for a specific package, locate the first package that handles logging.
-	if ($config['installedpackages']['package'] <> "") {
+	if (isset($config['installedpackages']['package'])) {
 		foreach ($config['installedpackages']['package'] as $package) {
-			if (is_array($package['logging'])) {
+			if (isset($package['logging']['logfilename']) && '' != $package['logging']['logfilename']) {
 				$pkgwithlogging = true;
 				$apkg = $package['name'];
 				$apkgid = $i;


### PR DESCRIPTION
by specifying it in /package/logging/logsocket element. Implements #4898.

Example:
<package>
	<logging>
		<logsocket>/var/appname/var/run/log</logsocket>
	</logging>
</package>