### PR TITLE
Verify types of input username and password

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -1530,6 +1530,10 @@ function getUserGroups($username, $authcfg, &$attributes = array()) {
 
 function authenticate_user($username, $password, $authcfg = NULL, &$attributes = array()) {
 
+	if (is_array($username) || is_array($password)) {
+		return false;
+	}
+
 	if (!$authcfg) {
 		return local_backed($username, $password);
 	}


### PR DESCRIPTION
This should prevent the possibility of illegal offsets. If you poke pfSense WebGUI you'll find some funny stuff. Username and Password should never be arrays at all.

Fussing version 2.2.6 with vulnerability auditing tools throws things like:
```Illegal offset type in isset or empty in /etc/inc/auth.inc on line 229```
```crypt() expects parameter 1 to be string, array given in /etc/inc/auth.inc on line 305```
```md5() expects parameter 1 to be string, array given in /etc/inc/auth.inc on line 311```

Thanks.