### PR TITLE
Standardize In / Out queues help text

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1603,10 +1603,10 @@ $group->add(new Form_Select(
 
 $section->add($group)->setHelp('Choose the Out queue/Virtual interface only if '.
 	'you have also selected In. The Out selection is applied to traffic leaving '.
-	'the interface where the rule is created, It is applied to traffic coming '.
+	'the interface where the rule is created, the In selection is applied to traffic coming '.
 	'into the chosen interface.<br />If you are creating a floating rule, if the '.
-	'direction is In then the same rules apply, if the direction is out the '.
-	'selections are reversed Out is for incoming and In is for outgoing.'
+	'direction is In then the same rules apply, if the direction is Out the '.
+	'selections are reversed, Out is for incoming and In is for outgoing.'
 );
 
 $group = new Form_Group('Ackqueue / Queue');


### PR DESCRIPTION
An "In" got changed to an "It" by https://github.com/pfsense/pfsense/commit/66066eda36fedf4df73bf03c6603ea76f9813327
This text already had most uses of the terms "In" and "Out" with capitals. That seems reasonable here so the text is clear about which of the words "in" and "out" are references to the "in" and "Out" queue rather than just ordinary uses of the English words.