### PR TITLE
allow packages in a www/subfolder/ (like haproxy) to use the service start/stop/restart links

### DIFF
--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -518,7 +518,7 @@ function get_service_control_GET_links($service, $addname = false) {
 			$link = '<a title="%s" href="status_services.php?mode=%s&amp;service=' . $service['name'] . '&amp;zone=' . $service['zone'] . '">';
 		break;
 		default:
-			$link = '<a title="%s" href="status_services.php?mode=%s&amp;service=' . $service['name'] . '">';
+			$link = '<a title="%s" href="/status_services.php?mode=%s&amp;service=' . $service['name'] . '">';
 	}
 
 	if (get_service_status($service)) {
@@ -530,7 +530,7 @@ function get_service_control_GET_links($service, $addname = false) {
 				$output .= "<a href=\"status_services.php?mode=restartservice&amp;service={$service['name']}&amp;zone={$service['zone']}\">";
 				break;
 			default:
-				$output .= "<a href=\"status_services.php?mode=restartservice&amp;service={$service['name']}\">";
+				$output .= "<a href=\"/status_services.php?mode=restartservice&amp;service={$service['name']}\">";
 		}
 		$output .= "<i class=\"fa fa-repeat\" title=\"" . sprintf(gettext("Restart %sService"), $stitle) . "\"></i></a>\n";
 		switch ($service['name']) {
@@ -541,7 +541,7 @@ function get_service_control_GET_links($service, $addname = false) {
 				$output .= "<a href=\"status_services.php?mode=stopservice&amp;service={$service['name']}&amp;zone={$service['zone']}\">";
 				break;
 			default:
-				$output .= "<a href=\"status_services.php?mode=stopservice&amp;service={$service['name']}\">";
+				$output .= "<a href=\"/status_services.php?mode=stopservice&amp;service={$service['name']}\">";
 		}
 		$output .= "<i class=\"fa fa-stop-circle-o\" title=\"" . sprintf(gettext("Stop %sService"), $stitle) . "\"></i></a>";
 	} else {


### PR DESCRIPTION
allow packages in a www/subfolder/ (like haproxy) to use the service start/stop/restart links