### PR TITLE
Only ask Proceed with upgrade question once

### DIFF
--- a/src/usr/local/sbin/pfSense-upgrade
+++ b/src/usr/local/sbin/pfSense-upgrade
@@ -319,6 +319,8 @@ pkg_upgrade() {
 				_echo "Before starting the upgrade process, the currently mounted nanobsd partition"
 				_echo "needs to be cloned to the secondary partition, where the update will happen"
 				_echo ""
+				_echo "After installation a reboot will be required to switch partition."
+				_echo ""
 				if [ -z "${yes}" ]; then
 					_echo -n "Proceed with upgrade? (y/N) "
 					read answer
@@ -326,9 +328,11 @@ pkg_upgrade() {
 						_echo "Aborting..."
 						_exit 0
 					fi
+					# Do not make the user have to answer again.
+					yes=1
 				fi
+				setup_nanobsd_env
 			fi
-			setup_nanobsd_env
 			need_reboot=1
 		fi
 


### PR DESCRIPTION
On nanoBSD there is a "Proceed with upgrade?" question warning about the duplicate slice. After answering "y" to that, the system does the duplicate slice, which takes some minutes. Then it asks again "Proceed with upgrade?" after displaying all the packages it will install.

That is a bit annoying at the console - I answer "y" and go off to make a cup of tea, only to come back and find that it is waiting asking again.

On nanoBSD a reboot is known to be required anyway, because even if it is some little package that gets upgraded, and not the core OS, the partition is always switched. So we can say that in the first warning and then skip asking "Proceed with upgrade?" a second time.

What do you think? Should it ask a 2nd time after displaying the packages to be installed? Or is it OK to skip that confirmation prompt?

Also, I moved the call to setup_nanobsd_env inside the "if nanobsd" - it worked like it was because setup_nanobsd_env returns without doing anything if the system is not nanobsd, but it just looked odd and there seems no point calling it when not nanobsd.