### PR TITLE
Status / System Logs - Tab Array

### DIFF
--- a/src/usr/local/www/status_logs_common.inc
+++ b/src/usr/local/www/status_logs_common.inc
@@ -137,7 +137,9 @@ function tab_array_logs_common() {
 					(($logfile == 'l2tps') && ($vpntype == "l2tp")),
 					"/status_logs_vpn.php?logfile=l2tps&amp;vpntype=l2tp");
 	}
-	display_top_tabs($tab_array, false, 'nav nav-tabs');
+	if ($tab_array) {
+		display_top_tabs($tab_array, false, 'tabs');
+	}
 }
 
 


### PR DESCRIPTION
Only call display_top_tabs function if there is a tab array to display.

The display_top_tabs function prefixes the type parameter with 'nav nav-'.  So passing 'nav nav-tabs' adds a nonexistent class; 'nav-nav'.  Only pass 'tabs' as the type.