### PR TITLE
Standardize NAT NPt

### DIFF
--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -175,7 +175,7 @@ if ($savemsg) {
 
 if (is_subsystem_dirty('natconf')) {
 	print_info_box_np(gettext('The NAT configuration has been changed.') . '<br />' .
-					  gettext('You must apply the changes in order for them to take effect.') . '<br />');
+					  gettext('You must apply the changes in order for them to take effect.'));
 }
 
 $tab_array = array();

--- a/src/usr/local/www/firewall_nat_1to1.php
+++ b/src/usr/local/www/firewall_nat_1to1.php
@@ -161,7 +161,7 @@ if ($savemsg) {
 
 if (is_subsystem_dirty('natconf')) {
 	print_info_box_np(gettext('The NAT configuration has been changed.') . '<br />' .
-					  gettext('You must apply the changes in order for them to take effect.') . '<br />');
+					  gettext('You must apply the changes in order for them to take effect.'));
 }
 
 $tab_array = array();
@@ -249,9 +249,9 @@ display_top_tabs($tab_array);
 						</td>
 
 						<td>
-							<a class="fa fa-pencil" title="<?=gettext("Edit rule")?>" href="firewall_nat_1to1_edit.php?id=<?=$i?>"></a>
-							<a class="fa fa-clone" title="<?=gettext("Add a new rule based on this one")?>" href="firewall_nat_1to1_edit.php?dup=<?=$i?>"></a>
-							<a class="fa fa-trash" title="<?=gettext("Delete rule")?>" href="firewall_nat_1to1.php?act=del&amp;id=<?=$i?>" ></a>
+							<a class="fa fa-pencil" title="<?=gettext("Edit mapping")?>" href="firewall_nat_1to1_edit.php?id=<?=$i?>"></a>
+							<a class="fa fa-clone" title="<?=gettext("Add a new mapping based on this one")?>" href="firewall_nat_1to1_edit.php?dup=<?=$i?>"></a>
+							<a class="fa fa-trash" title="<?=gettext("Delete mapping")?>" href="firewall_nat_1to1.php?act=del&amp;id=<?=$i?>"></a>
 						</td>
 
 					</tr>
@@ -273,7 +273,7 @@ display_top_tabs($tab_array);
 			<i class="fa fa-trash icon-embed-btn"></i>
 			<?=gettext("Delete"); ?>
 		</button>
-		<button type="submit" id="order-store" name="order-store" class="btn btn-primary btn-sm" disabled title="<?=gettext('Save rule order')?>">
+		<button type="submit" id="order-store" name="order-store" class="btn btn-primary btn-sm" disabled title="<?=gettext('Save mapping order')?>">
 			<i class="fa fa-save icon-embed-btn"></i>
 			<?=gettext("Save")?>
 		</button>

--- a/src/usr/local/www/firewall_nat_npt_edit.php
+++ b/src/usr/local/www/firewall_nat_npt_edit.php
@@ -63,20 +63,6 @@
 
 require_once("ipsec.inc");
 
-function natnptcmp($a, $b) {
-	return ipcmp($a['external'], $b['external']);
-}
-
-function nat_npt_rules_sort() {
-	global $g, $config;
-
-	if (!is_array($config['nat']['npt'])) {
-			return;
-	}
-
-	usort($config['nat']['npt'], "natnptcmp");
-}
-
 require("guiconfig.inc");
 require_once("interfaces.inc");
 require_once("filter.inc");
@@ -102,6 +88,11 @@ if (isset($_POST['id']) && is_numericint($_POST['id'])) {
 	$id = $_POST['id'];
 }
 
+if (isset($_GET['dup'])) {
+	$id = $_GET['dup'];
+	$after = $_GET['dup'];
+}
+
 if (isset($id) && $a_npt[$id]) {
 	$pconfig['disabled'] = isset($a_npt[$id]['disabled']);
 
@@ -118,12 +109,14 @@ if (isset($id) && $a_npt[$id]) {
 		$pconfig['interface'] = "wan";
 	}
 
-	$pconfig['external'] = $a_npt[$id]['external'];
 	$pconfig['descr'] = $a_npt[$id]['descr'];
 } else {
 	$pconfig['interface'] = "wan";
 }
 
+if (isset($_GET['dup'])) {
+	unset($id);
+}
 
 if ($_POST) {
 
@@ -161,9 +154,12 @@ if ($_POST) {
 		if (isset($id) && $a_npt[$id]) {
 			$a_npt[$id] = $natent;
 		} else {
-			$a_npt[] = $natent;
+			if (is_numeric($after)) {
+				array_splice($a_npt, $after+1, 0, array($natent));
+			} else {
+				$a_npt[] = $natent;
+			}
 		}
-		nat_npt_rules_sort();
 
 		if (write_config()) {
 			mark_subsystem_dirty('natconf');
@@ -185,24 +181,24 @@ function build_if_list() {
 
 	if ($config['l2tp']['mode'] == "server") {
 		if (have_ruleint_access("l2tp")) {
-			$interfaces['l2tp'] = "L2TP VPN";
+			$interfaces['l2tp'] = gettext("L2TP VPN");
 		}
 	}
 
 	if ($config['pppoe']['mode'] == "server") {
 		if (have_ruleint_access("pppoe")) {
-			$interfaces['pppoe'] = "PPPoE Server";
+			$interfaces['pppoe'] = gettext("PPPoE Server");
 		}
 	}
 
 	/* add ipsec interfaces */
 	if (ipsec_enabled() && have_ruleint_access("enc0")) {
-		$interfaces["enc0"] = "IPsec";
+		$interfaces["enc0"] = gettext("IPsec");
 	}
 
 	/* add openvpn/tun interfaces */
 	if ($config['openvpn']["openvpn-server"] || $config['openvpn']["openvpn-client"]) {
-		$interfaces["openvpn"] = "OpenVPN";
+		$interfaces["openvpn"] = gettext("OpenVPN");
 	}
 
 	return($interfaces);

--- a/src/usr/local/www/firewall_nat_out.php
+++ b/src/usr/local/www/firewall_nat_out.php
@@ -244,7 +244,8 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('natconf')) {
-	print_info_box_np(gettext("The NAT configuration has been changed.")."<br />".gettext("You must apply the changes in order for them to take effect."));
+	print_info_box_np(gettext('The NAT configuration has been changed.') . '<br />' .
+					  gettext('You must apply the changes in order for them to take effect.'));
 }
 
 $tab_array = array();
@@ -529,7 +530,7 @@ print($form);
 			<i class="fa fa-trash icon-embed-btn"></i>
 			<?=gettext("Delete"); ?>
 		</button>
-		<button type="submit" id="order-store" class="btn btn-primary btn-sm" value="Save changes" disabled name="order-store" title="<?=gettext('Save map order')?>">
+		<button type="submit" id="order-store" class="btn btn-primary btn-sm" value="Save changes" disabled name="order-store" title="<?=gettext('Save mapping order')?>">
 			<i class="fa fa-save icon-embed-btn"></i>
 			<?=gettext("Save")?>
 		</button>


### PR DESCRIPTION
Give NAT NPt GUI the same sort of interface as NAT 1:1
1) Checkbox to select multiple mappings and then delete selected
mappings
2) Tick/cross to enable/disable a mapping
3) Ability to "Add a new mapping based on this one"
4) Double-click to edit an entry
5) Ability to reorder mappings and save the new order - probably nobody
cares about that but it is easy to provide it the same as on other
forms, and so users can order the entries as they like.
Note: It used to try to automagically sort the entries based on ipcmp()
of the value of 'external' - that does not work in 2.2.* because
'external' is not a key at all for NPt. So I took that out - seemed more
consistent to provide the user drag-drop entry ordering feature.

Other bits of text in firewall NAT, 1:1 and Out standardized to make all
of them match.