### PR TITLE
HTML Compliance - Firewall / NAT / Port Forward / Edit

### DIFF
--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -771,8 +771,8 @@ $group->add(new Form_Select(
 $group->add(new Form_Input(
 	'srcbeginport_cust',
 	null,
-	'text',
-	$pconfig['srcbeginport'],
+	'number',
+	is_numeric($pconfig['srcbeginport']) ? $pconfig['srcbeginport'] : null,
 	['min' => '1', 'max' => '65536']
 ))->setHelp('Custom');
 
@@ -786,8 +786,8 @@ $group->add(new Form_Select(
 $group->add(new Form_Input(
 	'srcendport_cust',
 	null,
-	'text',
-	$pconfig['srcendport'],
+	'number',
+	is_numeric($pconfig['srcendport']) ? $pconfig['srcendport'] : null,
 	['min' => '1', 'max' => '65536']
 ))->setHelp('Custom');
 
@@ -834,8 +834,8 @@ $group->add(new Form_Select(
 $group->add(new Form_Input(
 	'dstbeginport_cust',
 	null,
-	'text',
-	$pconfig['dstbeginport'],
+	'number',
+	is_numeric($pconfig['dstbeginport']) ? $pconfig['dstbeginport'] : null,
 	['min' => '1', 'max' => '65536']
 ))->setHelp('Custom');
 
@@ -849,8 +849,8 @@ $group->add(new Form_Select(
 $group->add(new Form_Input(
 	'dstendport_cust',
 	null,
-	'text',
-	$pconfig['dstendport'],
+	'number',
+	is_numeric($pconfig['dstendport']) ? $pconfig['dstendport'] : null,
 	['min' => '1', 'max' => '65536']
 ))->setHelp('Custom');
 
@@ -883,8 +883,8 @@ $group->setHelp('Specify the port on the machine with the IP address entered abo
 $group->add(new Form_Input(
 	'localbeginport_cust',
 	null,
-	'text',
-	$pconfig['localbeginport'],
+	'number',
+	is_numeric($pconfig['localbeginport']) ? $pconfig['localbeginport'] : null,
 	['min' => '1', 'max' => '65536']
 ))->setHelp('Custom');
 


### PR DESCRIPTION
Attribute min/max not allowed on element input at this point.
<input class="form-control" name="srcbeginport_cust" id="srcbeginport_cust" type="text" value="any" min="1" max="65536">
<input class="form-control" name="srcendport_cust" id="srcendport_cust" type="text" value="any" min="1" max="65536">

Attribute min/max not allowed on element input at this point.
<input class="form-control" name="dstbeginport_cust" id="dstbeginport_cust" type="text" value="any" min="1" max="65536">
<input class="form-control" name="dstendport_cust" id="dstendport_cust" type="text" value="any" min="1" max="65536">

Attribute min/max not allowed on element input at this point.
<input class="form-control" name="localbeginport_cust" id="localbeginport_cust" type="text" min="1" max="65536">