### PR TITLE
Replace FONT tag with SPAN

### DIFF
--- a/src/usr/local/www/diag_smart.php
+++ b/src/usr/local/www/diag_smart.php
@@ -81,9 +81,9 @@ function add_colors($string) {
 	$patterns[0] = '/PASSED/';
 	$patterns[1] = '/FAILED/';
 	$patterns[2] = '/Warning/';
-	$replacements[0] = '<b><font color="#00ff00">' . gettext("PASSED") .  '</font></b>';
-	$replacements[1] = '<b><font color="#ff0000">' . gettext("FAILED") .  '</font></b>';
-	$replacements[2] = '<font color="#ff0000">'	   . gettext("Warning") . '</font>';
+	$replacements[0] = '<span class="text-success">' . gettext("PASSED") . '</span>';
+	$replacements[1] = '<span class="text-alert">' . gettext("FAILED") . '</span>';
+	$replacements[2] = '<span class="text-warning">' . gettext("Warning") . '</span>';
 	ksort($patterns);
 	ksort($replacements);
 	return preg_replace($patterns, $replacements, $string);

--- a/src/usr/local/www/system_usermanager_settings_test.php
+++ b/src/usr/local/www/system_usermanager_settings_test.php
@@ -92,16 +92,16 @@ if (!$authcfg) {
 
 	echo "<tr><td>" . gettext("Attempting connection to") . " " . "<td><center>" . htmlspecialchars($auth_server). "</b></center></td>";
 	if (ldap_test_connection($authcfg)) {
-		echo "<td><span class="text-center text-success">OK</span></td></tr>";
+		echo "<td><span class=\"text-center text-success\">OK</span></td></tr>";
 
 		echo "<tr><td>" . gettext("Attempting bind to") . " " . "<td><center>" . htmlspecialchars($auth_server). "</b></center></td>";
 		if (ldap_test_bind($authcfg)) {
-			echo "<td><span class="text-center text-success">OK</span></td></tr>";
+			echo "<td><span class=\"text-center text-success\">OK</span></td></tr>";
 
 			echo "<tr><td>" . gettext("Attempting to fetch Organizational Units from") . " " . "<td><center>" . htmlspecialchars($auth_server). "</b></center></td>";
 			$ous = ldap_get_user_ous(true, $authcfg);
 			if (count($ous)>1) {
-				echo "<td><span class="text-center text-success">OK</span></td></tr>";
+				echo "<td><span class=\"text-center text-success\">OK</span></td></tr>";
 				echo "</table>";
 				if (is_array($ous)) {
 					echo "<br/>";
@@ -112,17 +112,17 @@ if (!$authcfg) {
 					}
 				}
 			} else {
-				echo "<td><font color=red>" . gettext("failed") . "</td></tr>";
+				echo "<td><span class=\"text-alert\">" . gettext("failed") . "</span></td></tr>";
 			}
 
 			echo "</table><p/>";
 
 		} else {
-			echo "<td><font color=red>" . gettext("failed") . "</td></tr>";
+			echo "<td><span class=\"text-alert\">" . gettext("failed") . "</span></td></tr>";
 			echo "</table><p/>";
 		}
 	} else {
-		echo "<td><font color=red>" . gettext("failed") . "</td></tr>";
+		echo "<td><span class=\"text-alert\">" . gettext("failed") . "</span></td></tr>";
 		echo "</table><p/>";
 	}
 }


### PR DESCRIPTION
Replace FONT tag with SPAN tags and Bootstrap CLASS statement
Escape double quotes correctly in "system_usermanager_settings_test.php"