### PR TITLE
HTML Compliance - Interfaces / VLAN

### DIFF
--- a/src/usr/local/www/interfaces_vlan.php
+++ b/src/usr/local/www/interfaces_vlan.php
@@ -138,6 +138,7 @@ display_top_tabs($tab_array);
 					<th><?=gettext('VLAN tag');?></th>
 					<th><?=gettext('Priority');?></th>
 					<th><?=gettext('Description');?></th>
+					<th></th>
 				</tr>
 			</thead>
 <?php


### PR DESCRIPTION
A table row was 5 columns wide and exceeded the column count established by the first row (4).