### PR TITLE
services_pppoe_edit handle both GET and POST

### DIFF
--- a/src/usr/local/www/services_pppoe_edit.php
+++ b/src/usr/local/www/services_pppoe_edit.php
@@ -88,8 +88,8 @@ $a_pppoes = &$config['pppoes']['pppoe'];
 
 if (is_numericint($_GET['id'])) {
 	$id = $_GET['id'];
-
-if (isset($_POST['id']) && is_numericint($_POST['id']))
+}
+if (isset($_POST['id']) && is_numericint($_POST['id'])) {
 	$id = $_POST['id'];
 }
 


### PR DESCRIPTION
This wacky logic would only have got to the $_POST checks if $_GET['id'] was already set.
I haven't looked to analyse it - but how would anything using $_POST have worked?