### PR TITLE
Firewall / Rules - Consolidate Move Separators Function

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -4296,4 +4296,16 @@ function separator_rows($separators) {
 	return $seprows;
 }
 
+/* If the separator is located after the place ($ridx) where the rule was added or deleted, move the separator ($mvrows) */
+function move_separators(&$a_separators, $ridx, $mvnrows) {
+	if (is_array($a_separators)) {
+		foreach ($a_separators as $sepi => $separator) {
+			$seprow = substr($separator['row']['0'], 2);
+			if ($seprow > $ridx) {
+				$a_separators[$sepi]['row']['0'] = 'fr' . ($seprow + $mvnrows);
+			}
+		}
+	}
+}
+
 ?>

--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -142,13 +142,9 @@ if ($_GET['act'] == "del") {
 
 		// Update the separators
 		$a_separators = &$config['nat']['separator'];
-
-		for ($idx=0; isset($a_separators['sep' . $idx]); $idx++ ) {
-			$seprow = substr($a_separators['sep' . $idx]['row']['0'], 2);
-			if ($seprow > $_GET['id']) {
-				$a_separators['sep' . $idx]['row']['0'] = 'fr' . ($seprow - 1);
-			}
-		}
+		$ridx = $_GET['id'];
+		$mvnrows = -1;
+		move_separators($a_separators, $ridx, $mvnrows);
 
 		if (write_config()) {
 			mark_subsystem_dirty('natconf');
@@ -180,12 +176,9 @@ if (isset($_POST['del_x'])) {
 			unset($a_nat[$rulei]);
 
 			// Update the separators
-			for ($idx=0; isset($a_separators['sep' . $idx]); $idx++ ) {
-				$seprow = substr($a_separators['sep' . $idx]['row']['0'], 2);
-				if ($seprow > $rulei) {
-					$a_separators['sep' . $idx]['row']['0'] = 'fr' . ($seprow - 1);
-				}
-			}
+			$ridx = $rulei;
+			$mvnrows = -1;
+			move_separators($a_separators, $ridx, $mvnrows);
 		}
 
 		if (write_config()) {

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -518,15 +518,9 @@ if ($_POST) {
 
 				// Update the separators
 				$a_separators = &$config['nat']['separator'];
-
-				for ($idx=0; isset($a_separators['sep' . $idx]); $idx++ ) {
-					$seprow = substr($a_separators['sep' . $idx]['row']['0'], 2);
-
-					// If the separator is located after the place where the new rule is to go, increment the separator row
-					if ($seprow > $after) {
-						$a_separators['sep' . $idx]['row']['0'] = 'fr' . ($seprow + 1);
-					}
-				}
+				$ridx = $after;
+				$mvnrows = +1;
+				move_separators($a_separators, $ridx, $mvnrows);
 			} else {
 				$a_nat[] = $natent;
 			}

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -220,18 +220,11 @@ if ($_GET['act'] == "del") {
 		}
 		unset($a_filter[$_GET['id']]);
 
-		// get rule index within interface
-		$ifridx = ifridx($if, $_GET['id']);
-
 		// Update the separators
 		$a_separators = &$config['filter']['separator'][strtolower($if)];
-
-		for ($idx=0; isset($a_separators['sep' . $idx]); $idx++ ) {
-			$seprow = substr($a_separators['sep' . $idx]['row']['0'], 2);
-			if ($seprow > $ifridx) {
-				$a_separators['sep' . $idx]['row']['0'] = 'fr' . ($seprow - 1);
-			}
-		}
+		$ridx = ifridx($if, $_GET['id']);	// get rule index within interface
+		$mvnrows = -1;
+		move_separators($a_separators, $ridx, $mvnrows);
 
 		if (write_config()) {
 			mark_subsystem_dirty('filter');
@@ -259,16 +252,10 @@ if (isset($_POST['del_x'])) {
 			unset($a_filter[$rulei]);
 			$deleted = true;
 
-			// get rule index within interface
-			$ifridx = ifridx($if, $rulei);
-
 			// Update the separators
-			for ($idx=0; isset($a_separators['sep' . $idx]); $idx++ ) {
-				$seprow = substr($a_separators['sep' . $idx]['row']['0'], 2);
-				if ($seprow > $ifridx) {
-					$a_separators['sep' . $idx]['row']['0'] = 'fr' . ($seprow - 1);
-				}
-			}
+			$ridx = ifridx($if, $rulei);	// get rule index within interface
+			$mvnrows = -1;
+			move_separators($a_separators, $ridx, $mvnrows);
 		}
 
 		if ($deleted) {

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -921,20 +921,11 @@ if ($_POST) {
 					$tmpif = $if;
 				}
 
-				// get rule index within interface
-				$ifridx = ifridx($tmpif, $after);
-
 				// Update the separators
 				$a_separators = &$config['filter']['separator'][strtolower($tmpif)];
-
-				for ($idx=0; isset($a_separators['sep' . $idx]); $idx++ ) {
-					$seprow = substr($a_separators['sep' . $idx]['row']['0'], 2);
-
-					// If the separator is located after the place where the new rule is to go, increment the separator row
-					if ($seprow > $ifridx) {
-						$a_separators['sep' . $idx]['row']['0'] = 'fr' . ($seprow + 1);
-					}
-				}
+				$ridx = ifridx($tmpif, $after);	// get rule index within interface
+				$mvnrows = +1;
+				move_separators($a_separators, $ridx, $mvnrows);
 			} else {
 				$a_filter[] = $filterent;
 			}


### PR DESCRIPTION
Consolidate the moving of separators for add/copy/dup/delete into a generic function.