### PR TITLE
Crash Reporter compare choice with language-specific string #5792

### DIFF
--- a/src/usr/local/www/crash_reporter.php
+++ b/src/usr/local/www/crash_reporter.php
@@ -99,7 +99,7 @@ $crash_report_header .= "\nCrash report details:\n";
 exec("/usr/bin/grep -vi warning /tmp/PHP_errors.log", $php_errors);
 ?>
 <?php
-	if (gettext($_POST['Submit']) == "Yes") {
+	if (gettext($_POST['Submit']) == gettext("Yes")) {
 		echo gettext("Processing...");
 		if (!is_dir("/var/crash")) {
 			mkdir("/var/crash", 0750, true);
@@ -126,7 +126,7 @@ exec("/usr/bin/grep -vi warning /tmp/PHP_errors.log", $php_errors);
 		} else {
 			echo gettext("Could not find any crash files.");
 		}
-	} else if (gettext($_POST['Submit']) == "No") {
+	} else if (gettext($_POST['Submit']) == gettext("No")) {
 		array_map('unlink', glob("/var/crash/*"));
 		// Erase the contents of the PHP error log
 		fclose(fopen("/tmp/PHP_errors.log", 'w'));


### PR DESCRIPTION
I don't really understand why this has to be - the HTML has value="Yes" and value="No" - I thought those would be the strings sent along with "submit".
The translation of Yes and No should have been just for display purposes.
But after this change, I can submit or delete crash reports when the UI isin other languages.