### PR TITLE
diag_ipsec dodgy-looking things for bootstrap

### DIFF
--- a/src/usr/local/www/diag_ipsec.php
+++ b/src/usr/local/www/diag_ipsec.php
@@ -225,7 +225,7 @@ if (is_array($status['query']) && is_array($status['query']['ikesalist']) && is_
 					print('<br/>' . $identity);
 				} else {
 					if (empty($identity))
-						print(ettext("Unknown"));
+						print(gettext("Unknown"));
 					else
 						print($identity);
 				}
@@ -375,6 +375,7 @@ if (is_array($status['query']) && is_array($status['query']['ikesalist']) && is_
 					print(htmlspecialchars($childsa['dhgroup']) . '<br/>');
 				
 				if (!empty($childsa['esn']))
+					print(htmlspecialchars($childsa['esn']) . '<br/>');
 				
 				print(gettext("IPComp: ") . htmlspecialchars($childsa['ipcomp']));
 ?>


### PR DESCRIPTION
Does ettext() return some extra-terrestrial language translation? :)
The floating "if" at line 377 looks like it is missing its code block - I have guessed what it could be by cut/paste/change of the "if" statement above.
Note that this would have fallen through to putting the "IPComp" stuff inside this "if" statement. I do not think that is what is intended?
I see that we are not putting {} curlies around every code block any more - that is a shame, because this is just the sort of thing that can be prevented/noticed easily if {} are used everywhere.