### PR TITLE
Fixup old diag_logs references

### DIFF
--- a/src/etc/pfSense.obsoletedfiles
+++ b/src/etc/pfSense.obsoletedfiles
@@ -848,7 +848,7 @@
 /usr/local/www/services_proxyarp.php
 /usr/local/www/services_proxyarp_edit.php
 /usr/local/www/services_usermanager.php
-/usr/local/www/shortcuts/pkg_upnp.inc
+/usr/local/www/shortcuts/pkg_upnp.php
 /usr/local/www/sortable/sortable.min.js
 /usr/local/www/status_slbd_pool.php
 /usr/local/www/status_slbd_vs.php

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -374,7 +374,7 @@ $section->addInput(new Form_Checkbox(
 	'Log system messages (default: disabled).',
 	$pconfig['logsys']
 ))->setHelp('These options enable additional messages from NTP to be written to the System Log ' .
-			'<a href="diag_logs_ntpd.php">' . 'Status > System Logs > NTP' . '</a>');
+			'<a href="status_logs.php?logfile=ntpd">' . 'Status > System Logs > NTP' . '</a>');
 
 // Statistics logging section
 $btnadvstats = new Form_Button(

--- a/src/usr/local/www/shortcuts/pkg_upnp.inc
+++ b/src/usr/local/www/shortcuts/pkg_upnp.inc
@@ -4,7 +4,7 @@ global $shortcuts;
 
 $shortcuts['upnp'] = array();
 $shortcuts['upnp']['main'] = "pkg_edit.php?xml=miniupnpd.xml";
-$shortcuts['upnp']['log'] = "diag_logs_routing.php";
+$shortcuts['upnp']['log'] = "status_logs.php?logfile=routing";
 $shortcuts['upnp']['status'] = "status_upnp.php";
 $shortcuts['upnp']['service'] = "miniupnpd";
 


### PR DESCRIPTION
Note: The shortcuts for upnp were not showing. This was because
shortcuts.inc only includes *.inc files from /usr/local/www/shortcuts
So I have renamed pkg_upnp.php to pkg_upnp.inc
I notice that some time in the past it used to be pkg_upnp.inc because
that was in the obsoleted files list. So not sure what that was all
about.