### PR TITLE
Allow disabling DiffServ Code Point (DSCP) matching

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1406,7 +1406,7 @@ $section->addInput(new Form_Select(
 	'dscp',
 	'Diffserv Code Point',
 	$pconfig['dscp'],
-	["" => ''] + array_combine($firewall_rules_dscp_types, $firewall_rules_dscp_types)
+	["" => 'any'] + array_combine($firewall_rules_dscp_types, $firewall_rules_dscp_types)
 ));
 
 $section->addInput(new Form_Checkbox(


### PR DESCRIPTION
Allow disabling the addition of a DiffServ Code Point (DSCP) match to new or edited rules.

It is currently not possible to create a new rule without a DSCP matching attribute, which defaults to "af11". As a result, rules never match for no apparent reason.

This issue has previously been reported and fixed [1] but the fix no longer works, probably due to Bootstrap ignoring empty values in selects.

This changes adds a label "any" to the empty value in the select.

[1] https://redmine.pfsense.org/issues/4951#change-19876