### PR TITLE
Tidy up coding style for "services"

### DIFF
--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -508,26 +508,26 @@ function get_service_control_GET_links($service, $addname = false) {
 	if (get_service_status($service)) {
 		switch ($service['name']) {
 			case "openvpn":
-				$output .= "<a href='status_services.php?mode=restartservice&amp;service={$service['name']}&amp;vpnmode={$service['mode']}&amp;id={$service['vpnid']}'>";
+				$output .= "<a href=\"status_services.php?mode=restartservice&amp;service={$service['name']}&amp;vpnmode={$service['mode']}&amp;id={$service['vpnid']}\">";
 				break;
 			case "captiveportal":
-				$output .= "<a href='status_services.php?mode=restartservice&amp;service={$service['name']}&amp;zone={$service['zone']}'>";
+				$output .= "<a href=\"status_services.php?mode=restartservice&amp;service={$service['name']}&amp;zone={$service['zone']}\">";
 				break;
 			default:
-				$output .= "<a href='status_services.php?mode=restartservice&amp;service={$service['name']}'>";
+				$output .= "<a href=\"status_services.php?mode=restartservice&amp;service={$service['name']}\">";
 		}
-		$output .= "<i class=\"fa fa-repeat\" title='" . sprintf(gettext("Restart %sService"), $stitle) . "' alt='restart'></i></a>\n";
+		$output .= "<i class=\"fa fa-repeat\" title=\"" . sprintf(gettext("Restart %sService"), $stitle) . "\"></i></a>\n";
 		switch ($service['name']) {
 			case "openvpn":
-				$output .= "<a href='status_services.php?mode=stopservice&amp;service={$service['name']}&amp;vpnmode={$service['mode']}&amp;id={$service['vpnid']}'>";
+				$output .= "<a href=\"status_services.php?mode=stopservice&amp;service={$service['name']}&amp;vpnmode={$service['mode']}&amp;id={$service['vpnid']}\">";
 				break;
 			case "captiveportal":
-				$output .= "<a href='status_services.php?mode=stopservice&amp;service={$service['name']}&amp;zone={$service['zone']}'>";
+				$output .= "<a href=\"status_services.php?mode=stopservice&amp;service={$service['name']}&amp;zone={$service['zone']}\">";
 				break;
 			default:
-				$output .= "<a href='status_services.php?mode=stopservice&amp;service={$service['name']}'>";
+				$output .= "<a href=\"status_services.php?mode=stopservice&amp;service={$service['name']}\">";
 		}
-		$output .= "<i class=\"fa fa-stop\" title='" . sprintf(gettext("Stop %sService"), $stitle) . "' alt='stop'></i></a>";
+		$output .= "<i class=\"fa fa-stop\" title=\"" . sprintf(gettext("Stop %sService"), $stitle) . "\"></i></a>";
 	} else {
 		$service_enabled = is_service_enabled($service['name']);
 
@@ -553,7 +553,7 @@ function get_service_control_links($service, $addname = false) {
 			$link = '<a title="%s" href="#" id="captiveportal-%s-' . $service['zone'] . '">';
 		break;
 		default:
-			$link = '<a title="%s" href="#" value="" id="%s-' . $service['name'] . '">';
+			$link = '<a title="%s" href="#" id="%s-' . $service['name'] . '">';
 	}
 
 	if (get_service_status($service)) {
@@ -562,26 +562,26 @@ function get_service_control_links($service, $addname = false) {
 				$output .= '<a href="#" id="openvpn-restartservice-' . $service['mode'] . '-' . $service['vpnid'] . '" >';
 				break;
 			case "captiveportal":
-				$output .= '<a href="#" value="" id=captiveportal-restartservice-' . $service['zone'] . '">';
+				$output .= '<a href="#" id="captiveportal-restartservice-' . $service['zone'] . '">';
 				break;
 			default:
 				$output .= '<a href="#" id="restartservice-' . $service['name'] . '" >';
 		}
 
-		$output .= "<i class=\"fa fa-repeat\" title='" . sprintf(gettext("Restart %sService"), $stitle) . "' alt='restart'></i></a>\n";
+		$output .= "<i class=\"fa fa-repeat\" title=\"" . sprintf(gettext("Restart %sService"), $stitle) . "\"></i></a>\n";
 
 		switch ($service['name']) {
 			case "openvpn":
 				$output .= '<a href="#" id="openvpn-stopservice-' . $service['mode'] . '-' . $service['vpnid'] . '" >';
 				break;
 			case "captiveportal":
-				$output .= '<a href="#" value="" id=captiveportal-stopservice-' . $service['zone'] . '">';
+				$output .= '<a href="#" id="captiveportal-stopservice-' . $service['zone'] . '">';
 				break;
 			default:
 				$output .= '<a href="#" id="stopservice-' . $service['name'] . '">';
 		}
 
-		$output .= "<i class=\"fa fa-stop\" title='" . sprintf(gettext("Stop %sService"), $stitle) . "' alt='stop'></i></a>";
+		$output .= "<i class=\"fa fa-stop\" title=\"" . sprintf(gettext("Stop %sService"), $stitle) . "\"></i></a>";
 
 	} else {
 		$service_enabled = is_service_enabled($service['name']);

--- a/src/usr/local/www/status_services.php
+++ b/src/usr/local/www/status_services.php
@@ -70,8 +70,9 @@ require_once("shortcuts.inc");
 
 // Leave GET enabled in case any other pages use it.
 // ToDo: Check other pages and remove GET completely
-if(!$_GET && $_POST)
+if (!$_GET && $_POST) {
 	$_GET = $_POST;
+}
 
 $service_name = '';
 if (isset($_GET['service'])) {
@@ -136,9 +137,10 @@ if (count($services) > 0) {
 
 	uasort($services, "service_name_compare");
 
-	foreach($services as $service) {
-		if (empty($service['name']))
+	foreach ($services as $service) {
+		if (empty($service['name'])) {
 			continue;
+		}
 
 		if (empty($service['description'])) {
 			$service['description'] = get_pkg_descr($service['name']);
@@ -191,7 +193,7 @@ if (count($services) > 0) {
 	print_info_box(gettext("No services found"), 'danger');
 }
 ?>
-<script>
+<script type="text/javascript">
 //<![CDATA[
 events.push(function(){
 	// If a restart button is clicked, populate the hidden inputs and submit the form (via POST)


### PR DESCRIPTION
"service-utils.inc"
- be more consistent when using single/double quotes
- add missing double quotes in ID statement
- remove blank VALUE statement
- remove ALT from <i> tag, invalid in HTML5

"status_services.php"
- tidy up code style
- add type to SCRIPT tag