### PR TITLE
Add L2TP server's interface to mpd.conf (Bug #4830) - RELENG_2_2

### DIFF
--- a/etc/inc/vpn.inc
+++ b/etc/inc/vpn.inc
@@ -1890,6 +1890,11 @@ function vpn_l2tp_configure() {
 	switch ($l2tpcfg['mode']) {
 
 		case 'server':
+			$l2tp_listen="";
+			$ipaddr = get_interface_ip(get_failover_interface($l2tpcfg['interface']));
+			if (is_ipaddrv4($ipaddr)) {
+				 $l2tp_listen="set l2tp self $ipaddr";
+			}
 			if ($l2tpcfg['paporchap'] == "chap") {
 				$paporchap = "set link enable chap";
 			} else {
@@ -1948,6 +1953,7 @@ l2tp_standard:
 	set link yes acfcomp protocomp
 	set link no pap chap
 	{$paporchap}
+	{$l2tp_listen}
 	set link keep-alive 10 180
 
 EOD;


### PR DESCRIPTION
Backport of #1750 for RELENG_2_2

The interface gets saved OK in the config, but in /etc/inc.vpn.inc function vpn_l2tp_configure() there is no mention of 'interface'. There is simply no code to implement the selected interface.