### PR TITLE
Remove layer7 components divert

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2910,10 +2910,6 @@ function filter_generate_user_rule($rule) {
 					$aline['flags'] .= "/" . $rule['max-src-conn-rates'] . ", overload <virusprot> flush global ";
 				}
 
-				if (!empty($aline['divert'])) {
-					$aline['flags'] .= "max-packets 8 ";
-				}
-
 				$aline['flags'] .= " ) ";
 			}
 		}
@@ -2984,7 +2980,7 @@ function filter_generate_user_rule($rule) {
 	/* piece together the actual user rule */
 	$line .= $aline['type'] . $aline['direction'] . $aline['log'] . $aline['quick'] . $aline['interface'] .
 		$aline['reply'] . $aline['route'] . $aline['ipprotocol'] . $aline['prot'] . $aline['src'] . $aline['os'] . $aline['dst'] .
-		$aline['divert'] . $aline['icmp-type'] . $aline['icmp6-type'] . $aline['tag'] . $aline['tagged'] . $aline['dscp'] . $aline['tracker'] .
+		$aline['icmp-type'] . $aline['icmp6-type'] . $aline['tag'] . $aline['tagged'] . $aline['dscp'] . $aline['tracker'] .
 		$aline['vlanprio'] . $aline['vlanprioset'] . $aline['allowopts'] . $aline['flags'] . $aline['queue'] . $aline['dnpipe'] . $aline['schedlabel'];
 
 	unset($aline);


### PR DESCRIPTION
The setting of the 'divert' array key was only done by layer7, so these downstream bits of code are also now dead.

What happens to rules in old configs that had layer7 selected? Now that there is no code to react to any layer7 setting, those rules are probably going to apply whatever other settings they had, without the diversion to the layer7 processing? Will that make people's rulesets become automagically/unexpectedly more permissive? Should there be code in upgrade_config.inc to remove (or disable) any rules with layer7 specified?