### PR TITLE
Improve diag_authentication.php redmine #5440

### DIFF
--- a/src/usr/local/www/diag_authentication.php
+++ b/src/usr/local/www/diag_authentication.php
@@ -96,7 +96,14 @@ if ($_POST) {
 			$input_errors[] = gettext("Authentication failed.");
 		}
 	}
+} else {
+	if (isset($config['system']['webgui']['authmode'])) {
+		$pconfig['authmode'] = $config['system']['webgui']['authmode'];
+	} else {
+		$pconfig['authmode'] = "Local Database";
+	}
 }
+
 $pgtitle = array(gettext("Diagnostics"), gettext("Authentication"));
 $shortcut_section = "authentication";
 include("head.inc");
@@ -118,12 +125,6 @@ $section = new Form_Section('Authentication Test');
 foreach (auth_get_authserver_list() as $auth_server)
 	$serverlist[$auth_server['name']] = $auth_server['name'];
 
-if (isset($config['system']['webgui']['authmode'])) {
-	$pconfig['authmode'] = &$config['system']['webgui']['authmode'];
-}
-else {
-	$pconfig['authmode'] = "Local Database";
-}
 $section->addInput(new Form_Select(
 	'authmode',
 	'Authentication Server',


### PR DESCRIPTION
Move the code to select the default auth server so that it only happens the first time into the page. Now if the user selects a different auth server to test, and presses test, the results come back and the selected auth server is re-displayed (rather than the system default auth server being re-chosen every time).
Do not use address-of "&" when referring to the $config value - we do not ever intend to modify the config in here, so there seems no point in risking it by using a pointer.