### PR TITLE
Add brackets around self rule type #5283

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1264,7 +1264,7 @@ foreach (['src' => 'Source', 'dst' => 'Destination'] as $type => $name) {
 	);
 
 	if($type == 'dst') {
-		$ruleValues['self'] = "This firewall (self)";
+		$ruleValues['(self)'] = "This firewall (self)";
 	}
 
 	if (isset($a_filter[$id]['floating']) || $if == "FloatingRules")


### PR DESCRIPTION
It needs the brackets here - like in line 1271. The "(self)" with brackets is what is stored in config.xml in 2.2.* and needs to be the same here in 2.3. Otherwise other validation messages are spat out...