### PR TITLE
Do not show the delete row button if there is only 1 row

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -771,12 +771,17 @@ events.push(function(){
 		// Hide and disable rows other than the first
 		hideRowsAfter(1, (tab == 'urltable') || (tab == 'urltable_ports'));
 
-		// The add button and delete buttons must not show on  URL Table IP or URL table ports
-		if((tab == 'urltable') || (tab == 'urltable_ports')) {
+		// The add button must not show on URL Table IP or URL table ports
+		if ((tab == 'urltable') || (tab == 'urltable_ports')) {
 			hideClass('addbtn', true);
-			$('[id^=deleterow]').hide();
 		} else {
 			hideClass('addbtn', false);
+		}
+
+		// The delete button must not show on URL Table IP or URL table ports or if there are less than 2 rows
+		if ((tab == 'urltable') || (tab == 'urltable_ports') || ($('.repeatable').length < 2)) {
+			$('[id^=deleterow]').hide();
+		} else {
 			$('[id^=deleterow]').show();
 		}
 	}


### PR DESCRIPTION
The initial code and when switching between types (e.g. from URL table type to some other type) runs this typechange() function. Whenever we are displaying an alias that has only 1 row of data, we do not want to show the Delete row button.
That button is not usable when there is only 1 row of data, so there is not much point displaying it and tempting the user to press it.