### PR TITLE
Create the required number of rows for NTP time servers

### DIFF
--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -107,7 +107,7 @@ if ($_POST) {
 		unset($config['ntpd']['noselect']);
 		$timeservers = '';
 
-		for ($i = 0; $i < 10; $i++) {
+		for ($i = 0; $i < NUMTIMESERVERS; $i++) {
 			$tserver = trim($_POST["server{$i}"]);
 			if (!empty($tserver)) {
 				$timeservers .= "{$tserver} ";
@@ -299,8 +299,8 @@ $section->addInput(new Form_Select(
 			'Selecting no interfaces will listen on all interfaces with a wildcard.' . '<br />' .
 			'Selecting all interfaces will explicitly listen on only the interfaces/IPs specified.');
 
-$maxrows = 3;
 $timeservers = explode( ' ', $config['system']['timeservers']);
+$maxrows = max(count($timeservers), 1);
 for ($counter=0; $counter < $maxrows; $counter++) {
 	$group = new Form_Group($counter == 0 ? 'Time servers':'');
 	$group->addClass('repeatable');


### PR DESCRIPTION
depending on how many are already defined in the config, making sure to always have a minimum of 1.

Also I used the constant NUMTIMESERVERS that was defined up the top of this file to control the loop that limits the number saved to 10.

Note: There also needs to be a limit on the number of rows of time server data allowed to be added - at the moment you can keep pressing the Add button and enter loads of them, only the first 10 are saved.