### PR TITLE
Hide the delete row button when there is only 1 row remaining

### DIFF
--- a/src/usr/local/www/jquery/pfSenseHelpers.js
+++ b/src/usr/local/www/jquery/pfSenseHelpers.js
@@ -243,6 +243,9 @@ function delete_row(row) {
 }
 
 function add_row() {
+	// Show any deleterow buttons that may have been hidden when there was only 1 row.
+	$('[id^=deleterow]').show();
+
 	// Find the last repeatable group
 	var lastRepeatableGroup = $('.repeatable:last');
 
@@ -309,7 +312,14 @@ $('[id^=delete]').click(function(event) {
 			moveHelpText(event.target.id);
 
 		delete_row(event.target.id);
-	}
-	else
+	} else {
+		// This should not happen because when there is only 1 row remaining the delete button is hidden,
+		// so there should be no way for the user to click it.
 		alert('You may not delete the last row!');
+	}
+
+	// If there are less than 2 rows remaining, then hide the delete button.
+	if($('.repeatable').length < 2) {
+		$('[id^=deleterow]').hide();
+	}
 });


### PR DESCRIPTION
When deleting the 2nd-last row this causes the Delete button for the last remaining row to be hidden. Having no delete button for a single-row alias means there is no temptation for the user to press it, and thus no need for them to get the message 'You may not delete the last row!'.
When adding the 2nd row the Delete buttons will appear again. In this case the user can delete any of the rows, leaving 1 or more remaining.