### PR TITLE
interfaces_assign tab_array numbering RELENG_2_2

### DIFF
--- a/usr/local/www/interfaces_assign.php
+++ b/usr/local/www/interfaces_assign.php
@@ -476,10 +476,10 @@ if ($input_errors)
 	$tab_array[3] = array(gettext("VLANs"), false, "interfaces_vlan.php");
 	$tab_array[4] = array(gettext("QinQs"), false, "interfaces_qinq.php");
 	$tab_array[5] = array(gettext("PPPs"), false, "interfaces_ppps.php");
-	$tab_array[7] = array(gettext("GRE"), false, "interfaces_gre.php");
-	$tab_array[8] = array(gettext("GIF"), false, "interfaces_gif.php");
-	$tab_array[9] = array(gettext("Bridges"), false, "interfaces_bridge.php");
-	$tab_array[10] = array(gettext("LAGG"), false, "interfaces_lagg.php");
+	$tab_array[6] = array(gettext("GRE"), false, "interfaces_gre.php");
+	$tab_array[7] = array(gettext("GIF"), false, "interfaces_gif.php");
+	$tab_array[8] = array(gettext("Bridges"), false, "interfaces_bridge.php");
+	$tab_array[9] = array(gettext("LAGG"), false, "interfaces_lagg.php");
 	display_top_tabs($tab_array);
 ?>
 	</td></tr>


### PR DESCRIPTION
This was fixed in master for 2.3 by https://github.com/pfsense/pfsense/commit/50e6c063e6ec148917ff0bcb0bce8b0a08df5792 - in master all of these $tab_array entries, in each file that they appear in, had been modified to just use the $tab_array[] = form.
But in RELENG_2_2 that has not happened. So it seems nicer to just fix the numbering here to match what is already in the other interfaces_*.php files in RELENG_2_2.
Note that the code works OK without this "fix" - display_top_tabs() just loops through the existing array keys anyhow and so did not notice the missing number.