### PR TITLE
Experimental fix to correct 2.2 to 2.3 upgrade (master)

### DIFF
--- a/src/usr/local/share/pfSense/post_upgrade_command
+++ b/src/usr/local/share/pfSense/post_upgrade_command
@@ -4,6 +4,10 @@
 
 PFSENSETYPE=`cat /etc/platform`
 
+if [ "${PFSENSETYPE}" = "pfSense" ]; then
+	/etc/rc.php_ini_setup
+fi
+
 if [ "${PFSENSETYPE}" = "pfSense" -o "${PFSENSETYPE}" = "nanobsd" ]; then
 	touch /conf/needs_package_sync_after_reboot
 fi


### PR DESCRIPTION
See PR #2506

The method of this PR was **not tested** as it would require modifying the snapshot tarball, something I don't know how to do.

This places the same fix on the *post_upgrade_command* file.
Please double-check if this fix alone (in a system without #2506 applied) works.

Thanks. :)