### PR TITLE
Use different var name looping through columns

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -381,13 +381,12 @@ foreach ($widgets as $widgetname => $widgetconfig) {
 <?php
 	$columnWidth = 12 / $numColumns;
 
-	for ($i=1; $i<=$numColumns; $i++) {
-		echo '<div class="col-md-' . $columnWidth . '" id="widgets-col' . $i . '">';
+	for ($currentColumnNumber = 1; $currentColumnNumber <= $numColumns; $currentColumnNumber++) {
+		echo '<div class="col-md-' . $columnWidth . '" id="widgets-col' . $currentColumnNumber . '">';
 
-		//if col$i exists
-		if (isset($widgetColumns['col'.$i])) {
-
-			$columnWidgets = $widgetColumns['col'.$i];
+		//if col$currentColumnNumber exists
+		if (isset($widgetColumns['col'.$currentColumnNumber])) {
+			$columnWidgets = $widgetColumns['col'.$currentColumnNumber];
 
 			foreach ($columnWidgets as $widgetname => $widgetconfig) {
 				// Compose the widget title and include the title link if available
@@ -422,7 +421,7 @@ foreach ($widgets as $widgetname => $widgetconfig) {
 				<?php
 			}
 		} else {
-			echo '<div class="col-md-' . $columnWidth . '" id="widgets-col' . $i . '"></div>';
+			echo '<div class="col-md-' . $columnWidth . '" id="widgets-col' . $currentColumnNumber . '"></div>';
 		}
 		echo "</div>";
 	}


### PR DESCRIPTION
There is some problem with the var $i getting reset somehow somewhere
related to the include of each widget PHP code. I found that this was
doing $i = 1, $i = 2 and then $i = 2 again and I got fatal errors
because each file of widget code was being included twice.

Crash report begins.  Anonymous machine information:

amd64
10.2-STABLE
FreeBSD 10.2-STABLE #245 1b7c029(devel): Mon Dec 14 04:17:47 CST 2015

root@pfs23-amd64-builder:/usr/home/pfsense/pfsense/tmp/obj/usr/home/pfsense/pfsense/tmp/FreeBSD-src/sys/pfSense

Crash report details:

PHP Errors:
[17-Dec-2015 10:10:50 Asia/Kathmandu] PHP Fatal error:  Cannot redeclare
getServerDateItems() (previously declared in
/usr/local/www/widgets/widgets/ntp_status.widget.php:64) in
/usr/local/www/widgets/widgets/ntp_status.widget.php on line 64
[17-Dec-2015 10:10:50 Asia/Kathmandu] PHP Stack trace:
[17-Dec-2015 10:10:50 Asia/Kathmandu] PHP   1. {main}()
/usr/local/www/index.php:0
[17-Dec-2015 10:10:53 Asia/Kathmandu] PHP Fatal error:  Cannot redeclare
getServerDateItems() (previously declared in
/usr/local/www/widgets/widgets/ntp_status.widget.php:64) in
/usr/local/www/widgets/widgets/ntp_status.widget.php on line 64
[17-Dec-2015 10:10:53 Asia/Kathmandu] PHP Stack trace:
[17-Dec-2015 10:10:53 Asia/Kathmandu] PHP   1. {main}()
/usr/local/www/index.php:0
[17-Dec-2015 10:11:27 Asia/Kathmandu] PHP Fatal error:  Cannot redeclare
getServerDateItems() (previously declared in
/usr/local/www/widgets/widgets/ntp_status.widget.php:64) in
/usr/local/www/widgets/widgets/ntp_status.widget.php on line 64
[17-Dec-2015 10:11:27 Asia/Kathmandu] PHP Stack trace:
[17-Dec-2015 10:11:27 Asia/Kathmandu] PHP   1. {main}()
/usr/local/www/index.php:0