### PR TITLE
 run early shell commands earlier

### DIFF
--- a/etc/rc.bootup
+++ b/etc/rc.bootup
@@ -160,6 +160,9 @@ echo "Loading configuration...";
 parse_config_bootup();
 echo "done.\n";
 
+/* run any early shell commands specified in config.xml */
+system_do_shell_commands(1);
+
 if ($g['platform'] == "jail") {
 	/* We must determine what network settings have been configured for us */
 	$wanif = "lo0";	/* defaults, if the jail admin hasn't set us up */
@@ -232,9 +235,6 @@ load_crypto();
 
 /* enable optional thermal sensor modules */
 load_thermal_hardware();
-
-/* run any early shell commands specified in config.xml */
-system_do_shell_commands(1);
 
 /* set up our timezone */
 system_timezone_configure();


### PR DESCRIPTION
Early shell commands are not run early enough. Running at boot "ifconfig emX name ethX" for all interfaces in order to obtain a less driver-specific, hardware-independent, consistent network interface naming interferes with interface re-assignment and results in an unusable state.

Putting this before interface assignment check allows for keeping interface renaming commands within the config file, and not have to use manual rc.conf.local on the filesystem.