### PR TITLE
Fix missing stratum setting

### DIFF
--- a/etc/inc/system.inc
+++ b/etc/inc/system.inc
@@ -1616,6 +1616,10 @@ function system_ntp_configure($start_ntpd=true) {
 			$ntpcfg .= ' refid ';
 			$ntpcfg .= $config['ntpd']['gps']['refid'];
 		}
+		if (!empty($config['ntpd']['gps']['stratum'])) {
+			$ntpcfg .= ' stratum ';
+			$ntpcfg .= $config['ntpd']['gps']['stratum'];
+		}
 		$ntpcfg .= "\n";
 	}elseif (is_array($config['ntpd']) && !empty($config['ntpd']['gpsport'])
 		&& file_exists('/dev/'.$config['ntpd']['gpsport'])


### PR DESCRIPTION
Add missing stratum parameter to the ntpd.conf file when specified on
the Serial GPS page.