### PR TITLE
Rationalize add and delete buttons for limiter GUI

### DIFF
--- a/src/usr/local/www/firewall_shaper_vinterface.php
+++ b/src/usr/local/www/firewall_shaper_vinterface.php
@@ -434,7 +434,7 @@ if ($dfltmsg) {
 } else {
 	// Add global buttons
 	if (!$dontshow || $newqueue) {
-		if ($can_add || $addnewaltq) {
+		if ($can_add && ($action != "add")) {
 			if ($queue) {
 				$url = 'firewall_shaper_vinterface.php?pipe=' . $pipe . '&queue=' . $queue->GetQname() . '&action=add';
 			} else {
@@ -448,17 +448,19 @@ if ($dfltmsg) {
 			))->removeClass('btn-default')->addClass('btn-success');
 		}
 
-		if ($queue) {
-			$url = 'firewall_shaper_vinterface.php?pipe='. $pipe . '&queue=' . $queue->GetQname() . '&action=delete';
-		} else {
-			$url = 'firewall_shaper_vinterface.php?pipe='. $pipe . '&action=delete';
-		}
+		if ($action != "add") {
+			if ($queue) {
+				$url = 'firewall_shaper_vinterface.php?pipe='. $pipe . '&queue=' . $queue->GetQname() . '&action=delete';
+			} else {
+				$url = 'firewall_shaper_vinterface.php?pipe='. $pipe . '&action=delete';
+			}
 
-		$sform->addGlobal(new Form_Button(
-			'delete',
-			$queue ? 'Delete this queue':'Delete',
-			$url
-		))->removeClass('btn-default')->addClass('btn-danger');
+			$sform->addGlobal(new Form_Button(
+				'delete',
+				($queue && ($qname != $pipe)) ? 'Delete this queue':'Delete Limiter',
+				$url
+			))->removeClass('btn-default')->addClass('btn-danger');
+		}
 	}
 
 	// Print the form


### PR DESCRIPTION
1) When you click to add a new limiter or new queue, then the "Add new queue" button is displayed down the bottom. That is dumb - you are already adding and actually you need to enter the data and save first before adding something else.
2) When you are adding something (like in (1)) the Delete button is displayed. That is also dumb - there is nothing to delete until you have pressed save to add it!
3) When clicking on a Limiter at the top of the tree, the Delete button says "Delete this queue", but it is the top level limiter that is being edited and could be deleted, The $_GET/$_POST that happens sends "pipe" and "queue" both with the name of the top-level limiter. So in the end $queue always exists. So we only want the text "Delete this queue" if $queue exists and the queue name is NOT the same as the pipe name.

Note: These issues are also in 2.2.6 - see https://github.com/pfsense/pfsense/pull/2362 for the changes to fix in RELENG_2_2.