### PR TITLE
Explain which thing is blue

### DIFF
--- a/src/usr/local/www/pkg_mgr_installed.php
+++ b/src/usr/local/www/pkg_mgr_installed.php
@@ -217,7 +217,7 @@ if(empty($installed_packages)):?>
 		<i class="icon-large icon-info-sign"></i> = Information, &nbsp;
 		<i class="icon-large icon-retweet"></i> = Reinstall.
 		<br />
-		<font color="blue"><?=gettext("Blue")?></font> = <?=gettext("Newer version available")?>
+		<font color="blue"><?=gettext("Blue package name")?></font> = <?=gettext("Newer version available")?>
 	</span>
 </div>
 


### PR DESCRIPTION
On the installed packages table, the Version column version number has a hyper-link to the package changelog. That appears blue all the time. It is when the package name in the "Name" column is blue that there is a newer version available.
If you can think of some other way to make this clear without writing so much, then go for it.