### PR TITLE
Fix #5289 Available Packages version display

### DIFF
--- a/src/usr/local/www/pkg_mgr.php
+++ b/src/usr/local/www/pkg_mgr.php
@@ -184,17 +184,19 @@ if(!$pkg_info || !is_array($pkg_info)):?>
 			</td>
 
 <?php
-/*	// We no longer have a package revision history URL
 	 if (!$g['disablepackagehistory']):?>
 			<td>
-				<!-- XXX: $changeloglink is undefined -->
+<!-- We no longer have a package revision history URL
+	$changeloglink is undefined
 				<a target="_blank" title="<?=gettext("View changelog")?>" href="<?=htmlspecialchars($changeloglink)?>">
-					<?=htmlspecialchars($index['version'])?>
+-->
+				<?=htmlspecialchars($index['version'])?>
+<!--
 				</a>
+-->
 			</td>
 <?php 
 endif;
-*/
 ?>
 			<td>
 				<?=$index['desc']?>


### PR DESCRIPTION
I left the "View changelog" code that was commented out, for future reference I guess when that data becomes available.
$index['version'] is still happily available in the $index array - so it just needed to be uncommented.