### PR TITLE
Redmine #4918 DH groups 22-24 do not function

### DIFF
--- a/etc/inc/vpn.inc
+++ b/etc/inc/vpn.inc
@@ -99,6 +99,15 @@ function vpn_ipsec_convert_to_modp($index) {
 		case '21':
 			$convertion = "ecp521";
 			break;
+		case '22':
+			$convertion = "modp1024s160";
+			break;
+		case '23':
+			$convertion = "modp2048s224";
+			break;
+		case '24':
+			$convertion = "modp2048s256";
+			break;
 		case '28':
 			$convertion = "ecp256bp";
 			break;


### PR DESCRIPTION
When selecting DH group 22-24, the entry is not created properly in ipsec.conf. This resolves the issue.