### PR TITLE
Alternate way to correct rules for ticket #5451

### DIFF
--- a/src/etc/inc/openvpn.attributes.php
+++ b/src/etc/inc/openvpn.attributes.php
@@ -128,7 +128,7 @@ function parse_cisco_acl($attribs) {
 					$isblock = false;
 				}
 			} else if (trim($rule[$index]) == "any") {
-				$tmprule .= "from any";
+				$tmprule .= "from any ";
 				$index++;
 			} else {
 				$tmprule .= "from {$rule[$index]}";
@@ -143,16 +143,16 @@ function parse_cisco_acl($attribs) {
 			/* Destination */
 			if (trim($rule[$index]) == "host") {
 				$index++;
-				$tmprule .= " to {$rule[$index]} ";
+				$tmprule .= "to {$rule[$index]} ";
 				$index++;
 				if ($isblock == true) {
 					$isblock = false;
 				}
 			} else if (trim($rule[$index]) == "any") {
 				$index++;
-				$tmprule .= " to any";
+				$tmprule .= "to any";
 			} else {
-				$tmprule .= " to {$rule[$index]}";
+				$tmprule .= "to {$rule[$index]}";
 				$index++;
 				$netmask = cisco_to_cidr($rule[$index]);
 				$tmprule .= "/{$netmask} ";


### PR DESCRIPTION
The code here build up each clause in $tmprule and always adds a space at the end of the clause, in case there is another clause to come. The only place that did not do this was "from any" at line 131. Fixing that should fix the issue and keep it all consistent. There should be no need to add a space before all of the "to..." clauses.
Actually the first fix by @cbuechler https://github.com/pfsense/pfsense/commit/8e81f6a88180c5c9a280d78fd77788f7160b0d1a will work fine, but IMHO this is a little cleaner and will be easier for future maintainers to understand.