### PR TITLE
Fix description disappering when editing admin user

### DIFF
--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -274,7 +274,6 @@ if ($_POST['save']) {
 
 	if (!$input_errors) {
 
-
 		conf_mount_rw();
 		$userent = array();
 		if (isset($id) && $a_user[$id]) {
@@ -294,8 +293,12 @@ if ($_POST['save']) {
 			local_user_set_password($userent, $_POST['passwordfld1']);
 		}
 
+		/* only change description if sent */
+		if (isset($_POST['descr'])) {
+			$userent['descr'] = $_POST['descr'];
+		}
+
 		$userent['name'] = $_POST['usernamefld'];
-		$userent['descr'] = $_POST['descr'];
 		$userent['expires'] = $_POST['expires'];
 		$userent['authorizedkeys'] = base64_encode($_POST['authorizedkeys']);
 		$userent['ipsecpsk'] = $_POST['ipsecpsk'];


### PR DESCRIPTION
That field is usually marked as read-only so the browsers will not send it during POST causing the description to "magically" disappear. This commit fixes the problem by only editing the value when sent.

Tested & Working.

**edit**
Just a little clarification which is worth mentioning. The field in question is actually disabled via ```$input->setDisabled();``` and not marked read-only as I said above.