### PR TITLE
Add comprehensive high-level ip_compare() function

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -476,14 +476,17 @@ function ip_after($ip, $offset = 1) {
    Returns '' if not a valid IPv4/IPv6 address */
 function ip_to_hex($ip) {
 	$type = is_ipaddr($ip);
+	$expectedlen = -1;
 	// is_ipaddr() returns 4/6 if valid IPv4/IPv6, or '' if not valid
 	if ($type == 4) {
 		$result = str_pad(strtolower(dechex(ip2long32($ip))), 8, '0', STR_PAD_LEFT);
+		$expectedlen = 8;
 	} elseif ($type == 6) {
 		$result = strtolower(str_replace(Net_IPv6::uncompress($ip, true), ':', ''));
+		$expectedlen = 32;
 	}
 	// probably redundant not to return already but guarantees catching any subtle issues in hex conversion
-	if (isset($result) && ctype_xdigit($result) && (strlen($result) == 8 || strlen($result == 32))) {
+	if (isset($result) && ctype_xdigit($result) && strlen($result) == $expectedlen) {
 		return $result;
 	} else {
 		return '';

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -472,6 +472,163 @@ function ip_after($ip, $offset = 1) {
 	return long2ip32(ip2long($ip) + $offset);
 }
 
+/* Convert human-readable IPv4/IPv6 to lowercase 8 or 32 char hex for ease of comparison
+   Returns '' if not a valid IPv4/IPv6 address */
+function ip_to_hex($ip) {
+	$type = is_ipaddr($ip);
+	// is_ipaddr() returns 4/6 if valid IPv4/IPv6, or '' if not valid
+	if ($type == 4) {
+		$result = str_pad(strtolower(dechex(ip2long32($ip))), 8, '0', STR_PAD_LEFT);
+	} elseif ($type == 6) {
+		$result = strtolower(str_replace(Net_IPv6::uncompress($ip, true), ':', ''));
+	}
+	// probably redundant not to return already but guarantees catching any subtle issues in hex conversion
+	if (isset($result) && ctype_xdigit($result) && (strlen($result) == 8 || strlen($result == 32))) {
+		return $result;
+	} else {
+		return '';
+	}
+}
+
+/* 	High-level generic IP/subnet/range compare
+	ARGUMENTS:
+	     1) Data1: an IP/subnet/range, as a string or a structured array (array is simpler if subnet/range data is already separated out)
+	     2) Comparison operator: text string indicating condition to test, listed below
+	     3) Data2: the other data in the comparison, see Data1
+	     Optional param: 4 or 6 to stipulate IPs must be IPv4/IPv6, and to return '' (bad input) if not.
+	RETURN VALUE:
+	     true, false or '' for bad input
+	DATA1 / DATA2 EXAMPLES:
+	     IP:     AS STRING: '1.2.3.4'         AS ARRAY: array('ip', '1.2.3.4')
+	     Subnet: AS STRING: '1.2.3.4/24'      AS ARRAY: array('subnet', '1.2.3.4', 24)
+	     Range:  AS STRING: '1.2.3.4-5.6.7.8' AS ARRAY: array('range', '1.2.3.4', '5.6.7.8')
+	          and the same for IPv6
+	VALID COMPARISON TYPES (add more if useful):
+		IP to IP: 
+		     < <= = >= > !=  (not ==)
+		IP to RANGE/SUBNET: 
+		     'in' (true if IP in range/subnet) 
+		     '!in' (true if IP not in range/subnet)
+		     Only meaningful if $data1 = IP and $data2 = range/subnet
+		RANGE/SUBNET to RANGE/SUBNET: 
+		     'overlaps' (true if some or all IPs in common)
+		     'included-in' (true if 1st range/subnet completely included in, or identical to, 2nd range/subnet)
+		     '!overlaps' (true if no IPs in common, disjoint)
+		     		[Note: !included-in wouldn't be very meaningful]
+*/
+function ip_compare($data1, $comparison, $data2, $requiretype='any') {
+
+	// unpack data1/2 into d1/2, converting subnet to range, and validate data type + array sizes
+	if (is_array($data1)) {
+		//array data
+		if ($data1[0] == 'subnet'  && count($data1) == 3) {
+			$d1 = array('range', gen_subnet($data1[1], $data1[2]), gen_subnet_max($data1[1], $data1[2]));
+		} elseif (($data1[0] == 'ip' && count($data1) == 2) || ($data1[0] == 'range' && count($data1) == 3)) {
+			$d1 = $data1;
+		} else {
+			return '';
+		}
+	} elseif (is_string($data1)) {
+		// string data
+		if (count($d = explode('/', $data1)) == 2) {
+			// invalid subnet is picked up as error later
+			$d1 = array('range', gen_subnet($d[0], $d[1]), gen_subnet_max($d[0], $d[1]));
+		} elseif (count($d = explode('-', $data1)) == 2) {
+			$d1 = array('range', $d[0], $d[1]);
+		} else {
+			$d1 = array('ip', $data1);
+		}
+	} else {
+		return '';
+	}
+
+	if (is_array($data2)) {
+		//array data
+		if ($data2[0] == 'subnet'  && count($data2) == 3) {
+			$d2 = array('range', gen_subnet($data2[1], $data2[2]), gen_subnet_max($data2[1], $data2[2]));
+		} elseif (($data2[0] == 'ip' && count($data2) == 2) || ($data2[0] == 'range' && count($data2) == 3)) {
+			$d2 = $data2;
+		} else {
+			return '';
+		}
+	} elseif (is_string($data2)) {
+		// string data
+		if (count($d = explode('/', $data2)) == 2) {
+			// invalid subnet is picked up as error later
+			$d2 = array('range', gen_subnet($d[0], $d[1]), gen_subnet_max($d[0], $d[1]));
+		} elseif (count($d = explode('-', $data2)) == 2) {
+			$d2 = array('range', $d[0], $d[1]);
+		} else {
+			$d2 = array('ip', $data2);
+		}
+	} else {
+		return '';
+	}
+
+	//convert ips and range start-ends to hex, check range ordering, and collate a list of strlen() for IP type validation
+	list($d1[1], $d2[1]) = array(ip_to_hex($d1[1]), ip_to_hex($d2[1]));
+	$ip_sizes = array(strlen($d1[1]), strlen($d2[1]));
+	if ($d1[0] == 'range') {
+		$d1[2] = ip_to_hex($d1[2]);
+		$ip_sizes[] = strlen($d1[2]);
+		if ($d1[2] < $d1[1]) {
+			// check range start-end ordering: TRUE would be misordered range or some invalid IP data
+			return '';
+		}
+	}
+	if ($d2[0] == 'range') {
+		$d2[2] = ip_to_hex($d2[2]);
+		$ip_sizes[] = strlen($d2[2]);
+		if ($d2[2] < $d2[1]) {
+			// check range start-end ordering: TRUE would be misordered range or some invalid IP data
+			return '';
+		}
+	}
+
+	// validate IP type for all data (any prior function that failed and any bad IP/range/subnet will lead to bad data below)
+	$min__sizes = min($ip_sizes);
+	if (($min__sizes != 8 && $min_sizes != 32) || $min__sizes != max($ip_sizes)) {
+		// at least one IP, subnet, or range wasn't valid, or not all IPs are the same kind (4/6)
+		return '';
+	}
+
+	// check IPv4/IPv6 required, and if so, whether data complies
+	if (!(($requiretype == 4 && $min__sizes == 8) || ($requiretype == 6 && $min__sizes == 32) || $requiretype == 'any')) {
+		//required IPv4/IPv6 but IPs aren't correct number of hex chars, or invalid value of $requiretype
+		return '';
+	}
+
+	// IP data valid, now we check comparisons are meaningful and perform them
+	$c = $comparison;
+	if ($d1[0] == 'ip' && $d2[0] == 'ip' && in_array($c, array('<', '<=', '=', '>=', '>', '!='))) {
+		// IP to IP comparison
+		return (($d1[1] < $d2[1] && ($c == '<' || $c == '<=')) ||
+		   ($d1[1] == $d2[1] && ($c == '<=' || $c == '=' || $c == '>=')) ||
+		   ($d1[1] > $d2[1] && ($c == '>' || $c == '>=')));
+	} elseif ($d1[0] == 'ip' && $d2[0] == 'range' && in_array($c, array('in', '!in'))) {
+		// IP to range/subnet comparison
+		return (($d1[1] >= $d2[1] && $d1[1] <= $d2[2] && $c == 'in') ||
+		   (($d1[1] < $d2[1] || $d1[1] > $d2[2]) && $c == '!in'));
+	} elseif ($d1[0] == 'range' && $d2[0] == 'range' && in_array($c, array('overlaps', '!overlaps', 'included-in'))) {
+		// range/subnet to range/subnet comparison
+		if ($d1[2] < $d2[1] || $d1[1] > $d2[2]) {
+			// no overlap at all
+			$matchtype = 0;
+		} elseif ($d1[1] >= $d2[1] && $d1[2] <= $d2[2]) {
+			// complete inclusion (or identical)
+			$matchtype = 1;
+		} else {
+			// overlap to some degree but not inclusion
+			$matchtype = 2;
+		}
+		return (($c == '!overlaps' && $matchtype == 0) ||
+		   ($c == 'overlaps' && ($matchtype == 1 || $matchtype == 2)) ||
+		   ($c == 'included-in' && $matchtype == 2));
+	}
+	// comparison operator or comparison data types invalid
+	return '';
+}
+
 /* Return true if the first IP is 'before' the second */
 function ip_less_than($ip1, $ip2) {
 	// Compare as unsigned long because otherwise it wouldn't work when

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -521,7 +521,8 @@ function ip_to_hex($ip) {
 */
 function ip_compare($data1, $comparison, $data2, $requiretype='any') {
 
-	// unpack data1/2 into d1/2, converting subnet to range, and validate data type + array sizes
+	// unpack data1/2 into d1/2, convert any subnets to ranges, and validate data types + array sizes
+	// other kinds of invalid input lead to empty strings in data now, and picked up as an error later
 	if (is_array($data1)) {
 		//array data
 		if ($data1[0] == 'subnet'  && count($data1) == 3) {
@@ -534,7 +535,6 @@ function ip_compare($data1, $comparison, $data2, $requiretype='any') {
 	} elseif (is_string($data1)) {
 		// string data
 		if (count($d = explode('/', $data1)) == 2) {
-			// invalid subnet is picked up as error later
 			$d1 = array('range', gen_subnet($d[0], $d[1]), gen_subnet_max($d[0], $d[1]));
 		} elseif (count($d = explode('-', $data1)) == 2) {
 			$d1 = array('range', $d[0], $d[1]);
@@ -557,7 +557,6 @@ function ip_compare($data1, $comparison, $data2, $requiretype='any') {
 	} elseif (is_string($data2)) {
 		// string data
 		if (count($d = explode('/', $data2)) == 2) {
-			// invalid subnet is picked up as error later
 			$d2 = array('range', gen_subnet($d[0], $d[1]), gen_subnet_max($d[0], $d[1]));
 		} elseif (count($d = explode('-', $data2)) == 2) {
 			$d2 = array('range', $d[0], $d[1]);

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -572,7 +572,7 @@ function ip_compare($data1, $comparison, $data2, $requiretype='any') {
 		$d1[2] = ip_to_hex($d1[2]);
 		$ip_sizes[] = strlen($d1[2]);
 		if ($d1[2] < $d1[1]) {
-			// check range start-end ordering: TRUE would be misordered range or some invalid IP data
+			// check range start-end ordering: TRUE would be misordered range or $d1[2] invalid
 			return '';
 		}
 	}
@@ -580,7 +580,7 @@ function ip_compare($data1, $comparison, $data2, $requiretype='any') {
 		$d2[2] = ip_to_hex($d2[2]);
 		$ip_sizes[] = strlen($d2[2]);
 		if ($d2[2] < $d2[1]) {
-			// check range start-end ordering: TRUE would be misordered range or some invalid IP data
+			// check range start-end ordering: TRUE would be misordered range or $d2[2] invalid
 			return '';
 		}
 	}


### PR DESCRIPTION
A lot of end code needs to do IP/range/subnet comparisons, and detect features such as overlap, disjoint (non-overlap), containment (full inclusion), as well as the more usual < = > != type of comparison. These need to work over agnostic IPs as well as sometimes restricted to IPv4 or IPv6 by calling code. So util.inc contains a proliferation of comparison functions. 

Despite this, we still don't have several comparisons that are often needed (for example, an equivalent to check_subnets_overlap() for testing range overlap, or range v subnet overlap). These are often needed when validating DHCP, VPN and other IP data.

Rather than create new functions for each of these, this PR creates a comprehensive but straightforward generic ip comparison function ip_compare() that handles in one go, all comparisons of ip/subnet/range/IPv4/IPv6 that are likely to be needed, and which is fast and efficient.

Features:
-     ip, range or subnet comparison
-     handles input in string and factored form, so if a subnet is stored as ip/netmask already, or a range stored as start/end, it doesn't need to be converted to string only to convert back
  -          subnet       '::fe80/64' evaluated same as array('subnet', '::fe80', 64)
  -         range         '192.168.1.10-192.168.1.19' evaluated same as array('range', '192.168.1.10', '192.168.1.19')
  -          if it would be useful to handle INT format IPv4 IPs, that's trivial to add.
-    all common comparators handled (including overlap and inclusion); new ones are trivial to add
-    easy human-readable and concise code (see below) for easy debugging and review
-    IP agnostic by default, or restrict to IPv4/IPv6, as needed.
-    all data validated and bad input detected
-    no issues expected with x32/x64, uses hex strings for comparisons so same code copes with both IPv4/IPv6, avoiding all INT_SIZE issues and any duplicated code between IPv4/IPv6 handlers.
- Code is a lot shorter, more 'generic', and easier to review than current approach (which tends to need 2 separate functions for IPv4/v6 and individual review of each for logic errors). The logic is very clean and trivial to enhance if a new data type, data format or comparison is later found to be useful.

It therefore provides in one function, back-end functionality of all existing ip_more/less_than, ip-in-subnet/range, and subnet/range-overlap/inclusion functions. Also, all input is validated, and IPv4/IPv6 agnostic (or restricted as desired).  So existing functions and high level code can use this as a high-level back end for comparison functions, simplifying use of high level IP functions.

The function is internally documented so here are examples of use as a back-end to other comparison functions:

<pre>function ip_in_subnet_ipv4_or_ipv6($ip, $subnet) {
   return ip_compare($ip, 'in', $subnet);
}

function ip_in_subnet_ipv4_only($ip, $subnet_ip, $subnet_bits) {
   return ip_compare($ip, 'in', array('subnet', $subnet_ip, $subnet_bits), 4);
}

function ip1_less_than_ip2($ip1, $ip2) {
   return ip_compare($ip1, '<', $ip2);
}

function ip1_less_than_ip2_ipv4_only($ip1, $ip2) {
   return ip_compare($ip1, '<', $ip2, 4);
}

function subnets_overlap($sn1, $sn2) {
   return ip_compare($sn1, 'overlaps', $sn2);
}

function range_disjoint_from_subnet($range_start, $range_end, $subnet_ip, $subnet_bits) {
   return ip_compare(array('range', $range_start, $range_end), '!overlaps', array('subnet', $subnet_ip, $subnet_bits));
}

function subnet_in_subnet_ipv6_only($subnet1, $subnet2) {
   return ip_compare($subnet1, 'included-in', $subnet2, 6);
}

function subnet_overlaps_range($subnet, $range) {
   return ip_compare($subnet, 'overlaps', $range);
}
</pre>


And some examples of actual code, taken from services_dhcp.php:

<pre>
(1)

if (!ip_in_subnet($_POST['gateway'], gen_subnet($parent_ip, $parent_sn) . "/" . $parent_sn) ...

EQUIVALENT:

if (!ip_compare($_POST['gateway'], 'in', array('subnet', $parent_ip, $parent_sn), 4) ...
</pre>


<pre>
(2)

$subnet_start = ip2ulong(long2ip32(ip2long($ifcfgip) & gen_subnet_mask_long($ifcfgsn)));
$subnet_end = ip2ulong(long2ip32(ip2long($ifcfgip) | (~gen_subnet_mask_long($ifcfgsn))));
if (ip2ulong($_POST['range_from']) > ip2ulong($_POST['range_to'])) {
    $input_errors[] = gettext("The range is invalid (first element higher than second element).");
}
if (ip2ulong($_POST['range_from']) < $subnet_start || ip2ulong($_POST['range_to']) > $subnet_end) {
    $input_errors[] = gettext("The specified range lies outside of the current subnet.");
}

EQUIVALENT:

if (!ip_compare(array('range', $_POST['range_from'], $_POST['range_to']), 'included-in', array('subnet', $ifcfgip, $ifcfgsn), 4)) {
    $input_errors[] = gettext("The specified range is mis-ordered or not within the current subnet.");
}
</pre>


<pre>
(3)

$dynsubnet_start = ip2ulong($_POST['range_from']);
$dynsubnet_end = ip2ulong($_POST['range_to']);
if (is_array($a_maps)) {
    foreach ($a_maps as $map) {
        if (empty($map['ipaddr'])) {
            continue;
        }
        if ((ip2ulong($map['ipaddr']) >= $dynsubnet_start) &&
            (ip2ulong($map['ipaddr']) <= $dynsubnet_end)) {
            $input_errors[] = sprintf(gettext("The DHCP range cannot overlap any static DHCP mappings."));
            break;
        }
    }
}
            
EQUIVALENT:

if (is_array($a_maps)) {
    foreach ($a_maps as $map) {
        if (!empty($map['ipaddr']) && ip_compare($map['ipaddr'], 'in', array('range', $_POST['range_from'], $_POST['range_to']), 4) {
            $input_errors[] = gettext("The DHCP range cannot overlap any static DHCP mappings.");
            break;
        }
    }
}
</pre>
