### PR TITLE
Remove unused var in get_std_save_message

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -380,7 +380,6 @@ function print_info_box($msg, $class="alert-warning") {
 }
 
 function get_std_save_message($ok) {
-	global $d_sysrebootreqd_path;
 	$filter_related = false;
 	$filter_pages = array("nat", "filter");
 	$to_return = gettext("The changes have been applied successfully.");


### PR DESCRIPTION
$d_sysrebootreqd_path seems to be a leftover from some ancient group of global $d_* vars that are no longer used.