### PR TITLE
Redmine #5041 Improve reverse lookup zone name generation RELENG_2_2

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -625,10 +625,15 @@ EOPP;
 			}
 			$revsubnet = explode(".", $subnet);
 			$revsubnet = array_reverse($revsubnet);
-			foreach ($revsubnet as $octet) {
-				if ($octet != "0")
-					break;
+			// Always drop the end number, leaving at most 3 octets of the IP address
+			array_shift($revsubnet);
+			if (($ifcfgsn < 24) && ($revsubnet[0] == "0")) {
+				// We have x.y.0 and a subnet bit count that makes a bigger subnet than a /24
 				array_shift($revsubnet);
+				if (($ifcfgsn < 16) && ($revsubnet[0] == "0")) {
+					// We have x.0 and a subnet bit count that makes a bigger subnet than a /16
+					array_shift($revsubnet);
+				}
 			}
 			$newzone['ptr-domain'] = implode(".", $revsubnet) . ".in-addr.arpa";
 		}


### PR DESCRIPTION
Now 192.168.0.0/24 generates a reverse lookup of:
0.168.192.in-addr.arpa
Also previously something like 192.168.42.128/25 would have generated:
128.42.168.192.in-addr.arpa
which is not a valid zone.
Now that will generate:
42.168.192.in-addr.arpa
which is at least the zone concerned, even though it is inevitably "bigger" than the forward zone.
For in-between subnet bit counts I have attempted to keep the current behaviour:
172.16.12.0/22 becomes 12.16.172.in-addr.arpa (that does not cover all the 12,13,14 and 15 of the /22 !)
172.16.0.0/22 becomes 16.172.in-addr.arpa (bigger than a /22)
172.16.0.0/16 becomes 16.172.in-addr.arpa (expected and correct)
and similar stuff for /15 down to ... /8
This is all very odd - because actually, for example, if it is a /22
then it needs to be expanded into 4 reverse lookup zones. Should we be writing the many individual "/24" reverse lookup zones that make up the /23 /22 /21 or whatever?
But also what can be put in dhcpd.conf maybe can be a super-set of the reverse lookup name space and work fine?
I am not sure about all that, so best not to maybe break other working configurations that have unusual subnet bit counts.