### PR TITLE
filter.inc - Remove useless "could not find gateway" logspam (2.2.x)

### DIFF
--- a/etc/inc/filter.inc
+++ b/etc/inc/filter.inc
@@ -2512,14 +2512,10 @@ function filter_generate_user_rule($rule) {
 			$rg = get_interface_gateway_v6($rule['interface']);
 			if (is_ipaddrv6($rg))
 				$aline['reply'] = "reply-to ( {$ifcfg['ifv6']} {$rg} ) ";
-			else if ($rule['interface'] <> "pptp")
-				log_error(sprintf(gettext("Could not find IPv6 gateway for interface (%s)."), $rule['interface']));
 		} else {
 			$rg = get_interface_gateway($rule['interface']);
 			if (is_ipaddrv4($rg))
 				$aline['reply'] = "reply-to ( {$ifcfg['if']} {$rg} ) ";
-			else if ($rule['interface'] <> "pptp")
-				log_error(sprintf(gettext("Could not find IPv4 gateway for interface (%s)."), $rule['interface']));
 		}
 	}
 	/* if user has selected a custom gateway, lets work with it */


### PR DESCRIPTION
Same as #1831 - this is for RELENG_2_2 branch.