### PR TITLE
Remove special code for Status Captive Portal #5529

### DIFF
--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -269,10 +269,7 @@ $vpn_menu = msort(array_merge($vpn_menu, return_ext_menu("VPN")), 0);
 
 // Status
 $status_menu = array();
-if (count($config['captiveportal']) > 0) {
-	$status_menu[] = array(gettext("Captive Portal"), "/status_captiveportal.php");
-}
-
+$status_menu[] = array(gettext("Captive Portal"), "/status_captiveportal.php");
 $status_menu[] = array(gettext("CARP (failover)"), "/carp_status.php");
 $status_menu[] = array(gettext("Dashboard"), "/index.php");
 $status_menu[] = array(gettext("Gateways"), "/status_gateways.php");


### PR DESCRIPTION
The Captive Portal Status page has been fixed up so it displays nice stuff when there are no Captive Portal Zones defined.
On my system this test did not work consistently anyway. When displaying the Dashboard, Status->Captive Portal was in the menu. When displaying Services->Captive Portal (with no zones defined) then Status->Captive Portal was not in the menu.
I think that don't care to waste time investigating exactly why that was, because actually this special test here is not really needed anyway.