### PR TITLE
Redmine #5200 be less aggressive about DHCP Pool Notice V1

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -680,9 +680,27 @@ EOPP;
 			if (!(ip_in_subnet($poolconf['range']['from'], "{$subnet}/{$ifcfgsn}") && ip_in_subnet($poolconf['range']['to'], "{$subnet}/{$ifcfgsn}"))) {
 				// If the user has changed the subnet from the interfaces page and applied,
 				// but has not updated the DHCP range, then the range to/from of the pool can be outside the subnet.
-				// In that case, ignore the pool and post an error.
-				$error_msg = sprintf(gettext("Invalid DHCP pool %s - %s for %s subnet %s/%s detected. Please correct the settings in Services, DHCP Server"), $poolconf['range']['from'], $poolconf['range']['to'], convert_real_interface_to_friendly_descr($dhcpif), $subnet, $ifcfgsn);
-				file_notice("DHCP", $error_msg);
+				// This can also happen when implementing the batch of changes when the setup wizard reloads the new settings.
+				$do_file_notice = true;
+				$conf_ipv4_address = $ifcfg['ipaddr'];
+				$conf_ipv4_subnetmask = $ifcfg['subnet'];
+				if (is_ipaddrv4($conf_ipv4_address) && is_subnet("{$conf_ipv4_address}/{$conf_ipv4_subnetmask}")) {
+					$conf_subnet_base = gen_subnet($conf_ipv4_address, $conf_ipv4_subnetmask);
+					if (ip_in_subnet($poolconf['range']['from'], "{$conf_subnet_base}/{$conf_ipv4_subnetmask}") &&
+					    ip_in_subnet($poolconf['range']['to'], "{$conf_subnet_base}/{$conf_ipv4_subnetmask}")) {
+						// Even though the running interface subnet does not match the pool range,
+						// the interface subnet in the config file contains the pool range.
+						// We are somewhere part-way through a settings reload, e.g. after running the setup wizard.
+						// services_dhcpdv4_configure will be called again later when the new interface settings from
+						// the config are applied and at that time everything will match up.
+						// Ignore this pool on this interface for now without filing a notice.
+						$do_file_notice = false;
+					}
+				}
+				if ($do_file_notice) {
+					$error_msg = sprintf(gettext("Invalid DHCP pool %s - %s for %s subnet %s/%s detected. Please correct the settings in Services, DHCP Server"), $poolconf['range']['from'], $poolconf['range']['to'], convert_real_interface_to_friendly_descr($dhcpif), $subnet, $ifcfgsn);
+					file_notice("DHCP", $error_msg);
+				}
 				continue;
 			}
 			$dhcpdconf .= "	pool {\n";


### PR DESCRIPTION
The reload_all code that happens, for example, at the end of the setup wizard, seems to have multiple places down in the various calls to regenerate lots of stuff that end up calling services_dhcpd_configure multiple times at points where the new DHCP pool range is in $config[] but the new LAN interface settings are in $config[] but have not yet been applied to the interface.
Rather than try to sort all that out right now, I test if the DHCP pool range matches with the interface subnet in $config[] - if that is so then things are looking good - eventually the interface settings from $config[] will be applied to the actual interface and all will be well.
So in that case I don't bother to file_notice() - just silently skip the pool for now.