### PR TITLE
Hide the delete row button when there is only 1 row remaining

### DIFF
--- a/src/usr/local/www/jquery/pfSenseHelpers.js
+++ b/src/usr/local/www/jquery/pfSenseHelpers.js
@@ -292,6 +292,9 @@ function add_row() {
 	$('[id^=address]').autocomplete({
 		source: addressarray
 	});
+
+	// Show any deleterow buttons.
+	$('[id^=deleterow]').show();
 }
 
 // These are action buttons, not submit buttons
@@ -309,7 +312,14 @@ $('[id^=delete]').click(function(event) {
 			moveHelpText(event.target.id);
 
 		delete_row(event.target.id);
-	}
-	else
+	} else {
+		// This should not happen because when there is only 1 row remaining the delete button is hidden,
+		// so there should be no way for the user to click it.
 		alert('You may not delete the last row!');
+	}
+
+	// If there are less than 2 rows remaining, then hide the delete button.
+	if($('.repeatable').length < 2) {
+		$('[id^=deleterow]').hide();
+	}
 });


### PR DESCRIPTION
When deleting the 2nd-last row this happily causes the Delete button for the last remaining row to be hidden - that is the first thing I wanted to achieve. It gets rid of the button and thus the need for the message "You may not delete the last row!"to ever pop up.

When adding a row, I want to always show the delete row buttons (there is always at least 1 row already, so whenever "Add" is pressed then there will be at least 2 rows). I thought line 297 would do it easily - but no joy when testing it.

@sbeaver-netgate - what have I missed here?

If we do this, then "Delete" buttons at the end of rows should come and go automagically as required when rows are added and removed.