### PR TITLE
Allow '@' at hostname (Bug #3900, Bug #5051), allow '@.' and '*.' wildcards in hostname

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -376,7 +376,7 @@
 					} else {
 						$iptoset = $this->_dnsIP;
 					}
-					curl_setopt($ch, CURLOPT_URL, $server . $port . '?username=' . urlencode($this->_dnsUser) . '&pass=' . urlencode($this->_dnsPass) . '&hostname=' . $this->_dnsHost.'&ip=' . $iptoset);
+					curl_setopt($ch, CURLOPT_URL, $server . $port . '?username=' . urlencode($this->_dnsUser) . '&pass=' . urlencode($this->_dnsPass) . '&h[]=' . $this->_dnsHost.'&ip=' . $iptoset);
 					break;
 				case 'easydns':
 					$needsIP = TRUE;

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -117,8 +117,9 @@ if ($_POST) {
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (isset($_POST['host']) && in_array("host", $reqdfields)) {
-		/* Namecheap can have a @. in hostname */
-		if ($pconfig['type'] == "namecheap" && substr($_POST['host'], 0, 2) == '@.') {
+		/* Allow @. and *. in hostname */
+		/* NameCheap - Bug #3568; No-Ip - #3900 etc. */
+		if ((substr($_POST['host'], 0, 2) == '@.') || (substr($_POST['host'], 0, 2) == '*.')) {
 			$host_to_check = substr($_POST['host'], 2);
 		} else {
 			$host_to_check = $_POST['host'];

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -117,10 +117,12 @@ if ($_POST) {
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (isset($_POST['host']) && in_array("host", $reqdfields)) {
-		/* Allow @. and *. in hostname */
-		/* NameCheap - Bug #3568; No-Ip - #3900 etc. */
+		/* Allow @, @. and *. in hostname */
+		/* NameCheap - Bug #3568; No-Ip - Bug #3900, etc. */
 		if ((substr($_POST['host'], 0, 2) == '@.') || (substr($_POST['host'], 0, 2) == '*.')) {
 			$host_to_check = substr($_POST['host'], 2);
+		} elseif (substr($_POST['host'], 0, 1) == '@') {
+			$host_to_check = substr($_POST['host'], 1);
 		} else {
 			$host_to_check = $_POST['host'];
 		}


### PR DESCRIPTION
Forward-port of #1839 

Also, allow '@.' and '*.' in DynDNS hostnames regardless of provider. These overly restrictive and provider-specific checks only cause maintenance burden and are good for nothing.