### PR TITLE
Standardize breadcrumbs for User Manager tabs

### DIFF
--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -67,7 +67,7 @@
 require("guiconfig.inc");
 require_once("auth.inc");
 
-$pgtitle = array(gettext("System"), gettext("Authentication Servers"));
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Authentication Servers"));
 $shortcut_section = "authentication";
 
 if (is_numericint($_GET['id'])) {

--- a/src/usr/local/www/system_groupmanager.php
+++ b/src/usr/local/www/system_groupmanager.php
@@ -70,7 +70,7 @@
 
 require("guiconfig.inc");
 
-$pgtitle = array(gettext("System"), gettext("Group Manager"));
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Groups"));
 
 if (!is_array($config['system']['group'])) {
 	$config['system']['group'] = array();

--- a/src/usr/local/www/system_groupmanager_addprivs.php
+++ b/src/usr/local/www/system_groupmanager_addprivs.php
@@ -83,7 +83,7 @@ function admin_groups_sort() {
 
 require("guiconfig.inc");
 
-$pgtitle = array(gettext("System"), gettext("Group manager"), gettext("Add privileges"));
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Groups"), gettext("Add Privileges"));
 
 if (is_numericint($_GET['groupid'])) {
 	$groupid = $_GET['groupid'];

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -73,7 +73,7 @@ require("certs.inc");
 require("guiconfig.inc");
 
 // start admin user code
-$pgtitle = array(gettext("System"), gettext("User Manager"));
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Users"));
 
 if (isset($_POST['userid']) && is_numericint($_POST['userid'])) {
 	$id = $_POST['userid'];

--- a/src/usr/local/www/system_usermanager_addprivs.php
+++ b/src/usr/local/www/system_usermanager_addprivs.php
@@ -70,7 +70,7 @@ function admusercmp($a, $b) {
 
 require("guiconfig.inc");
 
-$pgtitle = array("System", "User manager", "Add privileges");
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Users"), gettext("Add Privileges"));
 
 if (is_numericint($_GET['userid'])) {
 	$userid = $_GET['userid'];

--- a/src/usr/local/www/system_usermanager_settings.php
+++ b/src/usr/local/www/system_usermanager_settings.php
@@ -76,7 +76,7 @@ else {
 $pconfig['backend'] = &$config['system']['webgui']['backend'];
 
 // Page title for main admin
-$pgtitle = array(gettext("System"), gettext("User manager settings"));
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Settings"));
 
 $save_and_test = false;
 


### PR DESCRIPTION
I think this is the way it should be to make it like everywhere else.
Even when in the "Groups" pages, it is still reached by "System" "User
Manager".