### PR TITLE
Unset $entries array after clearing table

### DIFF
--- a/src/usr/local/www/diag_tables.php
+++ b/src/usr/local/www/diag_tables.php
@@ -90,6 +90,7 @@ if ($_POST['clearall']) {
 			exec("/sbin/pfctl -t " . escapeshellarg($tablename) . " -T delete " . escapeshellarg($entry), $delete);
 		}
 	}
+	unset($entries);
 }
 
 if (($tablename == "bogons") || ($tablename == "bogonsv6")) {


### PR DESCRIPTION
Without this, when the table is cleared then the "now old and gone" entries are being redisplayed the first time after the clear table happens.