### PR TITLE
firewall_shaper_vinterface URL reference

### DIFF
--- a/src/usr/local/www/firewall_shaper_vinterface.php
+++ b/src/usr/local/www/firewall_shaper_vinterface.php
@@ -438,7 +438,7 @@ if ($dfltmsg) {
 			if ($queue) {
 				$url = 'firewall_shaper_vinterface.php?pipe=' . $pipe . '&queue=' . $queue->GetQname() . '&action=add';
 			} else {
-				$url = 'firewall_shaper.php?pipe='. $pipe . '&action=add';
+				$url = 'firewall_shaper_vinterface.php?pipe='. $pipe . '&action=add';
 			}
 
 			$sform->addGlobal(new Form_Button(
@@ -462,7 +462,7 @@ if ($dfltmsg) {
 	}
 
 	// Print the form
-	if($sform) {
+	if ($sform) {
 		$sform->setAction("firewall_shaper_vinterface.php");
 		print($sform);
 	}


### PR DESCRIPTION
As far as I can see this URL should be self-referring - to firewall_shaper_vinterface.php
But I am having trouble finding how to test it, because whenever $pipe is set, so is $queue so I never get down the "else".
Anyway, this seems an obvious fix, and there might be other stuff related to when creating a limiter as distinct from a queue inside that limiter.