### PR TITLE
HTML Compliance - System / User Manager / Users

### DIFF
--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -493,6 +493,7 @@ if (!($act == "new" || $act == "edit" || $input_errors)) {
 				<th><?=gettext("Full name")?></th>
 				<th><?=gettext("Disabled")?></th>
 				<th><?=gettext("Groups")?></th>
+				<th>&nbsp;</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -539,6 +540,7 @@ foreach ($a_user as $i => $userent):
 		<?=gettext("Delete")?>
 	</button>
 </nav>
+</form>
 
 <div id="infoblock">
 	<?=print_info_box(gettext("Additional users can be added here. User permissions for accessing " .
@@ -917,5 +919,5 @@ events.push(function() {
 //]]>
 </script>
 <?php
-
 include('foot.inc');
+?>


### PR DESCRIPTION
A table row was 6 columns wide and exceeded the column count established by the first row (5).
End tag div seen, but there were open elements.
Unclosed element form.
Close php tag.