### PR TITLE
put back the missing newline

### DIFF
--- a/etc/rc.banner
+++ b/etc/rc.banner
@@ -6,7 +6,7 @@
 	rc.banner
 	part of pfSense
 	Copyright (C) 2005 Scott Ullrich and Colin Smith
-	Copyright (C) 2009 Ermal Luçi
+	Copyright (C) 2009 Ermal LuÃ§i
 	All rights reserved
 
 	Redistribution and use in source and binary forms, with or without
@@ -119,5 +119,5 @@
 			);
 		}
 	}
-
+	printf("\n");
 ?>


### PR DESCRIPTION
Since 2.2 the console is missing the separating line between the interfaces list and the menu, which makes it harder to overlook on a VGA screen. This restores the appearance which we were used to during so many years.