### PR TITLE
reduce from 10000 to 100 the maximum Y axis of quality graphs.

### DIFF
--- a/etc/inc/rrd.inc
+++ b/etc/inc/rrd.inc
@@ -957,7 +957,7 @@ function create_gateway_quality_rrd($rrd_file) {
 	if (!file_exists("$rrd_file")) {
 		$rrdcreate = "$rrdtool create $rrd_file --step $rrdinterval ";
 		$rrdcreate .= "DS:loss:GAUGE:$valid:0:100 ";
-		$rrdcreate .= "DS:delay:GAUGE:$valid:0:100000 ";
+		$rrdcreate .= "DS:delay:GAUGE:$valid:0:100 ";
 		$rrdcreate .= "RRA:AVERAGE:0.5:1:1200 ";
 		$rrdcreate .= "RRA:AVERAGE:0.5:5:720 ";
 		$rrdcreate .= "RRA:AVERAGE:0.5:60:1860 ";


### PR DESCRIPTION
A large peak in ping delay often completely obscure the average trends in both delay and packet loss. 

This change reduces the maximum value for the Y axis to 100 (from 100000).

In the presense of intermittent large ping delays, this makes it easier to see the general trend in both ping delay and packet loss. 
