### PR TITLE
HTML Compliance - Firewall / Traffic Shaper / Queues

### DIFF
--- a/src/usr/local/www/firewall_shaper_queues.php
+++ b/src/usr/local/www/firewall_shaper_queues.php
@@ -265,5 +265,5 @@ display_top_tabs($tab_array);
 </form>
 
 <?php
-
 include("foot.inc");
+?>

--- a/src/usr/local/www/firewall_shaper_queues.php
+++ b/src/usr/local/www/firewall_shaper_queues.php
@@ -250,7 +250,7 @@ display_top_tabs($tab_array);
 
 <form action="firewall_shaper_queues.php" method="post" name="iform" id="iform">
 	<div class="panel panel-default">
-		<div class="panel-heading" align="center"><h2 class="panel-title"><?=$qname?></h2></div>
+		<div class="panel-heading text-center"><h2 class="panel-title"><?=$qname?></h2></div>
 		<div class="panel-body">
 			<div class="form-group">
 				<div class="col-sm-2 ">


### PR DESCRIPTION
The align attribute on the div element is obsolete. Use CSS instead.
<div class="panel-heading" align="center">

Close php tag