### PR TITLE
Redmine #5046 UEFI network booting arch 00:09 RELENG_2_2

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -844,6 +844,8 @@ EOD;
 				$dhcpdconf .= "		filename \"{$dhcpifconf['filename32']}\";\n";
 				$dhcpdconf .= "	} else if option arch = 00:07 {\n";
 				$dhcpdconf .= "		filename \"{$dhcpifconf['filename64']}\";\n";
+				$dhcpdconf .= "	} else if option arch = 00:09 {\n";
+				$dhcpdconf .= "		filename \"{$dhcpifconf['filename64']}\";\n";
 				$dhcpdconf .= "	} else {\n";
 				$dhcpdconf .= "		filename \"{$dhcpifconf['filename']}\";\n";
 				$dhcpdconf .= "	}\n\n";


### PR DESCRIPTION
This PR against RELENG_2_2 so the bug reporter can easily test. Then can also be applied to master.