### PR TITLE
Rationalize message display on diag_testport

### DIFF
--- a/src/usr/local/www/diag_testport.php
+++ b/src/usr/local/www/diag_testport.php
@@ -221,9 +221,9 @@ include("head.inc");
 // Handle the display of all messages here where the user can readily see them
 if ($input_errors) {
 	print_input_errors($input_errors);
-} elseif ($do_testport)	{
+} elseif ($do_testport) {
 	// User asked for a port test
-	if ($retval == 0)	{
+	if ($retval == 0) {
 		// Good host & port
 		$alert_text = '<div class="alert alert-success" role="alert">' . sprintf(gettext('Port test to host: %1$s Port: %2$s successful'), $host, $port);
 		if ($showtext) {

--- a/src/usr/local/www/diag_testport.php
+++ b/src/usr/local/www/diag_testport.php
@@ -222,28 +222,28 @@ include("head.inc");
 if ($input_errors) {
 	print_input_errors($input_errors);
 } else {
-	// New page
-	if (empty($result) && $retval != 0 && !$showtext) {
-	    print('<div class="alert alert-warning" role="alert">This page allows you to perform a simple TCP connection test to determine if a host is up and accepting connections on a given port.' .
-	          ' This test does not function for UDP since there is no way to reliably determine if a UDP port accepts connections in this manner.</div>');
-	}
-
-	// Good host & port
-	if ($retval == 0 && $do_testport == 1)	{
-		if (!$showtext) {
-			print('<div class="alert alert-success" role="alert">'.gettext("Port test to host: " . $host . " Port: " . $port . " successful").'</div>');
+	if ($do_testport)	{
+		// User asked for a port test
+		if ($retval == 0)	{
+			// Good host & port
+			if (!$showtext) {
+				print('<div class="alert alert-success" role="alert">' . sprintf(gettext('Port test to host: %1$s Port: %2$s successful'), $host, $port) . '</div>');
+			} else {
+				print('<div class="alert alert-success" role="alert">' . sprintf(gettext('Port test to host: %1$s Port: %2$s successful.'), $host, $port) . ' ' . gettext('Any text received from the host will be shown below the form.') . '</div>');
+			}
 		} else {
-			print('<div class="alert alert-success" role="alert">'.gettext("Port test to host: " . $host . " Port: " . $port . " successful") . '. Any text received from the host will be shown below the form.</div>');
+			// netcat exit value != 0
+			if ($showtext) {
+				print('<div class="alert alert-danger" role="alert">' . gettext('No output received, or connection failed. Try with "Show Remote Text" unchecked first.') . '</div>');
+			} else {
+				print('<div class="alert alert-danger" role="alert">' . gettext('Connection failed.') . '</div>');
+			}
 		}
-	}
-
-	// netcat exit value != 0
-	if ($retval != 0 && !empty($result)) {
-		if ($showtext) {
-			print('<div class="alert alert-danger" role="alert">'.gettext('No output received, or connection failed. Try with "Show Remote Text" unchecked first.').'</div>');
-		} else {
-			print('<div class="alert alert-danger" role="alert">'.gettext('Connection failed.').'</div>');
-		}
+	} else {
+		// First time, new page
+	    print('<div class="alert alert-warning" role="alert">' .
+			gettext('This page allows you to perform a simple TCP connection test to determine if a host is up and accepting connections on a given port.') . " " .
+			gettext('This test does not function for UDP since there is no way to reliably determine if a UDP port accepts connections in this manner.') . '</div>');
 	}
 }
 
@@ -300,15 +300,18 @@ $section->addInput(new Form_Select(
 $form->add($section);
 print $form;
 
-if ($ncoutput && !empty($result) && $showtext && $retval == 0): ?>
+// If the command succeeded, the user asked to see the output and there is output, then show it.
+if ($retval == 0 && $showtext && !empty($ncoutput)):
+?>
 	<div class="panel panel-default">
 		<div class="panel-heading">
-			<h2 class="panel-title">Received Remote Text</h2>
+			<h2 class="panel-title"><?=gettext('Received Remote Text')?></h2>
 		</div>
 		<div class="panel-body">
 			<pre><?= $ncoutput ?></pre>
 		</div>
 	</div>
-<?php endif;
+<?php
+endif;
 
 include("foot.inc");

--- a/src/usr/local/www/diag_testport.php
+++ b/src/usr/local/www/diag_testport.php
@@ -221,30 +221,29 @@ include("head.inc");
 // Handle the display of all messages here where the user can readily see them
 if ($input_errors) {
 	print_input_errors($input_errors);
-} else {
-	if ($do_testport)	{
-		// User asked for a port test
-		if ($retval == 0)	{
-			// Good host & port
-			if (!$showtext) {
-				print('<div class="alert alert-success" role="alert">' . sprintf(gettext('Port test to host: %1$s Port: %2$s successful'), $host, $port) . '</div>');
-			} else {
-				print('<div class="alert alert-success" role="alert">' . sprintf(gettext('Port test to host: %1$s Port: %2$s successful.'), $host, $port) . ' ' . gettext('Any text received from the host will be shown below the form.') . '</div>');
-			}
-		} else {
-			// netcat exit value != 0
-			if ($showtext) {
-				print('<div class="alert alert-danger" role="alert">' . gettext('No output received, or connection failed. Try with "Show Remote Text" unchecked first.') . '</div>');
-			} else {
-				print('<div class="alert alert-danger" role="alert">' . gettext('Connection failed.') . '</div>');
-			}
+} elseif ($do_testport)	{
+	// User asked for a port test
+	if ($retval == 0)	{
+		// Good host & port
+		$alert_text = '<div class="alert alert-success" role="alert">' . sprintf(gettext('Port test to host: %1$s Port: %2$s successful'), $host, $port);
+		if ($showtext) {
+			$alert_text .= ' ' . gettext('Any text received from the host will be shown below the form.');
 		}
 	} else {
-		// First time, new page
-	    print('<div class="alert alert-warning" role="alert">' .
-			gettext('This page allows you to perform a simple TCP connection test to determine if a host is up and accepting connections on a given port.') . " " .
-			gettext('This test does not function for UDP since there is no way to reliably determine if a UDP port accepts connections in this manner.') . '</div>');
+		// netcat exit value != 0
+		$alert_text = '<div class="alert alert-danger" role="alert">';
+		if ($showtext) {
+			$alert_text .= gettext('No output received, or connection failed. Try with "Show Remote Text" unchecked first.');
+		} else {
+			$alert_text .= gettext('Connection failed.');
+		}
 	}
+	print ($alert_text . '</div>');
+} else {
+	// First time, new page
+	print('<div class="alert alert-warning" role="alert">' .
+		gettext('This page allows you to perform a simple TCP connection test to determine if a host is up and accepting connections on a given port.') . " " .
+		gettext('This test does not function for UDP since there is no way to reliably determine if a UDP port accepts connections in this manner.') . '</div>');
 }
 
 $form = new Form('Test');


### PR DESCRIPTION
1) The logic of the various tests that determined which messages were displayed was all a bit odd, and there were ways that things could happen and no message was displayed. Now it displays the "warning" information message the first time, and 1 of the 4 possible result messages depending on the result status and if showtest was on.
2) Internationalize - put the gettext() into calls with full sentences and sprintf() wrappers as necessary.

Now I can get each of the 4 possible result messages, and always get a result message.