### PR TITLE
Internationalize console reboot script

### DIFF
--- a/src/etc/rc.initial.reboot
+++ b/src/etc/rc.initial.reboot
@@ -37,21 +37,11 @@
 
 	$fp = fopen('php://stdin', 'r');
 
-	echo <<<EOD
-
-{$g['product_name']} will reboot. This may take a few minutes, depending on your hardware.
-
-Do you want to proceed [y|n]? 
-EOD;
+	echo "\n" . sprintf(gettext("%s will reboot. This may take a few minutes, depending on your hardware."), $g['product_name']) . "\n";
+	echo gettext("Do you want to proceed [y|n]?") . " ";
 
 	if (strcasecmp(chop(fgets($fp)), "y") == 0) {
-
-		echo <<<EOD
-
-{$g['product_name']} is rebooting now.
-
-EOD;
-
+		echo "\n" . sprintf(gettext("%s is rebooting now."), $g['product_name']) . "\n";
 		system_reboot_sync();
 	}
 


### PR DESCRIPTION
This file previously had to have a space after "Do you want to proceed [y|n]?" to make the prompt for user input nice. That made it one of the few exceptions to the code style guide, where lines are not supposed to have blank space at the end.
Might as well have 1 less exception to the rule by internationalizing it, which removes the literal "EOD" echo output stuff.