### PR TITLE
print_info_box success

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -108,6 +108,7 @@ if ($g['disablecrashreporter'] != true) {
 
 		if ($x > 0) {
 			$savemsg = "{$g['product_name']} has detected a crash report or programming bug.  Click <a href='crash_reporter.php'>here</a> for more information.";
+			$class = "warning";
 		}
 	}
 }
@@ -304,7 +305,7 @@ $pgtitle = array(gettext("Status"), gettext("Dashboard"));
 include("head.inc");
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, $class);
 }
 
 pfSense_handle_custom_code("/usr/local/pkg/dashboard/pre_dashboard");

--- a/src/usr/local/www/interfaces_assign.php
+++ b/src/usr/local/www/interfaces_assign.php
@@ -274,6 +274,7 @@ if (isset($_POST['add']) && isset($_POST['if_add'])) {
 		write_config();
 
 		$savemsg = gettext("Interface has been added.");
+		$class = "success";
 	}
 
 } else if (isset($_POST['apply'])) {
@@ -284,12 +285,13 @@ if (isset($_POST['add']) && isset($_POST['if_add'])) {
 		write_config();
 
 		$retval = filter_configure();
-		$savemsg = get_std_save_message($retval);
 
 		if (stristr($retval, "error") <> true) {
 			$savemsg = get_std_save_message($retval);
+			$class = "success";
 		} else {
 			$savemsg = $retval;
+			$class = "danger";
 		}
 	}
 
@@ -461,6 +463,7 @@ if (isset($_POST['add']) && isset($_POST['if_add'])) {
 			link_interface_to_vlans($realid, "update");
 
 			$savemsg = gettext("Interface has been deleted.");
+			$class = "success";
 		}
 	}
 }
@@ -486,11 +489,14 @@ if (file_exists("/var/run/interface_mismatch_reboot_needed")) {
 	if ($_POST) {
 		if ($rebootingnow) {
 			$savemsg = gettext("The system is now rebooting.  Please wait.");
+			$class = "success";
 		} else {
 			$savemsg = gettext("Reboot is needed. Please apply the settings in order to reboot.");
+			$class = "warning";
 		}
 	} else {
 		$savemsg = gettext("Interface mismatch detected.  Please resolve the mismatch and click 'Apply changes'.  The firewall will reboot afterwards.");
+		$class = "warning";
 	}
 }
 
@@ -499,7 +505,7 @@ if (file_exists("/tmp/reload_interfaces")) {
 	print_info_box_np(gettext("The interface configuration has been changed.<br />You must apply the changes in order for them to take effect."));
 	echo "<br /></p>\n";
 } elseif ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, $class);
 }
 
 pfSense_handle_custom_code("/usr/local/pkg/interfaces_assign/pre_input_errors");

--- a/src/usr/local/www/load_balancer_virtual_server.php
+++ b/src/usr/local/www/load_balancer_virtual_server.php
@@ -128,7 +128,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 
 if (is_subsystem_dirty('loadbalancer')) {

--- a/src/usr/local/www/status_logs_filter_dynamic.php
+++ b/src/usr/local/www/status_logs_filter_dynamic.php
@@ -116,7 +116,7 @@ $pgtitle = array(gettext("Status"), gettext("System logs"), gettext($allowed_log
 include("head.inc");
 
 if (!$input_errors && $savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 	$manage_log_active = false;
 }
 

--- a/src/usr/local/www/status_logs_filter_summary.php
+++ b/src/usr/local/www/status_logs_filter_summary.php
@@ -102,7 +102,7 @@ $pgtitle = array(gettext("Status"), gettext("System logs"), gettext($allowed_log
 include("head.inc");
 
 if (!$input_errors && $savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 	$manage_log_active = false;
 }
 


### PR DESCRIPTION
In most situations we want the print_info_box() of $savemsg to be
'success'. If there was some problem saving, then it can be 'warning'.
These are a few places I have found so far that need this sort of fixing
up - more to come but sleep calls just now!
I made the change to index.php also to be consistent with the others,
even though it does not actually change anything "for real" because
'warning' is the default anyway. It will make it easy for people in
future to see that is the case, specially if they are adding other
$savemsg things that need to be 'success'.