### PR TITLE
Ticket #5451 for RELENG_2_2

### DIFF
--- a/etc/inc/openvpn.attributes.php
+++ b/etc/inc/openvpn.attributes.php
@@ -121,7 +121,7 @@ function parse_cisco_acl($attribs) {
 				if ($isblock == true)
 					$isblock = false;
 			} else if (trim($rule[$index]) == "any") {
-				$tmprule .= "from any";
+				$tmprule .= "from any ";
 				$index++;
 			} else {
 				$tmprule .= "from {$rule[$index]}";


### PR DESCRIPTION
Actually this can be fixed by adding just a space after "from any".
The code here builds up $tmprule and each time it adds a new clause it puts a space at the end, ready for if there is another clause to come. The "from any" here was the only offender in this scheme.
It seems good to me to still backport little easy fixes to RELENG_2_2. That way production users can get them easily if they like (with system patches or...).