### PR TITLE
HTML Compliance - Firewall / Rules / WAN

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -276,7 +276,7 @@ display_top_tabs($tab_array);
 	<div class="panel panel-default">
 		<div class="panel-heading"><?=gettext("Rules (Drag to change order)")?></div>
 		<div id="mainarea" class="table-responsive panel-body">
-			<table name="ruletable" class="table table-hover table-striped table-condensed">
+			<table class="table table-hover table-striped table-condensed">
 				<thead>
 					<tr>
 						<th><!-- checkbox --></th>
@@ -723,6 +723,7 @@ for ($i = 0; isset($a_filter[$i]); $i++):
 			"chosen. If no rule here matches, the per-interface or default rules are used. "));
 	}
 ?>
+	</div>
 	</div>
 </div>
 


### PR DESCRIPTION
Attribute name not allowed on element table at this point.
<table name="ruletable" class="table table-hover table-striped table-condensed">

Unclosed element div.
End tag for body seen, but there were unclosed elements.