### PR TITLE
redmine 5702 - change to use high level IPv4 functions where low level ip2long32() etc are used

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1243,7 +1243,7 @@ function openvpn_resync_csc(& $settings) {
 							$csc_conf .= "ifconfig-push {$ip} " . gen_subnet_mask($mask) . "\n";
 						} else {
 							/* Because this is being pushed, the order from the client's point of view. */
-							$baselong = ip2long32($ip) & gen_subnet_mask_long($mask);
+							$baselong = ip2ulong(gen_subnetv4($ip, $mask));
 							$serverip = long2ip32($baselong + 1);
 							$clientip = long2ip32($baselong + 2);
 							$csc_conf .= "ifconfig-push {$clientip} {$serverip}\n";

--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1243,9 +1243,9 @@ function openvpn_resync_csc(& $settings) {
 							$csc_conf .= "ifconfig-push {$ip} " . gen_subnet_mask($mask) . "\n";
 						} else {
 							/* Because this is being pushed, the order from the client's point of view. */
-							$baselong = ip2ulong(gen_subnetv4($ip, $mask));
-							$serverip = long2ip32($baselong + 1);
-							$clientip = long2ip32($baselong + 2);
+							$baselong = gen_subnetv4($ip, $mask);
+							$serverip = ip_after($baselong, 1);
+							$clientip = ip_after($baselong, 2);
 							$csc_conf .= "ifconfig-push {$clientip} {$serverip}\n";
 						}
 					}

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -464,12 +464,12 @@ function find_smallest_cidr_v4($number) {
 
 /* Return the previous IP address before the given address */
 function ip_before($ip, $offset = 1) {
-	return long2ip32(ip2long($ip) - $offset);
+	return long2ip32(ip2ulong($ip) - $offset);
 }
 
 /* Return the next IP address after the given address */
 function ip_after($ip, $offset = 1) {
-	return long2ip32(ip2long($ip) + $offset);
+	return long2ip32(ip2ulong($ip) + $offset);
 }
 
 /* Return true if the first IP is 'before' the second */

--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -1588,7 +1588,7 @@ function vpn_pppoe_configure(&$pppoecfg) {
 
 			for ($i = 0; $i < $pppoecfg['n_pppoe_units']; $i++) {
 
-				$clientip = long2ip32(ip2long($pppoecfg['remoteip']) + $i);
+				$clientip = ip_after($pppoecfg['remoteip'], $i);
 
 				if (isset($pppoecfg['radius']['radiusissueips']) && isset($pppoecfg['radius']['server']['enable'])) {
 					$issue_ip_type = "set ipcp ranges {$pppoecfg['localip']}/32 0.0.0.0/0";
@@ -1827,7 +1827,7 @@ EOD;
 
 			for ($i = 0; $i < $l2tpcfg['n_l2tp_units']; $i++) {
 
-				$clientip = long2ip32(ip2long($l2tpcfg['remoteip']) + $i);
+				$clientip = ip_after($l2tpcfg['remoteip'], $i);
 
 				if (isset ($l2tpcfg['radius']['radiusissueips']) && isset ($l2tpcfg['radius']['enable'])) {
 					$issue_ip_type = "set ipcp ranges {$l2tpcfg['localip']}/32 0.0.0.0/0";

--- a/src/usr/local/bin/dhcpd_gather_stats.php
+++ b/src/usr/local/bin/dhcpd_gather_stats.php
@@ -187,8 +187,8 @@ if (is_array($config['dhcpd'][$argv[1]])) {
 	}
 	$ifcfgip = get_interface_ip($dhcpif);
 	$ifcfgsn = get_interface_subnet($dhcpif);
-	$subnet_start = ip2ulong(long2ip32(ip2long($ifcfgip) & gen_subnet_mask_long($ifcfgsn)));
-	$subnet_end = ip2ulong(long2ip32(ip2long($ifcfgip) | (~gen_subnet_mask_long($ifcfgsn))));
+	$subnet_start = ip2ulong(gen_subnetv4($ifcfgip, $ifcfgsn));
+	$subnet_end = ip2ulong(gen_subnetv4_max($ifcfgip, $ifcfgsn));
 	
 	$result['range'] = (ip2ulong($config['dhcpd'][$dhcpif]['range']['to'])) - (ip2ulong($config['dhcpd'][$dhcpif]['range']['from'])) ;
 	

--- a/src/usr/local/bin/dhcpd_gather_stats.php
+++ b/src/usr/local/bin/dhcpd_gather_stats.php
@@ -187,23 +187,21 @@ if (is_array($config['dhcpd'][$argv[1]])) {
 	}
 	$ifcfgip = get_interface_ip($dhcpif);
 	$ifcfgsn = get_interface_subnet($dhcpif);
-	$subnet_start = ip2ulong(gen_subnetv4($ifcfgip, $ifcfgsn));
-	$subnet_end = ip2ulong(gen_subnetv4_max($ifcfgip, $ifcfgsn));
+	$subnet_start = gen_subnetv4($ifcfgip, $ifcfgsn);
+	$subnet_end = gen_subnetv4_max($ifcfgip, $ifcfgsn);
 	
 	$result['range'] = (ip2ulong($config['dhcpd'][$dhcpif]['range']['to'])) - (ip2ulong($config['dhcpd'][$dhcpif]['range']['from'])) ;
 	
 	foreach ($leases as $data) {
-		$lip = ip2ulong($data['ip']);
-		
 		if ($data['act'] != "active" && $data['act'] != "static" && $_GET['all'] != 1)
 			continue;
 		if ($data['act'] != "static") {
-			if (($lip >= ip2ulong($config['dhcpd'][$dhcpif]['range']['from'])) && ($lip <= ip2ulong($config['dhcpd'][$dhcpif]['range']['to']))) {
+			if (is_inrange_v4($data['ip'], $config['dhcpd'][$dhcpif]['range']['from'], $config['dhcpd'][$dhcpif]['range']['to'])) {
 					$result['active'] = $result['active'] + 1;
 			}
 		}
 		else {
-			if (($lip >= $subnet_start) && ($lip <= $subnet_end)) {
+			if (is_inrange_v4($data['ip'], $subnet_start, $subnet_end)) {
 				$result['static'] = $result['static'] + 1;
 			}
 		}

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -400,16 +400,15 @@ if (isset($_POST['submit'])) {
 
 		if (!$input_errors) {
 			/* make sure the range lies within the current subnet */
-			$subnet_start = ip2ulong(gen_subnetv4($ifcfgip, $ifcfgsn));
-			$subnet_end = ip2ulong(gen_subnetv4_max($ifcfgip, $ifcfgsn));
+			$subnet_start = gen_subnetv4($ifcfgip, $ifcfgsn);
+			$subnet_end = gen_subnetv4_max($ifcfgip, $ifcfgsn);
 
-			if ((ip2ulong($_POST['range_from']) < $subnet_start) || (ip2ulong($_POST['range_from']) > $subnet_end) ||
-			    (ip2ulong($_POST['range_to']) < $subnet_start) || (ip2ulong($_POST['range_to']) > $subnet_end)) {
-				$input_errors[] = gettext("The specified range lies outside of the current subnet.");
+			if (ip_greater_than($_POST['range_from'], $_POST['range_to'])) {
+				$input_errors[] = gettext("The range is invalid (first element higher than second element).");
 			}
 
-			if (ip2ulong($_POST['range_from']) > ip2ulong($_POST['range_to'])) {
-				$input_errors[] = gettext("The range is invalid (first element higher than second element).");
+			if (!is_inrange_v4($_POST['range_from'], $subnet_start, $subnet_end)) {
+				$input_errors[] = gettext("The specified range lies outside of the current subnet.");
 			}
 
 			if (is_numeric($pool) || ($act == "newpool")) {
@@ -438,15 +437,12 @@ if (isset($_POST['submit'])) {
 				$input_errors[] = sprintf(gettext("You must disable the DHCP relay on the %s interface before enabling the DHCP server."), $iflist[$if]);
 			}
 
-			$dynsubnet_start = ip2ulong($_POST['range_from']);
-			$dynsubnet_end = ip2ulong($_POST['range_to']);
 			if (is_array($a_maps)) {
 				foreach ($a_maps as $map) {
 					if (empty($map['ipaddr'])) {
 						continue;
 					}
-					if ((ip2ulong($map['ipaddr']) > $dynsubnet_start) &&
-					    (ip2ulong($map['ipaddr']) < $dynsubnet_end)) {
+					if (is_inrange_v4($map['ipaddr'], $_POST['range_from'], $_POST['range_to'])) {
 						$input_errors[] = sprintf(gettext("The DHCP range cannot overlap any static DHCP mappings."));
 						break;
 					}

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -400,8 +400,8 @@ if (isset($_POST['submit'])) {
 
 		if (!$input_errors) {
 			/* make sure the range lies within the current subnet */
-			$subnet_start = ip2ulong(long2ip32(ip2long($ifcfgip) & gen_subnet_mask_long($ifcfgsn)));
-			$subnet_end = ip2ulong(long2ip32(ip2long($ifcfgip) | (~gen_subnet_mask_long($ifcfgsn))));
+			$subnet_start = ip2ulong(gen_subnetv4($ifcfgip, $ifcfgsn));
+			$subnet_end = ip2ulong(gen_subnetv4_max($ifcfgip, $ifcfgsn));
 
 			if ((ip2ulong($_POST['range_from']) < $subnet_start) || (ip2ulong($_POST['range_from']) > $subnet_end) ||
 			    (ip2ulong($_POST['range_to']) < $subnet_start) || (ip2ulong($_POST['range_to']) > $subnet_end)) {

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -238,10 +238,7 @@ if ($_POST) {
 
 	/* make sure it's not within the dynamic subnet */
 	if ($_POST['ipaddr']) {
-		$dynsubnet_start = ip2ulong($config['dhcpd'][$if]['range']['from']);
-		$dynsubnet_end = ip2ulong($config['dhcpd'][$if]['range']['to']);
-		if ((ip2ulong($_POST['ipaddr']) >= $dynsubnet_start) &&
-		    (ip2ulong($_POST['ipaddr']) <= $dynsubnet_end)) {
+		if (is_inrange_v4($_POST['ipaddr']), $config['dhcpd'][$if]['range']['from'], $config['dhcpd'][$if]['range']['to'])) {
 			$input_errors[] = sprintf(gettext("The IP address must not be within the DHCP range for this interface."));
 		}
 

--- a/src/usr/local/www/services_pppoe_edit.php
+++ b/src/usr/local/www/services_pppoe_edit.php
@@ -161,8 +161,7 @@ if ($_POST) {
 		$_POST['remoteip'] = $pconfig['remoteip'] = gen_subnet($_POST['remoteip'], $_POST['pppoe_subnet']);
 		$subnet_start = ip2ulong($_POST['remoteip']);
 		$subnet_end = ip2ulong($_POST['remoteip']) + $_POST['pppoe_subnet'] - 1;
-		if ((ip2ulong($_POST['localip']) >= $subnet_start) &&
-		    (ip2ulong($_POST['localip']) <= $subnet_end)) {
+		if (is_inrange_v4($_POST['localip'], $_POST['remoteip'], ip_after($_POST['remoteip']), $_POST['pppoe_subnet'] - 1))) {
 			$input_errors[] = gettext("The specified server address lies in the remote subnet.");
 		}
 		if ($_POST['localip'] == get_interface_ip($_POST['interface'])) {

--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -401,7 +401,7 @@ foreach ($leases as $data):
 			if (!is_array($dhcpifconf['range'])) {
 				continue;
 			}
-			if (($lip >= ip2ulong($dhcpifconf['range']['from'])) && ($lip <= ip2ulong($dhcpifconf['range']['to']))) {
+			if (is_inrange_v4($lip, $dhcpifconf['range']['from'], $dhcpifconf['range']['to'])) {
 				$data['if'] = $dhcpif;
 				$dhcp_leases_subnet_counter[$dlsc]['dhcpif'] = $dhcpif;
 				$dhcp_leases_subnet_counter[$dlsc]['from'] = $dhcpifconf['range']['from'];

--- a/src/usr/local/www/vpn_l2tp.php
+++ b/src/usr/local/www/vpn_l2tp.php
@@ -132,7 +132,7 @@ if ($_POST) {
 		if (!$input_errors) {
 			$_POST['remoteip'] = $pconfig['remoteip'] = gen_subnet($_POST['remoteip'], $_POST['l2tp_subnet']);
 			$subnet_start = ip2ulong($_POST['remoteip']);
-			$subnet_end = ip2ulong($_POST['remoteip']) + $_POST['n_l2tp_units'] - 1;
+			$subnet_end = ip2ulong(ip_after($_POST['remoteip'], $_POST['n_l2tp_units'] - 1));
 
 			if ((ip2ulong($_POST['localip']) >= $subnet_start) &&
 			    (ip2ulong($_POST['localip']) <= $subnet_end)) {

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -447,7 +447,7 @@ if ($_POST) {
 		if (($pconfig['serverbridge_dhcp_end'] && !is_ipaddrv4($pconfig['serverbridge_dhcp_end']))) {
 			$input_errors[] = gettext("Server Bridge DHCP End must be an IPv4 address.");
 		}
-		if (ip2ulong($pconfig['serverbridge_dhcp_start']) > ip2ulong($pconfig['serverbridge_dhcp_end'])) {
+		if (ip_greater_than($pconfig['serverbridge_dhcp_start'], $pconfig['serverbridge_dhcp_end'])) {
 			$input_errors[] = gettext("The Server Bridge DHCP range is invalid (start higher than end).");
 		}
 	}


### PR DESCRIPTION
Redmine 5702 identified functions ip2long32(), long2ip32() and ip2ulong() as being used quite often in a way that might break on x64 (eg "~netmask | ip" without " ... & 0xFFFFFFFF"). A review shows that these functions are almost entirely being used to do IPv4 range comparisons and manipulation for which robust high level functions already exist (or for which robustness commits are ready but can't be PR'ed until the calling code is cleaned up!)

Phil Davis suggested that code shouldn't call these functions directly, but should use the high level functions for IP manipulation instead if possible. So this is the first go at doing so. Don't know if I got them all, but got almost all if not :) Also same needs doing in packages repo.

Github says this can't be merged but "can still be created". No idea what that means.

I've reported 4 minor possible issues and queries that I noticed in passing, at Redmine # 5720, which need very quick review. I've changed one of them in this commit *(src/usr/local/www/services_dhcp.php line 447-448: surely <= and >=, not < and > to test for overlap?)* because it looks wrong, but not the other 3. Please check if my "fix" is correct. 