### PR TITLE
Redmine #4279 Package reinstall displayed when shutting down before upgrade RELENG_2_2

### DIFF
--- a/etc/rc.bootup
+++ b/etc/rc.bootup
@@ -141,6 +141,12 @@ system_check_reset_button();
 if (file_exists("/root/firmware.tgz")) 
 	unlink("/root/firmware.tgz");
 
+/* Reinstall of packages after reboot has been requested */
+if (file_exists('/conf/needs_package_sync_after_reboot')) {
+	touch('/conf/needs_package_sync');
+	@unlink('/conf/needs_package_sync_after_reboot');
+}
+
 /* start devd (dhclient now uses it) */
 echo "Starting device manager (devd)...";
 mute_kernel_msgs();

--- a/etc/rc.firmware
+++ b/etc/rc.firmware
@@ -365,7 +365,7 @@ pfSenseNanoBSDupgrade)
 	echo "" >> /conf/upgrade_log.txt
 
 	# Trigger a package reinstallation on reboot
-	touch /conf/needs_package_sync
+	touch /conf/needs_package_sync_after_reboot
 
 	# remount /cf ro
 	/etc/rc.conf_mount_ro

--- a/usr/local/www/diag_backup.php
+++ b/usr/local/www/diag_backup.php
@@ -407,7 +407,7 @@ if ($_POST) {
 								/* this will be picked up by /index.php */
 								conf_mount_rw();
 								mark_subsystem_dirty("restore");
-								touch("/conf/needs_package_sync");
+								touch("/conf/needs_package_sync_after_reboot");
 								/* remove cache, we will force a config reboot */
 								if(file_exists("{$g['tmp_path']}/config.cache"))
 									unlink("{$g['tmp_path']}/config.cache");


### PR DESCRIPTION
Use a different flag file to indicate that a package reinstall is
required after a reboot is done first. This avoids the possibility that
the user navigates in the webGUI during the time while the shutdown is
in progress and is accidentally presented with the reinstall all
packages GUI button.
Early in rc.bootup switch the flag file to use its ordinary name, so
that all subsequent code in boot scripts and webGUI will work as it
already does to handle the package reinstall and notifying the user that
a package reinstall is about to be done or in progress...