### PR TITLE
filter.inc, allow tagging and tag checking for pf.conf rules quote the value

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2792,14 +2792,10 @@ function filter_generate_user_rule($rule) {
 		$aline['icmp6-type'] = "icmp6-type {$rule['icmptype']} ";
 	}
 	if (!empty($rule['tag'])) {
-		if (ctype_digit($rule['tag'])) {
-			$aline['tag'] = " tag \"" .$rule['tag']. "\" ";
-		} else {
-			$aline['tag'] = " tag " .$rule['tag']. " ";
-		}
+		$aline['tag'] = " tag \"" .$rule['tag']. "\" ";
 	}
 	if (!empty($rule['tagged'])) {
-		$aline['tagged'] = " tagged " .$rule['tagged'] . " ";
+		$aline['tagged'] = " tagged \"" .$rule['tagged']. "\" ";
 	}
 	if (!empty($rule['dscp'])) {
 		switch (strtolower($rule['dscp'])) {


### PR DESCRIPTION
filter.inc, allow tagging and tag checking for pf.conf rules with numbers,text,space-characters without generating a invalid ruleset