### PR TITLE
Log Widget - Source

### DIFF
--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -175,7 +175,7 @@ if (isset($_POST['lastsawtime'])) {
 			<td title="<?=htmlspecialchars($filterent['time'])?>"><?=substr(htmlspecialchars($filterent['time']),0,-3)?></td>
 			<td><?=htmlspecialchars($filterent['interface']);?></td>
 			<td><a href="diag_dns.php?host=<?=$filterent['srcip']?>"
-				title="<?=gettext("Reverse Resolve with DNS")?>"><?=$srcIP?></a>:<?=htmlspecialchars($filterent['srcport'])?>
+				title="<?=gettext("Reverse Resolve with DNS");?>"><?=$srcIP?></a>
 			</td>
 			<td><a href="diag_dns.php?host=<?=$filterent['dstip']?>"
 				title="<?=gettext("Reverse Resolve with DNS");?>"><?=$dstIP?></a>:<?=htmlspecialchars($filterent['dstport'])?>


### PR DESCRIPTION
Source port is not all that useful in widget view and takes up space better used by destination.
Add missing semi-colon.