### PR TITLE
Redmine #5492 case of acronyms in widget names

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -260,6 +260,13 @@ if ($config['widgets'] && $config['widgets']['sequence'] != "") {
 	}
 }
 
+## Replace any known acronyms in widget names with suitable mixed-case forms
+$input_acronyms = array("carp", "dns", "dyn dns", "gmirror", "ipsec", "ntp", "openvpn", "rss", "smart");
+$output_acronyms = array("CARP", "DNS", "Dynamic DNS", "gmirror", "IPsec", "NTP", "OpenVPN", "RSS", "SMART");
+foreach ($widgets as $widgetname => $widgetconfig) {
+	$widgets[$widgetname]['name'] = str_ireplace($input_acronyms, $output_acronyms, $widgetconfig['name']);
+}
+
 ##build list of php include files
 $phpincludefiles = array();
 $directory = "/usr/local/www/widgets/include/";


### PR DESCRIPTION
I am not sure how else to do this. If someone in future writes a widget about "Smart Carp" (an intelligent species of fish) then it will get turned into "SMART CARP". The other strings are not English words, or parts of English words, so not likely to be matched wrongly in future.

Note 1: The redmine issue also mentions changing "Dyn DNS Status" to "Dynamic DNS Status". For that reason I put a special entry to change any "dyn dns" to "Dynamic DNS". I also put the "dns" to "DNS" in case there are ever any other occurrences of "dns" in other widget names that would need to be changed to "DNS".

Note 2: "gmirror" to "gmirror" is not a mistake. str_ireplace() is case-insensitive. So this will replaces stuff like "Gmirror" with "gmirror".

Note 3: None of this stuff has gettext() translation support. But it did not in 2.2.* either. That is something else for future thought - how to take text that is generated from file names found at run-time and give translators a chance to translate it.