### PR TITLE
Fix widgetname variables

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -138,7 +138,7 @@ if ($_POST && $_POST['sequence']) {
 
 	foreach ($widgets as $widgetname => $widgetconfig) {
 		if ($_POST[$widgetname . '-config']) {
-			$config['widgets'][$widgetname . '-config'] = $_POST[$name . '-config'];
+			$config['widgets'][$widgetname . '-config'] = $_POST[$widgetname . '-config'];
 		}
 	}
 
@@ -254,8 +254,8 @@ if ($config['widgets'] && $config['widgets']['sequence'] != "") {
 
 	##find custom configurations of a particular widget and load its info to $pconfig
 	foreach ($widgets as $widgetname => $widgetconfig) {
-		if ($config['widgets'][$name . '-config']) {
-			$pconfig[$name . '-config'] = $config['widgets'][$name . '-config'];
+		if ($config['widgets'][$widgetname . '-config']) {
+			$pconfig[$widgetname . '-config'] = $config['widgets'][$widgetname . '-config'];
 		}
 	}
 }


### PR DESCRIPTION
These were wrong. But actually I don't think any widgets use this mechanism of $config['widgets']['mywidget-config'] - they seem to do their own thing making names for the keys they use in $config['widgets'] to store their settings. So I didn't find anything actually broken because of this.