### PR TITLE
Fix display of reject rules RELENG_2_2

### DIFF
--- a/etc/inc/filter_log.inc
+++ b/etc/inc/filter_log.inc
@@ -128,7 +128,7 @@ function in_arrayi($needle, $haystack) {
 }
 
 function parse_filter_line($line) {
-	global $config, $g;
+	global $config, $g, $buffer_rules_normal;
 
 	$flent = array();
 	$log_split = "";
@@ -149,6 +149,7 @@ function parse_filter_line($line) {
 	$flent['interface']  = convert_real_interface_to_friendly_descr($flent['realint']);
 	$flent['reason'] = $rule_data[$field++];
 	$flent['act'] = $rule_data[$field++];
+	$flent['acttype'] = $flent['act'];
 	$flent['direction'] = $rule_data[$field++];
 	$flent['version'] = $rule_data[$field++];
 
@@ -248,6 +249,14 @@ function parse_filter_line($line) {
 			$flent['version'] = $rule_data[$field++];
 			$flent['advskew'] = $rule_data[$field++];
 			$flent['advbase'] = $rule_data[$field++];
+		}
+		if ($flent['act'] == "block") {
+			// Check if the associated rule is actually a reject rule.
+			// A reject rule starts with "block return".
+			// A full block rule starts with "block drop".
+			if (substr($buffer_rules_normal[$flent['tracker']], 0 , 12) === "block return") {
+				$flent['acttype'] = "reject";
+			}
 		}
 	} else {
 		if($g['debug'])

--- a/etc/inc/filter_log.inc
+++ b/etc/inc/filter_log.inc
@@ -405,17 +405,18 @@ function handle_ajax($nentries, $tail = 50) {
 		 *  can update AJAX interface screen.
 		 */
 		$new_rules = "";
+		buffer_rules_load();
 		$filterlog = conv_log_filter($filter_logfile, $nentries, $tail);
 		/* We need this to always be in forward order for the AJAX update to work properly */
 		$filterlog = isset($config['syslog']['reverse']) ? array_reverse($filterlog) : $filterlog;
 		foreach($filterlog as $log_row) {
 			$row_time = strtotime($log_row['time']);
-			$img = "<img border='0' src='" . find_action_image($log_row['act']) . "' alt={$log_row['act']} title={$log_row['act']} />";
+			$img = "<img border='0' src='" . find_action_image($log_row['acttype']) . "' alt={$log_row['acttype']}/{$log_row['tracker']} title={$log_row['acttype']}/{$log_row['tracker']} />";
 			if($row_time > $lastsawtime) {
 				if ($log_row['proto'] == "TCP")
 					$log_row['proto'] .= ":{$log_row['tcpflags']}";
 
-				$img = "<a href=\"#\" onClick=\"javascript:getURL('diag_logs_filter.php?getrulenum={$log_row['rulenum']},{$log_row['rulenum']}', outputrule);\">{$img}</a>";
+				$img = "<a href=\"#\" onClick=\"javascript:getURL('diag_logs_filter.php?getrulenum={$log_row['rulenum']},{$log_row['tracker']},{$log_row['act']}', outputrule);\">{$img}</a>";
 				$new_rules .= "{$img}||{$log_row['time']}||{$log_row['interface']}||{$log_row['srcip']}||{$log_row['srcport']}||{$log_row['dstip']}||{$log_row['dstport']}||{$log_row['proto']}||{$log_row['version']}||" . time() . "||\n";
 			}
 		}

--- a/usr/local/www/diag_logs_filter.php
+++ b/usr/local/www/diag_logs_filter.php
@@ -301,8 +301,10 @@ include("head.inc");
 			</tr>
 <?php if (!isset($config['syslog']['rawfilter'])):
 	$iflist = get_configured_interface_with_descr(false, true);
-	if ($iflist[$interfacefilter])
+	if ($iflist[$interfacefilter]) {
 		$interfacefilter = $iflist[$interfacefilter];
+	}
+	buffer_rules_load();
 	if ($filterlogentries_submit) 
 		$filterlog = conv_log_filter($filter_logfile, $nentries, $nentries + 100, $filterfieldsarray);
 	else
@@ -329,8 +331,6 @@ include("head.inc");
 			  <td width="15%" class="listhdrr"><?=gettext("Proto");?></td>
 			</tr>
 			<?php
-			if ($config['syslog']['filterdescriptions'])
-				buffer_rules_load();
 			$rowIndex = 0;
 			foreach ($filterlog as $filterent): 
 			$evenRowClass = $rowIndex % 2 ? " listMReven" : " listMRodd";
@@ -339,7 +339,7 @@ include("head.inc");
 			  <td class="listMRlr nowrap" align="center" sorttable_customkey="<?=$filterent['act']?>">
 			  <center>
 			  <a onclick="javascript:getURL('diag_logs_filter.php?getrulenum=<?php echo "{$filterent['rulenum']},{$filterent['tracker']},{$filterent['act']}"; ?>', outputrule);">
-			  <img border="0" src="<?php echo find_action_image($filterent['act']);?>" width="11" height="11" align="middle" alt="<?php echo $filterent['act'] .'/'. $filterent['tracker'];?>" title="<?php echo $filterent['act'] .'/'. $filterent['tracker'];?>" />
+			  <img border="0" src="<?php echo find_action_image($filterent['acttype']);?>" width="11" height="11" align="middle" alt="<?php echo $filterent['acttype'] .'/'. $filterent['tracker'];?>" title="<?php echo $filterent['acttype'] .'/'. $filterent['tracker'];?>" />
 			  <?php if ($filterent['count']) echo $filterent['count'];?></a></center></td>
 			  <td class="listMRr nowrap"><?php echo htmlspecialchars($filterent['time']);?></td>
 			  <td class="listMRr nowrap">

--- a/usr/local/www/diag_logs_filter_dynamic.php
+++ b/usr/local/www/diag_logs_filter_dynamic.php
@@ -57,6 +57,7 @@ handle_ajax($nentries, $nentries + 20);
 if ($_POST['clear']) 
 	clear_log_file($filter_logfile);
 
+buffer_rules_load();
 $filterlog = conv_log_filter($filter_logfile, $nentries, $nentries + 100);
 
 $pgtitle = array(gettext("Status"),gettext("System logs"),gettext("Firewall (Dynamic View)"));
@@ -185,7 +186,7 @@ include("head.inc");
 			<tr class="<?=$evenRowClass?>">
 				<td class="listMRlr nowrap" align="center">
 				<a href="#" onclick="javascript:getURL('diag_logs_filter.php?getrulenum=<?php echo "{$filterent['rulenum']},{$filterent['tracker']},{$filterent['act']}"; ?>', outputrule);">
-				<img border="0" src="<?php echo find_action_image($filterent['act']);?>" width="11" height="11" alt="<?php echo $filterent['act'] .'/'. $filterent['tracker'];?>" title="<?php echo $filterent['act'] .'/'. $filterent['tracker'];?>" />
+				<img border="0" src="<?php echo find_action_image($filterent['acttype']);?>" width="11" height="11" alt="<?php echo $filterent['acttype'] .'/'. $filterent['tracker'];?>" title="<?php echo $filterent['acttype'] .'/'. $filterent['tracker'];?>" />
 				</a>
 				</td>
 				<td class="listMRr nowrap"><?php echo htmlspecialchars($filterent['time']);?></td>


### PR DESCRIPTION
on firewall log normal and dynamic views.
Firewall log entries that are for "reject" rules currently show the "block" red cross icon. That is because the data in filter.log just has the word "block", and so the downstream code that parses and displays the filter log on the UI does not get an easy chance to know if it is a "block" or "reject" rule.
The "block" vs "reject" information is in the config - we could look that up using the rule tracker number.  But that requires indexing through the config rules to match the tracker number.
There is already function buffer_rules_load(). Currently it is used to get the rule descriptions. Might as well call it all the time and then use the global array that it creates to work out if a block rule is really "block" or "reject". A "reject" rule starts with "block return".
There is already code in find_action_image() that returns the correct image for the "reject" case. It was just waiting to be passed "reject" instead of "block".
I noticed this in 2.3-ALPHA and when looking on 2.2.4 and 2.2.5 systems to see how it worked. That made me realise that it did not work on 2.2.* also.
Note: There is another bug with the firewall log dynamic view - new rows that are dynamically added do not get the rule tracker number added in. So they do not display the rule when you click the icon, and they also do not choose the "reject" icon. I will have a look at that separately, because it is a whole different issue with the JavaScript and how it passes stuff around.