### PR TITLE
system_advanced_firewall display State Timeouts section

### DIFF
--- a/src/usr/local/www/system_advanced_firewall.php
+++ b/src/usr/local/www/system_advanced_firewall.php
@@ -388,7 +388,7 @@ if ($_POST) {
 
 		// Kill filterdns when value changes, filter_configure() will restart it
 		if (($old_aliasesresolveinterval != $config['system']['aliasesresolveinterval']) &&
-			isvalidpid("{$g['varrun_path']}/filterdns.pid")) {
+		    isvalidpid("{$g['varrun_path']}/filterdns.pid")) {
 			killbypid("{$g['varrun_path']}/filterdns.pid");
 		}
 
@@ -405,10 +405,12 @@ if ($_POST) {
 $pgtitle = array(gettext("System"), gettext("Advanced"), gettext("Firewall and NAT"));
 include("head.inc");
 
-if ($input_errors)
+if ($input_errors) {
 	print_input_errors($input_errors);
-if ($savemsg)
+}
+if ($savemsg) {
 	print_info_box($savemsg);
+}
 
 $tab_array = array();
 $tab_array[] = array(gettext("Admin Access"), false, "system_advanced_admin.php");
@@ -522,7 +524,7 @@ $section->addInput(new Form_Input(
 	'default. On your system the default size is: %d',
 	[pfsense_default_table_entries_size()]);
 
-$section->addINput(new Form_Input(
+$section->addInput(new Form_Input(
 	'maximumfrags',
 	'Firewall Maximum Fragment Entries',
 	'text',
@@ -602,16 +604,16 @@ $section->addInput(new Form_Select(
 
 $form->add($section);
 
-if (count($config['interfaces']) > 1)
-{
+if (count($config['interfaces']) > 1) {
 	$section = new Form_Section('Network Address Translation');
 
-	if (isset($config['system']['disablenatreflection']))
+	if (isset($config['system']['disablenatreflection'])) {
 		$value = 'disable';
-	elseif (!isset($config['system']['enablenatreflectionpurenat']))
+	} elseif (!isset($config['system']['enablenatreflectionpurenat'])) {
 		$value = 'proxy';
-	else
+	} else {
 		$value = 'purenat';
+	}
 
 	$section->addInput(new Form_Select(
 		'natreflection',
@@ -681,71 +683,62 @@ if (count($config['interfaces']) > 1)
 
 $section = new Form_Section('State Timeouts');
 
-$group = new Form_Group('TCP Timeouts');
-$tcpTimeouts = array('First', 'Opening', 'Established', 'Closing', 'FIN', 'closed');
-foreach ($tcpTimeouts as $name)
-{
-	$group->add(new Form_Input(
-		'tcp'. strtolower($name) .'timeout',
+$tcpTimeouts = array('First', 'Opening', 'Established', 'Closing', 'FIN Wait', 'Closed');
+foreach ($tcpTimeouts as $name) {
+	$keyname = 'tcp'. strtolower(str_replace(" ", "", $name)) .'timeout';
+	$section->addInput(new Form_Input(
+		$keyname,
 		'TCP '. $name,
 		'number',
-		$config['system']['tcp'. strtolower($name) .'timeout']
+		$config['system'][$keyname]
 	))->setHelp('Enter value for TCP '. $name .' timeout in seconds. Leave blank for '.
 		'default (recommended).');
 }
 
-$section->add($group);
-
-$group = new Form_Group('UDP Timeouts');
 $udpTimeouts = array('First', 'Single', 'Multiple');
-foreach ($udpTimeouts as $name)
-{
-	$group->add(new Form_Input(
-		'udp'. strtolower($name) .'timeout',
+foreach ($udpTimeouts as $name) {
+	$keyname = 'udp'. strtolower(str_replace(" ", "", $name)) .'timeout';
+	$section->addInput(new Form_Input(
+		$keyname,
 		'UDP '. $name,
 		'number',
-		$config['system']['udo'. strtolower($name) .'timeout']
+		$config['system'][$keyname]
 	))->setHelp('Enter value for UDP '. $name .' timeout in seconds. Leave blank for '.
 		'default (recommended).');
 }
 
-$section->add($group);
-
-$group = new Form_Group('ICMP Timeouts');
-$udpTimeouts = array('First', 'Error');
-foreach ($udpTimeouts as $name)
-{
-	$group->add(new Form_Input(
-		'icmp'. strtolower($name) .'timeout',
-		'UDP '. $name,
+$icmpTimeouts = array('First', 'Error');
+foreach ($icmpTimeouts as $name) {
+	$keyname = 'icmp'. strtolower(str_replace(" ", "", $name)) .'timeout';
+	$section->addInput(new Form_Input(
+		$keyname,
+		'ICMP '. $name,
 		'number',
-		$config['system']['icmp'. strtolower($name) .'timeout']
+		$config['system'][$keyname]
 	))->setHelp('Enter value for ICMP '. $name .' timeout in seconds. Leave blank for '.
 		'default (recommended).');
 }
 
-$section->add($group);
-
-$group = new Form_Group('Other Timeouts');
-foreach ($udpTimeouts as $name)
-{
-	$group->add(new Form_Input(
-		'other'. strtolower($name) .'timeout',
+$otherTimeouts = array('First', 'Single', 'Multiple');
+foreach ($otherTimeouts as $name) {
+	$keyname = 'other'. strtolower(str_replace(" ", "", $name)) .'timeout';
+	$section->addInput(new Form_Input(
+		$keyname,
 		'Other '. $name,
 		'number',
-		$config['system']['other'. strtolower($name) .'timeout']
-	))->setHelp('Enter value for ICMP '. $name .' timeout in seconds. Leave blank for '.
+		$config['system'][$keyname]
+	))->setHelp('Enter value for Other '. $name .' timeout in seconds. Leave blank for '.
 		'default (recommended).');
 }
 
-$section->add($group);
+$form->add($section);
 
 print $form;
 
 ?>
 <script type="text/javascript">
 //<![CDATA[
-events.push(function(){
+events.push(function() {
 	// Change help text based on the selector value
 	function setHelpText(id, text) {
 		$('#' + id).parent().parent('div').find('span').html(text);
@@ -754,14 +747,15 @@ events.push(function(){
 	function setOptText(val) {
 		var htext = '<span class="text-success">';
 
-		if(val == 'normal')
+		if (val == 'normal') {
 			htext += 'The default optimization algorithm';
-		else if (val == 'high-latency')
+		} else if (val == 'high-latency') {
 			htext += 'Used for eg. satellite links. Expires idle connections later than default';
-		else if (val == 'aggressive')
+		} else if (val == 'aggressive') {
 			htext += 'Expires idle connections quicker. More efficient use of CPU and memory but can drop legitimate idle connections';
-		else if (val == 'conservative')
+		} else if (val == 'conservative') {
 			htext += 'Tries to avoid dropping any legitimate idle connections at the expense of increased memory usage and CPU utilization';
+		}
 
 		htext += '</span>';
 		setHelpText('optimization', htext);


### PR DESCRIPTION
A few little code style bits
Make the State Timeouts section actually appear (add the section to the form)
The State Timeouts section was trying to do groups of fields, which spread themselves horizontally. That did not fit across a reasonable screen nicely, specially for the 6 different TCP timeouts. So the groups thing is removed and each field is its own input in the section, all vertically below each other.
Fixed various cut-and-paste bugs in the variable naming of the timeouts code.
Added logic to be able to generate the key name (like tcpfinwaittimeout) from the screen displayed text (like "FIN Wait"). Previously the "FIN Wait" case would not work with the simple strtolower($name)

This works now. If someone wants to mess with grouping the TCP, UDP, ICMP and Other in some way, then great.