### PR TITLE
Stop Dynamic DNS from turning off CloudFlare

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -716,9 +716,7 @@
 							$hostData = array(
 								"content" => "{$this->_dnsIP}",
 								"type" => "A",
-								"name" => "{$this->_dnsHost}",
-								"proxiable" => false,
-								"proxied" => false
+								"name" => "{$this->_dnsHost}"
 							);
 							$data_json = json_encode($hostData);
 							$updateHostId = "https://{$dnsServer}/client/v4/zones/{$zone}/dns_records/{$host}";


### PR DESCRIPTION
By having 'proxiable' and 'proxied' values set to false, CloudFlare is turned off (i.e. not go through CloudFlare) for the domain when updating the DNS records.

Setting them to 'true' would turn CloudFlare on that domain, however the user may have disabled it for their own reasons and would not like it changed.

Instead, removing these two values will not alter the status of CloudFlare on the domain.

Tested with false/false, true/false, false/true, true/true in all scenarios.