### PR TITLE
Make block bogon rule display consistent

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -335,7 +335,7 @@ display_top_tabs($tab_array);
 						<td>*</td>
 						<td>*</td>
 						<td>*</td>
-						<td>*</td>
+						<td></td>
 						<td><?=gettext("Block bogon networks");?></td>
 						<td>
 							<a href="interfaces.php?if=<?=htmlspecialchars($if)?>" class="fa fa-cog" title="<?=gettext("Settings");?>"></a>


### PR DESCRIPTION
The block private networks and anti-lockout rules display in the firewall rules display with the schedule column blank. But the block bogon networks has an asterisk. That looks odd. I noticed it just now when looking at firewall rules in 2.3 and looked back in 2.2.5 also - it is the same there.