### PR TITLE
Fixed Stored XSS

### DIFF
--- a/src/usr/local/www/system_usermanager_settings.php
+++ b/src/usr/local/www/system_usermanager_settings.php
@@ -160,7 +160,7 @@ include("head.inc");
 											$selected = "selected=\"selected\"";
 										}
 ?>
-										<option value="<?=$auth_server['name'];?>" <?=$selected;?>><?=$auth_server['name'];?></option>
+										<option value="<?=$auth_server['name'];?>" <?=$selected;?>><?=htmlspecialchars($auth_server['name']);?></option>
 <?php
 									endforeach;
 ?>


### PR DESCRIPTION
I found a small Stored XSS bug in the Webgui so I decided to fix it. 

Triggering the bug: 

1) navigate to: https://[pfSense_IP_address]/system_authservers.php 
2) add a new server with Descriptive name = <script>alert("I am a bug")</script>
3) Save the new server
4) Navigate to the settings tab
5) you should see an alertbox with the following message "I am a bug" 

-Sivathmican Sivakumaran