### PR TITLE
system_usermanager remove unused code

### DIFF
--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -445,7 +445,7 @@ function build_cert_table() {
 			$certhtml .=		'<td>' . htmlspecialchars($ca['descr']) . '</td>';
 			$certhtml .=		'<td>';
 			$certhtml .=			'<a id="delcert' . $i .'" class="fa fa-trash no-confirm icon-pointer" title="';
-			$certhtml .=			gettext('Remove this certificate association? (Certificate will not be deleted)') . '">Delete</a>';
+			$certhtml .=			gettext('Remove this certificate association? (Certificate will not be deleted)') . '"></a>';
 			$certhtml .=		'</td>';
 			$certhtml .=	'</tr>';
 			$i++;
@@ -754,82 +754,58 @@ if ($act == "new" || $act == "edit" || $input_errors):
 
 		$form->add($section);
 	}
-else;
-		$section = new Form_Section('User Certificates');
 
-		foreach ((array)$a_user[$id]['cert'] as $i => $certref) {
-			$cert = lookup_cert($certref);
-			$ca = lookup_ca($cert['caref']);
+	// ==== Add user certificate for a new user
+	if (is_array($config['ca']) && count($config['ca']) > 0) {
+		$section = new Form_Section('Create certificate for user');
+		$section->addClass('cert-options');
 
-			// We reverse name and action for readability of longer names
-			$section->addInput(new Form_Checkbox(
-				'certid[]',
-				'Delete certificate',
-				$cert['descr']. (is_cert_revoked($cert) ? ' <b>revoked</b>' : ''),
-				false,
-				$i
+		$nonPrvCas = array();
+		foreach($config['ca'] as $ca) {
+			if (!$ca['prv']) {
+				continue;
+			}
+
+			$nonPrvCas[ $ca['refid'] ] = $ca['descr'];
+		}
+
+		if (!empty($nonPrvCas)) {
+			$section->addInput(new Form_Input(
+				'name',
+				'Descriptive name',
+				'text',
+				$pconfig['name']
+			));
+
+			$section->addInput(new Form_Select(
+				'caref',
+				'Certificate authority',
+				null,
+				$nonPrvCas
+			));
+
+			$section->addInput(new Form_Select(
+				'keylen',
+				'Key length',
+				2048,
+				array(
+					512 => '512 bits',
+					1024 => '1024 bits',
+					2048 => '2049 bits',
+					4096 => '4096 bits',
+				)
+			));
+
+			$section->addInput(new Form_Input(
+				'lifetime',
+				'Lifetime',
+				'number',
+				$pconfig['lifetime']
 			));
 		}
 
-		#FIXME; old ui supplied direct export links to each certificate
-
-		$section->addInput(new Form_StaticText(
-			null,
-			new Form_Button(null, 'add certificate', 'system_certmanager.php?act=new&userid='. $id).
-			new Form_Button(null, 'export certificates', 'system_certmanager.php')
-		));
-
-		// ==== Add user certificate for a new user
-		if (is_array($config['ca']) && count($config['ca']) > 0) {
-			$section = new Form_Section('Create certificate for user');
-			$section->addClass('cert-options');
-
-			$nonPrvCas = array();
-			foreach($config['ca'] as $ca) {
-				if (!$ca['prv']) {
-					continue;
-				}
-
-				$nonPrvCas[ $ca['refid'] ] = $ca['descr'];
-			}
-
-			if (!empty($nonPrvCas)) {
-				$section->addInput(new Form_Input(
-					'name',
-					'Descriptive name',
-					'text',
-					$pconfig['name']
-				));
-
-				$section->addInput(new Form_Select(
-					'caref',
-					'Certificate authority',
-					null,
-					$nonPrvCas
-				));
-
-				$section->addInput(new Form_Select(
-					'keylen',
-					'Key length',
-					2048,
-					array(
-						512 => '512 bits',
-						1024 => '1024 bits',
-						2048 => '2049 bits',
-						4096 => '4096 bits',
-					)
-				));
-
-				$section->addInput(new Form_Input(
-					'lifetime',
-					'Lifetime',
-					'number',
-					$pconfig['lifetime']
-				));
-			}
-
-			$form->add($section);
-		}
+		$form->add($section);
+	}
 
 endif;
 // ==== Paste a key for the new user


### PR DESCRIPTION
1) Line 448 "Remove this certificate association? (Certificate will not be deleted)" there was the text "Delete" being displayed and not looking good, in addition to the trash bin icon. Just the trash bin icon seems to be all that is needed.
2) Old line 757 there was a weird-looking "else;" - that seemed to be effectively an empty "else" clause hanging off the end of the "if" block above it. In that case it does nothing and I have removed it.
3) Remove the extra indent of a whole lot of code below old line 757 that actually was not in any "else" clause. This lines it up the way it actually works.
4) Old line 758
$section = new Form_Section('User Certificates');
That made a new $section and chunks of code below it added stuff to the section and then it was thrown away - there was nothing that actually added the section tp the form. That code is similar to what was already above that uses build_cert_table() to make a new Form_StaticText().
So I deleted the code from old line 758 that was functionally useless.

I think it all still works :)

Please review this carefully and make sure I have done good things. The code seemed a bit of a mess to me - maybe it was, or maybe I have no idea!