### PR TITLE
Remove syslog.conf entries on package uninstall (Bug #5210)

### DIFF
--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -863,14 +863,14 @@ function delete_package_xml($package_name, $when = "post-deinstall") {
 		}
 	}
 	/* syslog */
+	$need_syslog_restart = false;
 	if (is_array($pkg_info['logging']) && $pkg_info['logging']['logfilename'] <> "") {
 		$static_output .= "Syslog entries... ";
 		update_output_window($static_output);
-		remove_text_from_file("/etc/syslog.conf", $pkg_info['logging']['facilityname'] . "\t\t\t\t" . $pkg_info['logging']['logfilename']);
-		system_syslogd_start();
 		@unlink("{$g['varlog_path']}/{$pkg_info['logging']['logfilename']}");
 		$static_output .= "done.\n";
 		update_output_window($static_output);
+		$need_syslog_restart = true;
 	}
 
 	/* remove config.xml entries */
@@ -880,6 +880,13 @@ function delete_package_xml($package_name, $when = "post-deinstall") {
 	$static_output .= gettext("done.") . "\n";
 	update_output_window($static_output);
 	write_config("Removed {$package_name} package.\n");
+
+	/* remove package entry from /etc/syslog.conf if needed */
+	/* this must to be done after removing the entries from config.xml */
+	if ($need_syslog_restart) {
+		system_syslogd_start();
+	}
+
 	conf_mount_ro();
 }
 

--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -882,7 +882,7 @@ function delete_package_xml($package_name, $when = "post-deinstall") {
 	write_config("Removed {$package_name} package.\n");
 
 	/* remove package entry from /etc/syslog.conf if needed */
-	/* this must to be done after removing the entries from config.xml */
+	/* this must be done after removing the entries from config.xml */
 	if ($need_syslog_restart) {
 		system_syslogd_start();
 	}


### PR DESCRIPTION
The (broken, since it doesn't match the syslog entry) remove_text_from_file() is not needed at all. However, system_syslogd_start() must be run **after** the package entries are gone from config.xml, otherwise system_syslogd_start() just re-adds the (now almost removed) package logging configuration from there.