### PR TITLE
Save selected wireless interface

### DIFF
--- a/src/usr/local/www/interfaces_wireless_edit.php
+++ b/src/usr/local/www/interfaces_wireless_edit.php
@@ -210,7 +210,7 @@ $form = new Form();
 $section = new Form_Section('Wireless Interface Configuration');
 
 $section->addInput(new Form_Select(
-	'parent',
+	'if',
 	'Parent Interface',
 	$pconfig['if'],
 	build_parent_list()


### PR DESCRIPTION
This looks like a bug. I don't have a system with the necessary hardware running 2.3 right now to really test, but the code that processes the submit/apply looks for $_POST['if']
Please double-check on suitable hardware!