### PR TITLE
make sure that cron is running before reconfiguring it

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -2438,8 +2438,13 @@ function configure_cron() {
 	file_put_contents("/etc/crontab", $crontab_contents);
 	unset($crontab_contents);
 
+	/* make sure that cron is running and start it if it got somehow killed */
+	if (!is_process_running("cron")) {
+		exec("cd /tmp && /usr/sbin/cron -s 2>/dev/null");
+	} else {
 	/* do a HUP kill to force sync changes */
 	sigkillbypid("{$g['varrun_path']}/cron.pid", "HUP");
+	}
 
 	conf_mount_ro();
 }


### PR DESCRIPTION
Please, see https://github.com/pfsense/pfsense-packages/pull/997 for rationale. However, this is not limited to a single broken package, when cron goes away for whatever reason, you can keep reconfiguring it till blue in face but nothing will happen.