### PR TITLE
fix sending interim update accounting info

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -653,7 +653,7 @@ function captiveportal_prune_old() {
 
 	/* Is there any job to do? */
 	if (!$timeout && !$idletimeout && !isset($cpcfg['reauthenticate']) &&
-	    !isset($cpcfg['radiussession_timeout']) && !isset($vcpcfg['enable'])) {
+	    !isset($cpcfg['radiussession_timeout']) && !isset($vcpcfg['enable']) && !isset($cpcfg["radacct_enable"])  ) {
 		return;
 	}
 


### PR DESCRIPTION
when this conditions happens:
send RADIUS accounting packets: on
Reauthenticate connected users every minute: off
Accounting updates: interim update
captive portal doesn't send accounting info to radius server.because of that if statement