### PR TITLE
Consistent headings for Dynamic DNS

### DIFF
--- a/src/usr/local/www/services_dyndns.php
+++ b/src/usr/local/www/services_dyndns.php
@@ -106,7 +106,7 @@ display_top_tabs($tab_array);
 ?>
 <form action="services_dyndns.php" method="post" name="iform" id="iform">
 	<div class="panel panel-default">
-		<div class="panel-heading"><h2 class="panel-title"><?=gettext('Dynamic DNS clients')?></h2></div>
+		<div class="panel-heading"><h2 class="panel-title"><?=gettext('Dynamic DNS Clients')?></h2></div>
 		<div class="panel-body">
 			<div class="table-responsive">
 				<table class="table table-striped table-hover table-condensed">

--- a/src/usr/local/www/services_rfc2136.php
+++ b/src/usr/local/www/services_rfc2136.php
@@ -104,18 +104,18 @@ if ($input_errors) {
 
 <form action="services_rfc2136.php" method="post" name="iform" id="iform">
 	<div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('RFC2136 clients')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('RFC2136 Clients')?></h2></div>
 		<div class="panel-body">
 			<div class="table-responsive">
 				<table class="table table-striped table-hover table-condensed">
 					<thead>
 						<tr>
-							<th><?=gettext("IF")?></th>
+							<th><?=gettext("Interface")?></th>
 							<th><?=gettext("Server")?></th>
 							<th><?=gettext("Hostname")?></th>
 							<th><?=gettext("Cached IP")?></th>
 							<th><?=gettext("Description")?></th>
-							<th></th>
+							<th><?=gettext("Actions")?></th>
 						</tr>
 					</thead>
 					<tbody>


### PR DESCRIPTION
Other place like "Open VPN Clients" have the "Clients" capitalized - do
it here.
Dynamic DNS has column heading "Interface" - make RFC2136 the same.
Dynamic DNS (and most other places) have a column heading "Actions" -
make it the same for RFC2136.