### PR TITLE
This fix the issues #3900 and #5051 to make No-ip round robin DNS works.

### DIFF
--- a/etc/inc/dyndns.class
+++ b/etc/inc/dyndns.class
@@ -340,7 +340,7 @@
 					} else {
 						$iptoset = $this->_dnsIP;
 					}
-					curl_setopt($ch, CURLOPT_URL, $server . $port . '?username=' . urlencode($this->_dnsUser) . '&pass=' . urlencode($this->_dnsPass) . '&hostname=' . $this->_dnsHost.'&ip=' . $iptoset);
+					curl_setopt($ch, CURLOPT_URL, $server . $port . '?username=' . urlencode($this->_dnsUser) . '&pass=' . urlencode($this->_dnsPass) . '&h[]=' . $this->_dnsHost.'&ip=' . $iptoset);
 					break;
 				case 'easydns':
 					$needsIP = TRUE;

--- a/usr/local/www/services_dyndns_edit.php
+++ b/usr/local/www/services_dyndns_edit.php
@@ -115,9 +115,13 @@ if ($_POST) {
 		/* Namecheap can have a @. in hostname */
 		if ($pconfig['type'] == "namecheap" && substr($_POST['host'], 0, 2) == '@.')
 			$host_to_check = substr($_POST['host'], 2);
-		else
+		else {
+			$host_to_check = $_POST['host'];
+
 			/* No-ip (and maybe others) can have a @ in hostname */
-			$host_to_check = str_replace('@', '', $_POST['host']);
+			$last = strrpos($host_to_check, '@');
+			$host_to_check = substr_replace($host_to_check, '.', $last, 1);
+		}
 
 		if ($pconfig['type'] != "custom" && $pconfig['type'] != "custom-v6")
 			if (!is_domain($host_to_check))

--- a/usr/local/www/services_dyndns_edit.php
+++ b/usr/local/www/services_dyndns_edit.php
@@ -116,7 +116,8 @@ if ($_POST) {
 		if ($pconfig['type'] == "namecheap" && substr($_POST['host'], 0, 2) == '@.')
 			$host_to_check = substr($_POST['host'], 2);
 		else
-			$host_to_check = $_POST['host'];
+			/* No-ip (and maybe others) can have a @ in hostname */
+			$host_to_check = str_replace('@', '', $_POST['host']);
 
 		if ($pconfig['type'] != "custom" && $pconfig['type'] != "custom-v6")
 			if (!is_domain($host_to_check))

--- a/usr/local/www/services_dyndns_edit.php
+++ b/usr/local/www/services_dyndns_edit.php
@@ -120,7 +120,8 @@ if ($_POST) {
 
 			/* No-ip (and maybe others) can have a @ in hostname */
 			$last = strrpos($host_to_check, '@');
-			$host_to_check = substr_replace($host_to_check, '.', $last, 1);
+			if ($last !== false)
+				$host_to_check = substr_replace($host_to_check, '.', $last, 1);
 		}
 
 		if ($pconfig['type'] != "custom" && $pconfig['type'] != "custom-v6")


### PR DESCRIPTION
The paramater "&hostname" should be changed to "&h[]"
I think this affect only NO-IP DNS that uses round robin. Anyway the no-ip official client uses the "&h[]" parameter.

There's also a change to Dynamic DNS hostname allow '@' character (bug #3900).
