### PR TITLE
pkg_edit.php - fix issue where default value was not being populated for newly added fields (RELENG_2_2)

### DIFF
--- a/usr/local/www/pkg_edit.php
+++ b/usr/local/www/pkg_edit.php
@@ -539,10 +539,13 @@ if ($pkg['tabs'] <> "") {
 			$value = $_POST[$fieldname];
 			if (is_array($value)) $value = implode(',', $value);
 		} else {
-			if (isset($id) && $a_pkg[$id])
+			if (isset($id) && isset($a_pkg[$id][$fieldname])) {
 				$value = $a_pkg[$id][$fieldname];
-			else
-				$value = $pkga['default_value'];
+			} else {
+				if (isset($pkga['default_value'])) {
+					$value = $pkga['default_value'];
+				}
+			}
 		}
 		switch($pkga['type']){
 			case "input":


### PR DESCRIPTION
Backport from PR #1906 / PR #1787 for RELENG_2_2. 

Check if the actual $fieldname element is present in the $a_pkg[$id] array before trying to assign its value. Do same with default_value. Fixes issue where default value was not being populated for newly added fields.