### PR TITLE
php.php/pkg_edit.php - cleanups and fixes (resubmit of #1787)

### DIFF
--- a/src/usr/local/www/pkg.php
+++ b/src/usr/local/www/pkg.php
@@ -73,11 +73,6 @@ if ($pkg['include_file'] != "") {
 	require_once($pkg['include_file']);
 }
 
-$package_name = $pkg['menu'][0]['name'];
-$section      = $pkg['menu'][0]['section'];
-$config_path  = $pkg['configpath'];
-$title	      = $pkg['title'];
-
 if ($_REQUEST['startdisplayingat']) {
 	$startdisplayingat = $_REQUEST['startdisplayingat'];
 }
@@ -154,7 +149,7 @@ if ($pkg['custom_php_command_before_form'] <> "") {
 	eval($pkg['custom_php_command_before_form']);
 }
 
-$pgtitle = array($title);
+$pgtitle = array($pkg['title']);
 include("head.inc");
 
 ?>
@@ -378,7 +373,6 @@ include("head.inc");
 				</tr>
 <?php
 	$i = 0;
-	$pagination_startingrow = 0;
 	$pagination_counter = 0;
 	if ($evaledvar) {
 		foreach ($evaledvar as $ip) {

--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -90,13 +90,6 @@ if (!isset($pkg['adddeleteeditpagefields'])) {
 	$only_edit = false;
 }
 
-$package_name = $pkg['menu'][0]['name'];
-$section      = $pkg['menu'][0]['section'];
-$config_path  = $pkg['configpath'];
-$name         = $pkg['name'];
-$title        = $pkg['title'];
-$pgtitle      = $title;
-
 $id = $_GET['id'];
 if (isset($_POST['id'])) {
 	$id = htmlspecialchars($_POST['id']);
@@ -139,7 +132,6 @@ if ($pkg['custom_php_command_before_form'] <> "") {
 }
 
 if ($_POST) {
-	$firstfield = "";
 	$rows = 0;
 
 	$input_errors = array();
@@ -210,6 +202,7 @@ if ($_POST) {
 						$rowhelpername="row";
 						foreach ($fields['rowhelper']['rowhelperfield'] as $rowhelperfield) {
 							foreach ($_POST as $key => $value) {
+								$matches = array();
 								if (preg_match("/^{$rowhelperfield['fieldname']}(\d+)$/", $key, $matches)) {
 									$pkgarr[$rowhelpername][$matches[1]][$rowhelperfield['fieldname']] = $value;
 								}
@@ -285,12 +278,10 @@ if ($_POST) {
 
 if ($pkg['title'] <> "") {
 	$edit = ($only_edit ? '' : ": " . gettext("Edit"));
-	$title = $pkg['title'] . $edit;
+	$pgtitle = $pkg['title'] . $edit;
 } else {
-	$title = gettext("Package Editor");
+	$pgtitle = gettext("Package Editor");
 }
-
-$pgtitle = $title;
 
 if ($pkg['custom_php_after_head_command']) {
 	$closehead = false;
@@ -481,6 +472,7 @@ if ($pkg['tabs'] <> "") {
 		$advanced = "<td>&nbsp;</td>";
 		$advanced .= "<tr><td colspan=\"2\" class=\"listtopic\">". gettext("Advanced features") . "<br /></td></tr>\n";
 	}
+	$js_array = array();
 	foreach ($pkg['fields']['field'] as $pkga) {
 		if ($pkga['type'] == "sorting") {
 			continue;
@@ -582,10 +574,12 @@ if ($pkg['tabs'] <> "") {
 				$value = implode(',', $value);
 			}
 		} else {
-			if (isset($id) && $a_pkg[$id]) {
+			if (isset($id) && isset($a_pkg[$id][$fieldname])) {
 				$value = $a_pkg[$id][$fieldname];
 			} else {
-				$value = $pkga['default_value'];
+				if (isset($pkga['default_value'])) {
+					$value = $pkga['default_value'];
+				}
 			}
 		}
 		switch ($pkga['type']) {
@@ -963,13 +957,8 @@ if ($pkg['tabs'] <> "") {
 							if (isset($id) && $a_pkg[$id]) {
 								$value = $row[$fieldname];
 							}
-							$options = "";
 							$type = $rowhelper['type'];
-							$description = $rowhelper['description'];
 							$fieldname = $rowhelper['fieldname'];
-							if ($type == "option") {
-								$options = &$rowhelper['options']['option'];
-							}
 							if ($rowhelper['size']) {
 								$size = $rowhelper['size'];
 							} else if ($pkga['size']) {
@@ -1101,7 +1090,7 @@ if ($pkg['tabs'] <> "") {
  * ROW Helpers function
  */
 function display_row($trc, $value, $fieldname, $type, $rowhelper, $size) {
-	global $text, $config;
+	global $text;
 	echo "<td>\n";
 	switch ($type) {
 		case "input":
@@ -1202,13 +1191,12 @@ function fixup_string($string) {
  *  Parse templates if they are defined
  */
 function parse_package_templates() {
-	global $pkg, $config;
+	global $pkg;
 	$rows = 0;
 	if ($pkg['templates']['template'] <> "") {
 		foreach ($pkg['templates']['template'] as $pkg_template_row) {
 			$filename = $pkg_template_row['filename'];
 			$template_text = $pkg_template_row['templatecontents'];
-			$firstfield = "";
 			/* calculate total row helpers count and */
 			/* change fields defined as fieldname_fieldvalue to their value */
 			foreach ($pkg['fields']['field'] as $fields) {


### PR DESCRIPTION
Kindly merge this before conflicts arise again... Really wasting time here.

- Remove unused variables
- Initialize variables
- Check if the actual $fieldname element is present in the $a_pkg[$id] array before trying to assign its value. Do same with default_value. Fixes issue where default value was not being populated for newly added fields.