### PR TITLE
Allow to create empty bogons on nanoBSD

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -738,11 +738,15 @@ function filter_generate_aliases() {
 	$aliases .= "#Snort tables\n";
 	$aliases .= "table <snort2c>\n";
 	$aliases .= "table <virusprot>\n";
-	if (!file_exists("/etc/bogons")) {
-		@file_put_contents("/etc/bogons", "");
-	}
-	if (!file_exists("/etc/bogonsv6")) {
-		@file_put_contents("/etc/bogonsv6", "");
+	if (!file_exists("/etc/bogons") || !file_exists("/etc/bogonsv6")) {
+		conf_mount_rw();
+		if (!file_exists("/etc/bogons")) {
+			@file_put_contents("/etc/bogons", "");
+		}
+		if (!file_exists("/etc/bogonsv6")) {
+			@file_put_contents("/etc/bogonsv6", "");
+		}
+		conf_mount_ro();
 	}
 	$aliases .= "table <bogons> persist file \"/etc/bogons\"\n";
 	if (is_bogonsv6_used()) {


### PR DESCRIPTION
If for some reason the bogons file/s do not exist then this code creates
empty ones before making any use of them in the rule set.
On nanoBSD this can fail if the file system is mount RO.
Protect against this possibility by use conf_mount_rw and conf_mount_ro

Inspired by forum https://forum.pfsense.org/index.php?topic=89005.0
I saw this potential issue when looking at the code, so might as well fix it. But that forum post seems to be on a full install so might have some other issue with a missing /etc/bogons