### PR TITLE
Fix minor typos and correct code standards

### DIFF
--- a/src/usr/local/www/diag_reboot.php
+++ b/src/usr/local/www/diag_reboot.php
@@ -79,7 +79,7 @@ include("head.inc");
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	if (DEBUG) {
-	   print_info_box("Not actually rebooting (DEBUG is set true)", success);
+	   print_info_box("Not actually rebooting (DEBUG is set true)", 'success');
 	} else {
 		print('<div><pre>');
 		system_reboot();

--- a/src/usr/local/www/services_captiveportal_zones.php
+++ b/src/usr/local/www/services_captiveportal_zones.php
@@ -95,7 +95,7 @@ $shortcut_section = "captiveportal";
 include("head.inc");
 
 if ($savemsg) {
-	print_info_box($savemsg, success);
+	print_info_box($savemsg, 'success');
 }
 
 if (is_subsystem_dirty('captiveportal')) {

--- a/src/usr/local/www/status_logs_settings.php
+++ b/src/usr/local/www/status_logs_settings.php
@@ -226,7 +226,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg, success);
+	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -345,7 +345,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg, success);
+	print_info_box($savemsg, 'success');
 }
 ?>
 <div id="container">

--- a/src/usr/local/www/system_advanced_misc.php
+++ b/src/usr/local/www/system_advanced_misc.php
@@ -309,7 +309,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg, success);
+	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();

--- a/src/usr/local/www/system_crlmanager.php
+++ b/src/usr/local/www/system_crlmanager.php
@@ -364,7 +364,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg, 'sucess');
+	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();

--- a/src/usr/local/www/system_groupmanager_addprivs.php
+++ b/src/usr/local/www/system_groupmanager_addprivs.php
@@ -176,7 +176,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg, success);
+	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();

--- a/src/usr/local/www/system_usermanager_settings.php
+++ b/src/usr/local/www/system_usermanager_settings.php
@@ -127,7 +127,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg, success);
+	print_info_box($savemsg, 'success');
 }
 
 if ($save_and_test) {

--- a/src/usr/local/www/vpn_l2tp_users.php
+++ b/src/usr/local/www/vpn_l2tp_users.php
@@ -102,7 +102,7 @@ if ($_GET['act'] == "del") {
 include("head.inc");
 
 if ($savemsg) {
-	print_info_box($savemsg, success);
+	print_info_box($savemsg, 'success');
 }
 
 if (isset($config['l2tp']['radius']['enable'])) {


### PR DESCRIPTION
I've noticed some minor inconsistencies in how print_info_box was called with success parameter. This brings all the code to the same standard.