### PR TITLE
Show the delete button only if there is more than 1 row

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -763,13 +763,18 @@ events.push(function(){
 		var labelstr = <?php echo json_encode($label_str); ?>;
 		$('.repeatable:first').find('label').text(labelstr[tab]);
 
-		// The add button and delete buttons must not show on  URL Table IP or URL table ports
+		// The delete button at the end of each row is only shown when there is more than 1 row.
+		if($('[id^=deleterow]').length > 1) {
+			$('[id^=deleterow]').show();
+		} else {
+			$('[id^=deleterow]').hide();
+		}
+
+		// The add button must not show on URL Table IP or URL table ports
 		if((tab == 'urltable') || (tab == 'urltable_ports')) {
 			hideClass('addbtn', true);
-			$('[id^=deleterow]').hide();
 		} else {
 			hideClass('addbtn', false);
-			$('[id^=deleterow]').show();
 		}
 	}
 


### PR DESCRIPTION
This is not properly working piece of code!
@sbeaver-netgate 
If the alias edit screen only displays the "Delete" button when there is more than 1 row, then the user will never be able to click "Delete" on the last row, and thus will never need to see the popup "You may not delete the last row!"
Also then, if the user chooses a different alias type (e.g. a URL Table type that should have only 1 row), but already has multiple rows on their screen, the "Delete" buttons will stay and they can delete the extra rows that are no longer wanted.
This code fragment does the test. But leaving it inside typechange() means it is only activated if the user selects a different alias type. I am not a JavaScript events and BootStrap guy - how do I make this show/hide test happen whenever the "Add" or "Delete" row button is pressed?