### PR TITLE
Bump for Nuke fifolog support

### DIFF
--- a/src/conf.default/config.xml
+++ b/src/conf.default/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <pfsense>
-	<version>13.1</version>
+	<version>13.2</version>
 	<lastchange/>
 	<system>
 		<optimization>normal</optimization>


### PR DESCRIPTION
Should the default config version always be bumped to match the version in globals.inc when new upgrade code is committed?