### PR TITLE
interfaces_pps_edit use latest GLOB from RELENG_2_2

### DIFF
--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -559,9 +559,7 @@ function build_link_list() {
 		mwexec("/bin/mkdir -p /var/spool/lock");
 
 	if($pconfig['type'] == 'ppp') {
-		$serialports = glob("/dev/cua?[0-9]{,.[0-9]}", GLOB_BRACE);
-		//DEBUG
-		$serialports = glob("/dev/tty?[0-9]{,.[0-9]}", GLOB_BRACE);
+		$serialports = glob("/dev/cua[a-zA-Z][0-9]{,.[0-9],.[0-9][0-9],[0-9],[0-9].[0-9],[0-9].[0-9][0-9]}", GLOB_BRACE);
 
 		$serport_count = 0;
 


### PR DESCRIPTION
Use the latest cua* glob from the code in RELENG_2_2 that was "recently" modified to get this right.
Remove the debug version that looked for "tty" so that people can use it on real systems now.
Forum thread: https://forum.pfsense.org/index.php?topic=102111.0