### PR TITLE
HTML Compliance - Interfaces / Assign network ports

### DIFF
--- a/src/usr/local/www/interfaces_assign.php
+++ b/src/usr/local/www/interfaces_assign.php
@@ -528,6 +528,7 @@ display_top_tabs($tab_array);
 		<tr>
 			<th><?=gettext("Interface")?></th>
 			<th><?=gettext("Network port")?></th>
+			<th>&nbsp;</th>
 		</tr>
 	</thead>
 	<tbody>


### PR DESCRIPTION
A table row was 3 columns wide and exceeded the column count established by the first row (2).