### PR TITLE
Standardize gpsnoselect var name

### DIFF
--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -138,8 +138,8 @@ if ($_POST) {
 		unset($config['ntpd']['gps']['prefer']);
 	}
 
-	if (!empty($_POST['gpsselect'])) {
-		$config['ntpd']['gps']['noselect'] = $_POST['gpsselect'];
+	if (!empty($_POST['gpsnoselect'])) {
+		$config['ntpd']['gps']['noselect'] = $_POST['gpsnoselect'];
 	} elseif (isset($config['ntpd']['gps']['noselect'])) {
 		unset($config['ntpd']['gps']['noselect']);
 	}
@@ -321,7 +321,7 @@ $section->addInput(new Form_Checkbox(
 ));
 
 $section->addInput(new Form_Checkbox(
-	'gpsselect',
+	'gpsnoselect',
 	null,
 	'Do not use this clock, display for reference only (default: unchecked).',
 	$pconfig['noselect']
@@ -530,14 +530,14 @@ events.push(function() {
 
 	set_gps_default('<?=$pconfig['type']?>');
 
-	//	Checkboxes gpsprefer and gpsselect are mutually exclusive
+	//	Checkboxes gpsprefer and gpsnoselect are mutually exclusive
 	$('#gpsprefer').click(function() {
 		if ($(this).is(':checked')) {
-			$('#gpsselect').prop('checked', false);
+			$('#gpsnoselect').prop('checked', false);
 		}
 	});
 
-	$('#gpsselect').click(function() {
+	$('#gpsnoselect').click(function() {
 		if ($(this).is(':checked')) {
 			$('#gpsprefer').prop('checked', false);
 		}


### PR DESCRIPTION
It looks confusing that in the config there is ['noselect'] but the locally-used var in the GUI is gpsselect.
Reduce future confusion by replacing gpsselect -> gpsnoselect.
There is no actual bug here, just fixing naming consistency.