### PR TITLE
Remove extra spaces on welcome text

### DIFF
--- a/src/etc/rc
+++ b/src/etc/rc
@@ -185,7 +185,7 @@ echo
 cat /etc/ascii-art/pfsense-logo-small.txt
 echo
 echo
-echo "Welcome to ${product} ${version} ${platformbanner} ..."
+echo "Welcome to ${product} ${version}${platformbanner}..."
 echo
 
 /sbin/conscontrol mute off >/dev/null


### PR DESCRIPTION
Must be feeling OCD today. The console output had 2 spaces between "2.3-ALPHA" and "on the". I also removed the space before "..." because all the subsequent lines of console output have no space before the "...'.
Actually this is a title line, so maybe the "..." could be deleted here also :)