### PR TITLE
Continued: Fix port aliases (Seems you can't autosuggest an element of type "number")

### DIFF
--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -771,10 +771,9 @@ $group->add(new Form_Select(
 $group->add(new Form_Input(
 	'srcbeginport_cust',
 	null,
-	'number',
-	is_numeric($pconfig['srcbeginport']) ? $pconfig['srcbeginport'] : null,
-	['min' => '1', 'max' => '65536']
-))->setHelp('Custom');
+	'text',
+	$pconfig['srcbeginport']
+))->setPattern('[a-zA-Z0-9_]+')->setHelp('Custom');
 
 $group->add(new Form_Select(
 	'srcendport',
@@ -786,10 +785,9 @@ $group->add(new Form_Select(
 $group->add(new Form_Input(
 	'srcendport_cust',
 	null,
-	'number',
-	is_numeric($pconfig['srcendport']) ? $pconfig['srcendport'] : null,
-	['min' => '1', 'max' => '65536']
-))->setHelp('Custom');
+	'text',
+	$pconfig['srcendport']
+))->setPattern('[a-zA-Z0-9_]+')->setHelp('Custom');
 
 $group->setHelp('Specify the source port or port range for this rule. This is usually random and almost never ' .
 				'equal to the destination port range (and should usually be \'any\'). You can leave the \'to\' field ' .
@@ -835,9 +833,8 @@ $group->add(new Form_Input(
 	'dstbeginport_cust',
 	null,
 	'text',
-	is_numeric($pconfig['dstbeginport']) ? $pconfig['dstbeginport'] : null,
-	['min' => '1', 'max' => '65536']
-))->setHelp('Custom');
+	$pconfig['dstbeginport']
+))->setPattern('[a-zA-Z0-9_]+')->setHelp('Custom');
 
 $group->add(new Form_Select(
 	'dstendport',
@@ -850,9 +847,8 @@ $group->add(new Form_Input(
 	'dstendport_cust',
 	null,
 	'text',
-	is_numeric($pconfig['dstendport']) ? $pconfig['dstendport'] : null,
-	['min' => '1', 'max' => '65536']
-))->setHelp('Custom');
+	$pconfig['dstendport']
+))->setPattern('[a-zA-Z0-9_]+')->setHelp('Custom');
 
 $group->setHelp('Specify the port or port range for the destination of the packet for this mapping. ' .
 				'You can leave the \'to\' field empty if you only want to map a single port ');
@@ -884,9 +880,8 @@ $group->add(new Form_Input(
 	'localbeginport_cust',
 	null,
 	'text',
-	is_numeric($pconfig['localbeginport']) ? $pconfig['localbeginport'] : null,
-	['min' => '1', 'max' => '65536']
-))->setHelp('Custom');
+	$pconfig['localbeginport']
+))->setPattern('[a-zA-Z0-9_]+')->setHelp('Custom');
 
 $section->add($group);
 


### PR DESCRIPTION
Also
apply to src too.
remove is_numeric check
remove min/max (not valid on text fields; does not work)
add pattern in place of min/max