### PR TITLE
HTML Compliance - Traffic Graphs Widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/usr/local/www/widgets/widgets/traffic_graphs.widget.php
@@ -166,7 +166,7 @@ foreach ($ifdescrs as $ifname => $ifdescr):
 		<div class="col-sm-6 checkbox">
 <?php foreach ($ifdescrs as $ifname => $ifdescr): ?>
 			<label>
-				<input type="checkbox" name="shown[]"<?= $ifname?>]" value="<?=$ifname?>" <?= ($shown[$ifname]) ? "checked":""?> />
+				<input type="checkbox" name="shown[<?= $ifname?>]" value="<?=$ifname?>" <?= ($shown[$ifname]) ? "checked":""?> />
 				<?=$ifname?>
 			</label>
 <?php endforeach; ?>
@@ -189,7 +189,7 @@ foreach ($ifdescrs as $ifname => $ifdescr):
 	<div class="form-group">
 		<label for="refreshinterval" class="col-sm-3 control-label">Refresh Interval</label>
 		<div class="col-sm-6">
-			<input type="number" name="refreshinterval" value="<?=$refreshinterval?>" min="1" max="30" class="form-control" />
+			<input type="number" id="refreshinterval" name="refreshinterval" value="<?=$refreshinterval?>" min="1" max="30" class="form-control" />
 		</div>
 	</div>
 


### PR DESCRIPTION
Syntax typo?
No space between attributes.
Quote " in attribute name. Probable cause: Matching quote missing somewhere earlier.
Attribute wan]" not allowed on element input at this point.

The for attribute of the label element must refer to a non-hidden form control.  Add id tag.