### PR TITLE
Redmine #5759 print_info_box style

### DIFF
--- a/src/usr/local/www/firewall_shaper_vinterface.php
+++ b/src/usr/local/www/firewall_shaper_vinterface.php
@@ -433,7 +433,7 @@ display_top_tabs($tab_array);
 <?php
 
 if ($dfltmsg) {
-	print_info_box($dn_default_shaper_msg);
+	print_info_box($dn_default_shaper_msg, 'info');
 } else {
 	// Add global buttons
 	if (!$dontshow || $newqueue) {

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -499,14 +499,14 @@ echo '<li>'. get_shortcut_log_link($shortcut_section, false). '</li>';
 /* if upgrade in progress, alert user */
 if (is_subsystem_dirty('packagelock') || file_exists('/conf/needs_package_sync' && platform_booting())) {
 	if (file_exists('/conf/needs_package_sync') && platform_booting()) {
-		$info_text = sprintf(gettext("%s is booting then packages will be reinstalled in the background.<p>Do not make changes in the GUI until this is complete."), $g['product_name']);
+		$warning_text = sprintf(gettext("%s is booting then packages will be reinstalled in the background.<p>Do not make changes in the GUI until this is complete."), $g['product_name']);
 	} else {
 		$pgtitle = array(gettext("System"), gettext("Package Manager"));
-		$info_text = gettext("Packages are currently being reinstalled in the background.<p>Do not make changes in the GUI until this is complete.");
-		$info_text .= gettext("<p>If the above message is still displayed after a couple of hours, use the 'Clear Package Lock' button on the <a href='diag_backup.php' title='Backup/Restore'>Backup/Restore page</a> and reinstall packages manually.");
+		$warning_text = gettext("Packages are currently being reinstalled in the background.<p>Do not make changes in the GUI until this is complete.");
+		$warning_text .= gettext("<p>If the above message is still displayed after a couple of hours, use the 'Clear Package Lock' button on the <a href='diag_backup.php' title='Backup/Restore'>Backup/Restore page</a> and reinstall packages manually.");
 	}
 
-	print_info_box($info_text);
+	print_info_box($warning_text);
 }
 
 $pgtitle_output = true;

--- a/src/usr/local/www/load_balancer_pool.php
+++ b/src/usr/local/www/load_balancer_pool.php
@@ -128,7 +128,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 
 if (is_subsystem_dirty('loadbalancer')) {

--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -1471,7 +1471,7 @@ if (!empty($advanced)) {
 print($form);
 
 if ($pkg['note'] != "") {
-	print_info_box($pkg['note']);
+	print_info_box($pkg['note'], 'info');
 }
 
 if ($pkg['custom_php_after_form_command']) {

--- a/src/usr/local/www/pkg_mgr_install.php
+++ b/src/usr/local/www/pkg_mgr_install.php
@@ -374,7 +374,7 @@ if ($input_errors) {
 <?php endif;
 
 if ($firmwareupdate && !$firmwareversion) {
-	print_info_box(gettext("Unable to retrieve system versions"), danger);
+	print_info_box(gettext("Unable to retrieve system versions"), 'danger');
 }
 
 if ($_POST['mode'] == 'delete') {

--- a/src/usr/local/www/services_captiveportal_hostname.php
+++ b/src/usr/local/www/services_captiveportal_hostname.php
@@ -131,7 +131,7 @@ if ($_GET['act'] == "del" && !empty($cpzone) && isset($cpzoneid)) {
 include("head.inc");
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();
@@ -197,7 +197,7 @@ endif;
 </nav>
 
 <div class="infoblock">
-	<?=print_info_box($notestr)?>
+	<?=print_info_box($notestr, 'info')?>
 </div>
 
 <?php

--- a/src/usr/local/www/services_captiveportal_ip.php
+++ b/src/usr/local/www/services_captiveportal_ip.php
@@ -124,7 +124,7 @@ if ($_GET['act'] == "del" && !empty($cpzone) && isset($cpzoneid)) {
 include("head.inc");
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();

--- a/src/usr/local/www/services_captiveportal_vouchers.php
+++ b/src/usr/local/www/services_captiveportal_vouchers.php
@@ -431,7 +431,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg. 'success');
+	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -887,14 +887,17 @@ $section->addInput(new Form_Input(
 ));
 
 print($form);
-
+?>
+<div class="infoblock_open">
+<?php
 print_info_box(gettext('The DNS servers entered in ') . '<a href="system.php">' . gettext(' System: General setup') . '</a>' .
 			   gettext(' (or the ') . '<a href="services_dnsmasq.php"/>' . gettext('DNS forwarder') . '</a>, ' . gettext('if enabled) ') .
 			   gettext('will be assigned to clients by the DHCP server.') . '<br />' .
 			   gettext('The DHCP lease table can be viewed on the ') . '<a href="status_dhcpv6_leases.php">' .
-			   gettext('Status: DHCPv6 leases') . '</a>' . gettext(' page.'));
+			   gettext('Status: DHCPv6 leases') . '</a>' . gettext(' page.'),
+			   'info');
 ?>
-
+</div>
 <div class="panel panel-default">
 	<div class="panel-heading"><h2 class="panel-title">DHCPv6 Static Mappings for this interface.</h2></div>
 	<div class="panel-body table-responsive">

--- a/src/usr/local/www/services_rfc2136_edit.php
+++ b/src/usr/local/www/services_rfc2136_edit.php
@@ -165,7 +165,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 
 $form = new Form;

--- a/src/usr/local/www/services_snmp.php
+++ b/src/usr/local/www/services_snmp.php
@@ -217,7 +217,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 
 $form = new Form();

--- a/src/usr/local/www/services_wol.php
+++ b/src/usr/local/www/services_wol.php
@@ -84,8 +84,10 @@ if ($_GET['wakeall'] != "") {
 		/* Execute wol command and check return code. */
 		if (!mwexec("/usr/local/bin/wol -i {$bcip} {$mac}")) {
 			$savemsg .= sprintf(gettext('Sent magic packet to %1$s (%2$s)%3$s'), $mac, $description, ".<br />");
+			$class = 'success';
 		} else {
 			$savemsg .= sprintf(gettext('Please check the %1$ssystem log%2$s, the wol command for %3$s (%4$s) did not complete successfully%5$s'), '<a href="/status_logs.php">', '</a>', $description, $mac, ".<br />");
+			$class = 'warning';
 		}
 	}
 }
@@ -123,8 +125,10 @@ if ($_POST || $_GET['mac']) {
 			/* Execute wol command and check return code. */
 			if (!mwexec("/usr/local/bin/wol -i {$bcip} " . escapeshellarg($mac))) {
 				$savemsg .= sprintf(gettext("Sent magic packet to %s."), $mac);
+				$class = 'success';
 			} else {
 				$savemsg .= sprintf(gettext('Please check the %1$ssystem log%2$s, the wol command for %3$s did not complete successfully%4$s'), '<a href="/status_logs.php">', '</a>', $mac, ".<br />");
+				$class = 'warning';
 			}
 		}
 	}
@@ -141,12 +145,15 @@ if ($_GET['act'] == "del") {
 
 $pgtitle = array(gettext("Services"), gettext("Wake on LAN"));
 include("head.inc");
-
+?>
+<div class="infoblock_open">
+<?php
 print_info_box(gettext('This service can be used to wake up (power on) computers by sending special') . ' "' . gettext('Magic Packets') . '"<br />' .
-			   gettext('The NIC in the computer that is to be woken up must support Wake on LAN and must be properly configured (WOL cable, BIOS settings).'));
+			   gettext('The NIC in the computer that is to be woken up must support Wake on LAN and must be properly configured (WOL cable, BIOS settings).'),
+			   'info');
 
 ?>
-
+</div>
 <?php
 
 if ($input_errors) {
@@ -154,7 +161,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, $class);
 }
 
 $form = new Form('Send');

--- a/src/usr/local/www/status_logs_filter.php
+++ b/src/usr/local/www/status_logs_filter.php
@@ -353,7 +353,8 @@ if (!$rawfilter) {
 <?php
 print_info_box('<a href="https://doc.pfsense.org/index.php/What_are_TCP_Flags%3F">' .
 	gettext("TCP Flags") . '</a>: F - FIN, S - SYN, A or . - ACK, R - RST, P - PSH, U - URG, E - ECE, C - CWR' . '<br />' .
-	'<i class="fa fa-minus-square-o icon-primary"></i> = Add to block list., <i class="fa fa-plus-square-o icon-primary"></i> = Pass traffic, <i class="fa fa-info icon-primary"></i> = Resolve');
+	'<i class="fa fa-minus-square-o icon-primary"></i> = Add to block list., <i class="fa fa-plus-square-o icon-primary"></i> = Pass traffic, <i class="fa fa-info icon-primary"></i> = Resolve',
+	'info');
 ?>
 </div>
 

--- a/src/usr/local/www/status_logs_filter_dynamic.php
+++ b/src/usr/local/www/status_logs_filter_dynamic.php
@@ -480,7 +480,8 @@ if ($tcpcnt > 0) {
 <div class="infoblock">
 <?php
 	print_info_box('<a href="https://doc.pfsense.org/index.php/What_are_TCP_Flags%3F">' .
-					gettext("TCP Flags") . '</a>: F - FIN, S - SYN, A or . - ACK, R - RST, P - PSH, U - URG, E - ECE, C - CWR');
+		gettext("TCP Flags") . '</a>: F - FIN, S - SYN, A or . - ACK, R - RST, P - PSH, U - URG, E - ECE, C - CWR',
+		'info');
 ?>
 </div>
 <?php

--- a/src/usr/local/www/status_queues.php
+++ b/src/usr/local/www/status_queues.php
@@ -211,19 +211,15 @@ else: ?>
 <?php endif; ?>
 				</tbody>
 			</table>
-		<br />
+			<br />
+			<div class="infoblock_open">
 <?php
-		print_info_box(gettext("Queue graphs take 5 seconds to sample data"));
+	print_info_box(gettext("Queue graphs take 5 seconds to sample data"), 'info');
 ?>
+			</div>
 		</div>
 	</div>
 <br/>
-
-<?php
-
-
-
-?>
 
 <script type="text/javascript">
 //<![CDATA[

--- a/src/usr/local/www/status_wireless.php
+++ b/src/usr/local/www/status_wireless.php
@@ -242,10 +242,12 @@ display_top_tabs($tab_array);
 		</button>
 	</nav>
 </form>
-
+<div class="infoblock">
 <?php
 print_info_box('<b>Flags:</b> A = authorized, E = Extended Rate (802.11g), P = Power saving mode<br />' .
 			   '<b>Capabilities:</b> E = ESS (infrastructure mode), I = IBSS (ad-hoc mode), P = privacy (WEP/TKIP/AES), ' .
 			   'S = Short preamble, s = Short slot time', 'info');
-
+?>
+</div>
+<?php
 include("foot.inc");

--- a/src/usr/local/www/system_advanced_firewall.php
+++ b/src/usr/local/www/system_advanced_firewall.php
@@ -393,8 +393,10 @@ if ($_POST) {
 		$retval = filter_configure();
 		if (stristr($retval, "error") <> true) {
 			$savemsg = get_std_save_message($retval);
+			$class = 'success';
 		} else {
 			$savemsg = $retval;
+			$class = 'warning';
 		}
 	}
 }
@@ -406,7 +408,7 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, $class);
 }
 
 $tab_array = array();

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -162,8 +162,10 @@ if ($_POST) {
 		$retval = filter_configure();
 		if (stristr($retval, "error") <> true) {
 			$savemsg = get_std_save_message(gettext($retval));
+			$class = 'success';
 		} else {
 			$savemsg = gettext($retval);
+			$class = 'warning';
 		}
 	}
 }
@@ -175,7 +177,7 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, $class);
 }
 
 $tab_array = array();

--- a/src/usr/local/www/system_groupmanager.php
+++ b/src/usr/local/www/system_groupmanager.php
@@ -265,7 +265,7 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();

--- a/src/usr/local/www/system_groupmanager_addprivs.php
+++ b/src/usr/local/www/system_groupmanager_addprivs.php
@@ -150,7 +150,7 @@ if ($_POST) {
 
 /* if ajax is calling, give them an update message */
 if (isAjax()) {
-	print_info_box_np($savemsg);
+	print_info_box_np($savemsg, '', '', false, 'success');
 }
 
 function build_priv_list() {

--- a/src/usr/local/www/system_routes.php
+++ b/src/usr/local/www/system_routes.php
@@ -251,7 +251,7 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 if (is_subsystem_dirty('staticroutes')) {
 	print_info_box_np(gettext("The static route configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));

--- a/src/usr/local/www/system_usermanager_addprivs.php
+++ b/src/usr/local/www/system_usermanager_addprivs.php
@@ -154,7 +154,7 @@ function build_priv_list() {
 
 /* if ajax is calling, give them an update message */
 if (isAjax()) {
-	print_info_box_np($savemsg);
+	print_info_box_np($savemsg, '', '', false, 'success');
 }
 
 include("head.inc");

--- a/src/usr/local/www/system_usermanager_passwordmg.php
+++ b/src/usr/local/www/system_usermanager_passwordmg.php
@@ -117,7 +117,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 
 if ($islocal == false) {

--- a/src/usr/local/www/vpn_ipsec_mobile.php
+++ b/src/usr/local/www/vpn_ipsec_mobile.php
@@ -434,7 +434,7 @@ include("head.inc");
 
 <?php
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 if (is_subsystem_dirty('ipsec')) {
 	print_info_box_np(gettext("The IPsec tunnel configuration has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));

--- a/src/usr/local/www/vpn_ipsec_settings.php
+++ b/src/usr/local/www/vpn_ipsec_settings.php
@@ -210,8 +210,10 @@ if ($_POST) {
 		$retval = filter_configure();
 		if (stristr($retval, "error") <> true) {
 			$savemsg = get_std_save_message(gettext($retval));
+			$class = 'success';
 		} else {
 			$savemsg = gettext($retval);
+			$class = 'warning';
 		}
 
 		vpn_ipsec_configure($needsrestart);
@@ -253,7 +255,7 @@ function maxmss_checked(obj) {
 
 <?php
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, $class);
 }
 
 if ($input_errors) {

--- a/src/usr/local/www/vpn_l2tp.php
+++ b/src/usr/local/www/vpn_l2tp.php
@@ -215,7 +215,7 @@ if ($_POST) {
 
 		/* if ajax is calling, give them an update message */
 		if (isAjax()) {
-			print_info_box_np($savemsg);
+			print_info_box_np($savemsg, '', '', false, 'success');
 		}
 	}
 }
@@ -229,7 +229,7 @@ if ($input_errors) {
 }
 
 if ($savemsg) {
-	print_info_box($savemsg);
+	print_info_box($savemsg, 'success');
 }
 
 $tab_array = array();


### PR DESCRIPTION
Define the 'success' 'info' etc style of calls to print_info_box()

and I changed just a var name in head.inc so it would be obvious to future maintainers that the text strings there are all warnings (not info).