### PR TITLE
Fix issues #3900 and #5051 to make No-ip round robin DNS works.

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -395,7 +395,7 @@
 					} else {
 						$iptoset = $this->_dnsIP;
 					}
-					curl_setopt($ch, CURLOPT_URL, $server . $port . '?username=' . urlencode($this->_dnsUser) . '&pass=' . urlencode($this->_dnsPass) . '&hostname=' . $this->_dnsHost.'&ip=' . $iptoset);
+					curl_setopt($ch, CURLOPT_URL, $server . $port . '?username=' . urlencode($this->_dnsUser) . '&pass=' . urlencode($this->_dnsPass) . '&h[]=' . $this->_dnsHost.'&ip=' . $iptoset);
 					break;
 				case 'easydns':
 					$needsIP = TRUE;

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -146,6 +146,13 @@ if ($_POST) {
 			$host_to_check = substr($_POST['host'], 2);
 		} else {
 			$host_to_check = $_POST['host'];
+
+			/* No-ip (and maybe others) can have a @ in hostname */
+			$last_to_check = strrpos($host_to_check, '@');
+			if ($last_to_check !== false) {
+				$host_to_check = substr_replace($host_to_check, '.', $last_to_check, 1);
+			}
+			unset($last_to_check);
 		}
 
 		if ($pconfig['type'] != "custom" && $pconfig['type'] != "custom-v6") {


### PR DESCRIPTION
The paramater "&hostname" should be changed to "&h[]" (issue #5051).
I think this affect only NO-IP DNS that uses round robin. Anyway the no-ip official client uses the "&h[]" parameter.

There's also a change to Dynamic DNS hostname allow '@' character (issue #3900).
