### PR TITLE
Enhance error output when package file not found - RELENG_2_2

### DIFF
--- a/usr/local/www/pkg.php
+++ b/usr/local/www/pkg.php
@@ -56,10 +56,8 @@ if($xml == "") {
 	$pkg_realpath = realpath($pkg_full_path);
 	if (empty($pkg_realpath)) {
 		$path_error = sprintf(gettext("ERROR: Package path %s not found."), htmlspecialchars($pkg_full_path));
-	} else {
-		if (substr_compare($pkg_realpath, $pkg_xml_prefix, 0, strlen($pkg_xml_prefix))) {
-			$path_error = sprintf(gettext("ERROR: Invalid path %s specified."), htmlspecialchars($pkg_full_path));
-		}
+	} else if (substr_compare($pkg_realpath, $pkg_xml_prefix, 0, strlen($pkg_xml_prefix))) {
+		$path_error = sprintf(gettext("ERROR: Invalid path %s specified."), htmlspecialchars($pkg_full_path));
 	}
 
 	if (!empty($path_error)) {

--- a/usr/local/www/pkg.php
+++ b/usr/local/www/pkg.php
@@ -53,8 +53,17 @@ if($xml == "") {
 } else {
 	$pkg_xml_prefix = "/usr/local/pkg/";
 	$pkg_full_path = "{$pkg_xml_prefix}/{$xml}";
-	if (substr_compare(realpath($pkg_full_path), $pkg_xml_prefix, 0, strlen($pkg_xml_prefix))) {
-		print_info_box_np(gettext("ERROR: Invalid path specified."));
+	$pkg_realpath = realpath($pkg_full_path);
+	if (empty($pkg_realpath)) {
+		$path_error = sprintf(gettext("ERROR: Package path %s not found."), $pkg_full_path);
+	} else {
+		if (substr_compare($pkg_realpath, $pkg_xml_prefix, 0, strlen($pkg_xml_prefix))) {
+			$path_error = sprintf(gettext("ERROR: Invalid path %s specified."), $pkg_full_path);
+		}
+	}
+
+	if (!empty($path_error)) {
+		print_info_box_np($path_error . "<br />" . gettext("Try reinstalling the package.") . "<br />" . gettext("Use the back button on your browser to return to the previous page."));
 		die;
 	}
 

--- a/usr/local/www/pkg.php
+++ b/usr/local/www/pkg.php
@@ -55,10 +55,10 @@ if($xml == "") {
 	$pkg_full_path = "{$pkg_xml_prefix}/{$xml}";
 	$pkg_realpath = realpath($pkg_full_path);
 	if (empty($pkg_realpath)) {
-		$path_error = sprintf(gettext("ERROR: Package path %s not found."), $pkg_full_path);
+		$path_error = sprintf(gettext("ERROR: Package path %s not found."), htmlspecialchars($pkg_full_path));
 	} else {
 		if (substr_compare($pkg_realpath, $pkg_xml_prefix, 0, strlen($pkg_xml_prefix))) {
-			$path_error = sprintf(gettext("ERROR: Invalid path %s specified."), $pkg_full_path);
+			$path_error = sprintf(gettext("ERROR: Invalid path %s specified."), htmlspecialchars($pkg_full_path));
 		}
 	}
 


### PR DESCRIPTION
I had a system that had upgraded but the Notes package had not managed to (re)install. In that situation the Notes item is on the Status menu but there is no notes.xml or other notes code on the the system.
When I go to Status->Notes I get:
Warning: substr_compare(): The start position cannot exceed initial string length in /usr/local/www/pkg.php on line 56 File not found notes.xml

The warning is because realpath() returns false in this case and cannot be used is a parameter to substr_compare().

Handle this case, and make the error message more informative.

Note: In RELENG_2_2 print_info_box_np() puts a "Close" button and has no way to stop that. It looks dumb, but that can be cleaned up in 2.3 master. I am just doing this in RELENG_2_2 to avoid the PHP warning.