### PR TITLE
Add L2TP server's interface to mpd.conf (Bug #4830)

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -1645,6 +1645,11 @@ function vpn_l2tp_configure() {
 	switch ($l2tpcfg['mode']) {
 
 		case 'server':
+			$l2tp_listen="";
+			$ipaddr = get_interface_ip(get_failover_interface($l2tpcfg['interface']));
+			if (is_ipaddrv4($ipaddr)) {
+				 $l2tp_listen="set l2tp self $ipaddr";
+			}
 			if ($l2tpcfg['paporchap'] == "chap") {
 				$paporchap = "set link enable chap";
 			} else {
@@ -1703,6 +1708,7 @@ l2tp_standard:
 	set link yes acfcomp protocomp
 	set link no pap chap
 	{$paporchap}
+	{$l2tp_listen}
 	set link keep-alive 10 180
 
 EOD;


### PR DESCRIPTION
Resubmit of #1750

The interface gets saved OK in the config, but in /etc/inc.vpn.inc function vpn_l2tp_configure() there is no mention of 'interface'. There is simply no code to implement the selected interface.