### PR TITLE
Replace abbreviations with complete word

### DIFF
--- a/src/usr/local/www/diag_dump_states.php
+++ b/src/usr/local/www/diag_dump_states.php
@@ -165,7 +165,7 @@ print $form;
 <table class="table table-striped table-condensed table-hover sortable-theme-bootstrap" data-sortable>
 	<thead>
 		<tr>
-			<th><?=gettext("Int")?></th>
+			<th><?=gettext("Interface")?></th>
 			<th><?=gettext("Protocol")?></th>
 			<th><?=gettext("Source -> Router -> Destination")?></th>
 			<th><?=gettext("State")?></th>

--- a/src/usr/local/www/diag_dump_states.php
+++ b/src/usr/local/www/diag_dump_states.php
@@ -166,7 +166,7 @@ print $form;
 	<thead>
 		<tr>
 			<th><?=gettext("Int")?></th>
-			<th><?=gettext("Proto")?></th>
+			<th><?=gettext("Protocol")?></th>
 			<th><?=gettext("Source -> Router -> Destination")?></th>
 			<th><?=gettext("State")?></th>
 			<th></th> <!-- For the optional "Remove" button -->

--- a/src/usr/local/www/diag_states_summary.php
+++ b/src/usr/local/www/diag_states_summary.php
@@ -179,7 +179,7 @@ function print_summary_table($label, $iparr, $sort = TRUE) {
 						<tr>
 							<th ><?=gettext("IP");?></th>
 							<th class="text-center"># <?=gettext("States");?></th>
-							<th ><?=gettext("Proto");?></th>
+							<th ><?=gettext("Protocol");?></th>
 							<th class="text-center"># <?=gettext("States");?></th>
 							<th class="text-center"><?=gettext("Src Ports");?></th>
 							<th class="text-center"><?=gettext("Dst Ports");?></th>

--- a/src/usr/local/www/diag_states_summary.php
+++ b/src/usr/local/www/diag_states_summary.php
@@ -181,8 +181,8 @@ function print_summary_table($label, $iparr, $sort = TRUE) {
 							<th class="text-center"># <?=gettext("States");?></th>
 							<th ><?=gettext("Protocol");?></th>
 							<th class="text-center"># <?=gettext("States");?></th>
-							<th class="text-center"><?=gettext("Src Ports");?></th>
-							<th class="text-center"><?=gettext("Dst Ports");?></th>
+							<th class="text-center"><?=gettext("Source Ports");?></th>
+							<th class="text-center"><?=gettext("Dest. Ports");?></th>
 						</tr>
 					</thead>
 					<tbody>

--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -195,7 +195,7 @@ display_top_tabs($tab_array);
 					<tr>
 						<th><!-- Checkbox --></th>
 						<th><!-- Rule type --></th>
-						<th><?=gettext("If")?></th>
+						<th><?=gettext("Interface")?></th>
 						<th><?=gettext("Protocol")?></th>
 						<th><?=gettext("Src. addr")?></th>
 						<th><?=gettext("Src. ports")?></th>

--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -197,10 +197,10 @@ display_top_tabs($tab_array);
 						<th><!-- Rule type --></th>
 						<th><?=gettext("Interface")?></th>
 						<th><?=gettext("Protocol")?></th>
-						<th><?=gettext("Src. addr")?></th>
-						<th><?=gettext("Src. ports")?></th>
-						<th><?=gettext("Dest. addr")?></th>
-						<th><?=gettext("Dest. ports")?></th>
+						<th><?=gettext("Source Address")?></th>
+						<th><?=gettext("Source Ports")?></th>
+						<th><?=gettext("Dest. Address")?></th>
+						<th><?=gettext("Dest. Ports")?></th>
 						<th><?=gettext("NAT IP")?></th>
 						<th><?=gettext("NAT Ports")?></th>
 						<th><?=gettext("Description")?></th>

--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -196,7 +196,7 @@ display_top_tabs($tab_array);
 						<th><!-- Checkbox --></th>
 						<th><!-- Rule type --></th>
 						<th><?=gettext("If")?></th>
-						<th><?=gettext("Proto")?></th>
+						<th><?=gettext("Protocol")?></th>
 						<th><?=gettext("Src. addr")?></th>
 						<th><?=gettext("Src. ports")?></th>
 						<th><?=gettext("Dest. addr")?></th>

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -281,7 +281,7 @@ display_top_tabs($tab_array);
 					<tr>
 						<th><!-- checkbox --></th>
 						<th><!-- status icons --></th>
-						<th><?=gettext("Proto")?></th>
+						<th><?=gettext("Protocol")?></th>
 						<th><?=gettext("Source")?></th>
 						<th><?=gettext("Port")?></th>
 						<th><?=gettext("Destination")?></th>

--- a/src/usr/local/www/status_logs_filter.php
+++ b/src/usr/local/www/status_logs_filter.php
@@ -183,9 +183,9 @@ if (!$rawfilter) {
 		<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 			<thead>
 				<tr class="text-nowrap">
-					<th><?=gettext("Act")?></th>
+					<th><?=gettext("Action")?></th>
 					<th><?=gettext("Time")?></th>
-					<th><?=gettext("IF")?></th>
+					<th><?=gettext("Interface")?></th>
 <?php
 	if ($config['syslog']['filterdescriptions'] === "1") {
 ?>
@@ -197,7 +197,7 @@ if (!$rawfilter) {
 ?>
 					<th><?=gettext("Source")?></th>
 					<th><?=gettext("Destination")?></th>
-					<th><?=gettext("Proto")?></th>
+					<th><?=gettext("Protocol")?></th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/usr/local/www/status_logs_filter_dynamic.php
+++ b/src/usr/local/www/status_logs_filter_dynamic.php
@@ -406,12 +406,12 @@ function toggleListDescriptions() {
 			<table class="table table-striped table-hover table-condensed">
 				<thead>
 					<tr class="text-nowrap">
-						<th><?=gettext("Act")?></th>
+						<th><?=gettext("Action")?></th>
 						<th><?=gettext("Time")?></th>
-						<th><?=gettext("IF")?></th>
+						<th><?=gettext("Interface")?></th>
 						<th><?=gettext("Source")?></th>
 						<th><?=gettext("Destination")?></th>
-						<th><?=gettext("Proto")?></th>
+						<th><?=gettext("Protocol")?></th>
 					</tr>
 				</thead>
 				<tbody id="filter-log-entries">

--- a/src/usr/local/www/status_openvpn.php
+++ b/src/usr/local/www/status_openvpn.php
@@ -253,10 +253,10 @@ include("head.inc"); ?>
 						<th><?=gettext("Name"); ?></th>
 						<th><?=gettext("Status"); ?></th>
 						<th><?=gettext("Connected Since"); ?></th>
-						<th><?=gettext("Virtual Addr"); ?></th>
+						<th><?=gettext("Virtual Address"); ?></th>
 						<th><?=gettext("Remote Host"); ?></th>
 						<th><?=gettext("Bytes Sent"); ?></th>
-						<th><?=gettext("Bytes Rcvd"); ?></th>
+						<th><?=gettext("Bytes Received"); ?></th>
 						<th><?=gettext("Service"); ?></th>
 					</tr>
 				</thead>
@@ -309,10 +309,10 @@ include("head.inc"); ?>
 						<th><?=gettext("Name"); ?></th>
 						<th><?=gettext("Status"); ?></th>
 						<th><?=gettext("Connected Since"); ?></th>
-						<th><?=gettext("Virtual Addr"); ?></th>
+						<th><?=gettext("Virtual Address"); ?></th>
 						<th><?=gettext("Remote Host"); ?></th>
 						<th><?=gettext("Bytes Sent"); ?></th>
-						<th><?=gettext("Bytes Rcvd"); ?></th>
+						<th><?=gettext("Bytes Received"); ?></th>
 						<th><?=gettext("Service"); ?></th>
 					</tr>
 				</thead>

--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -131,9 +131,9 @@ if (isset($_POST['lastsawtime'])) {
 <table class="table table-striped table-hover">
 	<thead>
 		<tr>
-			<th><?=gettext("Act");?></th>
+			<th><?=gettext("Action");?></th>
 			<th><?=gettext("Time");?></th>
-			<th><?=gettext("IF");?></th>
+			<th><?=gettext("Interface");?></th>
 			<th><?=gettext("Source");?></th>
 			<th><?=gettext("Destination");?></th>
 		</tr>


### PR DESCRIPTION
I've found some abbreviations that could be replaced with complete words.
This should ease the understanding of every table column.