### PR TITLE
Remove duplicated code in firewall_aliases_edit

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -627,13 +627,6 @@ $form->addGlobal(new Form_Input(
 ));
 
 $form->addGlobal(new Form_Input(
-	'tab',
-	null,
-	'hidden',
-	$tab
-));
-
-$form->addGlobal(new Form_Input(
 	'origname',
 	null,
 	'hidden',


### PR DESCRIPTION
This hidden Form_Input is duplicated and I don't see why. The system seems to work OK with the duplication and without.