### PR TITLE
No XMLRPC Sync checkbox layout

### DIFF
--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -865,7 +865,7 @@ $section->addInput(new Form_Input(
 $section->addInput(new Form_Checkbox(
 	'nosync',
 	'No XMLRPC Sync',
-	null,
+	'Do not automatically sync to other CARP members',
 	$pconfig['nosync']
 ))->setHelp('This prevents the rule on Master from automatically syncing to other CARP members. ' .
 			'This does NOT prevent the rule from being overwritten on Slave.');


### PR DESCRIPTION
If null is passed for the text to go after the checkbox, then the checkbox does not line up nicely on the page with the other items above and below it. If some text (or even the empty string) is passed then the lineup is all good.
In this case it seems reasonable to put some text here, like is done higher up for "Disable" and "No RDR" checkboxes.