### PR TITLE
HTML Compliance - Form Button - HRef

### DIFF
--- a/src/usr/local/www/classes/Form/Button.class.php
+++ b/src/usr/local/www/classes/Form/Button.class.php
@@ -64,6 +64,9 @@ class Form_Button extends Form_Input
 		}
 
 		parent::__construct($name, $title, null);
+
+		if (isset($link))
+			unset($this->_attributes['name']);
 	}
 
 	protected function _getInput()


### PR DESCRIPTION
The name attribute is obsolete. Consider putting an id attribute on the nearest container instead.
The <a> name attribute is not supported in HTML5. Use the id attribute instead.