### PR TITLE
Make diag_arp info an infoblock

### DIFF
--- a/src/usr/local/www/diag_arp.php
+++ b/src/usr/local/www/diag_arp.php
@@ -384,7 +384,12 @@ events.push(function() {
 //]]>
 </script>
 
+<div class="infoblock blockopen">
 <?php
-print_info_box(gettext("Local IPv6 peers use ") . '<a href="diag_ndp.php">' . gettext("NDP") . '</a>' . gettext(" instead of ARP"), 'info');
+print_info_box(gettext("Local IPv6 peers use ") . '<a href="diag_ndp.php">' . gettext("NDP") . '</a>' . gettext(" instead of ARP"), 'info', false);
+?>
+</div>
 
-include("foot.inc")?>
+<?php
+include("foot.inc");
+?>


### PR DESCRIPTION
I might find a few of these while looking at various print_info_block calls, but this one for a start that works well as infoblock blockopen.