### PR TITLE
Internationalization of diag_defaults

### DIFF
--- a/src/usr/local/www/diag_defaults.php
+++ b/src/usr/local/www/diag_defaults.php
@@ -85,12 +85,12 @@ include("head.inc");
 <?php else:?>
 <div class="panel panel-default">
 	<div class="panel-heading">
-		<h2 class="panel-title">Are you sure you want to reset the system to the factory defaults?</h2>
+		<h2 class="panel-title"><?=gettext("Are you sure you want to reset the system to the factory defaults?")?></h2>
 	</div>
 	<div class="panel-body">
 		<div class="content">
 			<form action="diag_defaults.php" method="post">
-				<p><strong><?=gettext("If you click") . " &quot;" . gettext("Yes") . "&quot;, " . gettext("the firewall will:")?></strong></p>
+				<p><strong><?=sprintf(gettext('If you click %1$sYes%1$s the firewall will:'), "&quot;")?></strong></p>
 				<ul>
 					<li><?=gettext("Reset to factory defaults")?></li>
 					<li><?=gettext("LAN IP address will be reset to 192.168.1.1")?></li>
@@ -98,7 +98,7 @@ include("head.inc");
 					<li><?=gettext("Reboot after changes are installed")?></li>
 					<li><?=gettext("WAN interface will be set to obtain an address automatically from a DHCP server")?></li>
 					<li><?=gettext("webConfigurator admin username will be reset to 'admin'")?></li>
-					<li><?=gettext("webConfigurator admin password will be reset to")?> '<?=$g['factory_shipped_password']?>'</li>
+					<li><?=sprintf(gettext("webConfigurator admin password will be reset to '%s'"), $g['factory_shipped_password'])?></li>
 				</ul>
 				<p><strong><?=gettext("Are you sure you want to proceed?")?></strong></p>
 				<p>


### PR DESCRIPTION
A couple of typical fixes here:
1) Actually wrap the "Are you sure...?" question in gettext()
2) Use a single gettext() call combined with sprintf() and %s etc to construct a sentence in a single go.
3) Use %s rather than just appending a variable at the end of a sentence of text. That way there is no assumption that the variable text must go at the end in every language.

Once I have got the feel of the variations I come across, I will make myself a branch and change a whole bunch of files. But for now I have submitted a few things individually so it is easy for people to comment and give any helpful advice on how to do it better, before I go editing lots of files.

IMHO it will be good to cleanup and optimize the internationalized code, then life should be easier for future translators.