### PR TITLE
Add README.md with basic and contributors' information

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The pfSense project is a free network firewall distribution, based on the FreeBS
 
 pfSense software includes a web interface for the configuration of all included components. There is no need for any UNIX knowledge, no need to use the command line for anything, and no need to ever manually edit any rule sets. Users familiar with commercial firewalls catch on to the web interface quickly, though there can be a learning curve for users not familiar with commercial-grade firewalls.
 
+pfSense started as a fork of the [m0n0wall](http://m0n0.ch/wall/index.php m0n0wall project homepage) Project (which ended in 2015/02/15).
+
 pfSense is Copyright 2004-2015 [Electric Sheep Fencing LLC](https://electricsheepfencing.com "Electric Sheep Fencing LLC homepage") and published under a BSD license.
 Read more at [https://pfsense.org/](https://pfsense.org/ "The pfSense homepage") and support the team by buying a Gold Membership Subscription, bundled hardware appliances or commercial support.
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The pfSense project is a free network firewall distribution, based on the FreeBS
 pfSense software includes a web interface for the configuration of all included components. There is no need for any UNIX knowledge, no need to use the command line for anything, and no need to ever manually edit any rule sets. Users familiar with commercial firewalls catch on to the web interface quickly, though there can be a learning curve for users not familiar with commercial-grade firewalls.
 
 pfSense is Copyright 2004-2015 [Electric Sheep Fencing LLC](https://electricsheepfencing.com "Electric Sheep Fencing LLC homepage") and published under a BSD license.
-Read more at [https://pfsense.org/](https://pfsense.org/ "The pfSense homepage") and support the team with a Gold Membership Subscription, bundled hardware appliances or commercial support.
+Read more at [https://pfsense.org/](https://pfsense.org/ "The pfSense homepage") and support the team by buying a Gold Membership Subscription, bundled hardware appliances or commercial support.
 
 ## Contribute
 
-Contact [coreteam@pfsense.org](mailto:coreteam@pfsense.org "Mail to coreteam@pfsense.org) to get involved.
+Contact [coreteam@pfsense.org](mailto:coreteam@pfsense.org "Mail to coreteam@pfsense.org") to get involved.
 
 * Review our Developer Style Guide: https://doc.pfsense.org/index.php/Developer_Style_Guide
 * Familiarize yourself with our git repositories (and github in general): https://github.com/pfsense

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# pfSense
+
+## Overview
+
+The pfSense project is a free network firewall distribution, based on the FreeBSD operating system with a custom kernel and including third party free software packages for additional functionality. pfSense software, with the help of the package system, is able to provide the same functionality or more of common commercial firewalls, without any of the artificial limitations. It has successfully replaced every big name commercial firewall you can imagine in numerous installations around the world, including Check Point, Cisco PIX, Cisco ASA, Juniper, Sonicwall, Netgear, Watchguard, Astaro, and more.
+
+pfSense software includes a web interface for the configuration of all included components. There is no need for any UNIX knowledge, no need to use the command line for anything, and no need to ever manually edit any rule sets. Users familiar with commercial firewalls catch on to the web interface quickly, though there can be a learning curve for users not familiar with commercial-grade firewalls.
+
+pfSense is Copyright 2004-2015 [Electric Sheep Fencing LLC](https://electricsheepfencing.com "Electric Sheep Fencing LLC homepage") and published under a BSD license.
+Read more at [https://pfsense.org/](https://pfsense.org/ "The pfSense homepage") and support the team with a Gold Membership Subscription, bundled hardware appliances or commercial support.
+
+## Contribute
+
+Contact [coreteam@pfsense.org](mailto:coreteam@pfsense.org "Mail to coreteam@pfsense.org) to get involved.
+
+* Review our Developer Style Guide: https://doc.pfsense.org/index.php/Developer_Style_Guide
+* Familiarize yourself with our git repositories (and github in general): https://github.com/pfsense
+* Review the list of open bug reports and other issues: https://redmine.pfsense.org/projects/pfsense/issues
+* Review and Sign the license agreement (LA) and either the Individual or Corporate CLA: https://forum.pfsense.org/index.php?topic=76132.msg415051#msg415051
+
+Once you have the LA and CLA complete, you can submit changes as pull requests on github: https://help.github.com/articles/using-pull-requests/
+
+Our developers will review the submissions, offer feedback, and merge the changes if they are acceptable.


### PR DESCRIPTION
github repositories without a README.md are pretty uncommon these days.

I copied some introductory text from pfsense.org and added information given to me by Jamie Thompson. This README.md would also be the place to announce that the webGUI-part undergoes heavy changes towards Bootstrap (and link to the corresponding file, which contains valuable information about developer-setup btw). Please tell me if I should open a redmine isse beforehand in the future.

I have to admit that I am not familar with the build-tools and thus did not test whether adding a file at the top level breaks anything.