### PR TITLE
Redmine #5728 Fix delete row button in Firewall Schedule Edit

### DIFF
--- a/src/usr/local/www/firewall_schedule_edit.php
+++ b/src/usr/local/www/firewall_schedule_edit.php
@@ -701,7 +701,7 @@ events.push(function() {
 	$('[id^=Delete]').prop('type', 'button');
 
 	$('[id^=Delete]').click(function(event) {
-		delete_row(event.target.id.slice(6));
+		fse_delete_row(event.target.id.slice(6));
 	});
 });
 //]]>
@@ -1170,7 +1170,7 @@ function insertElements(tempFriendlyTime, starttimehour, starttimemin, stoptimeh
 	$(rowhtml.replace(/@/g, counter)).insertBefore(node);
 
 	$('[id^=delete]').click(function(event) {
-		delete_row(event.target.id.slice(6));
+		fse_delete_row(event.target.id.slice(6));
 	});
 
 	counter++;
@@ -1184,7 +1184,7 @@ function insertElements(tempFriendlyTime, starttimehour, starttimemin, stoptimeh
 }
 
 // If only everything were this simple
-function delete_row(row) {
+function fse_delete_row(row) {
 	$('.schedulegrp' + row).remove();
 }
 //]]>


### PR DESCRIPTION
The calls to delete_row() were going off to some other delete_row() function and not doing what was needed.
Give delete_row() here a unique name and it all works again.