### PR TITLE
HTML Compliance - Services / NTP / Serial GPS

### DIFF
--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -380,7 +380,7 @@ $btnadvgps->removeClass('btn-primary')->addClass('btn-default btn-sm');
 
 $section->addInput(new Form_StaticText(
 	'GPS Initialization',
-	$btnadvgps . '&nbsp' . 'Show GPS Initialization commands'
+	$btnadvgps . '&nbsp;' . 'Show GPS Initialization commands'
 ));
 
 $section->addInput(new Form_Textarea(


### PR DESCRIPTION
Named character reference was not terminated by a semicolon.
id="btnadvgps"/>&nbspShow GPS Initialization commands