### PR TITLE
Change comparison of username to certificate common name to be safer …

### DIFF
--- a/src/etc/inc/openvpn.auth-user.php
+++ b/src/etc/inc/openvpn.auth-user.php
@@ -117,7 +117,7 @@ if (file_exists("{$g['varetc_path']}/openvpn/{$modeid}.ca")) {
 
 $authenticated = false;
 
-if (($strictusercn === true) && ($common_name != $username)) {
+if (($strictusercn === true) && (mb_strtolower($common_name) !== mb_strtolower($username))) {
 	syslog(LOG_WARNING, "Username does not match certificate common name ({$username} != {$common_name}), access denied.\n");
 	if (isset($_GET['username'])) {
 		echo "FAILED";


### PR DESCRIPTION
…and case insensitive

Currently the username is compared against the common name using a standard PHP comparison,
this is unsafe because it might do unintended type conversions. So change the != comparison to
an !== comparison to make sure the types match.

see [this Stackoverflow thread](http://stackoverflow.com/questions/3333353/string-comparison-using-vs-strcmp) for some examples.


Since usernames on Windows systems are not case-sensitive and prone to case differences in
user input or auto filled fields we should allow case differences between the username and the
certificate common name.

In our case users were denied access because windows auto-filled the username field of the OpenVPN client with an upper case letter while the common names were all lower case in the certificates. This lead to unclear (to the user) access refusals.