### PR TITLE
subnet_size() and underlying function

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -811,11 +811,9 @@ function is_subnetoralias($subnet) {
 	}
 }
 
-/* Get number of addresses in an IPv4/IPv6 subnet.
-   optional arg $exact=true forces an error to be returned if it can't be represented exactly
-   
-   
-   
+/* Get number of addresses in an IPv4/IPv6 subnet (represented as a string)
+   optional $exact=true forces error (0) to be returned if it can't be represented exactly
+   Exact result not possible above PHP_MAX_INT which is about 2^31 addresses on x32 or 2^63 on x64
    Returns 0 for bad data or if cannot represent size as an INT when $exact is set. */
 function subnet_size($subnet, $exact=false) {
 	$parts = explode("/", $subnet);
@@ -829,11 +827,10 @@ function subnet_size($subnet, $exact=false) {
 	return 0;
 }
 
-/* Underlying function to get number of addresses in a subnet, given IP type and netmask size.
-   $exact=true forces detection of overflow, for huge subnets, and guarantees returned result is exact and an INT.
-   (Exact result not possible above PHP_MAX_INT which is about 2^31 on x32 or 2^63 on x64)
-   Hard to think where we need huge subnets in this way but detection by calling code is probably sensible to allow
-   Returns 0 for bad data or if result can't fit into INT and $exact=true is required */
+/* Get number of addresses in an IPv4/IPv6 subnet (represented numerically as IP type + bits)
+   optional $exact=true forces error (0) to be returned if it can't be represented exactly
+   Hard to think where we might need to count exactly a huge subnet but an overflow detection option is probably sensible
+   Returns 0 for bad data or if cannot represent size as an INT when $exact is set. */
 function subnet_size_by_netmask($iptype, $bits, $exact=false) {
 	if (!is_numericint($bits)) {
 		return 0;

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -811,15 +811,50 @@ function is_subnetoralias($subnet) {
 	}
 }
 
-function subnet_size($subnet) {
-	if (is_subnetv4($subnet)) {
-		list ($ip, $bits) = explode("/", $subnet);
-		return round(exp(log(2) * (32 - $bits)));
-	} else if (is_subnetv6($subnet)) {
-		list ($ip, $bits) = explode("/", $subnet);
-		return round(exp(log(2) * (128 - $bits)));
+/* Get number of addresses in an IPv4/IPv6 subnet.
+   optional arg $exact=true forces an error to be returned if it can't be represented exactly
+   
+   
+   
+   Returns 0 for bad data or if cannot represent size as an INT when $exact is set. */
+function subnet_size($subnet, $exact=false) {
+	$parts = explode("/", $subnet);
+	if (count($parts) == 2) {
+		if (is_ipaddrv4($ip)) {
+			return subnet_size_by_netmask(4, $bits, $exact);
+		} elseif (is_ipaddrv6($ip)) {
+			return subnet_size_by_netmask(6, $bits, $exact);
+		}
+	}
+	return 0;
+}
+
+/* Underlying function to get number of addresses in a subnet, given IP type and netmask size.
+   $exact=true forces detection of overflow, for huge subnets, and guarantees returned result is exact and an INT.
+   (Exact result not possible above PHP_MAX_INT which is about 2^31 on x32 or 2^63 on x64)
+   Hard to think where we need huge subnets in this way but detection by calling code is probably sensible to allow
+   Returns 0 for bad data or if result can't fit into INT and $exact=true is required */
+function subnet_size_by_netmask($iptype, $bits, $exact=false) {
+	if (!is_numericint($bits)) {
+		return 0;
+	} elseif ($iptype == 4 && $bits <= 32) {
+		$snsize = 32 - $bits;
+	} elseif ($iptype == 6 && $bits <= 128) {
+		$snsize = 128 - $bits;
 	} else {
 		return 0;
+	}
+
+	// 2**N returns an exact result as an INT if possible, and a float/double if not. 
+	// Detect this switch, rather than comparing $result<=PHP_MAX_INT or $bits >=8*PHP_INT_SIZE as it's (probably) easier to get completely reliable
+	$result = 2 ** $snsize;
+	
+	if ($exact && !is_int($result)) {
+		//exact required but can't represent result exactly as an INT
+		return 0;
+	} else {
+		// result ok, will be an INT where possible (guaranteed up to 2^31 addresses on x32/x64) and a float for 'huge' subnets
+		return $result;
 	}
 }
 

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -818,10 +818,10 @@ function is_subnetoralias($subnet) {
 function subnet_size($subnet, $exact=false) {
 	$parts = explode("/", $subnet);
 	if (count($parts) == 2) {
-		if (is_ipaddrv4($ip)) {
-			return subnet_size_by_netmask(4, $bits, $exact);
-		} elseif (is_ipaddrv6($ip)) {
-			return subnet_size_by_netmask(6, $bits, $exact);
+		if (is_ipaddrv4($parts[0])) {
+			return subnet_size_by_netmask(4, $parts[1], $exact);
+		} elseif (is_ipaddrv6($parts[0])) {
+			return subnet_size_by_netmask(6, $parts[1], $exact);
 		}
 	}
 	return 0;


### PR DESCRIPTION
Transparent tightening/enhancement. Added function subnet_size_from_netmask and modified existing function to use it.

1. Added a version of this that uses IP type and bit size rather than a string containing a subnet. More useful where $bits is known but base IP is irrelevant, which is the case in some DHCP/CARP/VPN code where we just want a `for (i=0; i<=$count-1; i++)` loop.
2. Rewrote existing function to use this (avoids duplication)
3. Added transparent optional argument $exact=false that allows calling code to specify an exact INT is required. This may be needed for loop control and some IP calculations, because for large subnets a FLOAT may be returned. (It's hard to think where exactness will matter on such a huge subnet that INT overflows, but this guarantees for calling code that the result will be an int, and may be useful in future)
4. Use ** operator (PHP 5.6) rather than exp(log). Tested and appears this returns INT where possible, up to 2^63 on x64, and a FLOAT if larger. (pow() seems identical. 1<< $bits wraps round to negative at 31/63 of course)
