### PR TITLE
services_rfc2136_edit remove unused $input

### DIFF
--- a/src/usr/local/www/services_rfc2136_edit.php
+++ b/src/usr/local/www/services_rfc2136_edit.php
@@ -224,7 +224,7 @@ $group->add(new Form_Checkbox(
 	'zone'
 ))->displayAsRadio();
 
-$group->add($input = new Form_Checkbox(
+$group->add(new Form_Checkbox(
 	'keytype',
 	'Key Type',
 	'Host',
@@ -232,7 +232,7 @@ $group->add($input = new Form_Checkbox(
 	'host'
 ))->displayAsRadio();
 
-$group->add($input = new Form_Checkbox(
+$group->add(new Form_Checkbox(
 	'keytype',
 	'Key Type',
 	'User',
@@ -280,7 +280,7 @@ $group->add(new Form_Checkbox(
 	'A'
 ))->displayAsRadio();
 
-$group->add($input = new Form_Checkbox(
+$group->add(new Form_Checkbox(
 	'recordtype',
 	'Record Type',
 	'AAAA (IPv6)',
@@ -288,7 +288,7 @@ $group->add($input = new Form_Checkbox(
 	'AAAA'
 ))->displayAsRadio();
 
-$group->add($input = new Form_Checkbox(
+$group->add(new Form_Checkbox(
 	'recordtype',
 	'Record Type',
 	'Both',


### PR DESCRIPTION
These bits if code that put new Form_Checkbox() into var $input do not seem to do anything useful. They just made me wonder why they were there.
If someone knows how they do anything useful, then please say so. Otherwise we can get rid of $input here.