### PR TITLE
status_ntpd missing start php

### DIFF
--- a/src/usr/local/www/status_ntpd.php
+++ b/src/usr/local/www/status_ntpd.php
@@ -295,7 +295,8 @@ if (($gps_ok) && ($gps_lat) && ($gps_lon)):
 							<td>
 								<?=$gps_alt . ' ' . $gps_alt_unit?>
 							</td>
-							}
+						<?php
+						}
 
 						if (isset($gps_sat) || isset($gps_satview)) { ?>
 							<td class="text-center"> <?php


### PR DESCRIPTION
This seems to be the only missing bit here. I think it would only cause a noticeable UI problem if isset($gps_alt).

If you have a system with a real GPS that has altitude, then please test!

There is also a bunch of formatting issues in this file - things that are not on tab stops... After this real bug is fixed I will then make a PR to sort out the white-space.