### PR TITLE
APU description correction

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2101,7 +2101,7 @@ function system_identify_specific_platform() {
 			return (array('name' => 'FW7541', 'descr' => 'Netgate FW7541'));
 			break;
 		case 'APU':
-			return (array('name' => 'APU', 'descr' => 'Netgate APU'));
+			return (array('name' => 'APU', 'descr' => 'PC Engines APU'));
 			break;
 		case 'RCC-VE':
 			return (array('name' => 'RCC-VE', 'descr' => 'Netgate RCC-VE'));


### PR DESCRIPTION
Just a small cosmetic change. I've corrected the description for the 'APU' embedded system. Netgate is not the manufacturer of the APU but just one of the many distributors. PC Engines is the manufacturer (and owner of it), same as for ALIX and WRAP.

Also see the output of /bin/kenv on my APU
smbios.chassis.maker="PC Engines"
smbios.planar.maker="PC Engines"
smbios.planar.product="APU"
...
smbios.system.maker="PC Engines"
smbios.system.product="APU"
