### PR TITLE
A proposal for 5431 https://redmine.pfsense.org/issues/5431

### DIFF
--- a/src/usr/local/www/bootstrap/css/pfSense-dark.css
+++ b/src/usr/local/www/bootstrap/css/pfSense-dark.css
@@ -157,6 +157,11 @@ ul.context-links li a {
     border-color: #212121;
 }
 
+.btn-breadcrumbbar {
+	color: #808080;
+    background-color: #404040;
+}
+
 .btn-default.active, .btn-default.focus, .btn-default:active, .btn-default:focus, .btn-default:hover, .open>.dropdown-toggle.btn-default {
     color: #ffffff;
     background-color: #424242;

--- a/src/usr/local/www/bootstrap/css/pfSense.css
+++ b/src/usr/local/www/bootstrap/css/pfSense.css
@@ -509,6 +509,11 @@ footer a {
     background-color: #1976D2;
 }
 
+.btn-breadcrumbbar {
+	color: #808080;
+    background-color: #D0D0D0;
+}
+
 .text-warning {
     color: #F57F17;
 }

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -486,7 +486,7 @@ echo '<li>'. get_shortcut_status_link($shortcut_section, false). '</li>';
 echo '<li>'. get_shortcut_log_link($shortcut_section, false). '</li>';
 
 ?>
-	<?php if ($pagetitle === 'Status: Dashboard'): ?>
+	<?php if ($dashboard_available_widgets_hidden): ?>
 		<li>
 			<a onclick="$('#widget-available').toggle(360);" title="<?=gettext("Show/Hide available widgets panel")?>">
 				<i class="btn-sm btn-breadcrumbbar">Widgets</i>

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -486,6 +486,14 @@ echo '<li>'. get_shortcut_status_link($shortcut_section, false). '</li>';
 echo '<li>'. get_shortcut_log_link($shortcut_section, false). '</li>';
 
 ?>
+	<?php if ($pagetitle === 'Status: Dashboard'): ?>
+		<li>
+			<a onclick="$('#widget-available').toggle(360);" title="<?=gettext("Show/Hide available widgets panel")?>">
+				<i class="btn-sm btn-breadcrumbbar">Widgets</i>
+			</a>
+		</li>
+	<?php endif?>
+
 	<?php if (!$g['disablehelpicon']): ?>
 		<li>
 			<a href="<?=$helpurl?>" target="_blank" title="<?=gettext("Help for items on this page")?>" class="help-icon">

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -312,7 +312,7 @@ pfSense_handle_custom_code("/usr/local/pkg/dashboard/pre_dashboard");
 
 ?>
 
-<div class="panel panel-default" id="widget-available">
+<div class="panel panel-default collapse out" id="widget-available">
 	<div class="panel-heading">
 		<h2 class="panel-title"><?=gettext("Available Widgets"); ?>
 			<span class="widget-heading-icon">
@@ -322,7 +322,7 @@ pfSense_handle_custom_code("/usr/local/pkg/dashboard/pre_dashboard");
 			</span>
 		</h2>
 	</div>
-	<div id="widget-available_panel-body" class="panel-body collapse out">
+	<div id="widget-available_panel-body" class="panel-body collapse in">
 		<div class="content">
 			<div class="row">
 <?php

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -301,6 +301,7 @@ if ($config['widgets'] && $config['widgets']['sequence'] != "") {
 }
 
 ## Set Page Title and Include Header
+$dashboard_available_widgets_hidden = true;
 $pgtitle = array(gettext("Status"), gettext("Dashboard"));
 include("head.inc");
 


### PR DESCRIPTION
A proposal for 5431 https://redmine.pfsense.org/issues/5431

A simple button next to the help icon (?) at right end of breadcrumb bar to show/hide the available widgets panel outer div.

The available widgets panel itself remains unchanged.
css btn-breadcrumbbar to blend button in with the breadcrumb bar to not be distracting.
Bootstrap framework remains intact.