### PR TITLE
fix padding in select boxes

### DIFF
--- a/src/usr/local/www/bootstrap/css/pfSense.css
+++ b/src/usr/local/www/bootstrap/css/pfSense.css
@@ -104,6 +104,9 @@ tr.disabled th {
     padding: 0 12px;
     margin-bottom: 5px;
 }
+.form-control option {
+    padding: inherit;
+}
 
 #login .form-control {
 	height: 34px;


### PR DESCRIPTION
Todo #5228
found this solution ... seems a lot less time consuming to fix all option-padding without having to add classes to the option fields on every page. 
i've clicked around the GUI a bit and it seems to behave pretty nicely