### PR TITLE
Fix #5890 find disk slices as candidates for loading "config.xml" at boot

### DIFF
--- a/etc/ecl.php
+++ b/etc/ecl.php
@@ -50,13 +50,9 @@ function get_swap_disks() {
 
 function get_disk_slices($disk) {
 	global $g, $debug;
-	$slices_array = array();
-	$slices = trim(exec("/bin/ls " . escapeshellarg("/dev/" . $disk . "s*") . " 2>/dev/null"));
+	$slices = glob("/dev/" . $disk . "s*");
 	$slices = str_replace("/dev/", "", $slices);
-	if($slices == "ls: No match.") 
-		return;
-	$slices_array = explode(" ", $slices);
-	return $slices_array;
+	return $slices;
 }
 
 function get_disks() {


### PR DESCRIPTION
Looking at "ecl.php" I can see that the intent is to look for external disks present at boot, and if a configuration file is found as "config.xml", or "conf/config.xml", this will be loaded as the configuration file.

This is the mechanism I wish to use for restoring a backup to standby hardware with minimal intervention.

When I trailled this, I found it to be non-functioning.  Even with debug enabled, the only output was:
```
External config loader 1.0 is now starting...
```

Further investigation led me to find that slices are discovered by using "/bin/ls /dev/{$disk}s*", and in commit 873c1701, this was surrounded with "escapeshellarg" so the wildcard is not expanded.

This fix switches to using "glob" to find the slices for a disk instead.

Now, booting (pfSense embeded in VM) I see:
```
External config loader 1.0 is now starting... da0s1 -> found config.xml
Backing up old configuration...
Restoring [da0s1] /tmp/mnt/cf/config.xml...
Cleaning up...
```