### PR TITLE
Status IPsec info box

### DIFF
--- a/src/usr/local/www/status_ipsec.php
+++ b/src/usr/local/www/status_ipsec.php
@@ -519,5 +519,17 @@ function show_childsa(id, buttonid) {
 
 <?php
 unset($status);
-print_info_box(gettext("You can configure IPsec ") . '<a href="vpn_ipsec.php">Here</a>');
+if (ipsec_enabled()) {
+?>
+<div class="infoblock">
+<?php
+} else {
+?>
+<div class="infoblock blockopen">
+<?php
+}
+print_info_box(sprintf(gettext('You can configure IPsec %1$shere%2$s'), '<a href="vpn_ipsec.php">', '</a>'), 'info', false);
+?>
+</div>
+<?php
 include("foot.inc"); ?>

--- a/src/usr/local/www/status_ipsec_leases.php
+++ b/src/usr/local/www/status_ipsec_leases.php
@@ -152,6 +152,17 @@ if (isset($mobile['pool']) && is_array($mobile['pool'])) {
 	print_info_box(gettext('No IPsec pools.'));
 }
 
-print_info_box(gettext('You can configure your IPsec subsystem by clicking ') . '<a href="vpn_ipsec.php">' . gettext("here.") . '</a>');
-
+if (ipsec_enabled()) {
+?>
+<div class="infoblock">
+<?php
+} else {
+?>
+<div class="infoblock blockopen">
+<?php
+}
+print_info_box(sprintf(gettext('You can configure IPsec %1$shere%2$s'), '<a href="vpn_ipsec.php">', '</a>'), 'info', false);
+?>
+</div>
+<?php
 include("foot.inc");

--- a/src/usr/local/www/status_ipsec_sad.php
+++ b/src/usr/local/www/status_ipsec_sad.php
@@ -135,7 +135,7 @@ if (count($sad)) {
 						$args .= "&amp;proto=" . rawurlencode($sa['proto']);
 						$args .= "&amp;spi=" . rawurlencode("0x" . $sa['spi']);
 					?>
-					<a class="btn btn-xs btn-danger" href="status_ipsec_sad.php?act=del&amp;<?=$args?>">Delete</a>
+					<a class="btn btn-xs btn-danger" href="status_ipsec_sad.php?act=del&amp;<?=$args?>"><?=gettext('Delete')?></a>
 				</td>
 			</tr>
 
@@ -149,6 +149,17 @@ if (count($sad)) {
 	print_info_box(gettext('No IPsec security associations.'));
 }
 
-print_info_box(gettext('You can configure your IPsec subsystem by clicking ') . '<a href="vpn_ipsec.php">' . gettext("here.") . '</a>');
-
+if (ipsec_enabled()) {
+?>
+<div class="infoblock">
+<?php
+} else {
+?>
+<div class="infoblock blockopen">
+<?php
+}
+print_info_box(sprintf(gettext('You can configure IPsec %1$shere%2$s'), '<a href="vpn_ipsec.php">', '</a>'), 'info', false);
+?>
+</div>
+<?php
 include("foot.inc");

--- a/src/usr/local/www/status_ipsec_spd.php
+++ b/src/usr/local/www/status_ipsec_spd.php
@@ -133,6 +133,17 @@ if (count($spd)) {
 	print_info_box(gettext('No IPsec security policies configured.'));
 }
 
-print_info_box(gettext('You can configure your IPsec subsystem by clicking ') . '<a href="vpn_ipsec.php">' . gettext("here.") . '</a>');
-
+if (ipsec_enabled()) {
+?>
+<div class="infoblock">
+<?php
+} else {
+?>
+<div class="infoblock blockopen">
+<?php
+}
+print_info_box(sprintf(gettext('You can configure IPsec %1$shere%2$s'), '<a href="vpn_ipsec.php">', '</a>'), 'info', false);
+?>
+</div>
+<?php
 include("foot.inc");


### PR DESCRIPTION
As well as internationalization of this info box, I have:
1) Made all of them the same text - it seemed odd that there were 2
different versions of text for the same thing.
2) Made it an info-level infoblock. It seemed odd to me that this was
showing as a warning - it is really just a helpful info with link.
3) Made it open on page load if IPsec is not enabled, otherwise if IPsec
is already enable it loads closed and the user can open and read it if
they care.

What do you think about this combination of things in the UI?

I suspect there are a few other places where there is a convenient link
'You can configure xxx here', but it shows as a warning.
If there is agreement about the infoblock approach I have suggested
here, then I can do similar in other places.