### PR TITLE
Make block bogon rule display consistent - RELENG_2_2

### DIFF
--- a/usr/local/www/firewall_rules.php
+++ b/usr/local/www/firewall_rules.php
@@ -391,7 +391,7 @@ include("head.inc");
 			<td class="listr" style="background-color: #E0E0E0">*</td>
 			<td class="listr" style="background-color: #E0E0E0">*</td>
 			<td class="listr" style="background-color: #E0E0E0">*</td>
-			<td class="listr" style="background-color: #E0E0E0">*</td>
+			<td class="listr" style="background-color: #E0E0E0">&nbsp;</td>
 			<td class="listbg"><?=gettext("Block bogon networks");?></td>
 			<td valign="middle" class="list nowrap">
 				<table border="0" cellspacing="0" cellpadding="1" summary="move rules before">


### PR DESCRIPTION
The block private networks and anti-lockout rules display in the firewall rules display with the schedule column blank. But the block bogon networks has an asterisk. That looks odd. I noticed it just now when looking at firewall rules in 2.3.
Might as well fix it here in RELENG_2_2.