### PR TITLE
Firewall / Rules - Display Separators Efficiency

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -4285,4 +4285,15 @@ function display_separator($separators, $nrules, $columns_in_table) {
 	}
 }
 
+/* Return a list of separator rows */
+function separator_rows($separators) {
+	$seprowns = array();
+	if (is_array($separators)) {
+		foreach ($separators as $sepn => $separator) {
+			$seprows[substr($separator['row']['0'], 2)] = true;
+		}
+	}
+	return $seprows;
+}
+
 ?>

--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -260,10 +260,16 @@ $columns_in_table = 13;
 $nnats = $i = 0;
 $separators = $config['nat']['separator'];
 
-// There can be a separator before any rules are listed
-display_separator($separators, $nnats, $columns_in_table);
+// Get a list of separator rows and use it to call the display separator function only for rows which there are separator(s).
+// More efficient than looping through the list of separators on every row.
+$seprows = separator_rows($separators);
 
 foreach ($a_nat as $natent):
+
+	// Display separator(s) for section beginning at rule n
+	if ($seprows[$nnats]) {
+		display_separator($separators, $nnats, $columns_in_table);
+	}
 
 	$alias = rule_columns_with_alias(
 		$natent['source']['address'],
@@ -426,10 +432,12 @@ foreach ($a_nat as $natent):
 	$i++;
 	$nnats++;
 
-	// There can be a separator before the next rule listed, or after the last rule listed
-	display_separator($separators, $nnats, $columns_in_table);
-
 endforeach;
+
+// There can be separator(s) after the last rule listed.
+if ($seprows[$nnats]) {
+	display_separator($separators, $nnats, $columns_in_table);
+}
 ?>
 				</tbody>
 			</table>

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -488,13 +488,19 @@ $columns_in_table = 13;
 $nrules = 0;
 $separators = $config['filter']['separator'][strtolower($if)];
 
-// There can be a separator before any rules are listed
-display_separator($separators, $nrules, $columns_in_table);
+// Get a list of separator rows and use it to call the display separator function only for rows which there are separator(s).
+// More efficient than looping through the list of separators on every row.
+$seprows = separator_rows($separators);
 
 for ($i = 0; isset($a_filter[$i]); $i++):
 	$filterent = $a_filter[$i];
 
 	if (($filterent['interface'] == $if && !isset($filterent['floating'])) || (isset($filterent['floating']) && "FloatingRules" == $if)) {
+
+		// Display separator(s) for section beginning at rule n
+		if ($seprows[$nrules]) {
+			display_separator($separators, $nrules, $columns_in_table);
+		}
 ?>
 					<tr id="fr<?=$nrules;?>" onClick="fr_toggle(<?=$nrules;?>)" ondblclick="document.location='firewall_rules_edit.php?id=<?=$i;?>';" <?=(isset($filterent['disabled']) ? ' class="disabled"' : '')?>>
 						<td>
@@ -800,10 +806,13 @@ for ($i = 0; isset($a_filter[$i]); $i++):
 					</tr>
 <?php
 		$nrules++;
-		// There can be a separator before the next rule listed, or after the last rule listed
-		display_separator($separators, $nrules, $columns_in_table);
 	}
 endfor;
+
+// There can be separator(s) after the last rule listed.
+if ($seprows[$nrules]) {
+	display_separator($separators, $nrules, $columns_in_table);
+}
 ?>
 				</tbody>
 			</table>


### PR DESCRIPTION
Use a list of separator rows to call the display separator function only for rows which there are separator(s).  More efficient than looping through the list of separators on every row.