### PR TITLE
diag_confbak make a single gettext

### DIFF
--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -149,7 +149,7 @@ if ($diff) {
 <div class="panel panel-default">
 	<div class="panel-heading">
 		<h2 class="panel-title">
-			<?=gettext("Configuration diff from ")?><?=date(gettext("n/j/y H:i:s"), $oldtime); ?><?=gettext(" to ")?><?=date(gettext("n/j/y H:i:s"), $newtime); ?>
+			<?=sprintf(gettext('Configuration diff from %1$s to %2$s'), date(gettext("n/j/y H:i:s"), $oldtime), date(gettext("n/j/y H:i:s"), $newtime))?>
 		</h2>
 	</div>
 	<div class="panel-body table-responsive">


### PR DESCRIPTION
Sentences that are constructed in pieces like this are a potential problem for translation, if the target language needs to use a different grammatical word order. e.g. in Nepali we would say datetime-dekhi datetime-samma (datetime-from datetime-to).
Organize it into a single gettext() that has the whole sentence in one go with numbering of the parameters so they can also be potentially re-ordered as needed in a translation.
I am having a look at a few places where the gettext() translation is missing, and noticed this kind of thing also. When I see this sort of sentence construction using sentence fragments built up with multiple gettext() calls I will fix them up like this and make PRs.