### PR TITLE
IPsec phase 2 display existing keylen

### DIFF
--- a/src/usr/local/www/vpn_ipsec_phase2.php
+++ b/src/usr/local/www/vpn_ipsec_phase2.php
@@ -659,7 +659,7 @@ foreach ($p2_ealgos as $algo => $algodata) {
 		$group->add(new Form_Select(
 			'keylen_' . $algo,
 			null,
-			$keylen == $pconfig["keylen_".$algo],
+			$pconfig["keylen_".$algo],
 			['auto' => 'Auto'] + $list
 		));
 	}


### PR DESCRIPTION
When you edit an IPsec phase2, if there are any particular key lengths already selected in the config for each of the encryption algorithms they are not displayed - they just all show as Auto. That then "accidentally" changes previous settings when you save.

Found as part of searching for dodgy-loking uses of "==".