### PR TITLE
Fix #5767 config validation errors when first enabling DNS Resolver

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -33,7 +33,7 @@ require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");
 
-function create_unbound_chroot_path() {
+function create_unbound_chroot_path($cfgsubdir = "") {
 	global $config, $g;
 
 	// Configure chroot
@@ -43,6 +43,14 @@ function create_unbound_chroot_path() {
 		chgrp($g['unbound_chroot_path'], "unbound");
 	}
 
+	if ($cfgsubdir != "") {
+		$cfgdir = $g['unbound_chroot_path'] . $cfgsubdir;
+		if (!is_dir($cfgdir)) {
+			mkdir($cfgdir);
+			chown($cfgdir, "unbound");
+			chgrp($cfgdir, "unbound");
+		}
+	}
 }
 
 /* Optimize Unbound for environment */
@@ -102,38 +110,41 @@ function unbound_optimization() {
 function test_unbound_config($unboundcfg, &$output) {
 	global $g;
 
-	$cfgfile = "{$g['unbound_chroot_path']}/unbound.test.conf";
-	$unboundcfgtxt = unbound_generate_config_text($unboundcfg);
-	file_put_contents($cfgfile, $unboundcfgtxt);
+	$cfgsubdir = "/test";
+	unbound_generate_config($unboundcfg, $cfgsubdir);
+	unbound_remote_control_setup($cfgsubdir);
+	do_as_unbound_user("unbound-anchor", $cfgsubdir);
+
+	$cfgdir = "{$g['unbound_chroot_path']}{$cfgsubdir}";
 
 	$rv = 0;
-	exec("/usr/local/sbin/unbound-checkconf {$cfgfile} 2>&1", $output, $rv);
-	unlink_if_exists($cfgfile);
+	exec("/usr/local/sbin/unbound-checkconf {$cfgdir}/unbound.conf 2>&1", $output, $rv);
+	rmdir_recursive($cfgdir);
 
 	return $rv;
 }
 
 
-function unbound_generate_config() {
+function unbound_generate_config($unboundcfg = NULL, $cfgsubdir = "") {
 	global $g;
 
-	$unboundcfgtxt = unbound_generate_config_text();
+	$unboundcfgtxt = unbound_generate_config_text($unboundcfg, $cfgsubdir);
 
 	// Configure static Host entries
-	unbound_add_host_entries();
+	unbound_add_host_entries($cfgsubdir);
 
 	// Configure Domain Overrides
-	unbound_add_domain_overrides();
+	unbound_add_domain_overrides("", $cfgsubdir);
 
 	// Configure Unbound access-lists
-	unbound_acls_config();
+	unbound_acls_config($cfgsubdir);
 
-	create_unbound_chroot_path();
-	file_put_contents("{$g['unbound_chroot_path']}/unbound.conf", $unboundcfgtxt);
+	create_unbound_chroot_path($cfgsubdir);
+	file_put_contents("{$g['unbound_chroot_path']}{$cfgsubdir}/unbound.conf", $unboundcfgtxt);
 }
 
 
-function unbound_generate_config_text($unboundcfg=NULL) {
+function unbound_generate_config_text($unboundcfg = NULL, $cfgsubdir = "") {
 
 	global $config, $g;
 	if (is_null($unboundcfg)) {
@@ -146,7 +157,7 @@ function unbound_generate_config_text($unboundcfg=NULL) {
 	// Setup DNSSEC support
 	if (isset($unboundcfg['dnssec'])) {
 		$module_config = "validator iterator";
-		$anchor_file = "auto-trust-anchor-file: {$g['unbound_chroot_path']}/root.key";
+		$anchor_file = "auto-trust-anchor-file: {$g['unbound_chroot_path']}{$cfgsubdir}/root.key";
 	} else {
 		$module_config = "iterator";
 	}
@@ -358,16 +369,16 @@ use-caps-for-id: {$use_caps}
 {$private_domains}
 
 # Access lists
-include: {$g['unbound_chroot_path']}/access_lists.conf
+include: {$g['unbound_chroot_path']}{$cfgsubdir}/access_lists.conf
 
 # Static host entries
-include: {$g['unbound_chroot_path']}/host_entries.conf
+include: {$g['unbound_chroot_path']}{$cfgsubdir}/host_entries.conf
 
 # dhcp lease entries
-include: {$g['unbound_chroot_path']}/dhcpleases_entries.conf
+include: {$g['unbound_chroot_path']}{$cfgsubdir}/dhcpleases_entries.conf
 
 # Domain overrides
-include: {$g['unbound_chroot_path']}/domainoverrides.conf
+include: {$g['unbound_chroot_path']}{$cfgsubdir}/domainoverrides.conf
 {$forward_conf}
 
 {$custom_options}
@@ -375,34 +386,34 @@ include: {$g['unbound_chroot_path']}/domainoverrides.conf
 ###
 # Remote Control Config
 ###
-include: {$g['unbound_chroot_path']}/remotecontrol.conf
+include: {$g['unbound_chroot_path']}{$cfgsubdir}/remotecontrol.conf
 
 EOD;
 
 	return $unboundconf;
 }
 
-function unbound_remote_control_setup() {
+function unbound_remote_control_setup($cfgsubdir = "") {
 	global $g;
 
-	if (!file_exists("{$g['unbound_chroot_path']}/remotecontrol.conf") || !file_exists("{$g['unbound_chroot_path']}/unbound_control.key")) {
+	if (!file_exists("{$g['unbound_chroot_path']}{$cfgsubdir}/remotecontrol.conf") || !file_exists("{$g['unbound_chroot_path']}{$cfgsubdir}/unbound_control.key")) {
 		$remotcfg = <<<EOF
 remote-control:
 	control-enable: yes
 	control-interface: 127.0.0.1
 	control-port: 953
-	server-key-file: "{$g['unbound_chroot_path']}/unbound_server.key"
-	server-cert-file: "{$g['unbound_chroot_path']}/unbound_server.pem"
-	control-key-file: "{$g['unbound_chroot_path']}/unbound_control.key"
-	control-cert-file: "{$g['unbound_chroot_path']}/unbound_control.pem"
+	server-key-file: "{$g['unbound_chroot_path']}{$cfgsubdir}/unbound_server.key"
+	server-cert-file: "{$g['unbound_chroot_path']}{$cfgsubdir}/unbound_server.pem"
+	control-key-file: "{$g['unbound_chroot_path']}{$cfgsubdir}/unbound_control.key"
+	control-cert-file: "{$g['unbound_chroot_path']}{$cfgsubdir}/unbound_control.pem"
 
 EOF;
 
-		create_unbound_chroot_path();
-		file_put_contents("{$g['unbound_chroot_path']}/remotecontrol.conf", $remotcfg);
+		create_unbound_chroot_path($cfgsubdir);
+		file_put_contents("{$g['unbound_chroot_path']}{$cfgsubdir}/remotecontrol.conf", $remotcfg);
 
 		// Generate our keys
-		do_as_unbound_user("unbound-control-setup");
+		do_as_unbound_user("unbound-control-setup", $cfgsubdir);
 
 	}
 }
@@ -476,7 +487,7 @@ function unbound_get_next_id() {
 }
 
 // Execute commands as the user unbound
-function do_as_unbound_user($cmd) {
+function do_as_unbound_user($cmd, $param1 = "") {
 	global $g;
 
 	switch ($cmd) {
@@ -490,26 +501,30 @@ function do_as_unbound_user($cmd) {
 			mwexec("echo '/usr/local/sbin/unbound-control reload' | /usr/bin/su -m unbound", true);
 			break;
 		case "unbound-anchor":
+			$root_key_file = "{$g['unbound_chroot_path']}{$param1}/root.key";
 			// sanity check root.key because unbound-anchor will fail without manual removal otherwise. redmine #5334
-			if (file_exists("{$g['unbound_chroot_path']}/root.key")) {
-				$rootkeycheck = mwexec("/usr/bin/grep 'autotrust trust anchor file' {$g['unbound_chroot_path']}/root.key", true);
+			if (file_exists($root_key_file)) {
+				$rootkeycheck = mwexec("/usr/bin/grep 'autotrust trust anchor file' {$root_key_file}", true);
 				if ($rootkeycheck != "0") {
-					log_error("Unbound root.key file is corrupt, removing and recreating.");
-					unlink_if_exists("{$g['unbound_chroot_path']}/root.key");
+					log_error("Unbound {$root_key_file} file is corrupt, removing and recreating.");
+					unlink_if_exists($root_key_file);
 				}
 			}
-			mwexec("echo '/usr/local/sbin/unbound-anchor -a {$g['unbound_chroot_path']}/root.key' | /usr/bin/su -m unbound", true);
-			pfSense_fsync("{$g['unbound_chroot_path']}/root.key");
+			mwexec("echo '/usr/local/sbin/unbound-anchor -a {$root_key_file}' | /usr/bin/su -m unbound", true);
+			// Only sync the file if this is the real (default) one, not a test one.
+			if ($param1 == "") {
+				pfSense_fsync($root_key_file);
+			}
 			break;
 		case "unbound-control-setup":
-			mwexec("echo '/usr/local/sbin/unbound-control-setup -d {$g['unbound_chroot_path']}' | /usr/bin/su -m unbound", true);
+			mwexec("echo '/usr/local/sbin/unbound-control-setup -d {$g['unbound_chroot_path']}{$param1}' | /usr/bin/su -m unbound", true);
 			break;
 		default:
 			break;
 	}
 }
 
-function unbound_add_domain_overrides($pvt_rev="") {
+function unbound_add_domain_overrides($pvt_rev="", $cfgsubdir = "") {
 	global $config, $g;
 
 	$domains = $config['unbound']['domainoverrides'];
@@ -547,12 +562,12 @@ function unbound_add_domain_overrides($pvt_rev="") {
 	if ($pvt_rev != "") {
 		return $domain_entries;
 	} else {
-		create_unbound_chroot_path();
-		file_put_contents("{$g['unbound_chroot_path']}/domainoverrides.conf", $domain_entries);
+		create_unbound_chroot_path($cfgsubdir);
+		file_put_contents("{$g['unbound_chroot_path']}{$cfgsubdir}/domainoverrides.conf", $domain_entries);
 	}
 }
 
-function unbound_add_host_entries() {
+function unbound_add_host_entries($cfgsubdir = "") {
 	global $config, $g;
 
 	if (empty($config['unbound']['system_domain_local_zone_type'])) {
@@ -585,11 +600,11 @@ function unbound_add_host_entries() {
 	}
 
 	// Write out entries
-	create_unbound_chroot_path();
-	file_put_contents("{$g['unbound_chroot_path']}/host_entries.conf", $unbound_entries);
+	create_unbound_chroot_path($cfgsubdir);
+	file_put_contents("{$g['unbound_chroot_path']}{$cfgsubdir}/host_entries.conf", $unbound_entries);
 
 	/* dhcpleases will write to this config file, make sure it exists */
-	@touch("{$g['unbound_chroot_path']}/dhcpleases_entries.conf");
+	@touch("{$g['unbound_chroot_path']}{$cfgsubdir}/dhcpleases_entries.conf");
 }
 
 function unbound_control($action) {
@@ -666,7 +681,7 @@ EOF;
 }
 
 // Unbound Access lists
-function unbound_acls_config() {
+function unbound_acls_config($cfgsubdir = "") {
 	global $g, $config;
 
 	if (!isset($config['unbound']['disable_auto_added_access_control'])) {
@@ -735,8 +750,8 @@ function unbound_acls_config() {
 		}
 	}
 	// Write out Access list
-	create_unbound_chroot_path();
-	file_put_contents("{$g['unbound_chroot_path']}/access_lists.conf", $aclcfg);
+	create_unbound_chroot_path($cfgsubdir);
+	file_put_contents("{$g['unbound_chroot_path']}{$cfgsubdir}/access_lists.conf", $aclcfg);
 
 }
 


### PR DESCRIPTION
Generate a complete set of test conf files in /var/unbound/test subdir when doing the validation of the tentative config that is being saved.
This avoids any dependency on any of the "real" files already existing in /var/unbound and also avoids the chance of overwriting a live file that is currently in use by the running unbound.
/var/unbound/test is removed once the validation has been done.
The real unbound conf files are created in /var/unbound like they always were after the user presses apply.