### PR TITLE
Enhance input error message for RADIUS secret

### DIFF
--- a/src/usr/local/www/vpn_l2tp.php
+++ b/src/usr/local/www/vpn_l2tp.php
@@ -120,7 +120,7 @@ if ($_POST) {
 		}
 
 		if ($_POST['radiussecret'] != $_POST['radiussecret_confirm']) {
-			$input_errors[] = gettext("Secret and confirmation must match");
+			$input_errors[] = gettext("RADIUS secret and confirmation must match");
 		}
 
 		if (!is_numericint($_POST['n_l2tp_units']) || $_POST['n_l2tp_units'] > 255) {


### PR DESCRIPTION
Make this input error message different to the one just above for the "ordinary" secret so that users can read the message and know which are the fields with the problem.