### PR TITLE
Remove preload token from HSTS header

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1273,7 +1273,7 @@ EOD;
 		$nginx_config .= "\t\tssl_protocols   TLSv1 TLSv1.1 TLSv1.2;\n";
 		$nginx_config .= "\t\tssl_ciphers \"EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH\";\n";
 		$nginx_config .= "\t\tssl_prefer_server_ciphers       on;\n";
-		$nginx_config .= "\t\tadd_header Strict-Transport-Security \"max-age=31536000; preload\";\n";
+		$nginx_config .= "\t\tadd_header Strict-Transport-Security \"max-age=31536000\";\n";
 		$nginx_config .= "\t\tadd_header X-Content-Type-Options nosniff;\n";
 		$nginx_config .= "\t\tssl_session_tickets off;\n";
 		$nginx_config .= "\t\tssl_stapling on;\n";


### PR DESCRIPTION
Please see the documentation on how to include your domain in the preload lists:

https://hstspreload.appspot.com