### PR TITLE
HTML Compliance - Status / Gateways

### DIFF
--- a/src/usr/local/www/status_gateways.php
+++ b/src/usr/local/www/status_gateways.php
@@ -191,7 +191,7 @@ display_top_tabs($tab_array);
 				}
 ?>
 
-				<td bgcolor="<?=$bgcolor?>">
+				<td style="background-color:<?=$bgcolor?>">
 					<strong><?=$online?></strong> <?php
 					if (!empty($lastchange)) { ?>
 						<br /><i><?=gettext("Last checked")?> <?=$lastchange?></i>


### PR DESCRIPTION
The bgcolor attribute on the td element is obsolete. Use CSS instead.