### PR TITLE
HTML Compliance - Collapsible Form Section HREF

### DIFF
--- a/src/usr/local/www/classes/Form/Section.class.php
+++ b/src/usr/local/www/classes/Form/Section.class.php
@@ -81,11 +81,11 @@ class Form_Section extends Form_Element
 
 		if ($this->_collapsible & COLLAPSIBLE) {
 			$hdricon = '<span class="widget-heading-icon">' .
-				'<a data-toggle="collapse" href="#' . $this->_attributes['id'] . ' .panel-body">' .
+				'<a data-toggle="collapse" href="#' . $this->_attributes['id'] . '_panel-body">' .
 					'<i class="fa fa-plus-circle"></i>' .
 				'</a>' .
 			'</span>';
-			$bodyclass = '<div class="panel-body collapse ';
+			$bodyclass = '<div id="' . $this->_attributes['id'] . '_panel-body" class="panel-body collapse ';
 			if (($this->_collapsible & SEC_CLOSED)) {
 				$bodyclass .= 'out">';
 			} else {


### PR DESCRIPTION
Bad value for attribute href on element a: Illegal character in fragment: not a URL code point.

`<a data-toggle="collapse" href="#<id> .panel-body">`
Syntax of URL:Any URL. For example: /hello, #canvas, or http://example.org/. Characters should be represented in NFC and spaces should be escaped as %20.

Fix is to set an id on the target.