### PR TITLE
Make bogons update message a success

### DIFF
--- a/src/usr/local/www/diag_tables.php
+++ b/src/usr/local/www/diag_tables.php
@@ -122,7 +122,7 @@ exec("/sbin/pfctl -sT", $tables);
 include("head.inc");
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 
 $form = new Form('Show');


### PR DESCRIPTION
When this actually works (after https://redmine.pfsense.org/issues/5742 is addressed) then the message here should be a success one.