### PR TITLE
Inconsistent naming of labels for alias types

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -571,7 +571,7 @@ $label_str = array(
 	'port' => gettext("Port"),
 	'url' => gettext("URL (IPs)"),
 	'url_ports' => gettext("URL (Ports)"),
-	'urltable' => gettext("URL (IPs)"),
+	'urltable' => gettext("URL Table (IPs)"),
 	'urltable_ports' => gettext("URL Table (Ports)")
 	);
 


### PR DESCRIPTION
In firewall aliases edit, if you select URL Table (IPs) then the row label said just "URL (IPs)"
But if you select URL Table (Ports) then the row label says "URL Table (Ports)"
That was inconsistent. I have chosen to add the word "Table" here. We could just as easily remove the work "Table" from the line below.