### PR TITLE
Text with max-src-conn-rate and max-src-conn-rates fields

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1476,7 +1476,7 @@ $section->addInput(new Form_Input(
 	'Max. src. conn. Rate',
 	'number',
 	$pconfig['max-src-conn-rate']
-))->setHelp('Maximum state entries per host');
+))->setHelp('Maximum new connections per host (TCP only)');
 
 $section->addInput(new Form_Input(
 	'max-src-conn-rates',
@@ -1484,7 +1484,7 @@ $section->addInput(new Form_Input(
 	'number',
 	$pconfig['max-src-conn-rates'],
 	['min' => 1, 'max' => 255]
-))->setHelp('Maximum new connections per host / per second(s) (TCP only)');
+))->setHelp('/ per how many second(s) (TCP only)');
 
 $section->addInput(new Form_Input(
 	'statetimeout',


### PR DESCRIPTION
I fixed up the text to read the best I could think of.
Actually in 2.2.* these 2 fields were horizontally across the page - so maybe someone can reformat this to look more like on 2.2.* ?