### PR TITLE
Change .editorconfig to reflect the guidelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 
 [*.{inc,php}]
 indent_style = tab
-tab_width = 8
+tab_width = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
According to the guidelines:

- use tabs (tabstop=4) for indenting