### PR TITLE
Feature #5729 Add Description to DHCP Leases list RELENG_2_2

### DIFF
--- a/usr/local/www/status_dhcp_leases.php
+++ b/usr/local/www/status_dhcp_leases.php
@@ -294,6 +294,7 @@ foreach($config['interfaces'] as $ifname => $ifarr) {
 			$slease['start'] = "";
 			$slease['end'] = "";
 			$slease['hostname'] = htmlentities($static['hostname']);
+			$slease['descr'] = htmlentities($static['descr']);
 			$slease['act'] = "static";
 			$slease['online'] = in_array(strtolower($slease['mac']), $arpdata_mac) ? 'online' : 'offline';
 			$slease['staticmap_array_index'] = $staticmap_array_index;
@@ -406,8 +407,7 @@ foreach ($leases as $data) {
 			echo "<td class=\"listr\">{$fspans}" . adjust_gmt($data['start']) . "{$fspane}</td>\n";
 			echo "<td class=\"listr\">{$fspans}" . adjust_gmt($data['end']) . "{$fspane}</td>\n";
 		} else {
-			echo "<td class=\"listr\">{$fspans} n/a {$fspane}</td>\n";
-			echo "<td class=\"listr\">{$fspans} n/a {$fspane}</td>\n";
+			echo "<td class=\"listr\" colspan=\"2\">{$fspans}" . htmlentities($data['descr']) . "{$fspane}</td>\n";
 		}
 		echo "<td class=\"listr\">{$fspans}{$data['online']}{$fspane}</td>\n";
 		echo "<td class=\"listr\">{$fspans}{$data['act']}{$fspane}</td>\n";


### PR DESCRIPTION
The start and end columns are n/a for static leases, and it is static leases for which we (might) have a description. So we could reuse the Start and End columns to show the description. That avoids any issue of using more screen width and how to fit all the columns.
I tried it at home on my 2.2.6 system and actually it is useful for me - the descriptions can be a lot more descriptive than the host name that I have put in the static mappings, so it is easier to know what is what on the status DHCP leases display with the description shown.
This is just an example based on RELENG_2_2 - but it might be the way to go?