### PR TITLE
HTML Compliance - Form Action Attribute

### DIFF
--- a/src/usr/local/www/classes/Form.class.php
+++ b/src/usr/local/www/classes/Form.class.php
@@ -35,8 +35,6 @@ class Form extends Form_Element
 	protected $_attributes = array(
 		'class' => array('form-horizontal' => true),
 		'method' => 'post',
-		// Empty is interpreted by all browsers to submit to the current URI
-		'action' => '',
 	);
 	protected $_sections = array();
 	protected $_global = array();
@@ -54,6 +52,9 @@ class Form extends Form_Element
 
 		if (false !== $submit)
 			$this->addGlobal($submit);
+
+		if (!isset($this->_attributes['action']))
+			$this->_attributes['action'] = htmlspecialchars($_SERVER['REQUEST_URI']);
 	}
 
 	public function add(Form_Section $section)


### PR DESCRIPTION
Fix Empty Form Action Attribute Violation

An empty form action attribute is an HTML4 and HTML5 specification violation.

http://www.w3.org/TR/html5/forms.html#attr-fs-action
"The action and formaction content attributes, if specified, must have a value that is a valid non-empty URL potentially surrounded by spaces."

The HTML4 specification requires that the form action attribute be present and contain a valid URI.  Empty is not a valid URI.

Though an empty form action attribute may currently function there is no guarantee it will continue to do so in the future or to do so as xpected.  Since it does not adhere to the specification it is left open for each browser to handle in any way they choose.  And to change that behavior at any time for any reason.

Populating the form action attribute with the current URI covers both HTML4 and HTML5 specifications.

Don't leave it open to browser interpretation.  Give explicit instructions to the browser by adhering to the specification.