### PR TITLE
Update pfsense-utils.inc

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1812,7 +1812,7 @@ function update_status($status) {
 	global $pkg_interface;
 
 	if ($pkg_interface == "console") {
-		echo "\r{$status}";
+		print ("{$status}");
 	}
 
 	/* ensure that contents are written out */


### PR DESCRIPTION
When installing packages, an extra line break is added by the "\r" ...     **echo "\r{$status}";**
The $status string typically contains a trailing "\n" as required. This allows printing a message in two steps.

**Writing configuration... done.**

1) print **"Writing configuration... "**
2) print **"done"** after the command completes on the same line.