### PR TITLE
Convert short open tags to full tags

### DIFF
--- a/src/usr/local/www/diag_dns.php
+++ b/src/usr/local/www/diag_dns.php
@@ -260,7 +260,7 @@ if (!$input_errors && $type) {
 		</ul>
 	</div>
 </div>
-<? endif?>
+<?php endif; ?>
 
 <!-- Second table displays the server resolution times -->
 <div class="panel panel-default">
@@ -275,11 +275,11 @@ if (!$input_errors && $type) {
 		</thead>
 
 		<tbody>
-<? foreach ((array)$dns_speeds as $qt):?>
+<?php foreach ((array)$dns_speeds as $qt):?>
 		<tr>
 			<td><?=$qt['dns_server']?></td><td><?=$qt['query_time']?></td>
 		</tr>
-<? endforeach?>
+<?php endforeach; ?>
 		</tbody>
 		</table>
 	</div>

--- a/src/usr/local/www/diag_ndp.php
+++ b/src/usr/local/www/diag_ndp.php
@@ -156,7 +156,7 @@ include("head.inc");
 
 						<?php if (isset($mac_man[$mac_hi])):?>
 							(<?=$mac_man[$mac_hi]?>)
-						<?endif?>
+						<?php endif; ?>
 
 					</td>
 					<td>

--- a/src/usr/local/www/diag_ndp.php
+++ b/src/usr/local/www/diag_ndp.php
@@ -154,7 +154,7 @@ include("head.inc");
 						?>
 						<?=$mac?>
 
-						<? if (isset($mac_man[$mac_hi])):?>
+						<?php if (isset($mac_man[$mac_hi])):?>
 							(<?=$mac_man[$mac_hi]?>)
 						<?endif?>
 

--- a/src/usr/local/www/exec.php
+++ b/src/usr/local/www/exec.php
@@ -240,7 +240,7 @@ if (!isBlank($_POST['txtCommand'])):?>
 			</div>
 		</div>
 	</div>
-<? endif ?>
+<?php endif; ?>
 
 <form action="exec.php" method="post" enctype="multipart/form-data" name="frmExecPlus" onsubmit="return frmExecPlus_onSubmit( this );">
 	<div class="panel panel-default">

--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -425,7 +425,7 @@ foreach ($leases as $data):
 
 						<?php if (isset($mac_man[$mac_hi])):?>
 							(<?=$mac_man[$mac_hi]?>)
-						<?endif?>
+						<?php endif; ?>
 					</td>
 					<td><?=htmlentities($data['hostname'])?></td>
 <?php if ($data['type'] != "static"):?>

--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -342,7 +342,7 @@ if (count($pools) > 0) {
 			</tr>
 		</thead>
 		<tbody>
-<? foreach ($pools as $data):?>
+<?php foreach ($pools as $data):?>
 			<tr>
 				<td><?=$data['name']?></td>
 				<td><?=$data['mystate']?></td>
@@ -350,7 +350,7 @@ if (count($pools) > 0) {
 				<td><?=$data['peerstate']?></td>
 				<td><?=adjust_gmt($data['peerdate'])?></td>
 			</tr>
-<? endforeach?>
+<?php endforeach; ?>
 		</tbody>
 		</table>
 	</div>
@@ -423,36 +423,36 @@ foreach ($leases as $data):
 					<td>
 						<?=$mac?>
 
-						<? if (isset($mac_man[$mac_hi])):?>
+						<?php if (isset($mac_man[$mac_hi])):?>
 							(<?=$mac_man[$mac_hi]?>)
 						<?endif?>
 					</td>
 					<td><?=htmlentities($data['hostname'])?></td>
-<? if ($data['type'] != "static"):?>
+<?php if ($data['type'] != "static"):?>
 					<td><?=adjust_gmt($data['start'])?></td>
 					<td><?=adjust_gmt($data['end'])?></td>
-<? else: ?>
+<?php else: ?>
 					<td>n/a</td>
 					<td>n/a</td>
-<? endif; ?>
+<?php endif; ?>
 					<td><?=$data['online']?></td>
 					<td><?=$data['act']?></td>
 					<td>
-<? if ($data['type'] == "dynamic"): ?>
+<?php if ($data['type'] == "dynamic"): ?>
 						<a class="fa fa-plus-square-o"	title="<?=gettext("Add static mapping")?>"	href="services_dhcp_edit.php?if=<?=$data['if']?>&amp;mac=<?=$data['mac']?>&amp;hostname=<?=htmlspecialchars($data['hostname'])?>"></a>
-<? else: ?>
+<?php else: ?>
 						<a class="fa fa-pencil"	title="<?=gettext('Edit static mapping')?>"	href="services_dhcp_edit.php?if=<?=$data['if']?>&amp;id=<?=$data['staticmap_array_index']?>"></a>
-<? endif; ?>
+<?php endif; ?>
 						<a class="fa fa-plus-square" title="<?=gettext("Add WOL mapping")?>" href="services_wol_edit.php?if=<?=$data['if']?>&amp;mac=<?=$data['mac']?>&amp;descr=<?=htmlentities($data['hostname'])?>"></a>
-<? if ($data['online'] != "online"):?>
+<?php if ($data['online'] != "online"):?>
 						<a class="fa fa-power-off" title="<?=gettext("Send WOL packet")?>" href="services_wol.php?if=<?=$data['if']?>&amp;mac=<?=$data['mac']?>"></a>
-<? endif; ?>
+<?php endif; ?>
 
-<? if ($data['type'] == "dynamic" && $data['online'] != "online"):?>
+<?php if ($data['type'] == "dynamic" && $data['online'] != "online"):?>
 						<a class="fa fa-trash" title="<?=gettext('Delete lease')?>"	href="status_dhcp_leases.php?deleteip=<?=$data['ip']?>&amp;all=<?=intval($_GET['all'])?>"></a>
-<? endif?>
+<?php endif; ?>
 					</td>
-<? endforeach; ?>
+<?php endforeach; ?>
 				</tr>
 			</tbody>
 		</table>
@@ -472,14 +472,14 @@ foreach ($leases as $data):
 				</tr>
 			</thead>
 			<tbody>
-<? foreach ($dhcp_leases_subnet_counter as $listcounters):?>
+<?php foreach ($dhcp_leases_subnet_counter as $listcounters):?>
 				<tr>
 					<td><?=$iflist[$listcounters['dhcpif']]?></td>
 					<td><?=$listcounters['from']?></td>
 					<td><?=$listcounters['to']?></td>
 					<td><?=$listcounters['count']?></td>
 				</tr>
-<? endforeach; ?>
+<?php endforeach; ?>
 			</tbody>
 		</table>
 	</div>

--- a/src/usr/local/www/status_dhcpv6_leases.php
+++ b/src/usr/local/www/status_dhcpv6_leases.php
@@ -498,7 +498,7 @@ foreach ($leases as $data):
 
 					<?php if (isset($mac_man[$mac_hi])):?>
 						(<?=$mac_man[$mac_hi]?>)
-					<?endif?>
+					<?php endif; ?>
 				</td>
 				<td><?=htmlentities($data['hostname'])?></td>
 <?php if ($data['type'] != "static"):?>

--- a/src/usr/local/www/status_dhcpv6_leases.php
+++ b/src/usr/local/www/status_dhcpv6_leases.php
@@ -411,7 +411,7 @@ if (count($pools) > 0) {
 			</tr>
 		</thead>
 		<tbody>
-<? foreach ($pools as $data):?>
+<?php foreach ($pools as $data):?>
 			<tr>
 				<td><?=$data['name']?></td>
 				<td><?=$data['mystate']?></td>
@@ -419,7 +419,7 @@ if (count($pools) > 0) {
 				<td><?=$data['peerstate']?></td>
 				<td><?=adjust_gmt($data['peerdate'])?></td>
 			</tr>
-<? endforeach?>
+<?php endforeach; ?>
 		</tbody>
 		</table>
 	</div>
@@ -496,30 +496,30 @@ foreach ($leases as $data):
 				<td>
 					<?=$mac?>
 
-					<? if (isset($mac_man[$mac_hi])):?>
+					<?php if (isset($mac_man[$mac_hi])):?>
 						(<?=$mac_man[$mac_hi]?>)
 					<?endif?>
 				</td>
 				<td><?=htmlentities($data['hostname'])?></td>
-<? if ($data['type'] != "static"):?>
+<?php if ($data['type'] != "static"):?>
 				<td><?=adjust_gmt($data['start'])?></td>
 				<td><?=adjust_gmt($data['end'])?></td>
-<? else: ?>
+<?php else: ?>
 				<td>n/a</td>
 				<td>n/a</td>
-<? endif; ?>
+<?php endif; ?>
 				<td><?=$data['online']?></td>
 				<td><?=$data['act']?></td>
 				<td>
-<? if ($data['type'] == "dynamic"): ?>
+<?php if ($data['type'] == "dynamic"): ?>
 					<a <a class="fa fa-plus-square-o" title="<?=gettext("Add static mapping")?>" href="services_dhcpv6_edit.php?if=<?=$data['if']?>&amp;duid=<?=$data['duid']?>&amp;hostname=<?=htmlspecialchars($data['hostname'])?>"></a>
-<? endif; ?>
+<?php endif; ?>
 					<a class="fa fa-plus-square" title="<?=gettext("Add WOL mapping")?>" href="services_wol_edit.php?if=<?=$data['if']?>&amp;mac=<?=$data['mac']?>&amp;descr=<?=htmlentities($data['hostname'])?>"></a>
-<? if ($data['type'] == "dynamic" && $data['online'] != "online"):?>
+<?php if ($data['type'] == "dynamic" && $data['online'] != "online"):?>
 					<a class="fa fa-trash" title="<?=gettext('Delete lease')?>"	href="status_dhcpv6_leases.php?deleteip=<?=$data['ip']?>&amp;all=<?=intval($_GET['all'])?>"></a>
-<? endif?>
+<?php endif; ?>
 				</td>
-<? endforeach; ?>
+<?php endforeach; ?>
 			</tr>
 		</tbody>
 		</table>
@@ -582,22 +582,22 @@ foreach ($prefixes as $data):
 				<td><i class="fa <?=$icon?>"></i></td>
 				<td>
 					<?=$data['prefix']?>
-<? if ($mappings[$data['iaid'] . $data['duid']]): ?>
+<?php if ($mappings[$data['iaid'] . $data['duid']]): ?>
 					<br />
 					<?=gettext('Routed To')?>: <?=$mappings[$data['iaid'] . $data['duid']]?>
-<? endif; ?>
+<?php endif; ?>
 				</td>
 				<td><?=$data['iaid']?></td>
 				<td><?=$data['duid']?></td>
-<? if ($data['type'] != "static"):?>
+<?php if ($data['type'] != "static"):?>
 				<td><?=adjust_gmt($data['start'])?></td>
 				<td><?=adjust_gmt($data['end'])?></td>
-<? else: ?>
+<?php else: ?>
 				<td>n/a</td>
 				<td>n/a</td>
-<? endif; ?>
+<?php endif; ?>
 				<td><?=$data['act']?></td>
-<? endforeach; ?>
+<?php endforeach; ?>
 			</tr>
 		</tbody>
 		</table>

--- a/src/usr/local/www/status_graph.php
+++ b/src/usr/local/www/status_graph.php
@@ -262,8 +262,8 @@ if (ipsec_enabled()) {
 			<object data="graph.php?ifnum=<?=htmlspecialchars($curif);?>&amp;ifname=<?=rawurlencode($ifdescrs[htmlspecialchars($curif)]);?>">
 				<param name="id" value="graph" />
 				<param name="type" value="image/svg+xml" />
-				<param name="width" value="<? echo $width; ?>" />
-				<param name="height" value="<? echo $height; ?>" />
+				<param name="width" value="<?php echo $width; ?>" />
+				<param name="height" value="<?php echo $height; ?>" />
 				<param name="pluginspage" value="http://www.adobe.com/svg/viewer/install/auto" />
 			</object>
 		</div>

--- a/src/usr/local/www/status_logs_vpn.php
+++ b/src/usr/local/www/status_logs_vpn.php
@@ -186,13 +186,13 @@ if (!$rawfilter) {
 							<?=htmlspecialchars($filterent['time'])?>
 						</td>
 						<td style="word-wrap:break-word; word-break:break-all; white-space:normal">
-							<? if ($filterent['action'] == "login") { ?>
+							<?php if ($filterent['action'] == "login") { ?>
 							<i class="fa fa-arrow-left" title="in"></i>
-							<? } else if ($filterent['action'] == "logout") { ?>
+							<?php } else if ($filterent['action'] == "logout") { ?>
 							<i class="fa fa-arrow-right" title="out"></i>
-							<? } else { ?>
+							<?php } else { ?>
 							<i><?=htmlspecialchars($filterent['action'])?></i>
-							<? } ?>
+							<?php } ?>
 						</td>
 						<td>
 							<?=htmlspecialchars($filterent['user'])?>

--- a/src/usr/local/www/system_gateways.php
+++ b/src/usr/local/www/system_gateways.php
@@ -319,7 +319,7 @@ foreach ($a_gateways as $i => $gateway):
 			<a href="system_gateways_edit.php?id=<?=$i?>" class="fa fa-pencil" title="<?=gettext('Edit');?>"></a>
 			<a href="system_gateways_edit.php?dup=<?=$i?>" class="fa fa-clone" title="<?=gettext('Copy')?>"></a>
 
-<? if (is_numeric($gateway['attribute'])): ?>
+<?php if (is_numeric($gateway['attribute'])): ?>
 	<?php if (isset($gateway['disabled'])) {
 	?>
 			<a href="?act=toggle&amp;id=<?=$i?>" class="fa fa-check-square-o" title="<?=gettext('Enable')?>"></a>
@@ -330,10 +330,10 @@ foreach ($a_gateways as $i => $gateway):
 	?>
 			<a href="system_gateways.php?act=del&amp;id=<?=$i?>" class="fa fa-trash" title="<?=gettext('Delete')?>"></a>
 
-<? endif?>
+<?php endif; ?>
 		</td>
 	</tr>
-<? endforeach?>
+<?php endforeach; ?>
 </tbody>
 </table>
 

--- a/src/usr/local/www/system_routes.php
+++ b/src/usr/local/www/system_routes.php
@@ -315,7 +315,7 @@ foreach ($a_routes as $i => $route):
 
 		</td>
 	</tr>
-<? endforeach?>
+<?php endforeach; ?>
 </table>
 
 <nav class="action-buttons">


### PR DESCRIPTION
Short open tag is discouraged since it is only available if enabled:
See https://secure.php.net/manual/en/language.basic-syntax.phptags.php

This PR may break other PRs that interact with this same files, so please consider if this is possible to integrate or not. I don't mind if this is rejected for that reason.

The ```<?php``` syntax is already used far more than the short one ```<?```.

Also the the tag ```<?=``` is always available regardless of the ```short_open_tag``` ini setting since PHP 5.4. The chances of that ever being removed from PHP are by far low, so I didn't touch that.