### PR TITLE
Don't kill an sshd parent process on exit from /etc/rc.initial

### DIFF
--- a/src/etc/rc.initial
+++ b/src/etc/rc.initial
@@ -171,7 +171,12 @@ case ${opmode} in
 	fi
 	;;
 "")
-	kill $PPID ; exit
+	ps -o command='' -c -p $PPID | grep -E '^sshd$' > /dev/null
+	if [ $? -eq 0 ]; then
+		exit
+	else
+		kill $PPID ; exit
+	fi
 	;;
 esac
 


### PR DESCRIPTION
This stops exiting a shell running in an SSH session from terminating the parent sshd process, which has the unwanted side effect of killing all other sessions running under that sshd process (including cloned shell sessions).

Cloned sessions are commonly encountered with Vandyke's SecureCRT client. It can be a huge problem to CTRL-D out of one shell only to find all other shells running in cloned sessions have been killed!