### PR TITLE
Add script to lint all files with PHP code

### DIFF
--- a/tools/scripts/php_lint.sh
+++ b/tools/scripts/php_lint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#
+# This is a little script that will use PHP's lint functionality to
+# check if syntax of PHP files is correct, ensuring less likelihood
+# of bad code making it's way into the project.
+#
+# For best results, execute this in an environment with PHP version
+# matching the one being used on the pfSense branch to be checked.
+#
+
+PHP_EXECUTABLE=`which php`
+
+if [ -x "${PHP_EXECUTABLE}" ]; then
+	"${PHP_EXECUTABLE}" -v
+	find . -type f -name "*.inc" -exec "${PHP_EXECUTABLE}" -n -l "{}" \; | grep -v "No syntax errors detected" 2>&1
+	find . -type f -name "*.php" -exec "${PHP_EXECUTABLE}" -n -l "{}" \; | grep -v "No syntax errors detected" 2>&1
+else
+	echo "PHP executable not found!"
+fi


### PR DESCRIPTION
Since there are sometimes syntax errors, having a script to perform some automated checking is a good idea. This is the first shell script I've coded, so I believe there is plenty of room for improvement.

It will output currently installed PHP version, then scan current directory and run php lint on all *.inc and *.php files and output any errors if found.

Tested & Working while running on pfSense shell.