### PR TITLE
Remove syslog.conf entries on package uninstall (Bug #5210) - RELENG_2_2

### DIFF
--- a/etc/inc/pkg-utils.inc
+++ b/etc/inc/pkg-utils.inc
@@ -1187,17 +1187,16 @@ function delete_package_xml($pkg) {
 		update_output_window($static_output);
 	}
 	/* syslog */
+	$need_syslog_restart = false;
 	if(is_array($pkg_info['logging']) && $pkg_info['logging']['logfilename'] <> "") {
 		$static_output .= "Syslog entries... ";
 		update_output_window($static_output);
-		remove_text_from_file("/etc/syslog.conf", $pkg_info['logging']['facilityname'] . "\t\t\t\t" . $pkg_info['logging']['logfilename']);
-		system_syslogd_start();
 		@unlink("{$g['varlog_path']}/{$pkg_info['logging']['logfilename']}");
 		$static_output .= "done.\n";
 		update_output_window($static_output);
+		$need_syslog_restart = true;
 	}
 	
-	conf_mount_ro();
 	/* remove config.xml entries */
 	$static_output .= gettext("Configuration... ");
 	update_output_window($static_output);
@@ -1205,6 +1204,14 @@ function delete_package_xml($pkg) {
 	$static_output .= gettext("done.") . "\n";
 	update_output_window($static_output);
 	write_config("Removed {$pkg} package.\n");
+	
+	/* remove package entry from /etc/syslog.conf if needed */
+	/* this must to be done after removing the entries from config.xml */
+	if ($need_syslog_restart) {
+		system_syslogd_start();
+	}
+
+	conf_mount_ro();
 }
 
 function expand_to_bytes($size) {

--- a/etc/inc/pkg-utils.inc
+++ b/etc/inc/pkg-utils.inc
@@ -1206,7 +1206,7 @@ function delete_package_xml($pkg) {
 	write_config("Removed {$pkg} package.\n");
 	
 	/* remove package entry from /etc/syslog.conf if needed */
-	/* this must to be done after removing the entries from config.xml */
+	/* this must be done after removing the entries from config.xml */
 	if ($need_syslog_restart) {
 		system_syslogd_start();
 	}


### PR DESCRIPTION
The (broken, since it doesn't match the syslog entry) remove_text_from_file() is not needed at all. However, system_syslogd_start() must be run **after** the package entries are gone from config.xml, otherwise system_syslogd_start() just re-adds the (now almost removed) package logging configuration from there.