### PR TITLE
Cleanup of diag_traceroute

### DIFF
--- a/src/usr/local/www/diag_traceroute.php
+++ b/src/usr/local/www/diag_traceroute.php
@@ -73,12 +73,12 @@ include("head.inc");
 define('MAX_TTL', 64);
 define('DEFAULT_TTL', 18);
 
+// Set defaults in case they are not supplied.
 $do_traceroute = false;
 $host = '';
 $ttl = DEFAULT_TTL;
-$pconfig['ttl'] = DEFAULT_TTL;
-$pconfig['ipproto'] = 'IPv4';
-$pconfig['sourceip'] = 'Any';
+$ipproto = 'ipv4';
+$sourceip = 'any';
 
 function create_sourceaddresslist() {
 	$list = array('any' => 'Any');
@@ -94,7 +94,6 @@ function create_sourceaddresslist() {
 
 if ($_POST || $_REQUEST['host']) {
 	unset($input_errors);
-	unset($do_traceroute);
 
 	/* input validation */
 	$reqdfields = explode(" ", "host ttl");
@@ -113,16 +112,12 @@ if ($_POST || $_REQUEST['host']) {
 		$input_errors[] = gettext("When using IPv6, the target host must be an IPv6 address or hostname.");
 	}
 
-	if (!$input_errors) {
-		$host = $_REQUEST['host'];
-	}
-
 	$sourceip = $_REQUEST['sourceip'];
 	$ttl = $_REQUEST['ttl'];
 	$resolve = $_REQUEST['resolve'];
 	$useicmp = $_REQUEST['useicmp'];
 
-	if ($_POST) {
+	if ($_POST && !$input_errors) {
 		$do_traceroute = true;
 	}
 
@@ -133,6 +128,31 @@ if ($_POST || $_REQUEST['host']) {
 
 if ($input_errors) {
 	print_input_errors($input_errors);
+}
+
+/* Do the traceroute and show any error */
+if ($do_traceroute) {
+	$useicmpparam = isset($useicmp) ? "-I" : "";
+	$n = isset($resolve) ? "" : "-n";
+
+	$command = "/usr/sbin/traceroute";
+	if ($ipproto == "ipv6") {
+		$command .= "6";
+		$ifaddr = is_ipaddr($sourceip) ? $sourceip : get_interface_ipv6($sourceip);
+	} else {
+		$ifaddr = is_ipaddr($sourceip) ? $sourceip : get_interface_ip($sourceip);
+	}
+
+	if ($ifaddr && (is_ipaddr($host) || is_hostname($host))) {
+		$srcip = "-s " . escapeshellarg($ifaddr);
+	}
+
+	$cmd = "{$command} {$n} {$srcip} -w 2 {$useicmpparam} -m " . escapeshellarg($ttl) . " " . escapeshellarg($host);
+	$result = shell_exec($cmd);
+
+	if (!$result) {
+		print_info_box(sprintf(gettext('Error: %s could not be traced/resolved'), $host));
+	}
 }
 
 $form = new Form('Traceroute');
@@ -150,14 +170,14 @@ $section->addInput(new Form_Input(
 $section->addInput(new Form_Select(
 	'ipproto',
 	'IP Protocol',
-	$pconfig['ipproto'],
+	$ipproto,
 	array('ipv4' => 'IPv4', 'ipv6' => 'IPv6')
 ))->setHelp('Select the protocol to use');
 
 $section->addInput(new Form_Select(
 	'sourceip',
 	'Source Address',
-	$pconfig['sourceip'],
+	$sourceip,
 	create_sourceaddresslist()
 ))->setHelp('Select source address for the trace');
 
@@ -186,34 +206,13 @@ $form->add($section);
 print $form;
 
 /* Show the traceroute results */
-if (!$input_errors && $do_traceroute) {
-
-	$useicmp = isset($_REQUEST['useicmp']) ? "-I" : "";
-	$n = isset($resolve) ? "" : "-n";
-
-	$command = "/usr/sbin/traceroute";
-	if ($ipproto == "ipv6") {
-		$command .= "6";
-		$ifaddr = is_ipaddr($sourceip) ? $sourceip : get_interface_ipv6($sourceip);
-	} else {
-		$ifaddr = is_ipaddr($sourceip) ? $sourceip : get_interface_ip($sourceip);
-	}
-
-	if ($ifaddr && (is_ipaddr($host) || is_hostname($host))) {
-		$srcip = "-s " . escapeshellarg($ifaddr);
-	}
-
-	$cmd = "{$command} {$n} {$srcip} -w 2 {$useicmp} -m " . escapeshellarg($ttl) . " " . escapeshellarg($host);
+if ($do_traceroute && $result) {
 ?>
 	<div class="panel panel-default">
-		<div class="panel-heading"><h2 class="panel-title">Results</h2></div>
+		<div class="panel-heading"><h2 class="panel-title"><?=gettext('Results')?></h2></div>
 		<div class="panel-body">
 <?php
-		if ($result = shell_exec($cmd)) {
-			print('<pre>'.$result.'</pre>');
-		} else {
-			print('Error: ' . $host . ' ' . gettext("could not be traced/resolved"));
-		}
+	print('<pre>' . $result . '</pre>');
 ?>
 		</div>
 	</div>


### PR DESCRIPTION
1) Internationalize
2) If there was a problem, then display it with print_info_box() up the top of the page.
3) Redisplay the user-selected IP protocol and source IP after a test. Previously those user selections always got reset to IPv4, any.
4) Remove some useless code that unset($do_traceroute) when it had happily been set to false a little earlier.
5) Remove some useless code that set $host when it had already been set a little earlier.