### PR TITLE
Enhance error output when package file not found

### DIFF
--- a/src/usr/local/www/pkg.php
+++ b/src/usr/local/www/pkg.php
@@ -77,10 +77,22 @@ if ($xml == "") {
 } else {
 	$pkg_xml_prefix = "/usr/local/pkg/";
 	$pkg_full_path = "{$pkg_xml_prefix}/{$xml}";
-	if (substr_compare(realpath($pkg_full_path), $pkg_xml_prefix, 0, strlen($pkg_xml_prefix))) {
-		print_info_box(gettext("ERROR: Invalid path specified."));
+	$pkg_realpath = realpath($pkg_full_path);
+	if (empty($pkg_realpath)) {
+		$path_error = sprintf(gettext("ERROR: Package path %s not found."), htmlspecialchars($pkg_full_path));
+	} else {
+		if (substr_compare($pkg_realpath, $pkg_xml_prefix, 0, strlen($pkg_xml_prefix))) {
+			$path_error = sprintf(gettext("ERROR: Invalid path %s specified."), htmlspecialchars($pkg_full_path));
+		}
+	}
+
+	if (!empty($path_error)) {
+		include("head.inc");
+		print_info_box($path_error . "<br />" . gettext("Try reinstalling the package."));
+		include("foot.inc");
 		die;
 	}
+
 	if (file_exists($pkg_full_path)) {
 		$pkg = parse_xml_config_pkg($pkg_full_path, "packagegui");
 	} else {

--- a/src/usr/local/www/pkg.php
+++ b/src/usr/local/www/pkg.php
@@ -80,10 +80,8 @@ if ($xml == "") {
 	$pkg_realpath = realpath($pkg_full_path);
 	if (empty($pkg_realpath)) {
 		$path_error = sprintf(gettext("ERROR: Package path %s not found."), htmlspecialchars($pkg_full_path));
-	} else {
-		if (substr_compare($pkg_realpath, $pkg_xml_prefix, 0, strlen($pkg_xml_prefix))) {
-			$path_error = sprintf(gettext("ERROR: Invalid path %s specified."), htmlspecialchars($pkg_full_path));
-		}
+	} else if (substr_compare($pkg_realpath, $pkg_xml_prefix, 0, strlen($pkg_xml_prefix))) {
+		$path_error = sprintf(gettext("ERROR: Invalid path %s specified."), htmlspecialchars($pkg_full_path));
 	}
 
 	if (!empty($path_error)) {


### PR DESCRIPTION
I had a system that had upgraded but the Notes package had not managed to (re)install. In that situation the Notes item is on the Status menu but there is no notes.xml or other notes code on the the system.
When I go to Status->Notes I get:
Warning: substr_compare(): The start position cannot exceed initial string length in /usr/local/www/pkg.php ...

The warning is because realpath() returns false in this case and cannot be used is a parameter to substr_compare().

Handle this case, and make the error message more informative.