### PR TITLE
Openvpn pam auth

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -1466,6 +1466,11 @@ function authenticate_user($username, $password, $authcfg = NULL, &$attributes =
 				$authenticated = true;
 			}
 			break;
+		case 'openvpn_PAM':
+			// In the openvpn flow, authenticate_user does not get called until after the
+			// openvpn-plugin-auth-pam.so is executed, so if PAM saz the user is OK, trust that
+			$authenticated = true;
+			break;
 		case 'radius':
 			if (radius_backed($username, $password, $authcfg, $attributes)) {
 				$authenticated = true;

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -135,6 +135,7 @@ $firewall_rules_dscp_types = array(
 
 $auth_server_types = array(
 	'ldap' => "LDAP",
+	'openvpn_PAM' => "OpenVPN PAM Plugin",
 	'radius' => "Radius");
 
 $ldap_urltypes = array(

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -365,9 +365,9 @@ function server_typechange(typ) {
 	// makes it easier to add more later
 	//
 	<?php
-		foreach ($a_server as $server):
+		foreach ($auth_server_types as $typename => $typedesc):
 	?>
-			document.getElementById("<?=$server['type'];?>").style.display="none";
+			document.getElementById("<?=$typename;?>").style.display="none";
 	<?php
 		endforeach;
 	?>
@@ -772,7 +772,8 @@ function select_clicked() {
 							</td>
 						</tr>
 					</table>
-
+					<table width="100%" border="0" cellpadding="6" cellspacing="0" id="openvpn_PAM" style="display:none" summary="">
+					</table>
 					<table width="100%" border="0" cellpadding="6" cellspacing="0" id="radius" style="display:none" summary="">
 						<tr>
 							<td colspan="2" class="list" height="12"></td>

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -123,6 +123,11 @@ if ($act == "edit") {
 			}
 		}
 
+		if ($pconfig['type'] == "openvpn_PAM") {
+			// Nothing special yet, might want to set a warning popup to make sure they know 
+			// PAM auth is their responsibility to setup
+		}
+
 		if ($pconfig['type'] == "radius") {
 			$pconfig['radius_host'] = $a_server[$id]['host'];
 			$pconfig['radius_auth_port'] = $a_server[$id]['radius_auth_port'];
@@ -189,6 +194,15 @@ if ($_POST) {
 			$reqdfieldsn[] = gettext("Bind user DN");
 			$reqdfieldsn[] = gettext("Bind Password");
 		}
+	}
+
+	if ($pconfig['type'] == "openvpn_PAM") {
+		$reqdfields = explode(" ",
+			"name type");
+		$reqdfieldsn = array(
+			gettext("Descriptive name"),
+			gettext("Type"));
+
 	}
 
 	if ($pconfig['type'] == "radius") {
@@ -285,6 +299,10 @@ if ($_POST) {
 			}
 		}
 
+		if ($pconfig['type'] == "openvpn_PAM") {
+			// Nothing special yet, just another no-op
+		}
+
 		if ($server['type'] == "radius") {
 
 			$server['host'] = $pconfig['radius_host'];
@@ -342,17 +360,18 @@ function server_typechange(typ) {
 		idx = document.getElementById("type").selectedIndex;
 		typ = document.getElementById("type").options[idx].value;
 	}
-
-	switch (typ) {
-		case "ldap":
-			document.getElementById("ldap").style.display="";
-			document.getElementById("radius").style.display="none";
-			break;
-		case "radius":
-			document.getElementById("ldap").style.display="none";
-			document.getElementById("radius").style.display="";
-			break;
-	}
+	//
+	// Reset display attribute on all auth_server types, then display the one we want, 
+	// makes it easier to add more later
+	//
+	<?php
+		foreach ($a_server as $server):
+	?>
+			document.getElementById("<?=$server['type'];?>").style.display="none";
+	<?php
+		endforeach;
+	?>
+	document.getElementById(typ).style.display="";
 }
 
 function ldap_urlchange() {


### PR DESCRIPTION
This adds a new auth server type to the gui, which relies on setup of the openvpn-plugin-auth-pam and local PAM.  When this is used to create an auth server, it can then be selected as the backend for authentication in the openvpn page, and the 'Client Export' page will properly show a client install package for 'Certificate with External Auth'.

I am happy to writeup a howto on this, just need to know where to get a login.