### PR TITLE
Interfaces - DHCP Advanced Options Tweaks

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -1903,17 +1903,17 @@ $section->addClass('dhcp');
 $group = new Form_Group('Options');
 
 $group->add(new Form_Checkbox(
-	'dhcpadv',
+	'adv_dhcp_config_advanced',
 	null,
 	'Advanced Configuration',
-	false
+	$pconfig['adv_dhcp_config_advanced']
 ))->setHelp('Use advanced DHCP configuration options.');
 
 $group->add(new Form_Checkbox(
-	'dhcpovr',
+	'adv_dhcp_config_file_override',
 	null,
 	'Configuration Override',
-	false
+	$pconfig['adv_dhcp_config_file_override']
 ))->setHelp('Override the configuration from this file.');
 
 $section->add($group);
@@ -2089,14 +2089,14 @@ $group->add(new Form_Checkbox(
 	'adv_dhcp6_config_advanced',
 	null,
 	'Advanced Configuration',
-	false
+	$pconfig['adv_dhcp6_config_advanced']
 ))->setHelp('Use advanced DHCPv6 configuration options.');
 
 $group->add(new Form_Checkbox(
 	'adv_dhcp6_config_file_override',
 	null,
 	'Configuration Override',
-	false
+	$pconfig['adv_dhcp6_config_file_override']
 ))->setHelp('Override the configuration from this file.');
 
 $section->add($group);
@@ -3536,8 +3536,8 @@ events.push(function() {
 	}
 
 	function setDHCPoptions() {
-		var adv = $('#dhcpadv').prop('checked');
-		var ovr = $('#dhcpovr').prop('checked');
+		var adv = $('#adv_dhcp_config_advanced').prop('checked');
+		var ovr = $('#adv_dhcp_config_file_override').prop('checked');
 
 		if (ovr) {
 			hideInput('dhcphostname', true);
@@ -3642,7 +3642,7 @@ events.push(function() {
 		prefill_provider();
 	});
 
-	$('#dhcpadv, #dhcpovr').click(function () {
+	$('#adv_dhcp_config_advanced, #adv_dhcp_config_file_override').click(function () {
 		setDHCPoptions();
 	});
 

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -1905,16 +1905,16 @@ $group = new Form_Group('Options');
 $group->add(new Form_Checkbox(
 	'dhcpadv',
 	null,
-	'Show DHCP advanced options',
+	'Advanced Configuration',
 	false
-));
+))->setHelp('Use advanced DHCP configuration options.');
 
 $group->add(new Form_Checkbox(
 	'dhcpovr',
 	null,
-	'Config file override',
+	'Configuration Override',
 	false
-));
+))->setHelp('Override the configuration from this file.');
 
 $section->add($group);
 
@@ -2023,16 +2023,16 @@ $group->add(new Form_Checkbox(
 ))->displayAsRadio();
 
 $group->setHelp('The values in these fields are DHCP protocol timings used when requesting a lease.' . '<br />' .
-				'<a href="http://www.freebsd.org/cgi/man.cgi?query=dhclient.conf&sektion=5#PROTOCOL_TIMING">' . 'See here more information' . '</a>');
+				'<a target="_blank" href="https://www.freebsd.org/cgi/man.cgi?query=dhclient.conf&sektion=5#PROTOCOL_TIMING">' . 'See here more information' . '</a>');
 
 $section->add($group);
 
 $section->addInput(new Form_Input(
 	'adv_dhcp_config_file_override_path',
-	'Config file override',
+	'Configuration File Override',
 	'text',
 	$pconfig['adv_dhcp_config_file_override_path']
-))->sethelp('The value in this field is the full absolute path to a DHCP client configuration file.	 [/[dirname/[.../]]filename[.ext]]' . '<br />' .
+))->setWidth(9)->sethelp('The value in this field is the full absolute path to a DHCP client configuration file.	 [/[dirname/[.../]]filename[.ext]]' . '<br />' .
 			'Value Substitutions in Config File: {interface}, {hostname}, {mac_addr_asciiCD}, {mac_addr_hexCD}' . '<br />' .
 			'Where C is U(pper) or L(ower) Case, and D is ":-." Delimiter (space, colon, hyphen, or period) (omitted for none).' . '<br />' .
 			'Some ISPs may require certain options be or not be sent.');
@@ -2047,7 +2047,7 @@ $section->addInput(new Form_Input(
 	'Send options',
 	'text',
 	$pconfig['adv_dhcp_send_options']
-))->sethelp('The values in this field are DHCP options to be sent when requesting a DHCP lease.	 [option declaration [, ...]]' . '<br />' .
+))->setWidth(9)->sethelp('The values in this field are DHCP options to be sent when requesting a DHCP lease.	 [option declaration [, ...]]' . '<br />' .
 			'Value Substitutions: {interface}, {hostname}, {mac_addr_asciiCD}, {mac_addr_hexCD}' . '<br />' .
 			'Where C is U(pper) or L(ower) Case, and D is " :-." Delimiter (space, colon, hyphen, or period) (omitted for none).' . '<br />' .
 			'Some ISPs may require certain options be or not be sent.');
@@ -2057,7 +2057,7 @@ $section->addInput(new Form_Input(
 	'Request options',
 	'text',
 	$pconfig['adv_dhcp_request_options']
-))->sethelp('The values in this field are DHCP option 55 to be sent when requesting a DHCP lease.  [option [, ...]]' . '<br />' .
+))->setWidth(9)->sethelp('The values in this field are DHCP option 55 to be sent when requesting a DHCP lease.  [option [, ...]]' . '<br />' .
 			'Some ISPs may require certain options be or not be requested.');
 
 $section->addInput(new Form_Input(
@@ -2065,15 +2065,16 @@ $section->addInput(new Form_Input(
 	'Require options',
 	'text',
 	$pconfig['adv_dhcp_required_options']
-))->sethelp('The values in this field are DHCP options required by the client when requesting a DHCP lease.	 [option [, ...]]');
+))->setWidth(9)->sethelp('The values in this field are DHCP options required by the client when requesting a DHCP lease.	 [option [, ...]]');
 
 $section->addInput(new Form_Input(
 	'adv_dhcp_option_modifiers',
 	'Option modifiers',
 	'text',
 	$pconfig['adv_dhcp_option_modifiers']
-))->sethelp('The values in this field are DHCP option modifiers applied to obtained DHCP lease.	 [modifier option declaration [, ...]]' . '<br />' .
-			'modifiers: (default, supersede, prepend, append)');
+))->setWidth(9)->sethelp('The values in this field are DHCP option modifiers applied to obtained DHCP lease.	 [modifier option declaration [, ...]]' . '<br />' .
+			'modifiers: (default, supersede, prepend, append)' . '<br />' .
+			'<a target="_blank" href="https://www.freebsd.org/cgi/man.cgi?query=dhclient.conf&sektion=5#LEASE_REQUIREMENTS_AND_REQUESTS">' . 'See here more information' . '</a>');
 
 $form->add($section);
 
@@ -2082,21 +2083,23 @@ $form->add($section);
 $section = new Form_Section('DHCP6 Client Configuration');
 $section->addClass('dhcp6');
 
-$section->addInput(new Form_Checkbox(
-	'adv_dhcp6_config_advanced',
-	'Advanced',
-	'Show DHCPv6 advanced options',
-	$pconfig['adv_dhcp6_config_advanced'],
-	'Selected'
-));
+$group = new Form_Group('Options');
 
-$section->addInput(new Form_Checkbox(
+$group->add(new Form_Checkbox(
+	'adv_dhcp6_config_advanced',
+	null,
+	'Advanced Configuration',
+	false
+))->setHelp('Use advanced DHCPv6 configuration options.');
+
+$group->add(new Form_Checkbox(
 	'adv_dhcp6_config_file_override',
-	'Config file override',
-	'Override the configuration from this file',
-	$pconfig['adv_dhcp6_config_file_override'],
-	'Selected'
-));
+	null,
+	'Configuration Override',
+	false
+))->setHelp('Override the configuration from this file.');
+
+$section->add($group);
 
 $section->addInput(new Form_Checkbox(
 	'dhcp6usev4iface',
@@ -2138,9 +2141,9 @@ $section->addInput(new Form_Input(
 	'Configuration File Override',
 	'text',
 	$pconfig['adv_dhcp6_config_file_override_path']
-))->setHelp('The value in this field is the full absolute path to a DHCP client configuration file.	 [/[dirname/[.../]]filename[.ext]]' . '<br />' .
+))->setWidth(9)->setHelp('The value in this field is the full absolute path to a DHCP client configuration file.	 [/[dirname/[.../]]filename[.ext]]' . '<br />' .
 			'Value Substitutions in Config File: {interface}, {hostname}, {mac_addr_asciiCD}, {mac_addr_hexCD}' . '<br />' .
-			'Where C is U(pper) or L(ower) Case, and D is \" :-.\" Delimiter (space, colon, hyphen, or period) (omitted for none).' . '<br />' .
+			'Where C is U(pper) or L(ower) Case, and D is " :-." Delimiter (space, colon, hyphen, or period) (omitted for none).' . '<br />' .
 			'Some ISPs may require certain options be or not be sent.');
 
 $form->add($section);
@@ -2153,17 +2156,17 @@ $section->addClass('dhcp6advanced');
 $section->addInput(new Form_Checkbox(
 	'adv_dhcp6_interface_statement_information_only_enable',
 	'Information only',
-	null,
+	'Exchange Information Only',
 	$pconfig['adv_dhcp6_interface_statement_information_only_enable'],
 	'Selected'
-));
+))->setHelp('Only exchange informational configuration parameters with servers.');
 
 $section->addInput(new Form_Input(
 	'adv_dhcp6_interface_statement_send_options',
 	'Send options',
 	'text',
 	$pconfig['adv_dhcp6_interface_statement_send_options']
-))->sethelp('DHCP send options to be sent when requesting a DHCP lease.	 [option declaration [, ...]]' . '<br />' .
+))->setWidth(9)->sethelp('DHCP send options to be sent when requesting a DHCP lease.	 [option declaration [, ...]]' . '<br />' .
 			'Value Substitutions: {interface}, {hostname}, {mac_addr_asciiCD}, {mac_addr_hexCD}' . '<br />' .
 			'Where C is U(pper) or L(ower) Case, and D is \" :-.\" Delimiter (space, colon, hyphen, or period) (omitted for none).' . '<br />' .
 			'Some DHCP services may require certain options be or not be sent.');
@@ -2173,7 +2176,7 @@ $section->addInput(new Form_Input(
 	'Request Options',
 	'text',
 	$pconfig['adv_dhcp6_interface_statement_request_options']
-))->sethelp('DHCP request options to be sent when requesting a DHCP lease.	[option [, ...]]' . '<br />' .
+))->setWidth(9)->sethelp('DHCP request options to be sent when requesting a DHCP lease.	[option [, ...]]' . '<br />' .
 			'Some DHCP services may require certain options be or not be requested.');
 
 $section->addInput(new Form_Input(
@@ -2181,7 +2184,7 @@ $section->addInput(new Form_Input(
 	'Scripts',
 	'text',
 	$pconfig['adv_dhcp6_interface_statement_script']
-))->sethelp('Absolute path to a script invoked on certain conditions including when a reply message is received.' . '<br />' .
+))->setWidth(9)->sethelp('Absolute path to a script invoked on certain conditions including when a reply message is received.' . '<br />' .
 			'[/[dirname/[.../]]filename[.ext]].');
 
 $group = new Form_Group('Identity Association Statement');
@@ -2353,6 +2356,8 @@ $group->add(new Form_Input(
 	'text',
 	$pconfig['adv_dhcp6_key_info_statement_expire']
 ))->sethelp('Expire');
+
+$group->setHelp('<a target="_blank" href="https://www.freebsd.org/cgi/man.cgi?query=dhcp6c.conf&sektion=5&apropos=0&manpath=FreeBSD+10.1-RELEASE+and+Ports#Interface_statement">' . 'See here more information' . '</a>');
 
 $section->add($group);
 


### PR DESCRIPTION
Lease requirements and requests typically contain large lists of options. Set the field width to use the available section space.
Apply a few tweaks for better clarity and consistency between DHCP and DHCPv6.
Include a more information link specific to each advanced panel.