### PR TITLE
Fix easyrule fbegin.inc echoed text

### DIFF
--- a/src/usr/local/www/easyrule.php
+++ b/src/usr/local/www/easyrule.php
@@ -87,9 +87,7 @@ if (stristr($retval, "error") == true) {
 	$message = $retval;
 }
 
-include("head.inc"); ?>
-
-include("fbegin.inc");
+include("head.inc");
 ?>
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 	<tr>
@@ -99,17 +97,22 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 
-if ($message) { ?>
+if ($message) {
+?>
 <br />
 <?=gettext("Message"); ?>: <?=$message;?>
 <br />
-<?php } else { ?>
-<?=gettext("This is the Easy Rule status page, mainly used to display errors when adding rules. " .
-"If you are seeing this, there apparently was not an error, and you navigated to the " .
-"page directly without telling it what to do"); ?>.<br /><br />
-<?=gettext("This page is meant to be called from the block/pass buttons on the Firewall Logs page"); ?>, <a href="status_logs_filter.php"><?=gettext("Status"); ?> &gt; <?=gettext("System Logs, " .
-"Firewall Tab"); ?></a>.
-<br />
-<?php } ?>
-</td></tr></table>
+<?php
+} else {
+	print_info_box(
+		gettext('This is the Easy Rule status page, mainly used to display errors when adding rules.') . ' ' .
+		gettext('If you are seeing this, there apparently was not an error, and you navigated to the page directly without telling it what to do.') .
+		'<br /><br />' .
+		gettext('This page is meant to be called from the block/pass buttons on the Firewall Logs page') .
+		', <a href="status_logs_filter.php">' . gettext("Status") . ' &gt; ' . gettext('System Logs') . ', ' . gettext('Firewall Tab') . '</a>.<br />');
+}
+?>
+		</td>
+	</tr>
+</table>
 <?php include("foot.inc"); ?>


### PR DESCRIPTION

![easyrule](https://cloud.githubusercontent.com/assets/1535615/12378610/6e50ddda-bd6b-11e5-9101-db102c7f90b3.png)
If you manually navigate directly to easyrule.php you get a bit of rubbish text displayed before the actual message about "This is the Easy Rule status page...". That is due to having too many closing PHP tags. Also, fbegin.inc does not need to be included anyway.

I also changed the message to be in a print_info_box() warning and sorted the internationalization a bit more.

There could be a bit more formatting done here after this - the page has a help icon that looks a bit lonely without the other usual panel-heading panel-title stuff.