### PR TITLE
xmlrpc_client.inc, silence the php 'crash' error, sync errors are reported through file-notices already.

### DIFF
--- a/src/etc/inc/xmlrpc_client.inc
+++ b/src/etc/inc/xmlrpc_client.inc
@@ -928,7 +928,7 @@ class XML_RPC_Client extends XML_RPC_Base {
 
         $ctx = stream_context_create($ctx_options);
 
-        $fp = stream_socket_client("{$this->protocol}{$server}:{$port}",
+        $fp = @stream_socket_client("{$this->protocol}{$server}:{$port}",
             $this->errno, $this->errstr,
             ($timeout > 0 ? $timeout : ini_get("default_socket_timeout")),
             STREAM_CLIENT_CONNECT, $ctx);


### PR DESCRIPTION
xmlrpc_client.inc, silence the php 'crash' error, sync errors are reported through file-notices already.