### PR TITLE
HTML Compliance - Checkbox Display As Radio Unique ID

### DIFF
--- a/src/usr/local/www/classes/Form/Checkbox.class.php
+++ b/src/usr/local/www/classes/Form/Checkbox.class.php
@@ -46,9 +46,15 @@ class Form_Checkbox extends Form_Input
 		$this->column->addClass('checkbox');
 	}
 
-	public function displayAsRadio()
+	public function displayAsRadio($id = null)
 	{
 		$this->_attributes['type'] = 'radio';
+
+		if ($id != null) {
+			$this->_attributes['id'] = $id;
+		} else {
+			$this->_attributes['id'] = $this->_attributes['name'] . '_' . $this->_attributes['value'] . ':' .substr(uniqid(), 9);
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
Ensure checkbox display as raido has unique id.

Allow an id to be passed in displayAsRadio() as argument[0].
If no argument is passed, construct id as name_value:uniqid.

Previous behavior was id = name.  So all the radio buttons of the set had same id.