### PR TITLE
HTML Compliance - Services Status Widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/services_status.widget.php
@@ -129,7 +129,7 @@ if (count($services) > 0) {
 	<div class="form-group">
 		<label for="inputPassword3" class="col-sm-3 control-label">Hidden services</label>
 		<div class="col-sm-6">
-			<select multiple id="servicestatusfilter" name="servicestatusfilter[]" class="form-control" height="5">
+			<select multiple id="servicestatusfilter" name="servicestatusfilter[]" class="form-control">
 			<?php foreach ($services as $service): ?>
 				<option <?=(in_array($service['name'], $skipservices)?'selected':'')?>><?=$service['name']?></option>
 			<?php endforeach; ?>


### PR DESCRIPTION
Attribute height not allowed on element select at this point.

The for attribute of the label element must refer to a non-hidden form control.
'<label for="inputPassword3" class="col-sm-3 control-label">Hidden services</label>'
Can't find an "inputPassword3" form element this binds too.  Maybe it's a placeholder for future feature.  Leaving it for now.