### PR TITLE
Firewall Log Widget - Revert Abbreviation

### DIFF
--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -133,9 +133,9 @@ if (isset($_POST['lastsawtime'])) {
 		<tr>
 			<th><?=gettext("Act");?></th>
 			<th><?=gettext("Time");?></th>
-			<th><?=gettext("If");?></th>
+			<th><?=gettext("IF");?></th>
 			<th><?=gettext("Source");?></th>
-			<th><?=gettext("Dest");?></th>
+			<th><?=gettext("Destination");?></th>
 		</tr>
 	</thead>
 	<tbody>


### PR DESCRIPTION
Fine to spell out 'Destination' here.
1) Field content already had column wide enough.
2) Consistent with firewall log.
3) Already translated.

Return interface abbreviation to it's original uppercase 'IF' to not look so much like the word 'If'.