### PR TITLE
Internationalize more text in diag_halt

### DIFF
--- a/src/usr/local/www/diag_halt.php
+++ b/src/usr/local/www/diag_halt.php
@@ -98,14 +98,14 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 
 <div class="panel panel-default">
 	<div class="panel-heading">
-		<h2 class="panel-title">Are you sure you want to halt the system?</h2>
+		<h2 class="panel-title"><?=gettext('Are you sure you want to halt the system?')?></h2>
 	</div>
 	<div class="panel-body">
 		<div class="content">
-			<p>Click "Halt" to halt the system immediately, or "No" to go to the system dashboard. (There will be a brief delay before the dashboard appears.)</p>
+			<p><?=gettext('Click "Halt" to halt the system immediately, or "No" to go to the system dashboard. (There will be a brief delay before the dashboard appears.)')?></p>
 			<form action="diag_halt.php" method="post">
-				<input type="submit" class="btn btn-danger pull-center" name="save" value="Halt">
-				<a href="/" class="btn btn-default">No</a>
+				<input type="submit" class="btn btn-danger pull-center" name="save" value="<?=gettext("Halt")?>">
+				<a href="/" class="btn btn-default"><?=gettext("No")?></a>
 			</form>
 		</div>
 	</div>


### PR DESCRIPTION
while I was looking at the panel-heading stuff, I noticed that there are whole chunks of text here that have no gettext() wrapper.