### PR TITLE
Update copyright-master.txt

### DIFF
--- a/src/usr/local/www/copyright-master.txt
+++ b/src/usr/local/www/copyright-master.txt
@@ -1,34 +1,34 @@
 /* ====================================================================
- *  Copyright (c)  2004-2015  Electric Sheep Fencing, LLC. All rights reserved. 
- *  Copyright (c)  2004, 2005 Scott Ullrich
+ *  Copyright (c) 2004-2015 Electric Sheep Fencing, LLC. All rights reserved.
+ *  Copyright (c) 2004, 2005 Scott Ullrich
  *
- *  Redistribution and use in source and binary forms, with or without modification, 
- *  are permitted provided that the following conditions are met: 
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
  *
  *  1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
+ *     this list of conditions and the following disclaimer.
  *
  *  2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in
- *      the documentation and/or other materials provided with the
- *      distribution. 
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
  *
- *  3. All advertising materials mentioning features or use of this software 
- *      must display the following acknowledgment:
- *      "This product includes software developed by the pfSense Project
- *       for use in the pfSense software distribution. (http://www.pfsense.org/). 
+ *  3. All advertising materials mentioning features or use of this software
+ *     must display the following acknowledgment:
+ *     "This product includes software developed by the pfSense Project
+ *     for use in the pfSense� software distribution. (http://www.pfsense.org/).
  *
  *  4. The names "pfSense" and "pfSense Project" must not be used to
- *       endorse or promote products derived from this software without
- *       prior written permission. For written permission, please contact
- *       coreteam@pfsense.org.
+ *     endorse or promote products derived from this software without
+ *     prior written permission. For written permission, please contact
+ *     coreteam@pfsense.org.
  *
  *  5. Products derived from this software may not be called "pfSense"
- *      nor may "pfSense" appear in their names without prior written
- *      permission of the Electric Sheep Fencing, LLC.
+ *     nor may "pfSense" appear in their names without prior written
+ *     permission of the Electric Sheep Fencing, LLC.
  *
  *  6. Redistributions of any form whatsoever must retain the following
- *      acknowledgment:
+ *     acknowledgment:
  *
  *  "This product includes software developed by the pfSense Project
  *  for use in the pfSense software distribution (http://www.pfsense.org/).
@@ -45,7 +45,5 @@
  *  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  *  OF THE POSSIBILITY OF SUCH DAMAGE.
- *
  *  ====================================================================
- *
  */


### PR DESCRIPTION
to match license.txt
So that whichever file someone uses as a template to paste in all files, it will be the same.
Or else delete copyright-master.txt
1) copyright-master.txt has a copyright line for Scott Ullrich - is that supposed to be there? Is it meant to go in the header of every file? What is the policy about putting/keeping the names of other previous contributors as copyright lines in the various source files?
2) At point 3. there is a special copyright symbol used. Does that work OK to go in ordinary text source code files?
3) The double-quotes at the start of "This product includes... on lines 18 and 33 are never closed - it bothered me, my brain-resident-text-parser routine failed :)

It would be good to have a really final version of this before someone re-pastes it into every code header!