### PR TITLE
Fix tooltip text for associated filter rules

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -361,19 +361,24 @@ for ($i = 0; isset($a_filter[$i]); $i++):
 							<input type="checkbox" id="frc<?=$nrules;?>" onClick="fr_toggle(<?=$nrules;?>)" name="rule[]" value="<?=$i;?>"/>
 						</td>
 
-						<td title="<?=gettext("traffic is ").$filterent['type']."ed"?>">
-
 	<?php
-		if ($filterent['type'] == "block")
+		if ($filterent['type'] == "block") {
 			$iconfn = "remove";
-		else if ($filterent['type'] == "reject")
+			$title_text = gettext("traffic is blocked");
+		} else if ($filterent['type'] == "reject") {
 			$iconfn = "fire";
-		else if ($filterent['type'] == "match")
+			$title_text = gettext("traffic is rejected");
+		} else if ($filterent['type'] == "match") {
 			$iconfn = "filter";
-		else
+			$title_text = gettext("traffic is matched");
+		} else {
 			$iconfn = "ok";
+			$title_text = gettext("traffic is passed");
+		}
 	?>
-					<i class="icon icon-<?=$iconfn?>"></i>
+						<td title="<?=$title_text?>">
+
+							<i class="icon icon-<?=$iconfn?>"></i>
 	<?php
 		$isadvset = firewall_check_for_advanced_options($filterent);
 		if ($isadvset)
@@ -382,7 +387,7 @@ for ($i = 0; isset($a_filter[$i]); $i++):
 		if (isset($filterent['log']))
 			print '<i class="icon icon-tasks" title="'. gettext("traffic is logged") .'"></i>';
 	?>
-				</td>
+						</td>
 	<?php
 		$alias = rule_columns_with_alias(
 			$filterent['source']['address'],


### PR DESCRIPTION
1) Add a port forward with associated filter rule
2) Go to firewall_rules and hover over the icon on the left of the associated rule.
It says "traffic is ed".

The problem is that, for whatever reason, an associated rule does not have ['type'] specified, even in config.xml. It is that way in 2.2.5, so not a new thing or regression. I guess that the back-end rule generation works by assuming that a rule in config.xml that does not have 'type' defined should be a pass rule.

So we can't write code anywhere that assumes that every rule has a defined 'type'.

This was different fixed text in 2.2.5, so there was no problem there.

In fixing this I also made the text explicit for each type. This will help with the gettext translation. The way it did it before, putting "ed" on the end, would not have worked for translation.