### PR TITLE
Redundant logic tests in a range check

### DIFF
--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -403,13 +403,12 @@ if (isset($_POST['submit'])) {
 			$subnet_start = ip2ulong(long2ip32(ip2long($ifcfgip) & gen_subnet_mask_long($ifcfgsn)));
 			$subnet_end = ip2ulong(long2ip32(ip2long($ifcfgip) | (~gen_subnet_mask_long($ifcfgsn))));
 
-			if ((ip2ulong($_POST['range_from']) < $subnet_start) || (ip2ulong($_POST['range_from']) > $subnet_end) ||
-			    (ip2ulong($_POST['range_to']) < $subnet_start) || (ip2ulong($_POST['range_to']) > $subnet_end)) {
-				$input_errors[] = gettext("The specified range lies outside of the current subnet.");
-			}
-
 			if (ip2ulong($_POST['range_from']) > ip2ulong($_POST['range_to'])) {
 				$input_errors[] = gettext("The range is invalid (first element higher than second element).");
+			}
+
+			if (ip2ulong($_POST['range_from']) < $subnet_start || ip2ulong($_POST['range_to']) > $subnet_end) {
+				$input_errors[] = gettext("The specified range lies outside of the current subnet.");
 			}
 
 			if (is_numeric($pool) || ($act == "newpool")) {


### PR DESCRIPTION
The logic here is redundant. It tests `IP1<START || IP2<START || IP1>END || IP2>END`. *Then* it tests if IP1<IP2 unsigned.

If the latter test succeeds (ie test that first) then IP1>=START *must imply* IP2>=START and IP2<=END *must imply* IP1<=END. In other words we only need to test:

START <= IP1 <= IP2 <= END, ie 3 logic tests (IP1<=IP2 && IP1>=START && IP2<=END) not 5 logic tests.