### PR TITLE
Improve helpfulness of smtp-test buttons help-text.

### DIFF
--- a/src/usr/local/www/system_advanced_notifications.php
+++ b/src/usr/local/www/system_advanced_notifications.php
@@ -358,7 +358,7 @@ $section->addInput(new Form_Input(
 	'submit',
 	'Test SMTP settings'
 ))->addClass('btn-info')->setHelp('A test notification will be sent even if the service is '.
-	'marked as disabled.');
+	'marked as disabled.  The last SAVED values will be used, not necessarily the values entered here.');
 
 $form->add($section);
 


### PR DESCRIPTION
I just ran into this while trying to make my smtp-settings work: The Test-Button in Advanced:Notifications does not actually take submitted values, it would have helped me if I'd known.

That means to play around and test with smtp-settings you need to 1) enter values 2) hit save 3) hit test.

In my eyes the correct option would be to make the settings an (ajax?) form and test with the settings entered (and/or make the button a "Save and Test" button). But this bit of help text should already improve the situation. Thanks.