### PR TITLE
Remove unused time-update-interval

### DIFF
--- a/src/conf.default/config.xml
+++ b/src/conf.default/config.xml
@@ -34,7 +34,6 @@
 		</user>
 		<nextuid>2000</nextuid>
 		<nextgid>2000</nextgid>
-		<time-update-interval>300</time-update-interval>
 		<timeservers>0.pfsense.pool.ntp.org</timeservers>
 		<webgui>
 			<protocol>https</protocol>

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -86,16 +86,12 @@ $pconfig['dns4gw'] = $config['system']['dns4gw'];
 
 $pconfig['dnsallowoverride'] = isset($config['system']['dnsallowoverride']);
 $pconfig['timezone'] = $config['system']['timezone'];
-$pconfig['timeupdateinterval'] = $config['system']['time-update-interval'];
 $pconfig['timeservers'] = $config['system']['timeservers'];
 $pconfig['language'] = $config['system']['language'];
 $pconfig['webguicss'] = $config['system']['webgui']['webguicss'];
 
 $pconfig['dnslocalhost'] = isset($config['system']['dnslocalhost']);
 
-if (!isset($pconfig['timeupdateinterval'])) {
-	$pconfig['timeupdateinterval'] = 300;
-}
 if (!$pconfig['timezone']) {
 	if (isset($g['default_timezone']) && !empty($g['default_timezone'])) {
 		$pconfig['timezone'] = $g['default_timezone'];
@@ -201,10 +197,6 @@ if ($_POST) {
 		}
 	}
 
-	$t = (int)$_POST['timeupdateinterval'];
-	if (($t < 0) || (($t > 0) && ($t < 6)) || ($t > 1440)) {
-		$input_errors[] = gettext("The time update interval must be either 0 (disabled) or between 6 and 1440.");
-	}
 	# it's easy to have a little too much whitespace in the field, clean it up for the user before processing.
 	$_POST['timeservers'] = preg_replace('/[[:blank:]]+/', ' ', $_POST['timeservers']);
 	$_POST['timeservers'] = trim($_POST['timeservers']);
@@ -219,7 +211,6 @@ if ($_POST) {
 		update_if_changed("domain", $config['system']['domain'], $_POST['domain']);
 		update_if_changed("timezone", $config['system']['timezone'], $_POST['timezone']);
 		update_if_changed("NTP servers", $config['system']['timeservers'], strtolower($_POST['timeservers']));
-		update_if_changed("NTP update interval", $config['system']['time-update-interval'], $_POST['timeupdateinterval']);
 
 		if ($_POST['language'] && $_POST['language'] != $config['system']['language']) {
 			$config['system']['language'] = $_POST['language'];


### PR DESCRIPTION
There is no longer any code for a UI field in 2.3 master.
In RELENG_2_2 system.php the code for the field display is commented
out.
The commented out code has been removed in the bootstrap conversion.
This removes the various bits of leftover processing and validation code
and the setting from the default config.