### PR TITLE
Miscellaneous tweaks to improve security

### DIFF
--- a/src/etc/rc.php_ini_setup
+++ b/src/etc/rc.php_ini_setup
@@ -199,6 +199,8 @@ log_errors=on
 error_log=/tmp/PHP_errors.log
 extension_dir=${EXTENSIONSDIR}
 date.timezone="${TIMEZONE}"
+session.hash_bits_per_character = 5
+session.hash_function = 1
 
 ; Extensions
 

--- a/src/etc/rc.php_ini_setup
+++ b/src/etc/rc.php_ini_setup
@@ -250,15 +250,12 @@ fi
 	/bin/cat >>/usr/local/etc/php.ini <<EOF
 
 [suhosin]
-suhosin.get.max_array_depth = 5000
 suhosin.get.max_array_index_length = 256
 suhosin.get.max_vars = 5000
 suhosin.get.max_value_length = 500000
-suhosin.post.max_array_depth = 5000
 suhosin.post.max_array_index_length = 256
 suhosin.post.max_vars = 5000
 suhosin.post.max_value_length = 500000
-suhosin.request.max_array_depth = 5000
 suhosin.request.max_array_index_length = 256
 suhosin.request.max_vars = 5000
 suhosin.request.max_value_length = 500000


### PR DESCRIPTION
I have done some small changes that should not introduce any breakage.

Array depth: No one sane would nest an array 5000 times ```$var[1][2][3]...[5000]```. Even the lowest default setting of 50 is far enough.

Session: Default is to use MD5 algorithm to generate the session hash. SHA1 might be better. Also increased hash_bits_per_character to keep the session file-name at 37 chars.

Thanks.