### PR TITLE
Make DHCP deny action configurable

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -776,20 +776,24 @@ EOPP;
 				}
 				$dhcpdconf .= "		allow members of \"" . str_replace(':', '', $mac) . "\";\n";
 			}
+			$deny_action = "deny";
+			if (isset($poolconf['nonak'])) {
+				$deny_action = "ignore";
+			}
 			$mac_deny_list = array_unique(explode(',', $poolconf['mac_deny']));
 			foreach ($mac_deny_list as $mac) {
 				if (empty($mac)) {
 					continue;
 				}
-				$dhcpdconf .= "		deny members of \"" . str_replace(':', '', $mac) . "\";\n";
+				$dhcpdconf .= "		$deny_action members of \"" . str_replace(':', '', $mac) . "\";\n";
 			}
 
 			if ($poolconf['failover_peerip'] <> "") {
-				$dhcpdconf .= "		deny dynamic bootp clients;\n";
+				$dhcpdconf .= "		$deny_action dynamic bootp clients;\n";
 			}
 
 			if (isset($poolconf['denyunknown'])) {
-			   $dhcpdconf .= "		deny unknown-clients;\n";
+				$dhcpdconf .= "		$deny_action unknown-clients;\n";
 			}
 
 			if ($poolconf['gateway'] && $poolconf['gateway'] != "none" && ($poolconf['gateway'] != $dhcpifconf['gateway'])) {

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -183,6 +183,7 @@ if (is_array($dhcpdconf)) {
 	list($pconfig['wins1'], $pconfig['wins2']) = $dhcpdconf['winsserver'];
 	list($pconfig['dns1'], $pconfig['dns2'], $pconfig['dns3'], $pconfig['dns4']) = $dhcpdconf['dnsserver'];
 	$pconfig['denyunknown'] = isset($dhcpdconf['denyunknown']);
+	$pconfig['nonak'] = isset($dhcpdconf['nonak']);
 	$pconfig['ddnsdomain'] = $dhcpdconf['ddnsdomain'];
 	$pconfig['ddnsdomainprimary'] = $dhcpdconf['ddnsdomainprimary'];
 	$pconfig['ddnsdomainkeyname'] = $dhcpdconf['ddnsdomainkeyname'];
@@ -540,6 +541,7 @@ if (isset($_POST['submit'])) {
 		$dhcpdconf['domain'] = $_POST['domain'];
 		$dhcpdconf['domainsearchlist'] = $_POST['domainsearchlist'];
 		$dhcpdconf['denyunknown'] = ($_POST['denyunknown']) ? true : false;
+		$dhcpdconf['nonak'] = ($_POST['nonak']) ? true : false;
 		$dhcpdconf['ddnsdomain'] = $_POST['ddnsdomain'];
 		$dhcpdconf['ddnsdomainprimary'] = $_POST['ddnsdomainprimary'];
 		$dhcpdconf['ddnsdomainkeyname'] = $_POST['ddnsdomainkeyname'];
@@ -772,6 +774,14 @@ $section->addInput(new Form_Checkbox(
 	'Only the clients defined below will get DHCP leases from this server.',
 	$pconfig['denyunknown']
 ));
+
+$section->addInput(new Form_Checkbox(
+	'nonak',
+	'Ignore denied clients',
+	'Denied clients will be ignored rather than rejected.',
+	$pconfig['nonak']
+));
+
 
 if (is_numeric($pool) || ($act == "newpool")) {
 	$section->addInput(new Form_Input(


### PR DESCRIPTION
The default behavior of PFsense is to send a DHCP NAK to denied clients. This is problematic in situations where there are multiple DHCP servers on the same subnet serving different sets of clients. This patch adds a config option to allow denied clients to be ignored rather then explicitly rejected.