### PR TITLE
Allow enable/disable rule for Firewall NAT Out

### DIFF
--- a/src/usr/local/www/firewall_nat_out.php
+++ b/src/usr/local/www/firewall_nat_out.php
@@ -354,7 +354,7 @@ print($form);
 				else:
 ?>
 							<a href="?act=toggle&amp;id=<?=$i?>">
-								<i class="fa <?= ($iconfn == "pass") ? "fa-check":"fa-hidden"?>" title="<?=gettext("Click to toggle enabled/disabled status")?>"></i>
+								<i class="fa <?= ($iconfn == "pass") ? "fa-check":"fa-times"?>" title="<?=gettext("Click to toggle enabled/disabled status")?>"></i>
 							</a>
 
 <?php


### PR DESCRIPTION
The code for it was all there, but the icon was hidden when the rule was disabled, so there was no wayto click to enable.
It all works for me with just this small change.