### PR TITLE
Firewall / Rules - Prevent Separator Orphanage

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -4267,7 +4267,7 @@ function ifridx($if, $ridx) {
 			$i++;
 		}
 	}
-	return $i;
+	return $ifridx;
 }
 
 /* display rules separators */


### PR DESCRIPTION
Prevent orphaning separator(s) at the bottom when deleting the rule at bottom of the list.