### PR TITLE
HTML Compliance - Form Input - Placeholder

### DIFF
--- a/src/usr/local/www/classes/Form/Input.class.php
+++ b/src/usr/local/www/classes/Form/Input.class.php
@@ -145,7 +145,9 @@ class Form_Input extends Form_Element
 
 	public function setPlaceholder($text)
 	{
-		$this->_attributes['placeholder'] = $text;
+		$placeholder_input_types = array('email', 'number', 'password', 'search', 'tel', 'text', 'url');
+		if (in_array(strtolower($this->_attributes['type']), $placeholder_input_types))
+			$this->_attributes['placeholder'] = $text;
 
 		return $this;
 	}


### PR DESCRIPTION
Attribute placeholder not allowed on element select at this point.
Attribute placeholder is only allowed when the input type is email, number, password, search, tel, text, or url.