### PR TITLE
Update Form_Input class

### DIFF
--- a/src/usr/local/www/classes/Form/Input.class.php
+++ b/src/usr/local/www/classes/Form/Input.class.php
@@ -30,7 +30,7 @@ class Form_Input extends Form_Element
 {
 	public $column;
 	protected $_tagName = 'input';
-	protected $_tagSelfClosing = true;
+	protected $_tagSelfClosing = false;
 	protected $_attributes = array(
 		'class' => array('form-control' => true),
 		'name' => null,


### PR DESCRIPTION
Set **$_tagSelfClosing** to false

Any HTML tag with the **class="form-control"** will be automatically closed, however, this causes problems for tags that should not be closed in this way, e.g. SELECT tags.  HTML5 does not require INPUT tags to be closed this way, so setting **$_tagSelfClosing** to false should not cause any issues.