### PR TITLE
status_logs_filter_summary make the info an info box

### DIFF
--- a/src/usr/local/www/status_logs_filter_summary.php
+++ b/src/usr/local/www/status_logs_filter_summary.php
@@ -157,7 +157,7 @@ print("<br />");
 $infomsg = sprintf(gettext('This is a summary of the last %1$s lines of the firewall log (Max %2$s).'), $gotlines, $lines);
 ?>
 <div>
-	<div id="infoblock">
+	<div id="infoblock_open">
 		<?=print_info_box($infomsg, 'info');?>
 	</div>
 </div>

--- a/src/usr/local/www/status_logs_filter_summary.php
+++ b/src/usr/local/www/status_logs_filter_summary.php
@@ -153,11 +153,14 @@ foreach ($filterlog as $fe) {
 	}
 }
 
-
 print("<br />");
-$infomsg = sprintf('This is a summary of the last %1$s lines of the firewall log (Max %2$s).', $gotlines, $lines);
-print_info_box($infomsg, info);
+$infomsg = sprintf(gettext('This is a summary of the last %1$s lines of the firewall log (Max %2$s).'), $gotlines, $lines);
 ?>
+<div>
+	<div id="infoblock">
+		<?=print_info_box($infomsg, 'info');?>
+	</div>
+</div>
 
 <script src="d3pie/d3pie.min.js"></script>
 <script src="d3pie/d3.min.js"></script>


### PR DESCRIPTION
The existing behavior in 2.3-BETA is that if you close this box with the "x" it goes away completely and you cannot get it back.
Do we want to make it a "proper" info box that can be open and closed as desired? (like I did here)
Note: with this change the info "i" is displayed in the closed state. Maybe it should be open by default?