### PR TITLE
Solved RADIUS Session-Timeout with wrong AcctStopTime

### DIFF
--- a/etc/inc/captiveportal.inc
+++ b/etc/inc/captiveportal.inc
@@ -655,9 +655,9 @@ function captiveportal_prune_old() {
 	 * If something is missed next run will catch it!
 	 */
 	$pruning_time = time();
-	$stop_time = $pruning_time;
 	foreach ($cpdb as $cpentry) {
 
+        $stop_time = $pruning_time;
 		$timedout = false;
 		$term_cause = 1;
 		if (empty($cpentry[11]))


### PR DESCRIPTION
When Idle-Timeout  set 
$stop_time = $lastact
at line 694, we need to reset 
$stop_time = $pruning_time
for the new iteration.