### PR TITLE
Fix webgui-redirect in system_advanced_admin

### DIFF
--- a/src/usr/local/www/system_advanced_admin.php
+++ b/src/usr/local/www/system_advanced_admin.php
@@ -393,7 +393,7 @@ $section->addInput(new Form_Input(
 	'users/browsers to access the GUI concurrently.');
 
 $section->addInput(new Form_Checkbox(
-	'disablehttpredirect',
+	'webgui-redirect',
 	'WebGUI redirect',
 	'Disable webConfigurator redirect rule',
 	$pconfig['disablehttpredirect']


### PR DESCRIPTION
This one also seems to be wrong.
Why do people use a different name for the $POST var?