### PR TITLE
Redmine #4925 Fix version comparison to know 10 is bigger than 9

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2239,8 +2239,8 @@ function version_compare_string($a, $b) {
 	}
 }
 function version_compare_numeric($a, $b) {
-	$a_arr = explode('.', rtrim($a, '.0'));
-	$b_arr = explode('.', rtrim($b, '.0'));
+	$a_arr = explode('.', rtrim($a, '.'));
+	$b_arr = explode('.', rtrim($b, '.'));
 
 	foreach ($a_arr as $n => $val) {
 		if (array_key_exists($n, $b_arr)) {


### PR DESCRIPTION
This rtrim of ".0" is stripping any "0" from the end of the passed-in version strings. That makes "2.3.10" become "2.3.1" which then removes any chance of the following nice comparison logic working.
Just removing the "0" seems fine. It keeps the supplied version data untouched, just getting rid of any trailing dots.
Apart from fixing the bug here, this change has the side-effect that a version change from "2.3" to "2.3.0" will now be seen as an upgrade.
What is the requirement for that?
Do you want to have extra logic that checks for "bare" zeroes on the end and make "2.3", "2.3.0", "2.3.0.0"... all be considered the same version?
This is a resubmit of PR #1810 after integrating with the current master.