### PR TITLE
Remove bonus debug from filter_log.inc

### DIFF
--- a/src/etc/inc/filter_log.inc
+++ b/src/etc/inc/filter_log.inc
@@ -235,11 +235,6 @@ function parse_unknown_log_line($line) {
 
 	list($all, $flent['time'], $flent['message']) = $log_split;
 
-	if($g['debug']) {
-		log_error(sprintf(gettext("There was a error parsing: %s.   Please report to mailing list or forum."), $flent['process']));
-	return "";
-	}
-
 	/* If there is time, and message, fields, then the line should be usable/good */
 	if (!( (trim($flent['time']) == "") && (trim($flent['message']) == "") )) {
 		return $flent;
@@ -273,11 +268,6 @@ function parse_system_log_line($line) {
 		return "";
 
 	list($all, $flent['time'], $flent['host'], $flent['process'], $flent['pid'], $flent['message']) = $log_split;
-
-	if($g['debug']) {
-		log_error(sprintf(gettext("There was a error parsing: %s.   Please report to mailing list or forum."), $flent['process']));
-	return "";
-	}
 
 	/* If there is time, process, and message, fields, then the line should be usable/good */
 	if (!( (trim($flent['time']) == "") && (trim($flent['process']) == "") && (trim($flent['message']) == "") )) {


### PR DESCRIPTION
These debug blocks look like they should not be in production. if 'debug' is turned on, then they would always log_error() and return for all log lines, even good ones.