### PR TITLE
Add support for TB when reporting bytes

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1753,7 +1753,9 @@ function resolve_retry($hostname, $retries = 5) {
 }
 
 function format_bytes($bytes) {
-	if ($bytes >= 1073741824) {
+	if ($bytes >= 1099511627776) {
+		return sprintf("%.2f TB", $bytes/1099511627776);
+	} else if ($bytes >= 1073741824) {
 		return sprintf("%.2f GB", $bytes/1073741824);
 	} else if ($bytes >= 1048576) {
 		return sprintf("%.2f MB", $bytes/1048576);


### PR DESCRIPTION
Forum: https://forum.pfsense.org/index.php?topic=106470.0
I believe that this should work OK on both 32 and 64 bit systems. A 32-bit system will convert big values of $bytes and big numbers like 1099511627776 to float first, then do the comparison. 64-bit systems will do (int) comparisons. Either way, in the end, the value is sprintf() into a float anyway.
I have tested on a 64-bit system.
I don't have access to a 32-bit system right now, so somebody should check that to make sure my theory works in practice.