### PR TITLE
HTML Compliance - Form Select - Empty

### DIFF
--- a/src/usr/local/www/classes/Form/Select.class.php
+++ b/src/usr/local/www/classes/Form/Select.class.php
@@ -66,7 +66,7 @@ class Form_Select extends Form_Input
 				$selected = ($sval == $value);
 			}
 
-			if (!empty($name) || $name == '0')
+			if (!empty(trim($name)) || is_numeric($name))
 				$options .= '<option value="'. htmlspecialchars($value) .'"'.($selected ? ' selected' : '').'>'. htmlspecialchars(gettext($name)) .'</option>';
 		}
 


### PR DESCRIPTION
Misses some corner cases such as boolean false and all white space.