### PR TITLE
Redmine #4924 Improve pkg version comparison RELENG_2_2

### DIFF
--- a/etc/inc/pkg-utils.inc
+++ b/etc/inc/pkg-utils.inc
@@ -237,9 +237,9 @@ function compare_pkg_versions($installed_pkg_ver, $available_pkg_ver) {
 			$val2_as_int = filter_var($available_arr[$n], FILTER_VALIDATE_INT);
 			if (($val1_as_int === false) || ($val2_as_int === false)) {
 				// One of them does not look like a genuine integer so use string comparison.
-				if (strcmp($val, $available_arr[$n]) > 0) {
+				if (strcasecmp($val, $available_arr[$n]) > 0) {
 					return 1;
-				} elseif (strcmp($val, $available_arr[$n]) < 0) {
+				} elseif (strcasecmp($val, $available_arr[$n]) < 0) {
 					return -1;
 				}
 			} else {

--- a/etc/inc/pkg-utils.inc
+++ b/etc/inc/pkg-utils.inc
@@ -209,6 +209,66 @@ function get_pkg_sizes($pkgs = 'all') {
 	return array();
 }
 
+/****f* pkg-utils/compare_pkg_versions
+ * NAME
+ *   compare_pkg_versions - Decide if the installed package is newer, the same or older than the available package.
+ * INPUTS
+ *   $installed_pkg_ver - the package version installed on the system.
+ *   $available_pkg_ver - the package version available from the package server.
+ * RESULT
+ *   -1 - the installed package is older (an upgrade is available)
+ *   0 - the package versions are the same
+ *   1 - the installed package is newer (somebody has installed a newer version than is officially available)
+ ******/
+function compare_pkg_versions($installed_pkg_ver, $available_pkg_ver) {
+	// If the strings are the same then short-cut all the processing.
+	if (strcmp($installed_pkg_ver, $available_pkg_ver) == 0) {
+		return 0;
+	}
+
+	// Split into pieces that are groups of digits and groups of non-digits.
+	$installed_arr = preg_split( '/([0-9]+)/', $installed_pkg_ver, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+	$available_arr = preg_split( '/([0-9]+)/', $available_pkg_ver, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+	foreach ($installed_arr as $n => $val) {
+		if (array_key_exists($n, $available_arr)) {
+			// Check if this piece looks like a genuine integer like "123", "0" rather than "05", "005", "1a", "abc".
+			// Note: At this point the pieces cannot be like "-1", "+1" so we do not need to worry about those possibilities that filter_var() will see as "genuine integers".
+			$val1_as_int = filter_var($val, FILTER_VALIDATE_INT);
+			$val2_as_int = filter_var($available_arr[$n], FILTER_VALIDATE_INT);
+			if (($val1_as_int === false) || ($val2_as_int === false)) {
+				// One of them does not look like a genuine integer so use string comparison.
+				if (strcmp($val, $available_arr[$n]) > 0) {
+					return 1;
+				} elseif (strcmp($val, $available_arr[$n]) < 0) {
+					return -1;
+				}
+			} else {
+				// Both look like genuine integers so compare as numbers.
+				if ($val1_as_int > $val2_as_int) {
+					return 1;
+				} elseif ($val1_as_int < $val2_as_int) {
+					return -1;
+				}
+			}
+		} else {
+			// The installed package version is greater, since all components have matched up to this point
+			// and available_arr doesn't have any more data.
+			return 1;
+		}
+	}
+
+	if (count($available_arr) > count($installed_arr)) {
+		// All the installed package components matched the corresponding available package components.
+		// The available package is longer than the installed package, so the installed package is old.
+		return -1;
+	} else {
+		// Both versions are of equal length and value.
+		return 0;
+	}
+
+	return $resp ? $resp : array();
+}
+
 /*
  * resync_all_package_configs() Force packages to setup their configuration and rc.d files.
  * This function may also print output to the terminal indicating progress.

--- a/usr/local/www/pkg_mgr_installed.php
+++ b/usr/local/www/pkg_mgr_installed.php
@@ -147,8 +147,10 @@ include("head.inc");
 									#check package version
 									$latest_package = $currentvers[$pkg['name']]['version'];
 									if ($latest_package) {
+										$pkg_compare_result = compare_pkg_versions($pkg['version'], $latest_package);
+
 										// we're running a newer version of the package
-										if(strcmp($pkg['version'], $latest_package) > 0) {
+										if ($pkg_compare_result > 0) {
 											$tdclass = "listbggrey";
 											if ($g['disablepackagehistory'])
 												$pkgver  = "<a>".gettext("Available") .": ". $latest_package . "<br />";
@@ -157,7 +159,7 @@ include("head.inc");
 											$pkgver .= gettext("Installed") .": ". $pkg['version']. "</a>";
 										}
 										// we're running an older version of the package
-										if(strcmp($pkg['version'], $latest_package) < 0) {
+										if ($pkg_compare_result < 0) {
 											$tdclass = "listbg";
 											if ($g['disablepackagehistory'])
 												$pkgver  = "<a><font color='#ffffff'>" . gettext("Available") .": ". $latest_package . "</font><br />";
@@ -166,7 +168,7 @@ include("head.inc");
 											$pkgver .= gettext("Installed") .": ". $pkg['version']."</font></a>";
 										}
 										// we're running the current version
-										if(!strcmp($pkg['version'], $latest_package)) {
+										if ($pkg_compare_result == 0) {
 											$tdclass = "listr";
 											if ($g['disablepackagehistory'])
 												$pkgver = "<a>{$pkg['version']}</a>";


### PR DESCRIPTION
This compares 2 package version strings by spliting the strings into pieces that are digits and pieces that are anything else. e.g.
"utility-24.9_5 pkg v4.5"
becomes
"utility-"
24
"."
9
"_"
5
" pkg v"
4
"."
5

A new version might be:
"utility-24.10_5 pkg v4.5"

Each component is compared.
If both corresponding components are "integer chunks" they are compared using "<" and ">" - that means that 10 becomes greater than 9.
If either component is not "integer" then string comparison is done. This makes the ordinary string changes work as expected and also stuff like "1.05" and "1.1" - a change like this will be seen as an upgrade (previously it might have been seen that ("05" = 5) and (5 > 1)).

Note that I have left the string comparison case-sensitive. If someone making their version string changes the "fixed text" they have put in the version string then anything is possible :) It is a bit difficult to guess all of that.

Also if people use alphabetic versioning that does not follow strcmp() sort order then there is always trouble - it works by luck with "-BETA" then "-RELEASE" because the English words happen to sort as expected.

I think this provides a reasonably generic way to compare version strings which should work for all the combinations used by reasonably imagined packages.