### PR TITLE
Wording of alias_info_popup tip RELENG_2_2

### DIFF
--- a/usr/local/www/guiconfig.inc
+++ b/usr/local/www/guiconfig.inc
@@ -1065,7 +1065,7 @@ function add_package_tabs($tabgroup, & $tab_array) {
 function alias_info_popup($alias_id){
 	global $config;
 	$maxlength = 60;
-	$close_title="title='".gettext('move mouse out this alias to hide')."'";
+	$close_title="title='".gettext('move mouse out of this alias to hide')."'";
 	if (is_array($config['aliases']['alias'][$alias_id])){
 		$alias_name=$config['aliases']['alias'][$alias_id];
 		$alias_objects_with_details = "<table width=\"100%\" border=\"0\" cellpadding=\"2\" cellspacing=\"0\" summary=\"alias info popup\">";


### PR DESCRIPTION
I noticed this while comparing alias popup behavior between 2.2.5-DEVELOPMENT and 2.3
Might as well fix the grammar here for 2.2.5
This tip does not exist in 2.3 because the popup works more nicely there and so this text is not needed.
Therefore this change does not need to be ported forward to master.