### PR TITLE
If webguicss is not yet specified then default to pfSense

### DIFF
--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -467,6 +467,10 @@ foreach ($css as $file) {
 	}
 }
 
+if (($pconfig['webguicss'] == "") || (!isset($csslist[$pconfig['webguicss']]))) {
+	$pconfig['webguicss'] = "pfSense.css";
+}
+
 $section = new Form_Section('Web configurator theme');
 
 $section->addInput(new Form_Select(


### PR DESCRIPTION
On systems where webguicss (the theme) was not yet set in the config, the selection here was defaulting to other than pfSense.
Now that pfSense-dark has come along, it happened to be first in the list. When I changed something else in General Setup today, my theme went to pfSense-dark because I did not notice the (accidentally) selected value that was in the field.

I also added a check for if the current webguicss is not a valid one - e.g. if a theme is selected in the config that is no longer on the system. That should help future-proof it so it will default back to pfSense.css in that case also.