### PR TITLE
Consistent use of System Update

### DIFF
--- a/src/usr/local/www/pkg_mgr_install.php
+++ b/src/usr/local/www/pkg_mgr_install.php
@@ -243,7 +243,7 @@ if ($_POST) {
 if ($_GET && $_GET['id'] == "firmware") {
 	$firmwareupdate = true;
 	$firmwareversion = get_system_pkg_version();
-	$headline = gettext("System update") ;
+	$headline = gettext("System Update") ;
 }
 
 $tab_array = array();
@@ -306,7 +306,7 @@ if ($input_errors) {
 <?php
 			} else if ($firmwareupdate) {
 ?>
-				<?=$g['product_name']?> <?=gettext(" system update")?>
+				<?=$g['product_name']?> <?=gettext(" System Update")?>
 <?php
 			} else {
 ?>
@@ -343,7 +343,7 @@ if ($input_errors) {
 ?>
 		<div class="form-group">
 			<label class="col-sm-2 control-label">
-				<?=gettext("Confirm Upgrade")?>
+				<?=gettext("Confirm Update")?>
 			</label>
 			<div class="col-sm-10">
 				<input type="hidden" name="id" value="firmware" />


### PR DESCRIPTION
In some places it said "System update" and in others "System Update" - be consistent.
The confirm button called it "Upgrade". Make that consistent with the existing use of the term "Update" for system updates.

Note: Packages are still said to be "upgraded" rather than "updated" - there are places where headings, confirm prompts etc will say "Upgrade package".
Is that intended? That the terminology for packages is to "upgrade" them and for the base system it is an "update"?