### PR TITLE
HTML Compliance - Picture Widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/picture.widget.php
+++ b/src/usr/local/www/widgets/widgets/picture.widget.php
@@ -71,7 +71,7 @@ if ($_POST) {
 
 ?>
 <a href="/widgets/widgets/picture.widget.php?getpic=true" target="_blank">
-	<img width="100%" height="100%" src="/widgets/widgets/picture.widget.php?getpic=true" alt="picture" />
+	<img style="width:100%; height:100%" src="/widgets/widgets/picture.widget.php?getpic=true" alt="picture" />
 </a>
 
 <!-- close the body we're wrapped in and add a configuration-panel -->
@@ -79,6 +79,6 @@ if ($_POST) {
 
 <form action="/widgets/widgets/picture.widget.php" method="post" enctype="multipart/form-data" class="form-inline">
 	<label for="pictfile">New picture: </label>
-	<input name="pictfile" type="file" class="form-control" />
+	<input id="pictfile" name="pictfile" type="file" class="form-control" />
 	<button type="submit" class="btn btn-default">Upload</button>
 </form>


### PR DESCRIPTION
In HTML 4.01, the width and height could be defined in pixels or in % of the containing element. In HTML5, the value must be in pixels.  Use css for specifying in %.
The for attribute of the label element must refer to a non-hidden form control.  Add id attribute.