### PR TITLE
Fix product_name syntax problem in diag_backup

### DIFF
--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -673,7 +673,7 @@ $section = new Form_Section('Restore backup');
 
 $section->addInput(new Form_StaticText(
 	null,
-	gettext("Open a ") . $g['[product_name'] . gettext(" configuration XML file and click the button below to restore the configuration.")
+	sprintf(gettext("Open a %s configuration XML file and click the button below to restore the configuration."), $g['product_name'])
 ));
 
 $section->addInput(new Form_Select(


### PR DESCRIPTION
Notice that the old line had $g['[product_name'] - a bonus "[" - that caused the product name to not actually appear in the output.

In fixing that, I also wrapped this in sprintf() - that makes it more flexible for translation into languages where the word order of an instruction like this does not start with the verb.