### PR TITLE
Fix #5411 firewall_nat_edit source negation

### DIFF
--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -695,6 +695,13 @@ $section->addInput(new Form_Select(
 
 $group = new Form_Group('Source');
 
+$group->add(new Form_Checkbox(
+	'srcnot',
+	'Source not',
+	'Invert match.',
+	$pconfig['srcnot']
+))->setWidth(2);
+
 $group->add(new Form_Select(
 	'srctype',
 	null,
@@ -756,6 +763,13 @@ $section->add($group);
 
 $group = new Form_Group('Destination');
 
+$group->add(new Form_Checkbox(
+	'dstnot',
+	'Destination not',
+	'Invert match.',
+	$pconfig['dstnot']
+))->setWidth(2);
+
 $group->add(new Form_Select(
 	'dsttype',
 	null,
@@ -808,14 +822,6 @@ $group->setHelp('Specify the port or port range for the destination of the packe
 				'You can leave the \'to\' field empty if you only want to map a single port ');
 
 $section->add($group);
-
-$section->addInput(new Form_Checkbox(
-	'dstnot',
-	null,
-	'Not (Invert the sense of the match)',
-	$pconfig['dstnot'],
-	'yes'
-));
 
 $section->addInput(new Form_IpAddress(
 	'localip',


### PR DESCRIPTION
And make the "not" checkboxes have the same layout as in firewall_rules_edit. That seems a better place to put the checkbox and consistency between similar GUI screens seems a good thing.