### PR TITLE
proposed fix Bug #5433

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -701,7 +701,7 @@ function dump_clog($logfile, $tail, $withorig = true, $grepfor = "", $grepinvert
 				$entry_text .= htmlspecialchars($logent[4] . " " . $logent[5]);
 			}
 			echo "<td style=\"white-space:nowrap;\">{$entry_date_time}</td>\n";
-			echo "<td>{$entry_text}</td>\n";
+			echo "<td style=\"word-wrap:break-word; word-break:break-all; white-space:normal\">{$entry_text}</td>\n";
 		} else {
 				echo "<td>" . htmlspecialchars($logent[5]) . "</td>\n";
 		}


### PR DESCRIPTION
set 'gui log entries' to 3000.
=> no horizontal scroll on my 2.3 system. (best to test on multiple systems/browsers)