### PR TITLE
Form Group - Empty Title GetText

### DIFF
--- a/src/usr/local/www/classes/Form/Group.class.php
+++ b/src/usr/local/www/classes/Form/Group.class.php
@@ -148,8 +148,9 @@ EOT;
 		$label = new Form_Element('label', false, ['for' => $target]);
 		$label->addClass('col-sm-'.Form::LABEL_WIDTH, 'control-label');
 
-		if (!empty(trim($this->_title)) || is_numeric($this->_title))
+		if (!empty(trim($this->_title)) || is_numeric($this->_title)) {
 			$title = htmlspecialchars(gettext($this->_title));
+		}
 
 		return <<<EOT
 	{$element}

--- a/src/usr/local/www/classes/Form/Group.class.php
+++ b/src/usr/local/www/classes/Form/Group.class.php
@@ -148,7 +148,8 @@ EOT;
 		$label = new Form_Element('label', false, ['for' => $target]);
 		$label->addClass('col-sm-'.Form::LABEL_WIDTH, 'control-label');
 
-		$title = htmlspecialchars(gettext($this->_title));
+		if (!empty(trim($this->_title)) || is_numeric($this->_title))
+			$title = htmlspecialchars(gettext($this->_title));
 
 		return <<<EOT
 	{$element}


### PR DESCRIPTION
Don't call gettext with an empty title.

There are undoubtedly other places that a check should be done before passing a variable only to a gettext call.

Fixes use case of form group class without a title from passing empty var to gettext.
Gettext returns header info. when an empty string/var is passed.

Perhaps a function should be created for this for consistency.
http://php.net/manual/en/function.gettext.php#108594

For groups without a title gettext returns header info.

To reproduce the issue select a non English language and open any of the following:
Services Load Balancer - edit
Diagnostics - Backup/Restore
Diagnostics - Status SMART
Status - System Logs - log filter and manage log panels
(not a comprehensive list)