### PR TITLE
pkg_edit.php - base64 encoding/decoding fixes (Bug #5134)

### DIFF
--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -690,7 +690,11 @@ foreach ($pkg['fields']['field'] as $pkga) {
 		// Create an input element. The format is slightly different depending on whether we are composing a group,
 		// section, or advanced section. This is true for every element type
 		case "input":
-			if($grouping) {
+			if (($pkga['encoding'] == 'base64') && !$get_from_post && !empty($value)) {
+				$value = base64_decode($value);
+			}
+
+			if ($grouping) {
 				$group->add(new Form_Input(
 					$pkga['fieldname'],
 					$pkga['fielddescr'],
@@ -718,8 +722,12 @@ foreach ($pkg['fields']['field'] as $pkga) {
 			break;
 
 		case "password":
+			if (($pkga['encoding'] == 'base64') && !$get_from_post && !empty($value)) {
+				$value = base64_decode($value);
+			}
+
 			// Create a password element
-			if($grouping) {
+			if ($grouping) {
 				$group->add(new Form_Input(
 					$pkga['fieldname'],
 					$pkga['fielddescr'],
@@ -1325,6 +1333,11 @@ foreach ($pkg['fields']['field'] as $pkga) {
 						}
 
 						$type = $rowhelper['type'];
+						if ($type == "input" || $type == "password" || $type == "textarea" ) {
+							if (($rowhelper['encoding'] == 'base64') && !$get_from_post && !empty($value)) {
+								$value = base64_decode($value);
+							}
+						}
 						$fieldname = $rowhelper['fieldname'];
 
 						if ($rowhelper['size']) {


### PR DESCRIPTION
Currently, the base64 encoding is only usable for textarea fields - see Bug #5134 for details. This really sucks as this feature is very much needed for things like passwords that screw up config.xml with special chars.

This adds base64_decode() to input and password field types if &lt;encoding&gt;base64&lt;/encoding&gt; tag is set for those fields (also for rowhelpers) to prevent the values from getting perpetually re-encoded which makes it unusable for those field types.

Ideally, usage of the &lt;encoding&gt; tag should be prevented for fields type where it doesn't make any sense whatsoever, someone else needs to look into that, the packages.dtd XSD schema is a pathetic useless POS.