### PR TITLE
Dashboard widget links use underlying file name

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -379,7 +379,7 @@ foreach ($widgets as $widgetname => $widgetconfig)
 <?php foreach ($columnWidgets as $widgetname => $widgetconfig):
 
 		// Compose the widget title and include the title link if available
-		$widgetlink = ${str_replace(' ', '_', strtolower($widgetconfig['name'])) . '_title_link'};
+		$widgetlink = ${$widgetname . '_title_link'};
 
 		if ((strlen($widgetlink) > 0)) {
 			$wtitle = '<a href="' . $widgetlink . '"> ' . $widgetconfig['name'] . '</a>';


### PR DESCRIPTION
when constructing the var name for _title_link.
Prior to this, the link for Dynamic DNS Status was not happening. That was because the text $widgetconfig['name'] is "Dynamic DNS Status". But the key of this array ($widgetname inside this loop) is the underlying file name "dyn_dns_status".
It works for all the widgets - their underlying file names and the var names $carp_status_title_link $dyn_dns_status_title_link and so on all match up.