### PR TITLE
pkg-utils.inc - stick xmlrpc.inc include back to avoid breaking packages

### DIFF
--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -59,6 +59,8 @@
 
 require_once("globals.inc");
 require_once("service-utils.inc");
+/* Do NOT remove until packages had time to get updated */
+require_once("xmlrpc.inc");
 
 if (file_exists("/cf/conf/use_xmlreader")) {
 	require_once("xmlreader.inc");


### PR DESCRIPTION
Removing this broke 29 packages which rely on it for configuration sync and include pkg-utils.inc instead of xmlrpc.inc.