### PR TITLE
[#4423] Fix RRD to recognise that ntp offset can be negative

### DIFF
--- a/src/etc/inc/rrd.inc
+++ b/src/etc/inc/rrd.inc
@@ -891,7 +891,7 @@ function enable_rrd_graphing() {
 			/* set up the ntpd rrd file */
 			if (!file_exists("$rrddbpath$ntpd")) {
 				$rrdcreate = "$rrdtool create $rrddbpath$ntpd --step $rrdntpdinterval ";
-				$rrdcreate .= "DS:offset:GAUGE:$ntpdvalid:0:1000 ";
+				$rrdcreate .= "DS:offset:GAUGE:$ntpdvalid:-1000:1000 ";
 				$rrdcreate .= "DS:sjit:GAUGE:$ntpdvalid:0:1000 ";
 				$rrdcreate .= "DS:cjit:GAUGE:$ntpdvalid:0:1000 ";
 				$rrdcreate .= "DS:wander:GAUGE:$ntpdvalid:0:1000 ";


### PR DESCRIPTION
[Redmine #4423](https://redmine.pfsense.org/issues/4423)

Fix the configuration of a new NTP RRD database to recognise that offset can be negative as well as positive.

N.B. This does not fix existing RRD databases. `rm /var/db/rrd/ntpd.rrd` at the command line following by 'Save' in the Settings tab of Status: RRD Graphs is recommended.