### PR TITLE
Rationalize add and delete buttons for limiter GUI RELENG_2_2

### DIFF
--- a/usr/local/www/firewall_shaper_vinterface.php
+++ b/usr/local/www/firewall_shaper_vinterface.php
@@ -317,7 +317,7 @@ $output_form .= gettext("Queue Actions");
 $output_form .= "</td><td valign=\"top\" class=\"vncellreq\" width=\"78%\">";
 
 $output_form .= "<input type=\"submit\" name=\"Submit\" value=\"" . gettext("Save") . "\" class=\"formbtn\" />";
-if ($can_add || $addnewaltq) {
+if ($can_add && ($action != "add")) {
 	$output_form .= "<a href=\"firewall_shaper_vinterface.php?pipe=";
 	$output_form .= $pipe; 
 	if ($queue) {
@@ -327,18 +327,20 @@ if ($can_add || $addnewaltq) {
 	$output_form .= "<input type=\"button\" class=\"formbtn\" name=\"add\" value=\"" . gettext("Add new queue") ."\" />";
 	$output_form .= "</a>";
 }
-$output_form .= "<a href=\"firewall_shaper_vinterface.php?pipe=";
-$output_form .= $pipe;
-if ($queue) {
-	$output_form .= "&amp;queue=" . $queue->GetQname();
+if ($action != "add") {
+	$output_form .= "<a href=\"firewall_shaper_vinterface.php?pipe=";
+	$output_form .= $pipe;
+	if ($queue) {
+		$output_form .= "&amp;queue=" . $queue->GetQname();
+	}
+	$output_form .= "&amp;action=delete\">";
+	$output_form .= "<input type=\"button\" class=\"formbtn\" name=\"delete\"";
+	if (($queue) && ($qname != $pipe))
+		$output_form .= " value=\"" . gettext("Delete this queue") ."\" />";
+	else
+		$output_form .= " value=\"" . gettext("Delete Limiter") ."\" />";
+	$output_form .= "</a>";
 }
-$output_form .= "&amp;action=delete\">";
-$output_form .= "<input type=\"button\" class=\"formbtn\" name=\"delete\"";
-if ($queue)
-	$output_form .= " value=\"" . gettext("Delete this queue") ."\" />";
-else
-	$output_form .= " value=\"" . gettext("Delete Limiter") ."\" />";
-$output_form .= "</a>";  
 $output_form .= "</td></tr>";
 $output_form .= "</table>";
 } 


### PR DESCRIPTION
This has annoyed me in the past. I noticed it in 2.3-BETA just now and went to look on a 2.2.6 system and realized it is an issue there also.
1) When you click to add a new limiter or new queue, then the "Add new queue" button is displayed down the bottom. That is dumb - you are already adding and actually you need to enter the data and save first before adding something else.
2) When you are adding something (like in (1)) the Delete button is displayed. That is also dumb - there is nothing to delete until you have press save to add it!
3) When clicking on a Limiter at the top of the tree, the Delete button syas "Delete this queue", but it is the top level limiter that is being edited and could be deleted, The $_GET/$_POST that happens sends "pipe" and "queue" both with the name of the top-level limiter. So in the end $queue always exists. So we only want the text "Delete this queue" if $queue exists and the queue name is NOT the same as the pipe name.

I am submitting this for RELENG_2_2 because I wanted to sort that out anyway to understand what was wrong and how it should behave.

Then I can look at 2.3-BETA and make it work nicely there...