### PR TITLE
Be consistent with "Download file"

### DIFF
--- a/src/usr/local/www/exec.php
+++ b/src/usr/local/www/exec.php
@@ -269,7 +269,7 @@ if (!isBlank($_POST['txtCommand'])):?>
 		print('<div class="alert alert-success" role="alert">' . $ulmsg .'</div>');
 ?>
 	<div class="panel panel-default">
-		<div class="panel-heading"><h2 class="panel-title"><?=gettext('Upload a file')?></h2></div>
+		<div class="panel-heading"><h2 class="panel-title"><?=gettext('Upload file')?></h2></div>
 		<div class="panel-body">
 			<input name="ulfile" type="file" class="btn btn-default btn-sm btn-file" id="ulfile" />
 			<br />


### PR DESCRIPTION
The download section is headed "Download file" but the upload section was "Upload a file".
Be consistent - I have chosen to change to "Upload file".
Could just as easily make the download heading "Download a file".
Not sure it matters - just use the same convention in both places.