### PR TITLE
Fix #5778 do not save changes if interface description matches an alias name

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -1640,7 +1640,7 @@ foreach ($mediaopts as $mediaopt) {
 	}
 }
 
-$pgtitle = array(gettext("Interfaces"), $pconfig['descr']);
+$pgtitle = array(gettext("Interfaces"), $wancfg['descr']);
 $shortcut_section = "interfaces";
 
 $types4 = array("none" => gettext("None"), "staticv4" => gettext("Static IPv4"), "dhcp" => gettext("DHCP"), "ppp" => gettext("PPP"), "pppoe" => gettext("PPPoE"), "pptp" => gettext("PPTP"), "l2tp" => gettext("L2TP"));

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -540,6 +540,16 @@ if ($_POST['apply']) {
 			break;
 		}
 	}
+
+	/* Is the description already used as an alias name? */
+	if (is_array($config['aliases']['alias'])) {
+		foreach ($config['aliases']['alias'] as $alias) {
+			if ($alias['name'] == $_POST['descr']) {
+				$input_errors[] = sprintf(gettext("Sorry, an alias with the name %s already exists."), $_POST['descr']);
+			}
+		}
+	}
+
 	if (is_numeric($_POST['descr'])) {
 		$input_errors[] = gettext("The interface description cannot contain only numbers.");
 	}


### PR DESCRIPTION
See https://redmine.pfsense.org/issues/5778 for details of how to reproduce the problem.

Note that similar code to make the "Sorry, an alias with the name XXX already exists" message is also at the top of interfaces.inc - it compares the current interface descr from the config with the currently existing alias names. That check would help warn the user if someone managed to add an alias name that matched the interface name. I guess it was there from some time in the past when the alias edit code did not cross-validate the alias name with the interface descriptions. I have left that check there - it does no harm to have it "just in case".

The new code that I added checks the proposed interface description in $_POST against the existing alias names and will give an input_error if there is a match.