### PR TITLE
restart_service() - do not attempt to stop service that is not running

### DIFF
--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -155,7 +155,9 @@ function restart_service($name) {
 		return;
 	}
 
-	stop_service($name);
+	if (is_service_running($name)) {
+		stop_service($name);
+	}
 	start_service($name);
 
 	if (is_array($config['installedpackages']) && is_array($config['installedpackages']['service'])) {


### PR DESCRIPTION
Attempting to stop service that's not running just produces useless log noise.

BTW - dunno what was the idea behind restart_service_if_running() but it appears to be completely unused both in pfSense and in packages, suspect mainly because it doesn't make any sense as implemented.