### PR TITLE
HTML Compliance - Form Select another try

### DIFF
--- a/src/usr/local/www/classes/Form/Select.class.php
+++ b/src/usr/local/www/classes/Form/Select.class.php
@@ -66,7 +66,14 @@ class Form_Select extends Form_Input
 				$selected = ($sval == $value);
 			}
 
-			$options .= '<option value="'. htmlspecialchars($value) .'"'.($selected ? ' selected' : '').'>'. htmlspecialchars(gettext($name)) .'</option>';
+			if (!empty($name) || $name == '0') {
+				$name_str = htmlspecialchars(gettext($name));
+			} else {
+				// Fixes HTML5 validation: Element option without attribute label must not be empty
+				$name_str = "&nbsp;";
+			}
+
+			$options .= '<option value="'. htmlspecialchars($value) .'"'.($selected ? ' selected' : '').'>'. $name_str .'</option>';
 		}
 
 		return <<<EOT


### PR DESCRIPTION
Element option without attribute label must not be empty.
This is a revised attempt at what was done in commit https://github.com/pfsense/pfsense/commit/bc3b831d82b58a0bc4822e14d30e4643536b603e
A few random searches gave the suggestion that when you want a blank as the option text, you can get past the validation by making it a non-breaking space. An ordinary space seems to be consider empty for the purposes of this HTML5 validation rule.
Here are some random search results for your reading pleasure:
http://w3schools.invisionzone.com/index.php?showtopic=50403
http://stackoverflow.com/questions/22237658/html5-validation-error-with-select-required-attribute
https://github.com/wet-boew/wet-boew/issues/2721