### PR TITLE
Only enable Restore Configuration if a file is selected

### DIFF
--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -799,7 +799,11 @@ events.push(function() {
 	});
 
 	$('#conffile').change(function () {
-		$('.restore').prop('disabled', false);
+		if (document.getElementById("conffile").value) {
+			$('.restore').prop('disabled', false);
+		} else {
+			$('.restore').prop('disabled', true);
+		}
     });
 	// ---------- On initial page load ------------------------------------------------------------
 


### PR DESCRIPTION
If the user clicks "Choose File" and then cancels the file selection dialog, disable the "Restore Configuration" button.