### PR TITLE
diag_nanobsd do not show reference count 0

### DIFF
--- a/src/usr/local/www/diag_nanobsd.php
+++ b/src/usr/local/www/diag_nanobsd.php
@@ -168,7 +168,9 @@ $section->addInput(new Form_StaticText(
 if (is_writable("/")) {
 	$refcount = refcount_read(1000);
 	/* refcount_read returns -1 when shared memory section does not exist */
-	if ($refcount == 1 || $refcount == -1) {
+	/* refcount can be zero here when the user has set nanobsd_force_rw */
+	/* refcount 1 is normal, so only display the count for abnormal values */
+	if ($refcount == 1 || $refcount == 0 || $refcount == -1) {
 		$refdisplay = "";
 	} else {
 		$refdisplay = " (Reference count " . $refcount . ")";


### PR DESCRIPTION
When the user has selected "Keep media mounted read/write at all times." then the value of $refcount will be zero even though is_writable() is true. That is a normal condition.
We only want to display the (Reference count n) text when the reference count is abnormal.
This is a "bug" in 2.2.* also, not a regression in 2.3-ALPHA. But it might as well just be changed in master 2.3. Not much point back-porting little crud like this to RELENG_2_2 nowadays.