### PR TITLE
Fix identification of IPv6 interface with PPP-type ifaces and DHCP6

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -5329,7 +5329,7 @@ function get_interface_ipv6($interface = "wan", $flush = false) {
 			case 'pptp':
 			case 'ppp':
 				if ($config['interfaces'][$interface]['ipaddrv6'] == 'dhcp6') {
-					$realif = get_real_interface($interface, 'inet6', true);
+					$realif = get_real_interface($interface, 'inet6', false);
 				}
 				break;
 		}


### PR DESCRIPTION
This has been broken ever since commited in 420aa48

As noted on https://redmine.pfsense.org/issues/3670 - the get_interface_ipv6() function in /etc/inc/interfaces.php incorrectly identifies the interface as the physical hardware interface. As a result, no global IPv6 address can be found (empty $ifcfgipv6) - https://redmine.pfsense.org/issues/3556