### PR TITLE
Add pfBlockerNG as a known special widget name Redmine #5611

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -261,8 +261,8 @@ if ($config['widgets'] && $config['widgets']['sequence'] != "") {
 }
 
 ## Replace any known acronyms in widget names with suitable mixed-case forms
-$input_acronyms = array("carp", "dns", "dyn dns", "gmirror", "ipsec", "ntp", "openvpn", "rss", "smart");
-$output_acronyms = array("CARP", "DNS", "Dynamic DNS", "gmirror", "IPsec", "NTP", "OpenVPN", "RSS", "SMART");
+$input_acronyms = array("carp", "dns", "dyn dns", "gmirror", "ipsec", "ntp", "openvpn", "rss", "smart", "pfblockerng");
+$output_acronyms = array("CARP", "DNS", "Dynamic DNS", "gmirror", "IPsec", "NTP", "OpenVPN", "RSS", "SMART", "pfBlockerNG");
 foreach ($widgets as $widgetname => $widgetconfig) {
 	$widgets[$widgetname]['name'] = str_ireplace($input_acronyms, $output_acronyms, $widgetconfig['name']);
 }


### PR DESCRIPTION
I guess pfBlockerNG is a well known enough package to have its special case coded here?
Or does there need to be a way that packages can specify the form of their widget name when it is not just the capitalised name of the widget file?