### PR TITLE
classes/Form/Textarea.class.php, setNoWrap, make it work properly on FireFox and Chromium

### DIFF
--- a/src/usr/local/www/classes/Form/Textarea.class.php
+++ b/src/usr/local/www/classes/Form/Textarea.class.php
@@ -51,7 +51,7 @@ class Form_Textarea extends Form_Input
 
 	public function setNoWrap()
 	{
-		$this->_attributes['style'] = 'white-space: nowrap; width: auto;';
+		$this->_attributes['style'] = 'white-space: pre;';
 
 		return $this;
 	}


### PR DESCRIPTION
classes/Form/Textarea.class.php, setNoWrap, make it work properly on FireFox and Chromium