### PR TITLE
Status IPsec inconsistent Logs tab

### DIFF
--- a/src/usr/local/www/diag_ipsec.php
+++ b/src/usr/local/www/diag_ipsec.php
@@ -124,7 +124,6 @@ $tab_array[] = array(gettext("Overview"), true, "diag_ipsec.php");
 $tab_array[] = array(gettext("Leases"), false, "diag_ipsec_leases.php");
 $tab_array[] = array(gettext("SAD"), false, "diag_ipsec_sad.php");
 $tab_array[] = array(gettext("SPD"), false, "diag_ipsec_spd.php");
-$tab_array[] = array(gettext("Logs"), false, "diag_logs.php?logfile=ipsec");
 display_top_tabs($tab_array);
 ?>
 

--- a/src/usr/local/www/diag_ipsec_leases.php
+++ b/src/usr/local/www/diag_ipsec_leases.php
@@ -81,7 +81,6 @@ $tab_array[] = array(gettext("Overview"), false, "diag_ipsec.php");
 $tab_array[] = array(gettext("Leases"), true, "diag_ipsec_leases.php");
 $tab_array[] = array(gettext("SAD"), false, "diag_ipsec_sad.php");
 $tab_array[] = array(gettext("SPD"), false, "diag_ipsec_spd.php");
-$tab_array[] = array(gettext("Logs"), false, "diag_logs.php?logfile=ipsec");
 display_top_tabs($tab_array);
 
 if (isset($mobile['pool']) && is_array($mobile['pool'])) {

--- a/src/usr/local/www/diag_ipsec_sad.php
+++ b/src/usr/local/www/diag_ipsec_sad.php
@@ -92,7 +92,6 @@ $tab_array[] = array(gettext("Overview"), false, "diag_ipsec.php");
 $tab_array[] = array(gettext("Leases"), false, "diag_ipsec_leases.php");
 $tab_array[] = array(gettext("SAD"), true, "diag_ipsec_sad.php");
 $tab_array[] = array(gettext("SPD"), false, "diag_ipsec_spd.php");
-$tab_array[] = array(gettext("Logs"), false, "diag_logs.php?logfile=ipsec");
 display_top_tabs($tab_array);
 
 if (count($sad)) {

--- a/src/usr/local/www/diag_ipsec_spd.php
+++ b/src/usr/local/www/diag_ipsec_spd.php
@@ -85,7 +85,6 @@ $tab_array[0] = array(gettext("Overview"), false, "diag_ipsec.php");
 $tab_array[1] = array(gettext("Leases"), false, "diag_ipsec_leases.php");
 $tab_array[2] = array(gettext("SAD"), false, "diag_ipsec_sad.php");
 $tab_array[3] = array(gettext("SPD"), true, "diag_ipsec_spd.php");
-$tab_array[4] = array(gettext("Logs"), false, "diag_logs.php?logfile=ipsec");
 display_top_tabs($tab_array);
 
 if (count($spd)) {


### PR DESCRIPTION
For some reason Status->IPsec has a "Logs" tab in addition to the
"Overview", "Leases", "SAD" and "SPD" tabs. The "Logs" tab takes you off
to the logs screens, and so when you click the tab all the other tabs
are gone and are replaced by all the "Logs" interface tabs.
That seems odd and inconsistent. Other Status displays do not have this
(e.g. Status->DHCP, Status->Load Balancer, Status->OpenVPN). With all
these, direct access to the associated log page is by the shortcut icon.
Status->IPsec also has the shortcut icon to go to the logs, and it works
fine.

So I am suggesting to remove the "Logs" tab here.