### PR TITLE
Redmine #5613 avoid Reset to Factory Defaults PHP warnings

### DIFF
--- a/src/etc/inc/config.lib.inc
+++ b/src/etc/inc/config.lib.inc
@@ -618,7 +618,7 @@ function reset_factory_defaults($lock = false) {
 	/* clear out /conf */
 	$dh = opendir($g['conf_path']);
 	while ($filename = readdir($dh)) {
-		if (($filename != ".") && ($filename != "..")) {
+		if (($filename != ".") && ($filename != "..") && (!is_dir($g['conf_path'] . "/" . $filename))) {
 			unlink_if_exists($g['conf_path'] . "/" . $filename);
 		}
 	}


### PR DESCRIPTION
On Reset to Factory Defaults there are some warnings given when unlink_if_exists() tries to unlink() directories in /conf - /conf/backup and /conf/sshd.
unlink does not work on directories.
This PR avoids the PHP warnings by not trying to remove the directories inside /conf.

As has been the case before this PR, the following things are thus left on the system after Reset to Factory Defaults:
/conf/backup - old config backups, which contain configs of the previous system.
/conf/sshd - old ssh keys.

For testing, this is handy. But for real "reset" should these be deleted?
In addition to this PR, should there be code to delete everything in /conf/backup and/or /conf/sshd?