### PR TITLE
add CONTRIBUTE.md file (which github will show on PR-creation)

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,13 @@
+## Contribute
+
+Contact [coreteam@pfsense.org](mailto:coreteam@pfsense.org "Mail to coreteam@pfsense.org") to get involved.
+
+* Review our Developer Style Guide: https://doc.pfsense.org/index.php/Developer_Style_Guide
+* Familiarize yourself with our git repositories (and github in general): https://github.com/pfsense
+* Review the list of open bug reports and other issues: https://redmine.pfsense.org/projects/pfsense/issues
+* Review and Sign the license agreement (LA) and either the Individual or Corporate CLA: https://forum.pfsense.org/index.php?topic=76132.msg415051#msg415051
+
+Once you have the LA and CLA complete, you can submit changes as pull requests on github: https://help.github.com/articles/using-pull-requests/
+
+Our developers will review the submissions, offer feedback, and merge the changes if they are acceptable.
+


### PR DESCRIPTION
As mentioned by @jlduran, a CONTRIBUTE.md file seems to be a good idea (https://github.com/pfsense/pfsense/pull/2137#issuecomment-161317343). Github will show this in the PR-creation page. Content copied from README.md, where I think it should stay (despite this non-DRY-ness).