### PR TITLE
For reinstallall there is no pkg specified

### DIFF
--- a/src/usr/local/www/pkg_mgr_install.php
+++ b/src/usr/local/www/pkg_mgr_install.php
@@ -223,7 +223,7 @@ if ($_POST) {
 		return;
 	}
 } else if ($_GET && !$_GET['id']) {
-	if (empty($_GET['pkg'])) {
+	if (empty($_GET['pkg']) && ($_GET['mode'] != 'reinstallall')) {
 		header("Location: pkg_mgr_installed.php");
 		return;
 	}


### PR DESCRIPTION
Reinstall all packages is currently just displaying the current list of installed packages. It does not prompt to reinstall.
Fix this test so that it will not apply to reinstallall. For reinstallall there is no pkg specified in the $_GET. It is invoked from diag_backup.php like:
header("Location: pkg_mgr_install.php?mode=reinstallall");