### PR TITLE
Fix parse error: syntax error, unexpected ')'

### DIFF
--- a/src/usr/local/www/services_igmpproxy.php
+++ b/src/usr/local/www/services_igmpproxy.php
@@ -106,7 +106,7 @@ if ($savemsg) {
 }
 
 if (is_subsystem_dirty('igmpproxy')) {
-	print_apply_box(gettext('The IGMP entry list has been changed.') . '<br />' . gettext('You must apply the changes in order for them to take effect.')));
+	print_apply_box(gettext('The IGMP entry list has been changed.') . '<br />' . gettext('You must apply the changes in order for them to take effect.'));
 }
 ?>
 


### PR DESCRIPTION
There is an extra parenthesis in /usr/local/www/services_igmpproxy.php on line 109