### PR TITLE
make sure that cron is running before reconfiguring it

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2438,8 +2438,13 @@ function configure_cron() {
 	file_put_contents("/etc/crontab", $crontab_contents);
 	unset($crontab_contents);
 
+	/* make sure that cron is running and start it if it got killed somehow */
+	if (!is_process_running("cron")) {
+		exec("cd /tmp && /usr/sbin/cron -s 2>/dev/null");
+	} else {
 	/* do a HUP kill to force sync changes */
 	sigkillbypid("{$g['varrun_path']}/cron.pid", "HUP");
+	}
 
 	conf_mount_ro();
 }

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2443,7 +2443,7 @@ function configure_cron() {
 		exec("cd /tmp && /usr/sbin/cron -s 2>/dev/null");
 	} else {
 	/* do a HUP kill to force sync changes */
-	sigkillbypid("{$g['varrun_path']}/cron.pid", "HUP");
+		sigkillbypid("{$g['varrun_path']}/cron.pid", "HUP");
 	}
 
 	conf_mount_ro();


### PR DESCRIPTION
This is a resubmit of #1814.

(When cron goes away for whatever reason, you can keep reconfiguring it till blue in face but nothing will happen.)