### PR TITLE
fix interface assignment menus running off VGA screen

### DIFF
--- a/src/etc/inc/config.console.inc
+++ b/src/etc/inc/config.console.inc
@@ -86,8 +86,9 @@ EOD;
 		$iflist = array();
 	} else {
 		foreach ($iflist as $iface => $ifa) {
+			$ifsmallist = trim($ifsmallist . " " . $iface);
 			echo sprintf("% -7s%s %s %s\n", $iface, $ifa['mac'],
-				$ifa['up'] ? "  (up)" : "(down)", $ifa['dmesg']);
+				$ifa['up'] ? "  (up)" : "(down)", substr($ifa['dmesg'], 0, 48));
 		}
 	}
 
@@ -190,6 +191,7 @@ EOD;
 					"VLAN tag {$vlan['tag']}, parent interface {$vlan['if']}");
 
 				$iflist[$vlan['if'] . '_vlan' . $vlan['tag']] = array();
+				$ifsmallist = trim($ifsmallist . " " . $vlan['if'] . '_vlan' . $vlan['tag']);
 			}
 		}
 
@@ -202,7 +204,8 @@ hitting 'a' to initiate auto detection.
 EOD;
 
 		do {
-			echo "\n" . gettext("Enter the WAN interface name or 'a' for auto-detection:") . " ";
+			echo "\n" . gettext("Enter the WAN interface name or 'a' for auto-detection") . " ";
+			printf(gettext("%s(%s or a): "), "\n", $ifsmallist);
 			$wanif = chop(fgets($fp));
 			if ($wanif === "") {
 				return;
@@ -214,12 +217,13 @@ EOD;
 				unset($wanif);
 				continue;
 			}
+			$ifsmallist = trim(str_replace("  ", " ", str_replace($wanif, "", $ifsmallist)));
 		} while (!$wanif);
 
 		do {
 			printf(gettext("%sEnter the LAN interface name or 'a' for auto-detection %s" .
 				"NOTE: this enables full Firewalling/NAT mode.%s" .
-				"(or nothing if finished):%s"), "\n", "\n", "\n", " ");
+				"(%s a or nothing if finished):%s"), "\n", "\n", "\n", $ifsmallist, " ");
 
 			$lanif = chop(fgets($fp));
 
@@ -239,6 +243,7 @@ EOD;
 				unset($lanif);
 				continue;
 			}
+			$ifsmallist = trim(str_replace("  ", " ", str_replace($lanif, "", $ifsmallist)));
 		} while (!$lanif);
 
 		/* optional interfaces */
@@ -257,7 +262,7 @@ EOD;
 				}
 
 				printf(gettext("%sEnter the Optional %s interface name or 'a' for auto-detection%s" .
-					"(or nothing if finished):%s"), "\n", $io, "\n", " ");
+					"(%s a or nothing if finished):%s"), "\n", $io, "\n", $ifsmallist, " ");
 
 				$optif[$i] = chop(fgets($fp));
 
@@ -274,6 +279,7 @@ EOD;
 						unset($optif[$i]);
 						continue;
 					}
+					$ifsmallist = trim(str_replace("  ", " ", str_replace($optif[$i], "", $ifsmallist)));
 				} else {
 					unset($optif[$i]);
 					break;

--- a/src/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
+++ b/src/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
@@ -250,97 +250,101 @@ msgstr ""
 msgid "Press ENTER to continue."
 msgstr ""
 
-#: etc/inc/config.console.inc:84 etc/inc/config.console.inc:484
+#: etc/inc/config.console.inc:85 etc/inc/config.console.inc:523
 msgid "No interfaces found!"
 msgstr ""
 
-#: etc/inc/config.console.inc:182
+#: etc/inc/config.console.inc:187
 msgid "VLAN interfaces:"
 msgstr ""
 
-#: etc/inc/config.console.inc:201
-msgid "Enter the WAN interface name or 'a' for auto-detection:"
+#: etc/inc/config.console.inc:207
+msgid "Enter the WAN interface name or 'a' for auto-detection"
 msgstr ""
 
-#: etc/inc/config.console.inc:209 etc/inc/config.console.inc:234
-#: etc/inc/config.console.inc:266 etc/inc/config.console.inc:507
+#: etc/inc/config.console.inc:208
+msgid "%s(%s or a): "
+msgstr ""
+
+#: etc/inc/config.console.inc:216 etc/inc/config.console.inc:242
+#: etc/inc/config.console.inc:278 etc/inc/config.console.inc:546
 #, php-format
 msgid "%sInvalid interface name '%s'%s"
 msgstr ""
 
-#: etc/inc/config.console.inc:216
+#: etc/inc/config.console.inc:224
 #, php-format
 msgid ""
 "%sEnter the LAN interface name or 'a' for auto-detection %sNOTE: this "
-"enables full Firewalling/NAT mode.%s(or nothing if finished):%s"
+"enables full Firewalling/NAT mode.%s(%s a or nothing if finished):%s"
 msgstr ""
 
-#: etc/inc/config.console.inc:251
+#: etc/inc/config.console.inc:261
 #, php-format
 msgid "%sOptional interface %s description found: %s"
 msgstr ""
 
-#: etc/inc/config.console.inc:253
+#: etc/inc/config.console.inc:264
 #, php-format
 msgid ""
-"%sEnter the Optional %s interface name or 'a' for auto-detection%s(or "
+"%sEnter the Optional %s interface name or 'a' for auto-detection%s(%s a or "
 "nothing if finished):%s"
 msgstr ""
 
-#: etc/inc/config.console.inc:260
+#: etc/inc/config.console.inc:271
 msgid "Optional"
 msgstr ""
 
-#: etc/inc/config.console.inc:294
+#: etc/inc/config.console.inc:307
 msgid "The interfaces will be assigned as follows:"
 msgstr ""
 
-#: etc/inc/config.console.inc:408
+#: etc/inc/config.console.inc:447
 #, php-format
 msgid "%sWriting configuration..."
 msgstr ""
 
-#: etc/inc/config.console.inc:410
+#: etc/inc/config.console.inc:449
 #, php-format
 msgid "done.%s"
 msgstr ""
 
-#: etc/inc/config.console.inc:417
+#: etc/inc/config.console.inc:457
 msgid "One moment while we reload the settings..."
 msgstr ""
 
-#: etc/inc/config.console.inc:418
+#: etc/inc/config.console.inc:458
 msgid " done!"
 msgstr ""
 
-#: etc/inc/config.console.inc:438
+#: etc/inc/config.console.inc:478
 #, php-format
 msgid "Detected link-up on interface %s.%s"
 msgstr ""
 
-#: etc/inc/config.console.inc:443
+#: etc/inc/config.console.inc:483
 #, php-format
 msgid "No link-up detected.%s"
 msgstr ""
 
-#: etc/inc/config.console.inc:482
+#: etc/inc/config.console.inc:521
 msgid "VLAN Capable interfaces:"
 msgstr ""
 
-#: etc/inc/config.console.inc:497
+#: etc/inc/config.console.inc:536
 msgid "No VLAN capable interfaces detected."
 msgstr ""
 
-#: etc/inc/config.console.inc:501
+#: etc/inc/config.console.inc:540
 msgid ""
 "Enter the parent interface name for the new VLAN (or nothing if finished):"
 msgstr ""
 
-#: etc/inc/config.console.inc:514
+#: etc/inc/config.console.inc:553
 msgid "Enter the VLAN tag (1-4094):"
 msgstr ""
 
-#: etc/inc/config.console.inc:518
+#: etc/inc/config.console.inc:557
 #, php-format
 msgid "%sInvalid VLAN tag '%s'%s"
 msgstr ""


### PR DESCRIPTION
Resubmit of #1805 with requested gettext handling changes. Be so kind and merge it before yet another round of conflicts. This ain't really funny any more.

Credits: @nagyrobi  - this code ain 't mine, merely resubmitting it due to conflicts.

Original description from previous PR:
---------
When using VGA console, interface assignment can be a real pain in the ass because of the standard 80 columns width.

Dmesg reports the many interface description names in very long strings that don't fit in a row, this breaks the nice appearance of the interface list in the assignment menu.
The aestethics is one thing, but the real pain is that the interface list goes off screen by the time the menu asks for the WAN interface name, if there are many interfaces present. It's a real problem to choose from a list which is not visible anymore.

One fix is to maximize the length of the interface description to 48 chars.

The second fix (and also improvement for better overlooking when the list really goes off) is to print a small list of the interface names at each question. This is necessary because when somebody wants to assign the first interface to the last Optional port, the big list will be way off screen by then, and the name of it won't be visible.

This also makes it nice clean and straightforward.