### PR TITLE
Avoid triggering initial wizard before reboot

### DIFF
--- a/src/etc/inc/config.lib.inc
+++ b/src/etc/inc/config.lib.inc
@@ -246,7 +246,7 @@ function parse_config_bootup() {
 			if (strstr($g['platform'], "cdrom")) {
 				/* try copying the default config. to the floppy */
 				echo gettext("Resetting factory defaults...") . "\n";
-				reset_factory_defaults(true);
+				reset_factory_defaults(true, false);
 				if (!file_exists("{$g['conf_path']}/config.xml")) {
 					echo gettext("No XML configuration file found - using factory defaults.\n" .
 								 "Make sure that the configuration floppy disk with the conf/config.xml\n" .
@@ -604,7 +604,7 @@ function write_config($desc="Unknown", $backup = true, $write_config_only = fals
  * RESULT
  *   integer	- indicates completion
  ******/
-function reset_factory_defaults($lock = false) {
+function reset_factory_defaults($lock = false, $reboot_required = true) {
 	global $g;
 
 	conf_mount_rw();
@@ -631,7 +631,12 @@ function reset_factory_defaults($lock = false) {
 	disable_security_checks();
 
 	/* call the wizard */
-	touch("/conf/trigger_initial_wizard");
+	if ($reboot_required) {
+		// If we need a reboot first then touch a different trigger file.
+		touch("/conf/trigger_initial_wizard_after_reboot");
+	} else {
+		touch("/conf/trigger_initial_wizard");
+	}
 	if (!$lock) {
 		unlock($lockkey);
 	}

--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -138,6 +138,12 @@ if (file_exists('/conf/needs_package_sync_after_reboot')) {
 	@unlink('/conf/needs_package_sync_after_reboot');
 }
 
+/* Triggering of the initial setup wizard after reboot has been requested */
+if (file_exists('/conf/trigger_initial_wizard_after_reboot')) {
+	touch('/conf/trigger_initial_wizard');
+	@unlink('/conf/trigger_initial_wizard_after_reboot');
+}
+
 /* start devd (dhclient now uses it) */
 echo "Starting device manager (devd)...";
 mute_kernel_msgs();


### PR DESCRIPTION
If you use the webGUI to reset to factory defaults, then while the
existing system is shutting down you navigate off to the dashboard, the
initial setup wizard will start. The trigger_initial_wizard flag file is
deleted, and so after the reboot the initial setup wizard will not be
triggered.
This change fixes that sequence of events by using a different flag file
across the reboot, and switching it back to the usual flag file name
during the subsequent boot up.