### PR TITLE
Add server response to failed custom updates; make debugging much easier

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -1274,7 +1274,7 @@
 					if ($successful_update == true) {
 						$status = "phpDynDNS: (Success) IP Address Updated Successfully!";
 					} else {
-						$status = "phpDynDNS: (Error) Result did not match.";
+						$status = "phpDynDNS: (Error) Result did not match. [$data]";
 					}
 					break;
 				case 'cloudflare':


### PR DESCRIPTION
When using the custom option for ddns, debugging issues is much, much easier if the response of failed api calls is included in the error message.  This patch adds that response so it can be seen in the logs.