### PR TITLE
Some improvements in PHP code and configurations

### DIFF
--- a/src/etc/rc.php_ini_setup
+++ b/src/etc/rc.php_ini_setup
@@ -181,6 +181,7 @@ implicit_flush = true
 magic_quotes_gpc = Off
 max_execution_time = 900
 max_input_time = 1800
+max_input_vars = 5000
 register_argc_argv = On
 register_long_arrays = Off
 variables_order = "GPCS"

--- a/src/usr/local/www/diag_sockets.php
+++ b/src/usr/local/www/diag_sockets.php
@@ -148,7 +148,7 @@ gettext('This page shows the output for the commands: "sockstat -4lL" and "socks
 				'<dt>ADDRESS</dt>		<dd>(UNIX sockets only) For bound sockets, this is the file-name of the socket. For other sockets, it is the name, PID and file descriptor number of the peer, or "(none)" if the socket is neither bound nor connected.</dd>' .
 				'<dt>LOCAL ADDRESS</dt> <dd>(Internet sockets only) The address the local end of the socket is bound to (see getsockname(2)).</dd>' .
 				'<dt>FOREIGN ADDRESS</dt><dd>(Internet sockets only) The address the foreign end of the socket is bound to (see getpeername(2)).</dd>' .
-			'</dl>'), info);
+			'</dl>'), 'info');
 ?>
 </div>
 </div>

--- a/src/usr/local/www/firewall_aliases.php
+++ b/src/usr/local/www/firewall_aliases.php
@@ -315,7 +315,7 @@ display_top_tabs($tab_array);
 		<?=print_info_box(gettext('Aliases act as placeholders for real hosts, networks or ports. They can be used to minimize the number ' .
 			'of changes that have to be made if a host, network or port changes. <br />' .
 			'You can enter the name of an alias instead of the host, network or port where indicated. The alias will be resolved according to the list above.' . '<br />' .
-			'If an alias cannot be resolved (e.g. because you deleted it), the corresponding element (e.g. filter/NAT/shaper rule) will be considered invalid and skipped.'), info)?>
+			'If an alias cannot be resolved (e.g. because you deleted it), the corresponding element (e.g. filter/NAT/shaper rule) will be considered invalid and skipped.'), 'info')?>
 	</div>
 </div>
 

--- a/src/usr/local/www/firewall_nat_1to1.php
+++ b/src/usr/local/www/firewall_nat_1to1.php
@@ -283,7 +283,7 @@ display_top_tabs($tab_array);
 			   gettext('If you add a 1:1 NAT entry for any of the interface IPs on this system, ' .
 					   'it will make this system inaccessible on that IP address. i.e. if ' .
 					   'you use your WAN IP address, any services on this system (IPsec, OpenVPN server, etc.) ' .
-					   'using the WAN IP address will no longer function.'), info)?>
+					   'using the WAN IP address will no longer function.'), 'info')?>
 
 </div>
 

--- a/src/usr/local/www/firewall_schedule.php
+++ b/src/usr/local/www/firewall_schedule.php
@@ -280,7 +280,7 @@ endforeach;
 </nav>
 
 <div id="infoblock">
-	<?=print_info_box(gettext('Schedules act as placeholders for time ranges to be used in Firewall Rules.'), info)?>
+	<?=print_info_box(gettext('Schedules act as placeholders for time ranges to be used in Firewall Rules.'), 'info')?>
 </div>
 
 <?php

--- a/src/usr/local/www/firewall_shaper.php
+++ b/src/usr/local/www/firewall_shaper.php
@@ -507,7 +507,7 @@ if ($dfltmsg) {
 ?>
 <div>
 	<div id="infoblock">
-		<?=print_info_box($default_shaper_msg, info)?>
+		<?=print_info_box($default_shaper_msg, 'info')?>
 	</div>
 </div>
 <?php

--- a/src/usr/local/www/firewall_virtual_ip.php
+++ b/src/usr/local/www/firewall_virtual_ip.php
@@ -366,7 +366,7 @@ endforeach;
 
 <div id="infoblock">
 	<?=print_info_box(gettext('The virtual IP addresses defined on this page may be used in ') . '<a href="firewall_nat.php">' . gettext('NAT') . '</a>' . gettext(' mappings.') . '<br />' .
-			   gettext('You can check the status of your CARP Virtual IPs and interfaces ') . '<a href="status_carp.php">' . gettext('here') . '</a>', info)?>
+			   gettext('You can check the status of your CARP Virtual IPs and interfaces ') . '<a href="status_carp.php">' . gettext('here') . '</a>', 'info')?>
 </div>
 
 <?php

--- a/src/usr/local/www/firewall_virtual_ip_edit.php
+++ b/src/usr/local/www/firewall_virtual_ip_edit.php
@@ -491,7 +491,7 @@ print($form);
 
 <div id="infoblock">
 	<?=print_info_box(gettext("Proxy ARP and Other type Virtual IPs cannot be bound to by anything running on the firewall, such as IPsec, OpenVPN, etc.  Use a CARP or IP Alias type address for these types.") . '<br />' .
-			   sprintf(gettext("For more information on CARP and the above values, visit the OpenBSD %s"), '<a href="http://www.openbsd.org/faq/pf/carp.html">CARP FAQ</a>.'), info)?>
+			   sprintf(gettext("For more information on CARP and the above values, visit the OpenBSD %s"), '<a href="http://www.openbsd.org/faq/pf/carp.html">CARP FAQ</a>.'), 'info')?>
 </div>
 
 <script type="text/javascript">

--- a/src/usr/local/www/interfaces_groups.php
+++ b/src/usr/local/www/interfaces_groups.php
@@ -158,7 +158,7 @@ display_top_tabs($tab_array);
 
 <div id="infoblock">
 	<?=print_info_box(gettext('Interface Groups allow you to setup rules for multiple interfaces without duplicating the rules.<br />' .
-					   'If you remove members from an interface group, the group rules are no longer applicable to that interface.'), info)?>
+					   'If you remove members from an interface group, the group rules are no longer applicable to that interface.'), 'info')?>
 
 </div>
 <?php

--- a/src/usr/local/www/interfaces_qinq.php
+++ b/src/usr/local/www/interfaces_qinq.php
@@ -185,7 +185,7 @@ endforeach;
 <div id="infoblock">
 	<?=print_info_box(sprintf(gettext('Not all drivers/NICs support 802.1Q QinQ tagging properly. <br />On cards that do not explicitly support it, ' .
 		'QinQ tagging will still work, but the reduced MTU may cause problems.<br />' .
-		'See the %s handbook for information on supported cards.'), $g['product_name']), info)?>
+		'See the %s handbook for information on supported cards.'), $g['product_name']), 'info')?>
 </div>
 
 <?php

--- a/src/usr/local/www/interfaces_vlan.php
+++ b/src/usr/local/www/interfaces_vlan.php
@@ -174,7 +174,7 @@ display_top_tabs($tab_array);
 	<?=print_info_box(sprintf(gettext('NOTE: Not all drivers/NICs support 802.1Q '.
 		'VLAN tagging properly. <br />On cards that do not explicitly support it, VLAN '.
 		'tagging will still work, but the reduced MTU may cause problems.<br />See the '.
-		'%s handbook for information on supported cards.'), $g['product_name']), info)?>
+		'%s handbook for information on supported cards.'), $g['product_name']), 'info')?>
 </div>
 <script type="text/javascript">
 //<![CDATA[

--- a/src/usr/local/www/services_captiveportal_ip.php
+++ b/src/usr/local/www/services_captiveportal_ip.php
@@ -194,7 +194,7 @@ endif;
 
 <div id="infoblock">
 <?=print_info_box(gettext('Adding allowed IP addresses will allow IP access to/from these addresses through the captive portal without being taken to the portal page. ' .
-					   'This can be used for a web server serving images for the portal page or a DNS server on another network, for example.'), info)?>
+					   'This can be used for a web server serving images for the portal page or a DNS server on another network, for example.'), 'info')?>
 </div>
 
 <?php

--- a/src/usr/local/www/services_captiveportal_mac.php
+++ b/src/usr/local/www/services_captiveportal_mac.php
@@ -256,7 +256,7 @@ endif;
 </nav>
 
 <div id="infoblock">
-	<?=print_info_box(gettext('Adding MAC addresses as "pass" MACs allows them access through the captive portal automatically without being taken to the portal page.'), info)?>
+	<?=print_info_box(gettext('Adding MAC addresses as "pass" MACs allows them access through the captive portal automatically without being taken to the portal page.'), 'info')?>
 </div>
 <?php
 include("foot.inc");

--- a/src/usr/local/www/services_captiveportal_vouchers.php
+++ b/src/usr/local/www/services_captiveportal_vouchers.php
@@ -639,7 +639,7 @@ print($form);
 <div class="rolledit">
 <?php
 	print_info_box(gettext('Changing any Voucher parameter (apart from managing the list of Rolls) on this page will render existing vouchers useless if they were generated with different settings. ' .
-							'Specifying the Voucher Database Synchronization options will not record any other value from the other options. They will be retrieved/synced from the master.'), info);
+							'Specifying the Voucher Database Synchronization options will not record any other value from the other options. They will be retrieved/synced from the master.'), 'info');
 ?>
 </div>
 

--- a/src/usr/local/www/services_dnsmasq.php
+++ b/src/usr/local/www/services_dnsmasq.php
@@ -352,7 +352,7 @@ print_info_box(sprintf("If the DNS forwarder is enabled, the DHCP".
 	" is checked. If you don't use that option (or if you use".
 	" a static IP address on WAN), you must manually specify at".
 	" least one DNS server on the %sSystem:".
-	"General setup%s page.",'<a href="system.php">','</a>','<a href="system.php">','</a>'), info);
+	"General setup%s page.",'<a href="system.php">','</a>','<a href="system.php">','</a>'), 'info');
 ?>
 
 <div class="panel panel-default">
@@ -432,7 +432,7 @@ endforeach;
 
 <?php
 print_info_box(gettext("Entries in this section override individual results from the forwarders.") .
-				gettext("Use these for changing DNS results or for adding custom DNS records."), info);
+				gettext("Use these for changing DNS results or for adding custom DNS records."), 'info');
 ?>
 
 <div class="panel panel-default">
@@ -496,6 +496,6 @@ events.push(function() {
 </script>
 <?php
 print_info_box(gettext("Entries in this area override an entire domain, and subdomains, by specifying an".
-						" authoritative DNS server to be queried for that domain."), info);
+						" authoritative DNS server to be queried for that domain."), 'info');
 
 include("foot.inc");

--- a/src/usr/local/www/services_igmpproxy.php
+++ b/src/usr/local/www/services_igmpproxy.php
@@ -185,7 +185,7 @@ endforeach;
 
 <div id="infoblock">
 <?=print_info_box(gettext('Please add the interface for upstream, the allowed subnets, and the downstream interfaces you would like the proxy to allow. ' .
-					   'Only one "upstream" interface can be configured.'), info)?>
+					   'Only one "upstream" interface can be configured.'), 'info')?>
 </div>
 <?php
 include("foot.inc");

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -550,7 +550,7 @@ endforeach;
 		" entered in %sSystem: General setup%s".
 		" or those obtained via DHCP or PPP on WAN if &quot;Allow".
 		" DNS server list to be overridden by DHCP/PPP on WAN&quot;".
-		" is checked."), '<a href="system.php">', '</a>'), info)?>
+		" is checked."), '<a href="system.php">', '</a>'), 'info')?>
 </div>
 
 <?php include("foot.inc");

--- a/src/usr/local/www/status_logs_filter_summary.php
+++ b/src/usr/local/www/status_logs_filter_summary.php
@@ -156,7 +156,7 @@ foreach ($filterlog as $fe) {
 
 print("<br />");
 $infomsg = sprintf('This is a summary of the last %1$s lines of the firewall log (Max %2$s).', $gotlines, $lines);
-print_info_box($infomsg, info);
+print_info_box($infomsg, 'info');
 ?>
 
 <script src="d3pie/d3pie.min.js"></script>

--- a/src/usr/local/www/status_wireless.php
+++ b/src/usr/local/www/status_wireless.php
@@ -246,6 +246,6 @@ display_top_tabs($tab_array);
 <?php
 print_info_box('<b>Flags:</b> A = authorized, E = Extended Rate (802.11g), P = Power saving mode<br />' .
 			   '<b>Capabilities:</b> E = ESS (infrastructure mode), I = IBSS (ad-hoc mode), P = privacy (WEP/TKIP/AES), ' .
-			   'S = Short preamble, s = Short slot time', info);
+			   'S = Short preamble, s = Short slot time', 'info');
 
 include("foot.inc");

--- a/src/usr/local/www/system_gateway_groups.php
+++ b/src/usr/local/www/system_gateway_groups.php
@@ -204,7 +204,7 @@ endforeach;
 <div id="infoblock">
 	<?=print_info_box(gettext('Remember to use these Gateway Groups in firewall rules in order to enable load balancing, failover, ' .
 						   'or policy-based routing.' . '<br />' .
-						   'Without rules directing traffic into the Gateway Groups, they will not be used.'), info)?>
+						   'Without rules directing traffic into the Gateway Groups, they will not be used.'), 'info')?>
 </div>
 <?php
 include("foot.inc");

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -549,7 +549,7 @@ foreach ($a_user as $i => $userent):
 	"Some system object properties can be modified but they cannot be deleted.") .
 	'<br /><br />' .
 	gettext("Accounts added here are also used for other parts of the system " .
-	"such as OpenVPN, IPsec, and Captive Portal."), info)?>
+	"such as OpenVPN, IPsec, and Captive Portal."), 'info')?>
 </div>
 
 <?php

--- a/src/usr/local/www/vpn_ipsec.php
+++ b/src/usr/local/www/vpn_ipsec.php
@@ -565,7 +565,7 @@ display_top_tabs($tab_array);
 	<?=print_info_box('<strong>' . gettext("Note:") . '</strong><br />' .
 	gettext("You can check your IPsec status at ") . '<a href="status_ipsec.php">' . gettext("Status:IPsec") . '</a>.<br />' .
 	gettext("IPsec Debug Mode can be enabled at ") . '<a href="vpn_ipsec_settings.php">' .gettext("VPN:IPsec:Advanced Settings") . '</a>.<br />' .
-	gettext("IPsec can be set to prefer older SAs at ") . '<a href="vpn_ipsec_settings.php">' . gettext("VPN:IPsec:Advanced Settings") . '</a>', info)?>
+	gettext("IPsec can be set to prefer older SAs at ") . '<a href="vpn_ipsec_settings.php">' . gettext("VPN:IPsec:Advanced Settings") . '</a>', 'info')?>
 </div>
 
 <script type="text/javascript">

--- a/src/usr/local/www/vpn_l2tp.php
+++ b/src/usr/local/www/vpn_l2tp.php
@@ -368,7 +368,7 @@ $form->add($section);
 
 print($form);
 
-print_info_box(gettext("Don't forget to add a firewall rule to permit traffic from L2TP clients!"), info);
+print_info_box(gettext("Don't forget to add a firewall rule to permit traffic from L2TP clients!"), 'info');
 ?>
 
 <script type="text/javascript">


### PR DESCRIPTION
I've noticed some minor inconsistencies in how print_info_box was called with info parameter. This brings all the code to the same standard.

Additionally, since Suhosin has a configured limit of 5000 maximum input variables, for consistency, PHP should be configured with a similar setting (the default is just 1000). This will allow BIG forms to save without any problem in the future.

Thanks.