### PR TITLE
Redmine #5200 be less aggressive about DHCP Pool Notice V2

### DIFF
--- a/etc/inc/services.inc
+++ b/etc/inc/services.inc
@@ -680,9 +680,28 @@ EOPP;
 			if (!(ip_in_subnet($poolconf['range']['from'], "{$subnet}/{$ifcfgsn}") && ip_in_subnet($poolconf['range']['to'], "{$subnet}/{$ifcfgsn}"))) {
 				// If the user has changed the subnet from the interfaces page and applied,
 				// but has not updated the DHCP range, then the range to/from of the pool can be outside the subnet.
-				// In that case, ignore the pool and post an error.
+				// This can also happen when implementing the batch of changes when the setup wizard reloads the new settings.
 				$error_msg = sprintf(gettext("Invalid DHCP pool %s - %s for %s subnet %s/%s detected. Please correct the settings in Services, DHCP Server"), $poolconf['range']['from'], $poolconf['range']['to'], convert_real_interface_to_friendly_descr($dhcpif), $subnet, $ifcfgsn);
-				file_notice("DHCP", $error_msg);
+				$do_file_notice = true;
+				$conf_ipv4_address = $ifcfg['ipaddr'];
+				$conf_ipv4_subnetmask = $ifcfg['subnet'];
+				if (is_ipaddrv4($conf_ipv4_address) && is_subnet("{$conf_ipv4_address}/{$conf_ipv4_subnetmask}")) {
+					$conf_subnet_base = gen_subnet($conf_ipv4_address, $conf_ipv4_subnetmask);
+					if (ip_in_subnet($poolconf['range']['from'], "{$conf_subnet_base}/{$conf_ipv4_subnetmask}") &&
+					    ip_in_subnet($poolconf['range']['to'], "{$conf_subnet_base}/{$conf_ipv4_subnetmask}")) {
+						// Even though the running interface subnet does not match the pool range,
+						// the interface subnet in the config file contains the pool range.
+						// We are somewhere part-way through a settings reload, e.g. after running the setup wizard.
+						// services_dhcpdv4_configure will be called again later when the new interface settings from
+						// the config are applied and at that time everything will match up.
+						// Ignore this pool on this interface for now and just log the error to the system log.
+						log_error($error_msg);
+						$do_file_notice = false;
+					}
+				}
+				if ($do_file_notice) {
+					file_notice("DHCP", $error_msg);
+				}
 				continue;
 			}
 			$dhcpdconf .= "	pool {\n";


### PR DESCRIPTION
This one will log_error() the DHCP pool message when it detects the inconsistency at the end of the setup wizard during reload all.
That way it can still be seen in the system log that this happened, and one day someone might chase down all the steps in the "reload all" process.
Compare this with https://github.com/pfsense/pfsense/pull/1935 and choose which way you would like to go.