### PR TITLE
Fix comparator name and add missing quotes

### DIFF
--- a/src/usr/local/www/system_groupmanager_addprivs.php
+++ b/src/usr/local/www/system_groupmanager_addprivs.php
@@ -102,7 +102,7 @@ if (!is_array($a_group['priv'])) {
 
 // Make a local copy and sort it
 $spriv_list = $priv_list;
-uasort($spriv_list, admusercmp);
+uasort($spriv_list, "cpusercmp");
 
 if ($_POST) {
 

--- a/src/usr/local/www/system_usermanager_addprivs.php
+++ b/src/usr/local/www/system_usermanager_addprivs.php
@@ -90,7 +90,7 @@ if (!is_array($a_user['priv'])) {
 
 // Make a local copy and sort it
 $spriv_list = $priv_list;
-uasort($spriv_list, admusercmp);
+uasort($spriv_list, "admusercmp");
 
 if ($_POST) {
 


### PR DESCRIPTION
Comparator name was wrong on system_groupmanager_addprivs.php and quotes were missing around the comparator name at system_usermanager_addprivs.php