### PR TITLE
Add check of IPv4 only IPs on IPv6 SplitV64

### DIFF
--- a/src/etc/inc/IPv6.inc
+++ b/src/etc/inc/IPv6.inc
@@ -843,6 +843,11 @@ class Net_IPv6
         if (strstr($ip, '.')) {
 
             $pos      = strrpos($ip, ':');
+
+            if(false === $pos) {
+                return array("", $ip);
+            }
+
             $ip{$pos} = '_';
             $ipPart   = explode('_', $ip);
 


### PR DESCRIPTION
Will prevent access to wrong string offset.