### PR TITLE
Config history info - make it an info box

### DIFF
--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -206,9 +206,18 @@ $form->add($section);
 print($form);
 
 if (is_array($confvers)) {
-	print_info_box(gettext('To view the differences between an older configuration and a newer configuration, ' .
-						   'select the older configuration using the left column of radio options and select the newer configuration in the right column, ' .
-						   'then press the "Diff" button.'));
+?>
+<div>
+	<div id="infoblock">
+		<?=print_info_box(
+			gettext(
+				'To view the differences between an older configuration and a newer configuration, ' .
+				'select the older configuration using the left column of radio options and select the newer configuration in the right column, ' .
+				'then press the "Diff" button.'),
+			'info')?>
+	</div>
+</div>
+<?php
 }
 ?>
 


### PR DESCRIPTION
Currently this display as an orange box. It seems to me that it is ordinary info and should be an info box (displaying in blue).
Note: with the current behavior the text is always displayed, after changing it to an info box the "i" icon has to be clicked to show the text.
Do we sometimes(like in this example) want the info text to be automagically displayed on initial page load?