### PR TITLE
Fix misplaced quote (resolves syntax error)

### DIFF
--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -510,7 +510,7 @@ $group->add(new Form_Select(
 	'source_type',
 	null,
 	(($pconfig['source'] == "any") || ($pconfig['source'] == "(self)")) ? $pconfig['source'] : "network",
-	array('any' => gettext('Any'), '(self)' => gettext('This Firewall (self))', 'network' => gettext('Network'))
+	array('any' => gettext('Any'), '(self)' => gettext('This Firewall (self)'), 'network' => gettext('Network'))
 ))->setHelp('Type')->setWidth('3');
 
 $group->add(new Form_IpAddress(

--- a/src/usr/local/www/interfaces_wireless_edit.php
+++ b/src/usr/local/www/interfaces_wireless_edit.php
@@ -223,7 +223,7 @@ $section->addInput(new Form_Select(
 	array(
 		'bss' => 'Infrastructure (BSS)',
 		'adhoc' => 'Ad-hoc (IBSS)',
-		'hostap' => gettext('Access Point)'
+		'hostap' => gettext('Access Point')
 	)
 ));
 


### PR DESCRIPTION
My automatic syntax checker found this error:
```Parse error: syntax error, unexpected '=>' (T_DOUBLE_ARROW) in ./pfsense/src/usr/local/www/firewall_nat_out_edit.php on line 513```

I've corrected it.

**edit:**
Added fix for
```Parse error: syntax error, unexpected ';' in ./pfsense/src/usr/local/www/interfaces_wireless_edit.php on line 228```