### PR TITLE
HTML Compliance - Firewall / Schedules / Edit

### DIFF
--- a/src/usr/local/www/firewall_schedule_edit.php
+++ b/src/usr/local/www/firewall_schedule_edit.php
@@ -286,8 +286,8 @@ function build_date_table() {
 		$mostr .= '" class="col-md-6">';
 
 		$mostr .=
-			'<table class="table table-condensed" border="1" cellspacing="1" cellpadding="1" id="calTable' . $monthcounter . $yearcounter . '" >
-				<thead><tr class="info"><td colspan="7" align="center" ><b>' . date("F_Y", mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter))) . '</b></td>
+			'<table class="table table-condensed table-bordered" id="calTable' . $monthcounter . $yearcounter . '" >
+				<thead><tr class="info"><td colspan="7" class="text-center"><b>' . date("F_Y", mktime(0, 0, 0, date($monthcounter), 1, date($yearcounter))) . '</b></td>
 				</tr>
 				<tr>
 					<th class="text-center" style="cursor: pointer;" onclick="daytoggle(\'w1p1\');">' . gettext("Mon") . '</th>
@@ -325,7 +325,14 @@ function build_date_table() {
 						$mostr .= '<td class="text-center"></td>';
 					}
 
-					if ($positioncounter == 7 || $daycounter > $numberofdays) {
+					if ($daycounter > $numberofdays) {
+						while ($positioncounter < 7) {
+							$mostr .= '<td class="text-center"></td>';
+							$positioncounter++;
+						}
+					}
+
+					if ($positioncounter == 7) {
 						$positioncounter = 1;
 						$mostr .= "</tr>";
 					} else {


### PR DESCRIPTION
The align attribute on the td element is obsolete. Use CSS instead.
The cellspacing attribute on the table element is obsolete. Use CSS instead.
The cellpadding attribute on the table element is obsolete. Use CSS instead.
The border attribute on the table element is presentational markup. Consider using CSS instead. 
A table row was 6 columns wide, which is less than the column count established by the first row (7).