### PR TITLE
Fixup firewall rules schedule status images

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -528,7 +528,7 @@ for ($i = 0; isset($a_filter[$i]); $i++):
 		$image = "";
 		if (!isset($filterent['disabled'])) {
 			if ($schedstatus) {
-				if ($iconfn == "block" || $iconfn == "reject") {
+				if ($filterent['type'] == "block" || $filterent['type'] == "reject") {
 					$image = "times-circle";
 					$dispcolor = "text-danger";
 					$alttext = gettext("Traffic matching this rule is currently being denied");
@@ -539,13 +539,13 @@ for ($i = 0; isset($a_filter[$i]); $i++):
 				}
 				$printicon = true;
 			} else if ($filterent['sched']) {
-				if ($iconfn == "block" || $iconfn == "reject") {
+				if ($filterent['type'] == "block" || $filterent['type'] == "reject") {
 					$image = "times-circle";
 				} else {
-					$image = "times-circle";
+					$image = "play-circle";
 				}
 				$alttext = gettext("This rule is not currently active because its period has expired");
-				$dispcolor = "text-danger";
+				$dispcolor = "text-warning";
 				$printicon = true;
 			}
 		}


### PR DESCRIPTION
1) $iconfn is not the var that contains the 'type' of block or reject.
2) In the bottom if-else of the diff "times-circle" was repeated twice.
3) It seemed odd to me that wen the schedule was out of its time that the icons would always be in "text-danger" color. My suggestion, make them "text-warning" which distinguishes them from the green or red that is shown when the schedule is active.