### PR TITLE
Fix #5261 last time I hope

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1241,16 +1241,19 @@ foreach (['src' => 'Source', 'dst' => 'Destination'] as $type => $name) {
 		$pconfig[$type.'not']
 	))->setWidth(2);
 
-	$ruleType = $pconfig[$type];
-
-	if ($pconfig[$type] == 'any') {
-		$ruleType = 'any';
-	} elseif (!is_specialnet($pconfig[$type])) {
-		$ruleType = 'network';
+	// The rule type dropdown on the GUI can be one of the special names like
+	// "any" "LANnet" "LAN address"... or "Single host or alias" or "Network"
+	if (is_specialnet($pconfig[$type])) {
+		// It is one of the special names, let it through as-is.
+		$ruleType = $pconfig[$type];
 	} elseif ((is_ipaddrv6($pconfig[$type]) && $pconfig[$type.'mask'] == 128) ||
 	    (is_ipaddrv4($pconfig[$type]) && $pconfig[$type.'mask'] == 32) ||
 	    (is_alias($pconfig[$type]))) {
+		// It is a single-host IP address or an alias
 		$ruleType = 'single';
+	} else {
+		// Everything else must be a network
+		$ruleType = 'network';
 	}
 
 	$ruleValues = array(


### PR DESCRIPTION
The previous version was considering "Single host or alias" to be "Network" because the !is_specialnet() test came first - and that matched both 'network' and 'single' types, which are both not a special net.
If have re-ordered the tests so that it is written in a positive order. I think that makes it easier to read.
1) If is_specialnet then pass the special name straight through to $ruleType.
2) Next see if it is a single IP address or alias.
3) The rest must (should, had better) be 'network'.

I tried editing all sorts of aliases with various types and this works for me.