### PR TITLE
LAGG edit fixes

### DIFF
--- a/src/usr/local/www/interfaces_lagg_edit.php
+++ b/src/usr/local/www/interfaces_lagg_edit.php
@@ -163,6 +163,7 @@ if (isset($id) && $a_laggs[$id]) {
 if ($_POST) {
 	unset($input_errors);
 	$pconfig = $_POST;
+	$pconfig['members'] = implode(',', $_POST['members']);
 
 	/* input validation */
 	$reqdfields = explode(" ", "members proto");
@@ -223,7 +224,6 @@ function build_member_list() {
 	$memberlist = array('list' => array(),
 						'selected' => array());
 
-	$members_array = explode(',', $pconfig['members']);
 	foreach ($portlist as $ifn => $ifinfo) {
 		if (array_key_exists($ifn, $realifchecklist)) {
 			continue;
@@ -242,6 +242,11 @@ function build_member_list() {
 $pgtitle = array(gettext("Interfaces"), gettext("LAGG"), gettext("Edit"));
 $shortcut_section = "interfaces";
 include("head.inc");
+
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+
 $form = new Form();
 
 $section = new Form_Section('LAGG Configuration');


### PR DESCRIPTION
1) $_POST['members'] is an array, but $pconfig['members'] should be a comma-separated list. So the general copy "$pconfig = $_POST;" needs to be followed by setting up 'members' in particular.
2) $members_array is never used - so throw it away.
3) Add code so that input errors are actually displayed to the user.

Forum thread: https://forum.pfsense.org/index.php?topic=104352.0