### PR TITLE
Added the possibility to use wildcard hostnames in certificate manager SAN fields

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -830,12 +830,12 @@ function is_unqualified_hostname($hostname) {
 }
 
 /* returns true if $hostname is a valid hostname, with or without being a fully-qualified domain name. */
-function is_hostname($hostname) {
+function is_hostname($hostname, $allow_wildcard=false) {
 	if (!is_string($hostname)) {
 		return false;
 	}
 
-	if (is_domain($hostname)) {
+	if (is_domain($hostname, $allow_wildcard=false)) {
 		if ((substr_count($hostname, ".") == 1) && ($hostname[strlen($hostname)-1] == ".")) {
 			/* Only a single dot at the end like "test." - hosts cannot be directly in the root domain. */
 			return false;
@@ -848,12 +848,18 @@ function is_hostname($hostname) {
 }
 
 /* returns true if $domain is a valid domain name */
-function is_domain($domain) {
+function is_domain($domain, $allow_wildcard=false) {
 	if (!is_string($domain)) {
 		return false;
 	}
 
-	if (preg_match('/^(?:(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i', $domain)) {
+	if ($allow_wildcard) {
+		$domain_regex = '/^(?:(?:[a-z_0-9\*]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i';
+	} else {
+		$domain_regex = '/^(?:(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i';
+	}
+
+	if (preg_match($domain_regex, $domain)) {
 		return true;
 	} else {
 		return false;

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -835,7 +835,7 @@ function is_hostname($hostname, $allow_wildcard=false) {
 		return false;
 	}
 
-	if (is_domain($hostname, $allow_wildcard=false)) {
+	if (is_domain($hostname, $allow_wildcard)) {
 		if ((substr_count($hostname, ".") == 1) && ($hostname[strlen($hostname)-1] == ".")) {
 			/* Only a single dot at the end like "test." - hosts cannot be directly in the root domain. */
 			return false;
@@ -852,7 +852,6 @@ function is_domain($domain, $allow_wildcard=false) {
 	if (!is_string($domain)) {
 		return false;
 	}
-
 	if ($allow_wildcard) {
 		$domain_regex = '/^(?:(?:[a-z_0-9\*]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9])\.)*(?:[a-z_0-9]|[a-z_0-9][a-z_0-9\-]*[a-z_0-9\.])$/i';
 	} else {

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -234,13 +234,13 @@ if ($act == "csr") {
 }
 
 if ($_POST) {
-	
+
 	// This is just the blank altername name that is added for display purposes. We don't want to validate/save it
 	if($_POST['altname_value0']  == "") {
 		unset($_POST['altname_type0']);
 		unset($_POST['altname_value0']);
 	}
-	
+
 	if ($_POST['save'] == gettext("Save")) {
 		$input_errors = array();
 		$pconfig = $_POST;
@@ -323,8 +323,8 @@ if ($_POST) {
 			foreach ($altnames as $idx => $altname) {
 				switch ($altname['type']) {
 					case "DNS":
-						if (!is_hostname($altname['value'])) {
-							array_push($input_errors, "DNS subjectAltName values must be valid hostnames or FQDNs");
+						if (!is_hostname($altname['value'], true)) {
+							array_push($input_errors, "DNS subjectAltName values must be valid hostnames, FQDNs or wildcard domains.");
 						}
 						break;
 					case "IP":
@@ -551,7 +551,7 @@ include("head.inc");
 
 if ($input_errors)
 	print_input_errors($input_errors);
-	
+
 if ($savemsg)
 	print_info_box($savemsg, 'success');
 


### PR DESCRIPTION
This is a resubmit of the bug fix for #3733 (https://redmine.pfsense.org/issues/3733)

This fix now allows the administrator to specify additional wildcard domains in the subjectAlternativeName fields when issuing a new certificate.

This would normally have caused the error message

```
DNS subjectAltName values must be valid hostnames or FQDNs
```
although it is valid to place wildcard domains as the subjectAlternativeName extension.

@cbuechler 
I have signed up for the ICLA with the same username as I use in github (dachande). 