### PR TITLE
Backport Redmine #5440 to RELENG_2_2

### DIFF
--- a/usr/local/www/diag_authentication.php
+++ b/usr/local/www/diag_authentication.php
@@ -66,6 +66,14 @@ if ($_POST) {
 			$input_errors[] = gettext("Authentication failed.");
 		}
 	}
+} else {
+	// Choose a reasonable initial default.
+	if (isset($config['system']['webgui']['authmode'])) {
+		$pconfig['authmode'] = $config['system']['webgui']['authmode'];
+	}
+	else {
+		$pconfig['authmode'] = "Local Database";
+	}
 }
 $pgtitle = array(gettext("Diagnostics"),gettext("Authentication"));
 $shortcut_section = "authentication";


### PR DESCRIPTION
The code in RELENG_2_2 for system_usermanager_settings.php seems to work OK in RELENG_2_2 so I did not touch anything there.
But diag_authentication.php had nothing about $pconfig on initial page load. This extra code makes it select a reasonable default auth server when the page first loads. After that, each time the user does "Test", the page comes back with the previously selected auth server, user name and password (like it did already) - so that seems good.