### PR TITLE
HTML Compliance - Form Select

### DIFF
--- a/src/usr/local/www/classes/Form/Select.class.php
+++ b/src/usr/local/www/classes/Form/Select.class.php
@@ -66,7 +66,8 @@ class Form_Select extends Form_Input
 				$selected = ($sval == $value);
 			}
 
-			$options .= '<option value="'. htmlspecialchars($value) .'"'.($selected ? ' selected' : '').'>'. htmlspecialchars(gettext($name)) .'</option>';
+			if (!empty($name) || $name == '0')
+				$options .= '<option value="'. htmlspecialchars($value) .'"'.($selected ? ' selected' : '').'>'. htmlspecialchars(gettext($name)) .'</option>';
 		}
 
 		return <<<EOT


### PR DESCRIPTION
Element option without attribute label must not be empty.