### PR TITLE
Experimental fix to correct 2.2 to 2.3 upgrade (RELENG_2_2)

### DIFF
--- a/etc/rc.firmware
+++ b/etc/rc.firmware
@@ -477,6 +477,12 @@ pfSenseupgrade)
 	# Remove saved commit ID for gitsync
 	rm -f /etc/version.gitsync
 
+	PFSENSETYPE=`cat /etc/platform`
+
+	if [ "${PFSENSETYPE}" = "pfSense" ]; then
+		/etc/rc.php_ini_setup
+	fi
+
 	# If /tmp/post_upgrade_command exists after update
 	# then execute the command.
 	if [ -f /tmp/post_upgrade_command ]; then


### PR DESCRIPTION
This applies to pfSense platform (the one installed from LiveCD to HDD). It prevents a bunch of php errors related to extension loading failures. Other platforms have not been tested and thereby this procedure was not implemented.

**This has been tested in the following way:**
1. Installed 2.2.6 amd64 from LiveCD to HDD
2. Enabled SSH (and thereby SFTP capabilities)
3. Uploaded the modified file
4. Did a firmware upgrade procedure to 2.3 via Web GUI using latest full upgrade snapshot

Previously, doing a firmware upgrade procedure to 2.3 would yell a lot of php errors during post_upgrade_command tasks. This commit fixes (or workarounds it) for pfSense platform.

Thank you! :)