### PR TITLE
Escape RADIUS secret in strongswan.conf

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -504,7 +504,7 @@ EOD;
 			$radius_server_txt .= <<<EOD
 				{$nice_user_source} {
 					address = {$auth_server['host']}
-					secret = {$auth_server['radius_secret']}
+					secret = "{$auth_server['radius_secret']}"
 					auth_port = {$auth_server['radius_auth_port']}
 					acct_port = {$auth_server['radius_acct_port']}
 				}


### PR DESCRIPTION
If a RADIUS secret is, for example, `#secret-key#`, EAP-RADIUS authentication will fail, as the `#` can be interpreted by the `strongswan.conf` parser as a comment.

To avoid this from happening, set the key within double quotes.