### PR TITLE
Redmine #4279 Package reinstall displayed when shutting down before upgrade

### DIFF
--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -132,6 +132,12 @@ if (file_exists("/root/firmware.tgz")) {
 	unlink("/root/firmware.tgz");
 }
 
+/* Reinstall of packages after reboot has been requested */
+if (file_exists('/conf/needs_package_sync_after_reboot')) {
+	touch('/conf/needs_package_sync');
+	@unlink('/conf/needs_package_sync_after_reboot');
+}
+
 /* start devd (dhclient now uses it) */
 echo "Starting device manager (devd)...";
 mute_kernel_msgs();

--- a/src/usr/local/share/pfSense/post_upgrade_command
+++ b/src/usr/local/share/pfSense/post_upgrade_command
@@ -5,7 +5,7 @@
 PFSENSETYPE=`cat /etc/platform`
 
 if [ "${PFSENSETYPE}" = "pfSense" -o "${PFSENSETYPE}" = "nanobsd" ]; then
-	touch /conf/needs_package_sync
+	touch /conf/needs_package_sync_after_reboot
 fi
 
 if [ "${PFSENSETYPE}" = "nanobsd" ]; then

--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -372,7 +372,7 @@ if ($_POST) {
 								/* this will be picked up by /index.php */
 								conf_mount_rw();
 								mark_subsystem_dirty("restore");
-								touch("/conf/needs_package_sync");
+								touch("/conf/needs_package_sync_after_reboot");
 								/* remove cache, we will force a config reboot */
 								if (file_exists("{$g['tmp_path']}/config.cache")) {
 									unlink("{$g['tmp_path']}/config.cache");


### PR DESCRIPTION
Use a different flag file to indicate that a package reinstall is
required after a reboot is done first. This avoids the possibility that
the user navigates in the webGUI during the time while the shutdown is
in progress and is accidentally presented with the reinstall all
packages GUI button.
Early in rc.bootup switch the flag file to use its ordinary name, so
that all subsequent code in boot scripts and webGUI will work as it
already does to handle the package reinstall and notifying the user that
a package reinstall is about to be done or in progress...