### PR TITLE
HTML Compliance - Firewall / Aliases / Edit

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -699,7 +699,7 @@ while ($counter < count($addresses)) {
 		'address' . $counter,
 		'Address',
 		$address
-	))->addMask('address_subnet' . $counter, $address_subnet)->setWidth(4)->setPattern('[0-9, a-z, A-Z and .');
+	))->addMask('address_subnet' . $counter, $address_subnet)->setWidth(4)->setPattern('[a-zA-Z0-9\-\.\:]+');
 
 	$group->add(new Form_Input(
 		'detail' . $counter,


### PR DESCRIPTION
Bad value [0-9, a-z, A-Z and . for attribute pattern on element input: Unterminated character class 
<input class="form-control" name="address0" id="address0" type="text" value="" pattern="[0-9, a-z, A-Z and ." placeholder="Address">