### PR TITLE
Use the _title var to make the widget title

### DIFF
--- a/src/usr/local/www/widgets/include/carp_status.inc
+++ b/src/usr/local/www/widgets/include/carp_status.inc
@@ -1,7 +1,7 @@
 <?php
 
 //set variable for custom title
-$carp_status_title = "Carp Status";
+$carp_status_title = "CARP Status";
 $carp_status_title_link = "carp_status.php";
 
 ?>

--- a/src/usr/local/www/widgets/include/dyn_dns_status.inc
+++ b/src/usr/local/www/widgets/include/dyn_dns_status.inc
@@ -1,7 +1,7 @@
 <?php
 
 //set variable for custom title
-$dyn_dns_status_title = "Dyn DNS Status";
+$dyn_dns_status_title = "Dynamic DNS Status";
 $dyn_dns_status_title_link = "services_dyndns.php";
 
 ?>


### PR DESCRIPTION
Each widget has an include file that already has the required widget
title in a var like $dyn_dns_status_title $carp_status_title etc.
Use that var to set the displayed title of the widget, rather than the
stuff that was capitalizing the file name and then having a list of
special cases...
This meant the loop that includes the widget include files had to be
moved higher up in the code.