### PR TITLE
Fix gen_subnetv4_max

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -392,7 +392,7 @@ function gen_subnetv4_max($ipaddr, $bits) {
 		if ($bits == 32) {
 			return $ipaddr;
 		}
-		return long2ip32(ip2long($ipaddr) | ~gen_subnet_mask_long($bits));
+		return long2ip32(ip2long($ipaddr) | (~gen_subnet_mask_long($bits) & 0xFFFFFFFF));
 	}
 	return "";
 }

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -798,10 +798,10 @@ $section->addInput(new Form_StaticText(
 ));
 
 // Compose a string to display the required address ranges
-$range_from = ip2long(long2ip32(ip2long($ifcfgip) & gen_subnet_mask_long($ifcfgsn)));
+$range_from = ip2long(gen_subnetv4($ifcfgip, $ifcfgsn));
 $range_from++;
 
-$range_to = ip2long(long2ip32(ip2long($ifcfgip) | (~gen_subnet_mask_long($ifcfgsn))));
+$range_to = ip2long(gen_subnetv4_max($ifcfgip, $ifcfgsn));
 $range_to--;
 
 $rangestr = long2ip32($range_from) . ' - ' . long2ip32($range_to);


### PR DESCRIPTION
and use it in services_dhcp rather than trying to do the similar calculation in-line.
Should fix redmine #5654 and probably a bunch of other things that use gen_subnet_max.

The main thing here is that gen_subnet_mask_long will make a mask that has some top bits out of the bottom 32 set. On a 64-bit system you might get:
0x00000000FFFFFF00

For a 24 bit mask - 8 low bits clear, then 24 network bits set, then the high bits will be clear.

When flipping the bits to try and get the bottom hosts bits, you get:
0xFFFFFFFF000000FF

Need to ignore anything above the bottom 32 bits - & with 0xFFFFFFFF does that.

I suspect this was a problem on 64-bit systems, but probably worked in 32-bit land.
