### PR TITLE
Interface Stats Widget make rows standard size

### DIFF
--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -95,7 +95,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 
 	foreach ($rows as $key => $name) {
 		print("<tr>");
-		print(	"<th>" . $name . "</th>");
+		print(	"<td><b>" . $name . "</b></td>");
 
 		foreach ($ifdescrs as $ifdescr => $ifname) {
 			$ifinfo = get_interface_info($ifdescr);


### PR DESCRIPTION
The rows of data were taller than expected, and the name "Packets In", "Packets Out" etc. in the left column did not line up exactly horizontally with the numbers in the other columns. Seems to be because the "name" column was a "th" tag. If it is just "td" like the numbers then everything lines up and the row height is less (it then looks the same as other widgets that have this style of table).
I put in the bold tag to keep the "Packets In" "Packets Out"... names bold. Is there some other fancy way that should be done with styles... somewhere, or is hardcoding a "b" tag OK?

Note: This would also resolve the comments in forum topic https://forum.pfsense.org/index.php?topic=103605.0 - that is talking about the Interface Statistics Widget row spacing in 2.2.5 - where the rows are also taller than those on other widgets. Of course the poster of that thread would have to go to 2.3 to get the benefit here.