### PR TITLE
status_dhcp6_leases incorrect comparison operator

### DIFF
--- a/src/usr/local/www/status_dhcpv6_leases.php
+++ b/src/usr/local/www/status_dhcpv6_leases.php
@@ -119,11 +119,11 @@ function leasecmp($a, $b) {
 function adjust_gmt($dt) {
 	global $config;
 
-	$dhcpv6leaseinlocaltime == "no";
+	$dhcpv6leaseinlocaltime = "no";
 	if (is_array($config['dhcpdv6'])) {
 		$dhcpdv6 = $config['dhcpdv6'];
-		foreach ($dhcpdv6 as $dhcpv6leaseinlocaltime) {
-			$dhcpv6leaseinlocaltime = $dhcpv6leaseinlocaltime['dhcpv6leaseinlocaltime'];
+		foreach ($dhcpdv6 as $dhcpdv6params) {
+			$dhcpv6leaseinlocaltime = $dhcpdv6params['dhcpv6leaseinlocaltime'];
 			if ($dhcpv6leaseinlocaltime == "yes") {
 				break;
 			}


### PR DESCRIPTION
rather than assignment.
Also $dhcpv6leaseinlocaltime  was also being re-used as the value part of the foreach - that looks not so good also.
Even so, I think the old code would have worked by good luck - in the end $dhcpv6leaseinlocaltime is only compared to "yes" anyway, so if it ended up as unset, or some part of a sub-array of $config['dhcpdv6'] or... it still functioned like "no".
I found this by a quick scan through the output of:
find /usr -type f -exec grep -H "^[^(]*==" {} \;
That returns a lot of other stuff, but the bad uses of "==" stand out.