### PR TITLE
service-utils.inc - add fallback for stop_service() for package-defined services

### DIFF
--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -138,6 +138,8 @@ function stop_service($name) {
 				}
 				if (!empty($service['stopcmd'])) {
 					eval($service['stopcmd']);
+				} elseif (!empty($service['executable'])) {
+					mwexec("/usr/bin/killall " . escapeshellarg($service['executable']));
 				}
 
 				break;


### PR DESCRIPTION
To avoid adding silly undocumented bloat to packages like here: https://redmine.pfsense.org/issues/5468

If package defines a service executable, chances are that killing that executable will indeed stop the service as intended, instead of doing nothing and pretending that it worked.