### PR TITLE
WebGUI Left Column Labels Hyper

### DIFF
--- a/src/usr/local/www/classes/Form/Group.class.php
+++ b/src/usr/local/www/classes/Form/Group.class.php
@@ -108,6 +108,8 @@ EOT;
 
 	public function __toString()
 	{
+		global $config;
+
 		$element = parent::__toString();
 
 		// Automatically determine width for inputs without explicit set
@@ -133,6 +135,9 @@ EOT;
 		$target = $this->_labelTarget->getId();
 		$inputs = implode('', $this->_inputs);
 		$help = $this->_getHelp();
+
+		if (!isset($config['system']['webgui']['webguileftcolumnhyper']))
+			$target = null;
 
 		$label = new Form_Element('label', false, ['for' => $target]);
 		$label->addClass('col-sm-'.Form::LABEL_WIDTH, 'control-label');

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -92,6 +92,7 @@ $pconfig['language'] = $config['system']['language'];
 $pconfig['webguicss'] = $config['system']['webgui']['webguicss'];
 $pconfig['webguifixedmenu'] = $config['system']['webgui']['webguifixedmenu'];
 $pconfig['dashboardcolumns'] = $config['system']['webgui']['dashboardcolumns'];
+$pconfig['webguileftcolumnhyper'] = isset($config['system']['webgui']['webguileftcolumnhyper']);
 $pconfig['dnslocalhost'] = isset($config['system']['dnslocalhost']);
 
 if (!$pconfig['timezone']) {
@@ -230,6 +231,9 @@ if ($_POST) {
 			$config['system']['language'] = $_POST['language'];
 			set_language($config['system']['language']);
 		}
+
+		unset($config['system']['webgui']['webguileftcolumnhyper']);
+		$config['system']['webgui']['webguileftcolumnhyper'] = $_POST['webguileftcolumnhyper'] ? true : false;
 
 		/* XXX - billm: these still need updating after figuring out how to check if they actually changed */
 		$olddnsservers = $config['system']['dnsserver'];
@@ -501,6 +505,13 @@ $section->addInput(new Form_Input(
 	$pconfig['dashboardcolumns'],
 	[min => 1, max => 4]
 ))->setHelp('<span class="badge" title="This feature is in BETA">BETA</span>');
+
+$section->addInput(new Form_Checkbox(
+	'webguileftcolumnhyper',
+	'Left Column Labels',
+	'Active',
+	$pconfig['webguileftcolumnhyper']
+))->setHelp('If selected, clicking a label in the left column will select/toggle the first item of the group.');
 
 $form->add($section);
 


### PR DESCRIPTION
WebGUI Left Column Labels Hyper

Touch Screen Usability Annoyance
https://forum.pfsense.org/index.php?topic=104135.0

Clicking the labels in the left column selects/activates the first item.  This is the perfectly natural place for scrolling with thumb.
 
No big problem really for input fields, but check boxes and buttons are inadvertently selected/toggled resulting in unintended configuration changes.
 
Would be real nice if the labels in the left column were not "active".

This commit provides an option in System - General Setup page to enable/disable this "feature".

There is probably a better way, but this appears to be functional.  For now at least it seems to work for me anyway.  Just have to eliminate (null) the for attribute on the group labels so it doesn't have a target.