### PR TITLE
fix interface assignment menus running off VGA screen

### DIFF
--- a/etc/inc/config.console.inc
+++ b/etc/inc/config.console.inc
@@ -86,8 +86,9 @@ EOD;
 		$iflist = array();
 	} else {
 		foreach ($iflist as $iface => $ifa) {
+			$ifsmallist = trim($ifsmallist . " " . $iface);
 			echo sprintf("% -7s%s %s %s\n", $iface, $ifa['mac'],
-				$ifa['up'] ? "  (up)" : "(down)", $ifa['dmesg']);
+				$ifa['up'] ? "  (up)" : "(down)", substr($ifa['dmesg'], 0, 48));
 		}
 	}
 
@@ -190,6 +191,7 @@ EOD;
 					"VLAN tag {$vlan['tag']}, parent interface {$vlan['if']}");
 
 				$iflist[$vlan['if'] . '_vlan' . $vlan['tag']] = array();
+				$ifsmallist = trim($ifsmallist . " " . $vlan['if'] . '_vlan' . $vlan['tag']);
 			}
 		}
 
@@ -202,7 +204,8 @@ hitting 'a' to initiate auto detection.
 EOD;
 
 		do {
-			echo "\n" . gettext("Enter the WAN interface name or 'a' for auto-detection:") . " ";
+			echo "\n" . gettext("Enter the WAN interface name or 'a' for auto-detection") . " ";
+			echo "\n" . gettext("(") . $ifsmallist . gettext(" or a): ");
 			$wanif = chop(fgets($fp));
 			if ($wanif === "") {
 				return;
@@ -219,7 +222,7 @@ EOD;
 		do {
 			printf(gettext("%sEnter the LAN interface name or 'a' for auto-detection %s" .
 				"NOTE: this enables full Firewalling/NAT mode.%s" .
-				"(or nothing if finished):%s"), "\n", "\n", "\n", " ");
+				"(") . $ifsmallist . gettext(" a or nothing if finished):%s"), "\n", "\n", "\n", " ");
 
 			$lanif = chop(fgets($fp));
 
@@ -257,7 +260,7 @@ EOD;
 				}
 
 				printf(gettext("%sEnter the Optional %s interface name or 'a' for auto-detection%s" .
-					"(or nothing if finished):%s"), "\n", $io, "\n", " ");
+					"(") . $ifsmallist . gettext(" a or nothing if finished):%s"), "\n", $io, "\n", " ");
 
 				$optif[$i] = chop(fgets($fp));
 

--- a/etc/inc/config.console.inc
+++ b/etc/inc/config.console.inc
@@ -217,6 +217,7 @@ EOD;
 				unset($wanif);
 				continue;
 			}
+			$ifsmallist = trim(str_replace("  ", " ", str_replace($wanif, "", $ifsmallist)));
 		} while (!$wanif);
 
 		do {
@@ -242,6 +243,7 @@ EOD;
 				unset($lanif);
 				continue;
 			}
+			$ifsmallist = trim(str_replace("  ", " ", str_replace($lanif, "", $ifsmallist)));
 		} while (!$lanif);
 
 		/* optional interfaces */
@@ -277,6 +279,7 @@ EOD;
 						unset($optif[$i]);
 						continue;
 					}
+					$ifsmallist = trim(str_replace("  ", " ", str_replace($optif[$i], "", $ifsmallist)));
 				} else {
 					unset($optif[$i]);
 					break;


### PR DESCRIPTION
When using VGA console, interface assignment can be a real pain in the ass because of the standard 80 columns width.

Dmesg reports the many interface description names in very long strings that don't fit in a row, this breaks the nice appearance of the interface list in the assignment menu.
The aestethics is one thing, but the real pain is that the interface list goes off screen by the time the menu asks for the WAN interface name, if there are many interfaces present. It's a real problem to choose from a list which is not visible anymore.

One fix is to maximize the length of the interface description to 48 chars.

The second fix (and also improvement for better overlooking when the list really goes off) is to print a small list of the interface names at each question. This is necessary because when somebody wants to assign the first interface to the last Optional port, the big list will be way off screen by then, and the name of it won't be visible.

This also makes it nice clean and straightforward.

The problem:
![assign_interfaces_list_goes_off_the_screen](https://cloud.githubusercontent.com/assets/1550668/9018456/5c555032-37df-11e5-8b13-58324a21f39e.png)

The fixes:
![assign_interfaces_list_maxwidth](https://cloud.githubusercontent.com/assets/1550668/9018458/5dd329ca-37df-11e5-93b6-009226fd76eb.png)

![assign_interfaces_smallist_every_question](https://cloud.githubusercontent.com/assets/1550668/9018462/67e04024-37df-11e5-9e4f-6e5b99d176a3.png)

![assign_interfaces_smallist_vlan_question](https://cloud.githubusercontent.com/assets/1550668/9018465/6a0d20c4-37df-11e5-9601-1ecc3143036d.png)