### PR TITLE
Standardize print_apply_box usage

### DIFF
--- a/src/usr/local/www/firewall_shaper.php
+++ b/src/usr/local/www/firewall_shaper.php
@@ -430,7 +430,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('shaper')) {
-	print_apply_box(gettext("The traffic shaper configuration has been changed. You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The traffic shaper configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 $tab_array = array();

--- a/src/usr/local/www/firewall_shaper_queues.php
+++ b/src/usr/local/www/firewall_shaper_queues.php
@@ -236,7 +236,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('shaper')) {
-	print_apply_box(gettext("The traffic shaper configuration has been changed. You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The traffic shaper configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 $tab_array = array();

--- a/src/usr/local/www/firewall_shaper_vinterface.php
+++ b/src/usr/local/www/firewall_shaper_vinterface.php
@@ -408,7 +408,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('shaper')) {
-	print_apply_box(gettext("The traffic shaper configuration has been changed. You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The traffic shaper configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 $tab_array = array();

--- a/src/usr/local/www/interfaces_assign.php
+++ b/src/usr/local/www/interfaces_assign.php
@@ -502,7 +502,7 @@ if (file_exists("/var/run/interface_mismatch_reboot_needed")) {
 
 if (file_exists("/tmp/reload_interfaces")) {
 	echo "<p>\n";
-	print_apply_box(gettext("The interface configuration has been changed.<br />You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The interface configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 	echo "<br /></p>\n";
 } elseif ($savemsg) {
 	print_info_box($savemsg, $class);

--- a/src/usr/local/www/load_balancer_monitor.php
+++ b/src/usr/local/www/load_balancer_monitor.php
@@ -118,7 +118,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('loadbalancer')) {
-	print_apply_box(gettext("The load balancer configuration has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The load balancer configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 /* active tabs */

--- a/src/usr/local/www/load_balancer_pool.php
+++ b/src/usr/local/www/load_balancer_pool.php
@@ -132,7 +132,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('loadbalancer')) {
-	print_apply_box(sprintf(gettext("The load balancer configuration has been changed%sYou must apply the changes in order for them to take effect."), "<br />"));
+	print_apply_box(gettext("The load balancer configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 /* active tabs */

--- a/src/usr/local/www/load_balancer_setting.php
+++ b/src/usr/local/www/load_balancer_setting.php
@@ -131,7 +131,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('loadbalancer')) {
-	print_apply_box(gettext("The load balancer configuration has been changed") . ' ' .
+	print_apply_box(gettext("The load balancer configuration has been changed.") . ' ' .
 					gettext("You must apply the changes in order for them to take effect."));
 }
 

--- a/src/usr/local/www/load_balancer_virtual_server.php
+++ b/src/usr/local/www/load_balancer_virtual_server.php
@@ -132,7 +132,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('loadbalancer')) {
-	print_apply_box(gettext("The virtual server configuration has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The virtual server configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 /* active tabs */

--- a/src/usr/local/www/services_captiveportal_mac.php
+++ b/src/usr/local/www/services_captiveportal_mac.php
@@ -189,7 +189,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('passthrumac')) {
-	print_apply_box(gettext("The captive portal MAC address configuration has been changed.<br />You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The captive portal MAC address configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 $tab_array = array();

--- a/src/usr/local/www/services_captiveportal_zones.php
+++ b/src/usr/local/www/services_captiveportal_zones.php
@@ -99,7 +99,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('captiveportal')) {
-	print_apply_box(gettext("The Captive Portal entry list has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The Captive Portal entry list has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 ?>
 <form action="services_captiveportal_zones.php" method="post">

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -715,7 +715,7 @@ if (isset($config['dhcrelay']['enable'])) {
 }
 
 if (is_subsystem_dirty('staticmaps')) {
-	print_apply_box(gettext("The static mapping configuration has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The static mapping configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 /* active tabs */

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -456,7 +456,7 @@ if ($dhcrelay_enabled) {
 }
 
 if (is_subsystem_dirty('staticmaps')) {
-	print_apply_box(gettext('The static mapping configuration has been changed') . '.<br />' . gettext('You must apply the changes in order for them to take effect.'));
+	print_apply_box(gettext('The static mapping configuration has been changed.') . '<br />' . gettext('You must apply the changes in order for them to take effect.'));
 }
 
 /* active tabs */

--- a/src/usr/local/www/services_dnsmasq.php
+++ b/src/usr/local/www/services_dnsmasq.php
@@ -225,7 +225,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('hosts')) {
-	print_apply_box(gettext("The DNS forwarder configuration has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The DNS forwarder configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 $form = new Form();

--- a/src/usr/local/www/services_igmpproxy.php
+++ b/src/usr/local/www/services_igmpproxy.php
@@ -106,7 +106,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('igmpproxy')) {
-	print_apply_box(gettext('The IGMP entry list has been changed.' . '<br />' . 'You must apply the changes in order for them to take effect.'));
+	print_apply_box(gettext('The IGMP entry list has been changed.') . '<br />' . gettext('You must apply the changes in order for them to take effect.')));
 }
 ?>
 

--- a/src/usr/local/www/services_pppoe.php
+++ b/src/usr/local/www/services_pppoe.php
@@ -122,7 +122,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('vpnpppoe')) {
-	print_apply_box(gettext('The PPPoE entry list has been changed') . '.<br />' . gettext('You must apply the changes in order for them to take effect.'));
+	print_apply_box(gettext('The PPPoE entry list has been changed.') . '<br />' . gettext('You must apply the changes in order for them to take effect.'));
 }
 ?>
 

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -262,7 +262,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('unbound')) {
-	print_apply_box(gettext("The configuration of the DNS Resolver has been changed. You must apply changes for them to take effect."));
+	print_apply_box(gettext("The DNS Resolver configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 $tab_array = array();

--- a/src/usr/local/www/services_unbound_acls.php
+++ b/src/usr/local/www/services_unbound_acls.php
@@ -218,7 +218,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('unbound')) {
-	print_apply_box(gettext("The configuration of the DNS Resolver, has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The DNS Resolver configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 $tab_array = array();

--- a/src/usr/local/www/services_unbound_advanced.php
+++ b/src/usr/local/www/services_unbound_advanced.php
@@ -231,7 +231,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('unbound')) {
-	print_apply_box(gettext("The configuration of the DNS Resolver has been changed. You must apply changes for them to take effect."));
+	print_apply_box(gettext("The DNS Resolver configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 $tab_array = array();

--- a/src/usr/local/www/status_lb_pool.php
+++ b/src/usr/local/www/status_lb_pool.php
@@ -145,7 +145,7 @@ if ($_POST) {
 }
 
 if (is_subsystem_dirty('loadbalancer')) {
-	print_apply_box(gettext('The load balancer configuration has been changed. You must apply the changes in order for them to take effect.'));
+	print_apply_box(gettext("The load balancer configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 /* active tabs */

--- a/src/usr/local/www/system_advanced_sysctl.php
+++ b/src/usr/local/www/system_advanced_sysctl.php
@@ -175,7 +175,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('sysctl') && ($act != "edit" )) {
-	print_apply_box(gettext("The firewall tunables have changed. You must apply the configuration for them to take affect."));
+	print_apply_box(gettext("The firewall tunables have changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 $tab_array = array();

--- a/src/usr/local/www/system_gateway_groups.php
+++ b/src/usr/local/www/system_gateway_groups.php
@@ -131,7 +131,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('staticroutes')) {
-	print_apply_box(sprintf(gettext("The gateway configuration has been changed.%sYou must apply the changes in order for them to take effect."), "<br />"));
+	print_apply_box(gettext("The gateway configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 
 $tab_array = array();

--- a/src/usr/local/www/vpn_ipsec.php
+++ b/src/usr/local/www/vpn_ipsec.php
@@ -268,7 +268,7 @@ display_top_tabs($tab_array);
 	}
 
 	if (is_subsystem_dirty('ipsec')) {
-		print_apply_box(gettext("The IPsec tunnel configuration has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));
+		print_apply_box(gettext("The IPsec tunnel configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 	}
 ?>
 

--- a/src/usr/local/www/vpn_ipsec_keys.php
+++ b/src/usr/local/www/vpn_ipsec_keys.php
@@ -115,7 +115,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('ipsec')) {
-	print_apply_box(gettext("The IPsec tunnel configuration has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The IPsec tunnel configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 ?>
 

--- a/src/usr/local/www/vpn_ipsec_mobile.php
+++ b/src/usr/local/www/vpn_ipsec_mobile.php
@@ -437,7 +437,7 @@ if ($savemsg) {
 	print_info_box($savemsg, 'success');
 }
 if (is_subsystem_dirty('ipsec')) {
-	print_apply_box(gettext("The IPsec tunnel configuration has been changed") . ".<br />" . gettext("You must apply the changes in order for them to take effect."));
+	print_apply_box(gettext("The IPsec tunnel configuration has been changed.") . "<br />" . gettext("You must apply the changes in order for them to take effect."));
 }
 foreach ($a_phase1 as $ph1ent) {
 	if (isset($ph1ent['mobile'])) {

--- a/src/usr/local/www/vpn_l2tp_users.php
+++ b/src/usr/local/www/vpn_l2tp_users.php
@@ -110,7 +110,7 @@ if (isset($config['l2tp']['radius']['enable'])) {
 }
 
 if (is_subsystem_dirty('l2tpusers')) {
-	print_apply_box(gettext("The l2tp user list has been modified") . ".<br />" . gettext("You must apply the changes in order for them to take effect") . ".<br /><b>" . gettext("Warning: this will terminate all current l2tp sessions!") . "</b>");
+	print_apply_box(gettext("The l2tp user list has been modified.") . "<br />" . gettext("You must apply the changes in order for them to take effect") . ".<br /><b>" . gettext("Warning: this will terminate all current l2tp sessions!") . "</b>");
 }
 
 


### PR DESCRIPTION
1) For the translators, it should be better to do it consistently. Then
they only need to have 1 translation of "You must apply the changes in
order for them to take effect" and can translate each of the other
custom sentences individually.
2) The full-stop should always go at the end of the sentence, inside the
gettext(). There are some languages where the full-stop is not the same
as European. e.g. In Nepal we use the vertical bar for end of sentence.