### PR TITLE
filter.inc - Remove useless "could not find gateway" logspam

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2731,15 +2731,11 @@ function filter_generate_user_rule($rule) {
 			$rg = get_interface_gateway_v6($rule['interface']);
 			if (is_ipaddrv6($rg)) {
 				$aline['reply'] = "reply-to ( {$ifcfg['ifv6']} {$rg} ) ";
-			} else if ($rule['interface'] <> "pptp") {
-				log_error(sprintf(gettext("Could not find IPv6 gateway for interface (%s)."), $rule['interface']));
 			}
 		} else {
 			$rg = get_interface_gateway($rule['interface']);
 			if (is_ipaddrv4($rg)) {
 				$aline['reply'] = "reply-to ( {$ifcfg['if']} {$rg} ) ";
-			} else if ($rule['interface'] <> "pptp") {
-				log_error(sprintf(gettext("Could not find IPv4 gateway for interface (%s)."), $rule['interface']));
 			}
 		}
 	}


### PR DESCRIPTION
Resubmit of #1784.

See Bug #4102 and others. Getting completely pointless "errors" noise for completely normal situations in logs is NOT cool. Other annoyed users:
https://forum.pfsense.org/index.php?topic=91455.0
https://forum.pfsense.org/index.php?topic=96918.0