### PR TITLE
Fix #3209 editing unassigned VLAN tag can change an assigned interface

### DIFF
--- a/src/usr/local/www/interfaces_vlan_edit.php
+++ b/src/usr/local/www/interfaces_vlan_edit.php
@@ -146,7 +146,7 @@ if ($_POST) {
 		if (isset($id) && $a_vlans[$id]) {
 			if (($a_vlans[$id]['if'] != $_POST['if']) || ($a_vlans[$id]['tag'] != $_POST['tag'])) {
 				if (!empty($a_vlans[$id]['vlanif'])) {
-					$confif = convert_real_interface_to_friendly_interface_name($vlan['vlanif']);
+					$confif = convert_real_interface_to_friendly_interface_name($a_vlan['vlanif']);
 					// Destroy previous vlan
 					pfSense_interface_destroy($a_vlans[$id]['vlanif']);
 				} else {
@@ -262,4 +262,3 @@ $form->add($section);
 print $form;
 
 include("foot.inc");
-


### PR DESCRIPTION
To reproduce:
a) Create VLAN 10 on some real device (e.g. em0)
b) Create VLAN 11 similarly.
c) Assign VLAN 11 (the last one in the vlan array in the config) to OPT1.
d) Edit VLAN 10 tag to be 12.
The OPT1 assignment becomes to em0 tag 12.

This is because of the wrong reference to $vlan['vlanif'] that is fixed here. At this point $vlan is a leftover from a previous loop that went through all the VLANs in the config - so it happens to be the last one from the config.

Hopefully this fixes all the various ways people have reported this in redmine #3209.