### PR TITLE
Fix case wildcard of package names for reinstallall

### DIFF
--- a/src/usr/local/sbin/pfSense-upgrade
+++ b/src/usr/local/sbin/pfSense-upgrade
@@ -561,7 +561,7 @@ pkg_delete() {
 # Reinstall every pfSense-pkg-* package
 pkg_reinstall_all() {
 	for _pkg in $(pkg query -e '%a == 0' %n); do
-		case ${_pkg} in "${pkg_prefix}*" )
+		case ${_pkg} in "${pkg_prefix}"* )
 			_echo "Reinstalling ${_pkg}"
 			pkg_install ${_pkg} 1
 			;;


### PR DESCRIPTION
Introduced by https://github.com/pfsense/pfsense/commit/e3b43e4bfe5a3e69028c1ab7e0e4a632ff5ee499
None of the packages were being matched here, none of them would be reinstalled. A "reinstallall" would complete very quickly with "Success" message but actually do nothing.