### PR TITLE
Services - DNS Forwarder - Host Overrides - Case Sensitivity

### DIFF
--- a/src/usr/local/www/services_dnsmasq.php
+++ b/src/usr/local/www/services_dnsmasq.php
@@ -372,10 +372,10 @@ foreach ($a_hosts as $i => $hostent):
 ?>
 				<tr>
 					<td>
-						<?=strtolower($hostent['host'])?>
+						<?=$hostent['host']?>
 					</td>
 					<td>
-						<?=strtolower($hostent['domain'])?>
+						<?=$hostent['domain']?>
 					</td>
 					<td>
 						<?=$hostent['ip']?>
@@ -395,10 +395,10 @@ foreach ($a_hosts as $i => $hostent):
 ?>
 				<tr>
 					<td>
-						<?=strtolower($alias['host'])?>
+						<?=$alias['host']?>
 					</td>
 					<td>
-						<?=strtolower($alias['domain'])?>
+						<?=$alias['domain']?>
 					</td>
 					<td>
 						Alias for <?=$hostent['host'] ? $hostent['host'] . '.' . $hostent['domain'] : $hostent['domain']?>
@@ -451,7 +451,7 @@ foreach ($a_domainOverrides as $i => $doment):
 ?>
 				<tr>
 					<td>
-						<?=strtolower($doment['domain'])?>
+						<?=$doment['domain']?>
 					</td>
 					<td>
 						<?=$doment['ip']?>


### PR DESCRIPTION
Host and domain names are not case sensitive.  Maintain display case as entered.