### PR TITLE
UI Consistency

### DIFF
--- a/src/usr/local/www/firewall_schedule.php
+++ b/src/usr/local/www/firewall_schedule.php
@@ -126,7 +126,7 @@ if ($savemsg) {
 					<th><?=gettext("Name")?></th>
 					<th><?=gettext("Range: Date / Times / Name")?></th>
 					<th><?=gettext("Description")?></th>
-					<th><!--Buttons--></th>
+					<th><?=gettext("Actions")?></th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/usr/local/www/firewall_virtual_ip.php
+++ b/src/usr/local/www/firewall_virtual_ip.php
@@ -296,7 +296,7 @@ display_top_tabs($tab_array);
 					<th><?=gettext("Interface")?></th>
 					<th><?=gettext("Type")?></th>
 					<th><?=gettext("Description")?></th>
-					<th><!--Buttons--></th>
+					<th><?=gettext("Actions")?></th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/usr/local/www/interfaces_bridge.php
+++ b/src/usr/local/www/interfaces_bridge.php
@@ -127,16 +127,16 @@ $tab_array[] = array(gettext("LAGG"), false, "interfaces_lagg.php");
 display_top_tabs($tab_array);
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Bridge interfaces')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Bridge Interfaces')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed">
 				<thead>
 					<tr>
-					  <th><?=gettext("Interface"); ?></th>
-					  <th><?=gettext("Members"); ?></th>
-					  <th><?=gettext("Description"); ?></th>
-					  <th></th>
+						<th><?=gettext("Interface"); ?></th>
+						<th><?=gettext("Members"); ?></th>
+						<th><?=gettext("Description"); ?></th>
+						<th><?=gettext("Actions"); ?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/interfaces_gif.php
+++ b/src/usr/local/www/interfaces_gif.php
@@ -122,7 +122,7 @@ $tab_array[] = array(gettext("LAGG"), false, "interfaces_lagg.php");
 display_top_tabs($tab_array);
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('GIF interfaces')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('GIF Interfaces')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed">
@@ -131,7 +131,7 @@ display_top_tabs($tab_array);
 						<th><?=gettext("Interface"); ?></th>
 						<th><?=gettext("Tunnel to &hellip;"); ?></th>
 						<th><?=gettext("Description"); ?></th>
-						<th></th>
+						<th><?=gettext("Actions"); ?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/interfaces_gre.php
+++ b/src/usr/local/www/interfaces_gre.php
@@ -122,7 +122,7 @@ $tab_array[] = array(gettext("LAGG"), false, "interfaces_lagg.php");
 display_top_tabs($tab_array);
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('GRE interfacess')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('GRE Interfaces')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed">
@@ -131,7 +131,7 @@ display_top_tabs($tab_array);
 						<th><?=gettext("Interface"); ?></th>
 						<th><?=gettext("Tunnel to &hellip;"); ?></th>
 						<th><?=gettext("Description"); ?></th>
-						<th></th>
+						<th><?=gettext("Actions"); ?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/interfaces_groups.php
+++ b/src/usr/local/www/interfaces_groups.php
@@ -104,7 +104,7 @@ $tab_array[] = array(gettext("LAGG"), false, "interfaces_lagg.php");
 display_top_tabs($tab_array);
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Interface groups')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Interface Groups')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed">
@@ -113,7 +113,7 @@ display_top_tabs($tab_array);
 						<th><?=gettext('Name');?></th>
 						<th><?=gettext('Members');?></th>
 						<th><?=gettext('Description');?></th>
-						<th></th>
+						<th><?=gettext('Actions');?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/interfaces_groups_edit.php
+++ b/src/usr/local/www/interfaces_groups_edit.php
@@ -220,7 +220,7 @@ $tab_array[10] = array(gettext("LAGG"), false, "interfaces_lagg.php");
 display_top_tabs($tab_array);
 
 $form = new Form;
-$section = new Form_Section('Interface Group Edit');
+$section = new Form_Section('Interface Group Configuration');
 
 $section->addInput(new Form_Input(
 	'ifname',

--- a/src/usr/local/www/interfaces_lagg.php
+++ b/src/usr/local/www/interfaces_lagg.php
@@ -129,16 +129,16 @@ $tab_array[] = array(gettext("LAGG"), true, "interfaces_lagg.php");
 display_top_tabs($tab_array);
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('LAGG interfaces')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('LAGG Interfaces')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed">
 				<thead>
 					<tr>
-					  <th><?=gettext("Interface"); ?></th>
-					  <th><?=gettext("Members"); ?></th>
-					  <th><?=gettext("Description"); ?></th>
-					  <th></th>
+						<th><?=gettext("Interface"); ?></th>
+						<th><?=gettext("Members"); ?></th>
+						<th><?=gettext("Description"); ?></th>
+						<th><?=gettext("Actions"); ?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/interfaces_ppps.php
+++ b/src/usr/local/www/interfaces_ppps.php
@@ -121,16 +121,16 @@ $tab_array[] = array(gettext("LAGG"), false, "interfaces_lagg.php");
 display_top_tabs($tab_array);
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('PPPS interfaces')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('PPP Interfaces')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed">
 				<thead>
 					<tr>
-					  <th><?=gettext("Interface"); ?></th>
-					  <th><?=gettext("Interface(s)/Port(s)"); ?></th>
-					  <th><?=gettext("Description"); ?></th>
-					  <th></th>
+						<th><?=gettext("Interface"); ?></th>
+						<th><?=gettext("Interface(s)/Port(s)"); ?></th>
+						<th><?=gettext("Description"); ?></th>
+						<th><?=gettext("Actions")?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -550,7 +550,7 @@ $linkparamstr = gettext('Bandwidth is set only for MLPPP connections and when li
 
 $form = new Form();
 
-$section = new Form_Section('PPPs Configuration');
+$section = new Form_Section('PPP Configuration');
 
 $section->addInput(new Form_Select(
 	'type',

--- a/src/usr/local/www/interfaces_qinq.php
+++ b/src/usr/local/www/interfaces_qinq.php
@@ -134,17 +134,17 @@ display_top_tabs($tab_array);
 
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('QinQ interfaces')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('QinQ Interfaces')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed">
 				<thead>
 					<tr>
-					  <th><?=gettext("Interface"); ?></th>
-					  <th><?=gettext("Tag");?></td>
-					  <th><?=gettext("QinQ members"); ?></th>
-					  <th><?=gettext("Description"); ?></th>
-					  <th></th>
+						<th><?=gettext("Interface"); ?></th>
+						<th><?=gettext("Tag");?></td>
+						<th><?=gettext("QinQ members"); ?></th>
+						<th><?=gettext("Description"); ?></th>
+						<th><?=gettext("Actions"); ?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/interfaces_qinq_edit.php
+++ b/src/usr/local/www/interfaces_qinq_edit.php
@@ -261,7 +261,7 @@ $form = new Form(new Form_Button(
 	gettext("Save")
 ));
 
-$section = new Form_Section('Interface QinQ Edit');
+$section = new Form_Section('QinQ Configuration');
 
 $section->addInput(new Form_Select(
 	'if',

--- a/src/usr/local/www/interfaces_vlan.php
+++ b/src/usr/local/www/interfaces_vlan.php
@@ -131,7 +131,7 @@ display_top_tabs($tab_array);
 	<input id="id" type="hidden" name="id" value=""/>
 
 	<div class="panel panel-default">
-		<div class="panel-heading"><h2 class="panel-title"><?=gettext('VLAN interfaces')?></h2></div>
+		<div class="panel-heading"><h2 class="panel-title"><?=gettext('VLAN Interfaces')?></h2></div>
 		<div class="panel-body">
 			<div class="table-responsive">
 				<table class="table table-striped table-hover table-condensed">
@@ -141,7 +141,7 @@ display_top_tabs($tab_array);
 							<th><?=gettext('VLAN tag');?></th>
 							<th><?=gettext('Priority');?></th>
 							<th><?=gettext('Description');?></th>
-							<th></th>
+							<th><?=gettext('Actions');?></th>
 						</tr>
 					</thead>
 					<tbody>

--- a/src/usr/local/www/interfaces_vlan_edit.php
+++ b/src/usr/local/www/interfaces_vlan_edit.php
@@ -208,7 +208,7 @@ if ($input_errors) {
 }
 
 $form = new Form;
-$section = new Form_Section('Interface VLAN Edit');
+$section = new Form_Section('VLAN Configuration');
 
 $section->addInput(new Form_Select(
 	'if',

--- a/src/usr/local/www/interfaces_wireless.php
+++ b/src/usr/local/www/interfaces_wireless.php
@@ -126,16 +126,16 @@ $tab_array[] = array(gettext("LAGG"), false, "interfaces_lagg.php");
 display_top_tabs($tab_array);
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Wireless interfaces')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Wireless Interfaces')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed">
 				<thead>
 					<tr>
-					  <th><?=gettext("Interface"); ?></th>
-					  <th><?=gettext("Mode"); ?></th>
-					  <th><?=gettext("Description"); ?></th>
-					  <th></th>
+						<th><?=gettext("Interface"); ?></th>
+						<th><?=gettext("Mode"); ?></th>
+						<th><?=gettext("Description"); ?></th>
+						<th><?=gettext("Actions"); ?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/interfaces_wireless_edit.php
+++ b/src/usr/local/www/interfaces_wireless_edit.php
@@ -207,7 +207,7 @@ if ($input_errors) {
 
 $form = new Form();
 
-$section = new Form_Section('Wireless Interface');
+$section = new Form_Section('Wireless Interface Configuration');
 
 $section->addInput(new Form_Select(
 	'parent',

--- a/src/usr/local/www/load_balancer_monitor.php
+++ b/src/usr/local/www/load_balancer_monitor.php
@@ -140,7 +140,7 @@ display_top_tabs($tab_array);
 						<th><?=gettext('Name')?></th>
 						<th><?=gettext('Type')?></th>
 						<th><?=gettext('Description')?></th>
-						<th><?=gettext('Action')?></th>
+						<th><?=gettext('Actions')?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/load_balancer_pool.php
+++ b/src/usr/local/www/load_balancer_pool.php
@@ -157,7 +157,7 @@ display_top_tabs($tab_array);
 						<th><?=gettext('Port')?></th>
 						<th><?=gettext('Monitor')?></th>
 						<th><?=gettext('Description')?></th>
-						<th></th>
+						<th><?=gettext('Actions')?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/load_balancer_virtual_server.php
+++ b/src/usr/local/www/load_balancer_virtual_server.php
@@ -158,7 +158,7 @@ display_top_tabs($tab_array);
 						<th><?=gettext('Pool'); ?></th>
 						<th><?=gettext('Fallback pool'); ?></th>
 						<th><?=gettext('Description'); ?></th>
-						<th><!-- Action buttons --></th>
+						<th><?=gettext('Actions'); ?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/services_igmpproxy.php
+++ b/src/usr/local/www/services_igmpproxy.php
@@ -122,7 +122,7 @@ if (is_subsystem_dirty('igmpproxy')) {
 							<th><?=gettext("Type")?></th>
 							<th><?=gettext("Values")?></th>
 							<th><?=gettext("Description")?></th>
-							<th></th>
+							<th><?=gettext("Actions")?></th>
 						</tr>
 					</thead>
 					<tbody>

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -283,7 +283,7 @@ display_top_tabs($tab_array);
 
 $form = new Form;
 
-$section = new Form_Section('NTP server configuration');
+$section = new Form_Section('NTP Server Configuration');
 
 $iflist = build_interface_list();
 

--- a/src/usr/local/www/services_pppoe.php
+++ b/src/usr/local/www/services_pppoe.php
@@ -138,7 +138,7 @@ if (is_subsystem_dirty('vpnpppoe')) {
 				<th><?=gettext("Local IP")?></th>
 				<th><?=gettext("Number of users")?></th>
 				<th><?=gettext("Description")?></th>
-				<th><!-- Action buttons --></th>
+				<th><?=gettext("Actions")?></th>
 			</tr>
 		</thead>
 		<tbody>

--- a/src/usr/local/www/services_wol.php
+++ b/src/usr/local/www/services_wol.php
@@ -200,7 +200,7 @@ print $form;
 						<th><?=gettext("Interface")?></th>
 						<th><?=gettext("MAC address")?></th>
 						<th><?=gettext("Description")?></th>
-						<th></th>
+						<th><?=gettext("Actions")?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -374,6 +374,7 @@ if (count($pools) > 0) {
 					<th><?=gettext("End")?></th>
 					<th><?=gettext("Online")?></th>
 					<th><?=gettext("Lease Type")?></th>
+					<th><?=gettext("Actions")?></th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/usr/local/www/status_dhcpv6_leases.php
+++ b/src/usr/local/www/status_dhcpv6_leases.php
@@ -449,6 +449,7 @@ if (empty($leases)) {
 				<th><?=gettext("End")?></th>
 				<th><?=gettext("Online")?></th>
 				<th><?=gettext("Lease Type")?></th>
+				<th><?=gettext("Actions")?></th>
 			</tr>
 		</thead>
 		<tbody>

--- a/src/usr/local/www/status_upnp.php
+++ b/src/usr/local/www/status_upnp.php
@@ -94,7 +94,7 @@ if (!$config['installedpackages'] ||
 ?>
 
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('UPnP rules')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext(gettext("UPnP &amp; NAT-PMP Rules"))?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -371,7 +371,7 @@ $section->addInput(new Form_Input(
 	'local hosts not running mDNS.');
 $form->add($section);
 
-$section = new Form_Section('DNS server settings');
+$section = new Form_Section('DNS Server Settings');
 
 for ($i=1; $i<5; $i++) {
 //	if (!isset($pconfig['dns'.$i]))
@@ -424,7 +424,7 @@ for ($i=1; $i<5; $i++) {
 
 $section->addInput(new Form_Checkbox(
 	'dnsallowoverride',
-	'DNS server override',
+	'DNS Server Override',
 	'Allow DNS server list to be overridden by DHCP/PPP on WAN',
 	$pconfig['dnsallowoverride']
 ))->setHelp(sprintf(gettext('If this option is set, %s will use DNS servers '.
@@ -434,7 +434,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'dnslocalhost',
-	'Disable DNS forwarder',
+	'Disable DNS Forwarder',
 	'Do not use the DNS Forwarder as a DNS server for the firewall',
 	$pconfig['dnslocalhost']
 ))->setHelp('By default localhost (127.0.0.1) will be used as the first DNS '.

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -396,7 +396,7 @@ if (!($act == "new" || $act == "edit" || $input_errors))
 {
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Authentication servers')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Authentication Servers')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>

--- a/src/usr/local/www/system_gateway_groups.php
+++ b/src/usr/local/www/system_gateway_groups.php
@@ -141,7 +141,7 @@ $tab_array[] = array(gettext("Gateway Groups"), true, "system_gateway_groups.php
 display_top_tabs($tab_array);
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Gateway groups')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Gateway Groups')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed">

--- a/src/usr/local/www/system_routes.php
+++ b/src/usr/local/www/system_routes.php
@@ -265,7 +265,7 @@ display_top_tabs($tab_array);
 
 ?>
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Static routes')?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Static Routes')?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed">

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -496,7 +496,7 @@ if (!($act == "new" || $act == "edit" || $input_errors)) {
 						<th><?=gettext("Full name")?></th>
 						<th><?=gettext("Disabled")?></th>
 						<th><?=gettext("Groups")?></th>
-						<th>&nbsp;</th>
+						<th><?=gettext("Actions")?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/vpn_ipsec_keys.php
+++ b/src/usr/local/www/vpn_ipsec_keys.php
@@ -138,7 +138,7 @@ if (is_subsystem_dirty('ipsec')) {
 						<th><?=gettext("Identifier"); ?></th>
 						<th><?=gettext("Type"); ?></th>
 						<th><?=gettext("Pre-Shared Key"); ?></th>
-						<th></th>
+						<th><?=gettext("Actions"); ?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -799,7 +799,7 @@ else:
 					<th><?=gettext("Protocol")?></th>
 					<th><?=gettext("Server")?></th>
 					<th><?=gettext("Description")?></th>
-					<th><!-- Buttons --></th>
+					<th><?=gettext("Actions")?></th>
 				</tr>
 			</thead>
 

--- a/src/usr/local/www/vpn_openvpn_csc.php
+++ b/src/usr/local/www/vpn_openvpn_csc.php
@@ -665,7 +665,7 @@ else :  // Not an 'add' or an 'edit'. Just the table of Override CSCs
 					<th><?=gettext("Disabled")?></th>
 					<th><?=gettext("Common Name")?></th>
 					<th><?=gettext("Description")?></th>
-					<th> <!-- Buttons --></th>
+					<th><?=gettext("Actions")?></th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -1200,7 +1200,7 @@ else:
 					<th><?=gettext("Protocol / Port")?></th>
 					<th><?=gettext("Tunnel Network")?></th>
 					<th><?=gettext("Description")?></th>
-					<th><!-- Buttons --></th>
+					<th><?=gettext("Actions")?></th>
 				</tr>
 			</thead>
 


### PR DESCRIPTION
1) Put the heading "Actions" at the top of all the "Actions" columns -
it was on some and not others.
2) Some more consistent capitalization of panel titles etc.
3) Most interfaces section edit pages had a section titled like "GIF
Configuration", "GRE Configuration". Make them all consistent, e.g.
"QinQ Configuration" rather than "Interface QinQ Edit"...