### PR TITLE
Add back display description option for status_graph

### DIFF
--- a/src/usr/local/www/status_graph.php
+++ b/src/usr/local/www/status_graph.php
@@ -193,6 +193,7 @@ $group->add(new Form_Select(
 	array (
 		''			=> 'IP Address',
 		'hostname'	=> 'Host Name',
+		'descr'		=> 'Description',
 		'fqdn'		=> 'FQDN'
 	)
 ))->setHelp('Display');


### PR DESCRIPTION
The code that provides the data for this is already in
bandwidth_by_ip.php in both 2.2.* and master 2.3.
The description option is in the Display dropdown list in 2.2.*, but it
got missed in the bootstrap conversion and integration process.
With just this 1-line addition the Display Description option can be
selected and works.