### PR TITLE
fix interface assignment menus running off VGA screen - RELENG_2_2

### DIFF
--- a/etc/inc/config.console.inc
+++ b/etc/inc/config.console.inc
@@ -85,8 +85,9 @@ EOD;
 		$iflist = array();
 	} else {
 		foreach ($iflist as $iface => $ifa) {
+			$ifsmallist = trim($ifsmallist . " " . $iface);
 			echo sprintf("% -7s%s %s %s\n", $iface, $ifa['mac'],
-				$ifa['up'] ? "  (up)" : "(down)", $ifa['dmesg']);
+				$ifa['up'] ? "  (up)" : "(down)", substr($ifa['dmesg'], 0, 48));
 		}
 	}
 
@@ -186,6 +187,7 @@ EOD;
 					"VLAN tag {$vlan['tag']}, parent interface {$vlan['if']}");
 	
 				$iflist[$vlan['if'] . '_vlan' . $vlan['tag']] = array();
+				$ifsmallist = trim($ifsmallist . " " . $vlan['if'] . '_vlan' . $vlan['tag']);
 			}
 		}
 	
@@ -198,7 +200,8 @@ hitting 'a' to initiate auto detection.
 EOD;
 	
 		do {
-			echo "\n" . gettext("Enter the WAN interface name or 'a' for auto-detection:") . " ";
+			echo "\n" . gettext("Enter the WAN interface name or 'a' for auto-detection") . " ";
+			printf(gettext("%s(%s or a): "), "\n", $ifsmallist);
 			$wanif = chop(fgets($fp));
 			if ($wanif === "") {
 				return;
@@ -210,12 +213,13 @@ EOD;
 				unset($wanif);
 				continue;
 			}
+			$ifsmallist = trim(str_replace("  ", " ", str_replace($wanif, "", $ifsmallist)));
 		} while (!$wanif);
 	
 		do {
 			printf(gettext("%sEnter the LAN interface name or 'a' for auto-detection %s" .
 			    "NOTE: this enables full Firewalling/NAT mode.%s" .
-				"(or nothing if finished):%s"), "\n", "\n", "\n", " ");
+				"(%s a or nothing if finished):%s"), "\n", "\n", "\n", $ifsmallist, " ");
 	
 			$lanif = chop(fgets($fp));
 			
@@ -235,6 +239,7 @@ EOD;
 				unset($lanif);
 				continue;
 			}
+			$ifsmallist = trim(str_replace("  ", " ", str_replace($lanif, "", $ifsmallist)));
 		} while (!$lanif);
 	
 		/* optional interfaces */
@@ -251,7 +256,7 @@ EOD;
 					printf(gettext("%sOptional interface %s description found: %s"), "\n", $io, $config['interfaces']['opt' . $io]['descr']);
 	
 				printf(gettext("%sEnter the Optional %s interface name or 'a' for auto-detection%s" .
-					"(or nothing if finished):%s"), "\n", $io, "\n", " ");
+					"(%s a or nothing if finished):%s"), "\n", $io, "\n", $ifsmallist, " ");
 		
 				$optif[$i] = chop(fgets($fp));
 		
@@ -267,6 +272,7 @@ EOD;
 						unset($optif[$i]);
 						continue;
 					}
+					$ifsmallist = trim(str_replace("  ", " ", str_replace($optif[$i], "", $ifsmallist)));
 				} else {
 					unset($optif[$i]);
 					break;

--- a/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
+++ b/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
@@ -259,7 +259,7 @@ msgid "VLAN interfaces:"
 msgstr ""
 
 #: etc/inc/config.console.inc:203
-msgid "Enter the WAN interface name or 'a' for auto-detection:"
+msgid "Enter the WAN interface name or 'a' for auto-detection"
 msgstr ""
 
 #: etc/inc/config.console.inc:204

--- a/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
+++ b/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
@@ -258,8 +258,12 @@ msgstr ""
 msgid "VLAN interfaces:"
 msgstr ""
 
-#: etc/inc/config.console.inc:201
+#: etc/inc/config.console.inc:203
 msgid "Enter the WAN interface name or 'a' for auto-detection:"
+msgstr ""
+
+#: etc/inc/config.console.inc:204
+msgid "%s(%s or a): "
 msgstr ""
 
 #: etc/inc/config.console.inc:209 etc/inc/config.console.inc:234
@@ -268,11 +272,11 @@ msgstr ""
 msgid "%sInvalid interface name '%s'%s"
 msgstr ""
 
-#: etc/inc/config.console.inc:216
+#: etc/inc/config.console.inc:220
 #, php-format
 msgid ""
 "%sEnter the LAN interface name or 'a' for auto-detection %sNOTE: this "
-"enables full Firewalling/NAT mode.%s(or nothing if finished):%s"
+"enables full Firewalling/NAT mode.%s(%s a or nothing if finished):%s"
 msgstr ""
 
 #: etc/inc/config.console.inc:251
@@ -280,10 +284,10 @@ msgstr ""
 msgid "%sOptional interface %s description found: %s"
 msgstr ""
 
-#: etc/inc/config.console.inc:253
+#: etc/inc/config.console.inc:258
 #, php-format
 msgid ""
-"%sEnter the Optional %s interface name or 'a' for auto-detection%s(or "
+"%sEnter the Optional %s interface name or 'a' for auto-detection%s(%s a or "
 "nothing if finished):%s"
 msgstr ""
 


### PR DESCRIPTION
Backport of #1925 / #1805 for RELENG_2_2

Credits: @nagyrobi  - this code ain 't mine, merely backported it.

Original description from previous PR:
---------

When using VGA console, interface assignment can be a real pain in the ass because of the standard 80 columns width.

Dmesg reports the many interface description names in very long strings that don't fit in a row, this breaks the nice appearance of the interface list in the assignment menu.
The aestethics is one thing, but the real pain is that the interface list goes off screen by the time the menu asks for the WAN interface name, if there are many interfaces present. It's a real problem to choose from a list which is not visible anymore.

One fix is to maximize the length of the interface description to 48 chars.

The second fix (and also improvement for better overlooking when the list really goes off) is to print a small list of the interface names at each question. This is necessary because when somebody wants to assign the first interface to the last Optional port, the big list will be way off screen by then, and the name of it won't be visible.

This also makes it nice clean and straightforward.