### PR TITLE
pkg_edit curlies

### DIFF
--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -1432,8 +1432,9 @@ print($form);
 
 if ($pkg['note'] != "") {
 	print_info_box($pkg['note']);
+}
 
-if ($pkg['custom_php_after_form_command'])
+if ($pkg['custom_php_after_form_command']) {
 	eval($pkg['custom_php_after_form_command']);
 }
 


### PR DESCRIPTION
This looks wrong - with the way the curlies were, the custom_php_after_form_command stuff was inside the ($pkg['note'] != "") block.
It looks like these should be 2 independent if statement blocks.