### PR TITLE
system_certmanager csr_dn_country keyname error

### DIFF
--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -869,7 +869,7 @@ $section->addInput(new Form_Select(
 $section->addInput(new Form_Select(
 	'csr_dn_country',
 	'Country Code',
-	$pconfig['dn_country'],
+	$pconfig['csr_dn_country'],
 	$dn_cc
 ));
 


### PR DESCRIPTION
Someone was recently reporting a problem with certificate signing requests. Maybe this will help.