### PR TITLE
pptp_local and pptp_remote are arrays

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -2754,13 +2754,13 @@ $section->addInput(new Form_Input(
 $section->addInput(new Form_IpAddress(
 	'pptp_local',
 	'Local IP address',
-	$pconfig['pptp_local']
+	$pconfig['pptp_local'][0]
 ))->addMask('pptp_subnet', $pconfig['pptp_subnet'][0]);
 
 $section->addInput(new Form_IpAddress(
 	'pptp_remote',
 	'Remote IP address',
-	$pconfig['pptp_remote']
+	$pconfig['pptp_remote'][0]
 ));
 
 $section->addInput(new Form_Checkbox(


### PR DESCRIPTION
I believe these should reference the [0] array element of pptp_local and pptp_remote. The code in interfaces.php only presents the [0] (first) array element to the user for editing.
The current code also does not preserve any additional pptp_local, pptp_subnet or pptp_remote entries in the coma-separated list in the config. That is redmine bug #4568.
I am currently integrating the fix for Redmine #4568 Preserve MLPPP settings when saving interface settings. The fix for that bug will add more code to preserve additional pptp_local, pptp_subnet or pptp_remote entries.
For now it would be good to have this little fix to the existing code - then the fix for redmine bug #4568 will sit nicely on top of it.