### PR TITLE
Limit interface MTU to 1500 if no explicit MTU configured

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3131,7 +3131,7 @@ function interface_vlan_adapt_mtu($vlanifs, $mtu) {
 		    !empty($config['interfaces'][$assignedport]['mtu'])) {
 			$if_mtu = $config['interfaces'][$assignedport]['mtu'];
 		} else {
-			$if_mtu = ($pppoe_mtu != 0 ? $pppoe_mtu : $mtu);
+			$if_mtu = ($pppoe_mtu != 0 ? $pppoe_mtu : ($mtu > 1500 ? 1500 : $mtu));
 		}
 
 		if (get_interface_mtu($vlan['vlanif']) != $if_mtu) {


### PR DESCRIPTION
This fixes a regression introduced by 5815d13659250c8319424268a1c8836928cd8cbf . Following that commit, VLANs on the same parent interface as a PPPoE parent interface finish up with an MTU of (PPPoE MTU + 8) if no MTU is configured explicitly. A LAN MTU of 1508 without explicit configuration was rather unexpected!