### PR TITLE
Display existing updatefreq

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -702,7 +702,13 @@ while ($counter < count($addresses)) {
 		list($address, $address_subnet) = explode("/", $addresses[$counter]);
 	} else {
 		$address = $addresses[$counter];
-		$address_subnet = "";
+		if (isset($pconfig['updatefreq'])) {
+			// Note: There is only 1 updatefreq possible.
+			// The alias types that use updatefreq only allow a single entry.
+			$address_subnet = $pconfig['updatefreq'];
+		} else {
+			$address_subnet = "";
+		}
 	}
 
 	$group = new Form_Group($counter == 0 ? $label_str[$tab]:'');


### PR DESCRIPTION
when user is editing an alias type that uses the subnet CIDR field as the URL table update frequency.
Forum: https://forum.pfsense.org/index.php?topic=105457.0