### PR TITLE
HTML Compliance - Dashboard - Widget Config Panel

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -403,7 +403,7 @@ foreach ($widgets as $widgetname => $widgetconfig) {
 					<div class="panel-heading">
 						<?=$wtitle?>
 						<span class="widget-heading-icon">
-							<a data-toggle="collapse" href="#widget-<?=$widgetname?> .panel-footer" class="config hidden">
+							<a data-toggle="collapse" href="#widget-<?=$widgetname?>_panel-footer" class="config hidden">
 								<i class="fa fa-wrench"></i>
 							</a>
 							<a data-toggle="collapse" href="#widget-<?=$widgetname?>_panel-body">

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -220,7 +220,7 @@ if ($_POST) {
 //]]>
 </script>
 
-<div class="panel-footer collapse">
+<div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
 <input type="hidden" id="gateways-config" name="gateways-config" value="" />
 
 <div id="gateways-settings" class="widgetconfigdiv" >

--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -221,7 +221,7 @@ events.push(function(){
 
 <!-- close the body we're wrapped in and add a configuration-panel -->
 </div>
-<div class="panel-footer collapse">
+<div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
 
 	<form action="/widgets/widgets/log.widget.php" method="post"
 		class="form-horizontal">

--- a/src/usr/local/www/widgets/widgets/picture.widget.php
+++ b/src/usr/local/www/widgets/widgets/picture.widget.php
@@ -75,7 +75,7 @@ if ($_POST) {
 </a>
 
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div class="panel-footer collapse">
+</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
 
 <form action="/widgets/widgets/picture.widget.php" method="post" enctype="multipart/form-data" class="form-inline">
 	<label for="pictfile">New picture: </label>

--- a/src/usr/local/www/widgets/widgets/rss.widget.php
+++ b/src/usr/local/www/widgets/widgets/rss.widget.php
@@ -154,7 +154,7 @@ if ($config['widgets']['rssfeed']) {
 </div>
 
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div class="panel-footer collapse">
+</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
 
 <form action="/widgets/widgets/rss.widget.php" method="post" class="form-horizontal">
 	<div class="form-group">

--- a/src/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/services_status.widget.php
@@ -123,7 +123,7 @@ if (count($services) > 0) {
 </table>
 
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div class="panel-footer collapse">
+</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
 
 <form action="/widgets/widgets/services_status.widget.php" method="post" class="form-horizontal">
 	<div class="form-group">

--- a/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
+++ b/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
@@ -191,7 +191,7 @@ function getBoolValueFromConfig(&$configArray, $valueKey, $defaultValue) {
 </div>
 <input type="hidden" id="thermal_sensors-config" name="thermal_sensors-config" value="" />
 
-<div id="thermal_sensors-settings" class="widgetconfigdiv panel-footer collapse" >
+<div id="widget-<?=$widgetname?>_panel-footer" class="widgetconfigdiv panel-footer collapse" >
 	<form action="/widgets/widgets/thermal_sensors.widget.php" method="post" id="iform_thermal_sensors_settings" name="iform_thermal_sensors_settings">
 	<table>
 		<tr>

--- a/src/usr/local/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/usr/local/www/widgets/widgets/traffic_graphs.widget.php
@@ -158,7 +158,7 @@ foreach ($ifdescrs as $ifname => $ifdescr):
 <?php endforeach; ?>
 
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div class="panel-footer collapse">
+</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
 
 <form action="/widgets/widgets/traffic_graphs.widget.php" method="post" class="form-horizontal">
 	<div class="form-group">


### PR DESCRIPTION
Bad value #widget-system_information .panel-footer for attribute href on element a: Illegal character in fragment: not a URL code point.
Fix the widget config/wrench icon href.
Add matching widgetname id tag to widgets configuration panel div element.

Note: Thermal Sensors widget config panel already had a different id tag.  Couldn't find anything that referenced it though.  If that is correct then it should be safe to change it to widgetname to be consistent with the other widgets.