### PR TITLE
Synchronize page titles with tab titles. Part 3

### DIFF
--- a/src/etc/inc/priv.defs.inc
+++ b/src/etc/inc/priv.defs.inc
@@ -797,8 +797,8 @@ $priv_list['page-services-igmpproxy-edit']['match'] = array();
 $priv_list['page-services-igmpproxy-edit']['match'][] = "services_igmpproxy_edit.php*";
 
 $priv_list['page-services-ntpd'] = array();
-$priv_list['page-services-ntpd']['name'] = gettext("WebCfg - Services: NTP");
-$priv_list['page-services-ntpd']['descr'] = gettext("Allow access to the 'Services: NTP' page.");
+$priv_list['page-services-ntpd']['name'] = gettext("WebCfg - Services: NTP Settings");
+$priv_list['page-services-ntpd']['descr'] = gettext("Allow access to the 'Services: NTP Settings' page.");
 $priv_list['page-services-ntpd']['match'] = array();
 $priv_list['page-services-ntpd']['match'][] = "services_ntpd.php*";
 

--- a/src/etc/inc/priv.defs.inc
+++ b/src/etc/inc/priv.defs.inc
@@ -44,8 +44,8 @@ $priv_list['page-diagnostics-authentication']['match'] = array();
 $priv_list['page-diagnostics-authentication']['match'][] = "diag_authentication.php*";
 
 $priv_list['page-diagnostics-backup-restore'] = array();
-$priv_list['page-diagnostics-backup-restore']['name'] = gettext("WebCfg - Diagnostics: Backup/restore");
-$priv_list['page-diagnostics-backup-restore']['descr'] = gettext("Allow access to the 'Diagnostics: Backup/restore' page.");
+$priv_list['page-diagnostics-backup-restore']['name'] = htmlspecialchars(gettext("WebCfg - Diagnostics: Backup & Restore"));
+$priv_list['page-diagnostics-backup-restore']['descr'] = htmlspecialchars(gettext("Allow access to the 'Diagnostics: Backup & Restore' page."));
 $priv_list['page-diagnostics-backup-restore']['match'] = array();
 $priv_list['page-diagnostics-backup-restore']['match'][] = "diag_backup.php*";
 

--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -58,8 +58,8 @@
 
 ##|+PRIV
 ##|*IDENT=page-diagnostics-backup-restore
-##|*NAME=Diagnostics: Backup/restore
-##|*DESCR=Allow access to the 'Diagnostics: Backup/restore' page.
+##|*NAME=Diagnostics: Backup & Restore
+##|*DESCR=Allow access to the 'Diagnostics: Backup & Restore' page.
 ##|*MATCH=diag_backup.php*
 ##|-PRIV
 
@@ -593,7 +593,7 @@ function build_area_list($showall) {
 	}
 }
 
-$pgtitle = array(gettext("Diagnostics"), gettext("Backup/Restore"), gettext("Backup/Restore"));
+$pgtitle = array(gettext("Diagnostics"), htmlspecialchars(gettext("Backup & Restore")), htmlspecialchars(gettext("Backup & Restore")));
 include("head.inc");
 
 if ($input_errors) {
@@ -617,7 +617,7 @@ endif;
 
 $tab_array = array();
 $tab_array[] = array(gettext("Config History"), false, "diag_confbak.php");
-$tab_array[] = array(gettext("Backup/Restore"), true, "diag_backup.php");
+$tab_array[] = array(htmlspecialchars(gettext("Backup & Restore")), true, "diag_backup.php");
 display_top_tabs($tab_array);
 
 $form = new Form(false);

--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -616,8 +616,8 @@ if (is_subsystem_dirty('restore')):
 endif;
 
 $tab_array = array();
-$tab_array[] = array(gettext("Config History"), false, "diag_confbak.php");
 $tab_array[] = array(htmlspecialchars(gettext("Backup & Restore")), true, "diag_backup.php");
+$tab_array[] = array(gettext("Config History"), false, "diag_confbak.php");
 display_top_tabs($tab_array);
 
 $form = new Form(false);

--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -132,7 +132,7 @@ cleanup_backupcache(false);
 $confvers = get_backups();
 unset($confvers['versions']);
 
-$pgtitle = array(gettext("Diagnostics"), gettext("Backup/Restore"), gettext("Config History"));
+$pgtitle = array(gettext("Diagnostics"), htmlspecialchars(gettext("Backup & Restore")), gettext("Config History"));
 include("head.inc");
 
 if ($savemsg) {
@@ -141,7 +141,7 @@ if ($savemsg) {
 
 $tab_array = array();
 $tab_array[] = array(gettext("Config History"), true, "diag_confbak.php");
-$tab_array[] = array(gettext("Backup/Restore"), false, "diag_backup.php");
+$tab_array[] = array(htmlspecialchars(gettext("Backup & Restore")), false, "diag_backup.php");
 display_top_tabs($tab_array);
 
 if ($diff) {

--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -140,8 +140,8 @@ if ($savemsg) {
 }
 
 $tab_array = array();
-$tab_array[] = array(gettext("Config History"), true, "diag_confbak.php");
 $tab_array[] = array(htmlspecialchars(gettext("Backup & Restore")), false, "diag_backup.php");
+$tab_array[] = array(gettext("Config History"), true, "diag_confbak.php");
 display_top_tabs($tab_array);
 
 if ($diff) {

--- a/src/usr/local/www/diag_smart.php
+++ b/src/usr/local/www/diag_smart.php
@@ -63,7 +63,17 @@
 
 require("guiconfig.inc");
 
+// What page, aka. action is being wanted
+// If they "get" a page but don't pass all arguments, smartctl will throw an error
+$action = (isset($_POST['action']) ? $_POST['action'] : $_GET['action']);
+
 $pgtitle = array(gettext("Diagnostics"), gettext("S.M.A.R.T. Status"));
+
+if ($action != 'config') {
+	$pgtitle[] = gettext('Information & Tests');
+} else {
+	$pgtitle[] = gettext('Config');
+}
 $smartctl = "/usr/local/sbin/smartctl";
 $smartd = "/usr/local/sbin/smartd";
 $start_script = "/usr/local/etc/rc.d/smartd.sh";
@@ -104,10 +114,6 @@ function smartmonctl($action) {
 	global $start_script;
 	shell_exec($start_script . escapeshellarg($action));
 }
-
-// What page, aka. action is being wanted
-// If they "get" a page but don't pass all arguments, smartctl will throw an error
-$action = (isset($_POST['action']) ? $_POST['action'] : $_GET['action']);
 $targetdev = basename($_POST['device']);
 
 if (!file_exists('/dev/' . $targetdev)) {
@@ -116,7 +122,7 @@ if (!file_exists('/dev/' . $targetdev)) {
 }
 
 $tab_array = array();
-$tab_array[0] = array(gettext("Information/Tests"), ($action != 'config'), $_SERVER['PHP_SELF'] . "?action=default");
+$tab_array[0] = array(gettext("Information & Tests"), ($action != 'config'), $_SERVER['PHP_SELF'] . "?action=default");
 $tab_array[1] = array(gettext("Config"), ($action == 'config'), $_SERVER['PHP_SELF'] . "?action=config");
 display_top_tabs($tab_array);
 

--- a/src/usr/local/www/diag_smart.php
+++ b/src/usr/local/www/diag_smart.php
@@ -70,7 +70,7 @@ $action = (isset($_POST['action']) ? $_POST['action'] : $_GET['action']);
 $pgtitle = array(gettext("Diagnostics"), gettext("S.M.A.R.T. Status"));
 
 if ($action != 'config') {
-	$pgtitle[] = gettext('Information & Tests');
+	$pgtitle[] = htmlspecialchars(gettext('Information & Tests'));
 } else {
 	$pgtitle[] = gettext('Config');
 }
@@ -122,7 +122,7 @@ if (!file_exists('/dev/' . $targetdev)) {
 }
 
 $tab_array = array();
-$tab_array[0] = array(gettext("Information & Tests"), ($action != 'config'), $_SERVER['PHP_SELF'] . "?action=default");
+$tab_array[0] = array(htmlspecialchars(gettext("Information & Tests")), ($action != 'config'), $_SERVER['PHP_SELF'] . "?action=default");
 $tab_array[1] = array(gettext("Config"), ($action == 'config'), $_SERVER['PHP_SELF'] . "?action=config");
 display_top_tabs($tab_array);
 

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1028,7 +1028,12 @@ function build_if_list() {
 	return($iflist);
 }
 
-$pgtitle = array(gettext("Firewall"), gettext("Rules"), gettext("Edit"));
+$pgtitle = array(gettext("Firewall"), gettext("Rules"));
+
+if ($if == "FloatingRules" || isset($pconfig['floating'])) {
+	$pgtitle[] = gettext('Floating');
+}
+$pgtitle[] = gettext("Edit");
 $shortcut_section = "firewall";
 
 $page_filename = "firewall_rules_edit.php";

--- a/src/usr/local/www/firewall_shaper.php
+++ b/src/usr/local/www/firewall_shaper.php
@@ -72,7 +72,7 @@ if ($_GET['reset'] != "") {
 	exit;
 }
 
-$pgtitle = array(gettext("Firewall"), gettext("Traffic Shaper"), gettext("Interfaces"));
+$pgtitle = array(gettext("Firewall"), gettext("Traffic Shaper"), gettext("By Interface"));
 $shortcut_section = "trafficshaper";
 
 $shaperIFlist = get_configured_interface_with_descr();

--- a/src/usr/local/www/firewall_shaper_queues.php
+++ b/src/usr/local/www/firewall_shaper_queues.php
@@ -218,7 +218,7 @@ if ($_POST['apply']) {
 	clear_subsystem_dirty('shaper');
 }
 
-$pgtitle = array(gettext("Firewall"), gettext("Traffic Shaper"), gettext("Queues"));
+$pgtitle = array(gettext("Firewall"), gettext("Traffic Shaper"), gettext("By Queue"));
 $shortcut_section = "trafficshaper";
 
 include("head.inc");

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -211,7 +211,7 @@ if ($g['platform'] == $g['product_name'] or $g['platform'] == "nanobsd") {
 }
 $system_menu[] = array(gettext("Setup Wizard"), "/wizard.php?xml=setup_wizard.xml");
 $system_menu[] = array(gettext("Routing"), "/system_gateways.php");
-$system_menu[] = array(gettext("Cert Manager"), "/system_camanager.php");
+$system_menu[] = array(gettext("Cert. Manager"), "/system_camanager.php");
 if (!isAllowedPage("system_usermanager.php*")) {
 	$system_menu[] = array(gettext("User Manager"), "/system_usermanager_passwordmg.php");
 } else {

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -253,7 +253,7 @@ $services_menu[] = array(gettext("DHCPv6 Relay"), "/services_dhcpv6_relay.php");
 
 if ($g['services_dhcp_server_enable']) {
 	$services_menu[] = array(gettext("DHCP Server"), "/services_dhcp.php");
-	$services_menu[] = array(gettext("DHCPv6 Server/RA"), "/services_dhcpv6.php");
+	$services_menu[] = array(htmlspecialchars(gettext("DHCPv6 Server & RA")), "/services_dhcpv6.php");
 }
 
 $services_menu[] = array(gettext("Dynamic DNS"), "/services_dyndns.php");

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -328,7 +328,7 @@ $status_menu = msort(array_merge($status_menu, return_ext_menu("Status")), 0);
 $diagnostics_menu = array();
 $diagnostics_menu[] = array(gettext("ARP Table"), "/diag_arp.php");
 $diagnostics_menu[] = array(gettext("Authentication"), "/diag_authentication.php");
-$diagnostics_menu[] = array(gettext("Backup/Restore"), "/diag_backup.php");
+$diagnostics_menu[] = array(htmlspecialchars(gettext("Backup & Restore")), "/diag_backup.php");
 $diagnostics_menu[] = array(gettext("Command Prompt"), "/exec.php");
 $diagnostics_menu[] = array(gettext("DNS Lookup"), "/diag_dns.php");
 $diagnostics_menu[] = array(gettext("Edit File"), "/edit.php");
@@ -535,7 +535,7 @@ if (is_subsystem_dirty('packagelock') || file_exists('/conf/needs_package_sync' 
 	} else {
 		$pgtitle = array(gettext("System"), gettext("Package Manager"));
 		$warning_text = gettext("Packages are currently being reinstalled in the background.<p>Do not make changes in the GUI until this is complete.");
-		$warning_text .= gettext("<p>If the above message is still displayed after a couple of hours, use the 'Clear Package Lock' button on the <a href='diag_backup.php' title='Backup/Restore'>Backup/Restore page</a> and reinstall packages manually.");
+		$warning_text .= gettext("<p>If the above message is still displayed after a couple of hours, use the 'Clear Package Lock' button on the <a href='diag_backup.php' title='Backup & Restore'>Backup & Restore page</a> and reinstall packages manually.");
 	}
 
 	print_info_box($warning_text);

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -207,7 +207,7 @@ $system_menu[] = array(gettext("Update"), "/pkg_mgr_install.php?id=firmware");
 $system_menu[] = array(gettext("General Setup"), "/system.php");
 $system_menu[] = array(gettext("High Avail. Sync"), "/system_hasync.php");
 if ($g['platform'] == $g['product_name'] or $g['platform'] == "nanobsd") {
-	$system_menu[] = array(gettext("Packages"), "/pkg_mgr_installed.php");
+	$system_menu[] = array(gettext("Package Manager"), "/pkg_mgr_installed.php");
 }
 $system_menu[] = array(gettext("Setup Wizard"), "/wizard.php?xml=setup_wizard.xml");
 $system_menu[] = array(gettext("Routing"), "/system_gateways.php");

--- a/src/usr/local/www/pkg_mgr.php
+++ b/src/usr/local/www/pkg_mgr.php
@@ -164,8 +164,8 @@ $pgtitle = array(gettext("System"), gettext("Package Manager"), gettext("Availab
 include("head.inc");
 
 $tab_array = array();
-$tab_array[] = array(gettext("Available Packages"), true, "pkg_mgr.php");
 $tab_array[] = array(gettext("Installed Packages"), false, "pkg_mgr_installed.php");
+$tab_array[] = array(gettext("Available Packages"), true, "pkg_mgr.php");
 display_top_tabs($tab_array);
 ?>
 <div class="panel panel-default" id="search-panel" style="display: none;">

--- a/src/usr/local/www/pkg_mgr_install.php
+++ b/src/usr/local/www/pkg_mgr_install.php
@@ -242,8 +242,8 @@ if ($firmwareupdate || ($_POST['id'] == "firmware")) {
 	$tab_array[] = array(gettext("Update Settings"), false, "system_update_settings.php");
 } else {
 	$pgtitle = array(gettext("System"), gettext("Package Manager"), gettext("Package Installer"));
-	$tab_array[] = array(gettext("Available Packages"), false, "pkg_mgr.php");
 	$tab_array[] = array(gettext("Installed Packages"), false, "pkg_mgr_installed.php");
+	$tab_array[] = array(gettext("Available Packages"), false, "pkg_mgr.php");
 	$tab_array[] = array(gettext("Package Installer"), true, "");
 }
 

--- a/src/usr/local/www/pkg_mgr_install.php
+++ b/src/usr/local/www/pkg_mgr_install.php
@@ -212,8 +212,6 @@ function waitfor_string_in_file($filename, $string, $timeout) {
 	return(false);
 }
 
-$headline = "<br />";
-
 if ($_POST) {
 	if (empty($_POST['id']) && $_POST['mode'] != 'reinstallall') {
 		header("Location: pkg_mgr_installed.php");
@@ -229,25 +227,6 @@ if ($_POST) {
 		header("Location: pkg_mgr_installed.php");
 		return;
 	}
-
-	switch ($_GET['mode']) {
-		case 'reinstallall':
-			$headline = gettext("Reinstall all Packages");
-			break;
-		case 'reinstallpkg':
-			if ($_GET['from'] && $_GET['to']) {
-				$headline = gettext("Upgrade Package");
-			} else {
-				$headline = gettext("Reinstall Package");
-			}
-			break;
-		case 'delete':
-			$headline = gettext("Remove Package");
-			break;
-		default:
-			$headline = gettext("Install Package");
-			break;
-	}
 }
 
 if ($_GET && $_GET['id'] == "firmware") {
@@ -262,7 +241,7 @@ if ($firmwareupdate || ($_POST['id'] == "firmware")) {
 	$tab_array[] = array(gettext("System Update"), true, "");
 	$tab_array[] = array(gettext("Update Settings"), false, "system_update_settings.php");
 } else {
-	$pgtitle = array(gettext("System"), gettext("Package Manager"), $headline);
+	$pgtitle = array(gettext("System"), gettext("Package Manager"), gettext("Package Installer"));
 	$tab_array[] = array(gettext("Available Packages"), false, "pkg_mgr.php");
 	$tab_array[] = array(gettext("Installed Packages"), false, "pkg_mgr_installed.php");
 	$tab_array[] = array(gettext("Package Installer"), true, "");
@@ -277,7 +256,6 @@ if ($input_errors) {
 
 ?>
 <form action="pkg_mgr_install.php" method="post" class="form-horizontal">
-<!--	<h2><?=$headline?></h2> -->
 <?php if (($POST['complete'] != "true")	 && (empty($_GET['mode']) && $_GET['id']) || (!empty($_GET['mode']) && (!empty($_GET['pkg']) || $_GET['mode'] == 'reinstallall'))):
 	if (empty($_GET['mode']) && $_GET['id']) {
 		$pkgname = str_replace(array("<", ">", ";", "&", "'", '"', '.', '/'), "", htmlspecialchars_decode($_GET['id'], ENT_QUOTES | ENT_HTML401));

--- a/src/usr/local/www/pkg_mgr_installed.php
+++ b/src/usr/local/www/pkg_mgr_installed.php
@@ -76,8 +76,8 @@ $pgtitle = array(gettext("System"), gettext("Package Manager"), gettext("Install
 include("head.inc");
 
 $tab_array = array();
-$tab_array[] = array(gettext("Available Packages"), false, "pkg_mgr.php");
 $tab_array[] = array(gettext("Installed Packages"), true, "pkg_mgr_installed.php");
+$tab_array[] = array(gettext("Available Packages"), false, "pkg_mgr.php");
 display_top_tabs($tab_array);
 
 $installed_packages = array();

--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -93,7 +93,7 @@ if (!is_array($config['captiveportal'])) {
 }
 $a_cp =& $config['captiveportal'];
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Configuration"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Configuration"));
 $shortcut_section = "captiveportal";
 
 if ($_GET['act'] == "viewhtml") {

--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -1057,7 +1057,7 @@ $section->addInput(new Form_Select(
 	'SSL Certificate',
 	$pconfig['certref'],
 	build_cert_list()
-))->setHelp('If no certificates are defined, you may define one here: ' . '<a href="system_certmanager.php">System &gt; Cert Manager</a>');
+))->setHelp('If no certificates are defined, you may define one here: ' . '<a href="system_certmanager.php">System &gt; Cert. Manager</a>');
 
 $section->addInput(new Form_Checkbox(
 	'nohttpsforwards',

--- a/src/usr/local/www/services_captiveportal_filemanager.php
+++ b/src/usr/local/www/services_captiveportal_filemanager.php
@@ -96,7 +96,7 @@ if (!is_array($config['captiveportal'])) {
 }
 $a_cp =& $config['captiveportal'];
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("File Manager"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("File Manager"));
 $shortcut_section = "captiveportal";
 
 if (!is_array($a_cp[$cpzone]['element'])) {

--- a/src/usr/local/www/services_captiveportal_hostname.php
+++ b/src/usr/local/www/services_captiveportal_hostname.php
@@ -92,7 +92,7 @@ if (isset($cpzone) && !empty($cpzone) && isset($a_cp[$cpzone]['zoneid'])) {
 	$cpzoneid = $a_cp[$cpzone]['zoneid'];
 }
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Allowed Hostnames"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Allowed Hostnames"));
 $shortcut_section = "captiveportal";
 
 if ($_GET['act'] == "del" && !empty($cpzone) && isset($cpzoneid)) {

--- a/src/usr/local/www/services_captiveportal_hostname_edit.php
+++ b/src/usr/local/www/services_captiveportal_hostname_edit.php
@@ -93,7 +93,7 @@ if (!is_array($config['captiveportal'])) {
 }
 $a_cp =& $config['captiveportal'];
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Allowed Hostnames"), gettext("Edit"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Allowed Hostnames"), gettext("Edit"));
 $shortcut_section = "captiveportal";
 
 if (is_numericint($_GET['id'])) {

--- a/src/usr/local/www/services_captiveportal_ip.php
+++ b/src/usr/local/www/services_captiveportal_ip.php
@@ -91,7 +91,7 @@ if (isset($cpzone) && !empty($cpzone) && isset($a_cp[$cpzone]['zoneid'])) {
 	$cpzoneid = $a_cp[$cpzone]['zoneid'];
 }
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Allowed IP Addresses"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Allowed IP Addresses"));
 $shortcut_section = "captiveportal";
 
 if ($_GET['act'] == "del" && !empty($cpzone) && isset($cpzoneid)) {

--- a/src/usr/local/www/services_captiveportal_ip_edit.php
+++ b/src/usr/local/www/services_captiveportal_ip_edit.php
@@ -95,7 +95,7 @@ if (!is_array($config['captiveportal'])) {
 }
 $a_cp =& $config['captiveportal'];
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Allowed IP Addresses"), gettext("Edit"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Allowed IP Addresses"), gettext("Edit"));
 $shortcut_section = "captiveportal";
 
 if (is_numericint($_GET['id'])) {

--- a/src/usr/local/www/services_captiveportal_mac.php
+++ b/src/usr/local/www/services_captiveportal_mac.php
@@ -88,7 +88,7 @@ if (!is_array($config['captiveportal'])) {
 }
 $a_cp =& $config['captiveportal'];
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("MACs"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("MACs"));
 $shortcut_section = "captiveportal";
 
 $actsmbl = array('pass' => '<font color="green" size="4">&#x2714;</font>&nbsp;' . gettext("Pass"),

--- a/src/usr/local/www/services_captiveportal_mac_edit.php
+++ b/src/usr/local/www/services_captiveportal_mac_edit.php
@@ -98,7 +98,7 @@ if (!is_array($config['captiveportal'])) {
 }
 $a_cp =& $config['captiveportal'];
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("MACs"), gettext("Edit"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("MACs"), gettext("Edit"));
 $shortcut_section = "captiveportal";
 
 if (is_numericint($_GET['id'])) {

--- a/src/usr/local/www/services_captiveportal_vouchers.php
+++ b/src/usr/local/www/services_captiveportal_vouchers.php
@@ -108,7 +108,7 @@ if (empty($a_cp[$cpzone])) {
 	exit;
 }
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Vouchers"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Vouchers"));
 $shortcut_section = "captiveportal-vouchers";
 
 if (!is_array($config['voucher'][$cpzone]['roll'])) {

--- a/src/usr/local/www/services_captiveportal_vouchers_edit.php
+++ b/src/usr/local/www/services_captiveportal_vouchers_edit.php
@@ -83,7 +83,7 @@ if (!is_array($config['captiveportal'])) {
 }
 $a_cp =& $config['captiveportal'];
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Vouchers"), gettext("Edit"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Vouchers"), gettext("Edit"));
 $shortcut_section = "captiveportal-vouchers";
 
 if (!is_array($config['voucher'])) {

--- a/src/usr/local/www/services_captiveportal_zones.php
+++ b/src/usr/local/www/services_captiveportal_zones.php
@@ -90,7 +90,7 @@ if ($_GET['act'] == "del" && !empty($_GET['zone'])) {
 	exit;
 }
 
-$pgtitle = array(gettext("Services"), gettext("Captive Portal"), gettext("Zones"));
+$pgtitle = array(gettext("Services"), gettext("Captive Portal"));
 $shortcut_section = "captiveportal";
 include("head.inc");
 

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -716,6 +716,10 @@ function build_pooltable() {
 }
 
 $pgtitle = array(gettext("Services"), gettext("DHCP Server"));
+
+if (!empty($if) && !isset($config['dhcrelay']['enable']) && isset($iflist[$if])) {
+	$pgtitle[] = $iflist[$if];
+}
 $shortcut_section = "dhcp";
 
 include("head.inc");

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -407,7 +407,13 @@ $ip = $_SERVER['REMOTE_ADDR'];
 $mymac = `/usr/sbin/arp -an | grep '('{$ip}')' | cut -d" " -f4`;
 $mymac = str_replace("\n", "", $mymac);
 
-$pgtitle = array(gettext("Services"), gettext("DHCP Server"), gettext("Edit Static Mapping"));
+$iflist = get_configured_interface_with_descr();
+$ifname = '';
+
+if (!empty($if) && isset($iflist[$if])) {
+	$ifname = $iflist[$if];
+}
+$pgtitle = array(gettext("Services"), gettext("DHCP Server"), $ifname, gettext("Edit Static Mapping"));
 $shortcut_section = "dhcp";
 
 include("head.inc");

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -436,7 +436,12 @@ if ($_GET['act'] == "del") {
 	}
 }
 
-$pgtitle = array(gettext("Services"), gettext("DHCPv6 Server"));
+$pgtitle = array(gettext("Services"), gettext("DHCPv6 Server/RA"));
+
+if (!empty($if) && !$dhcrelay_enabled && isset($iflist[$if])) {
+	$pgtitle[] = $iflist[$if];
+}
+$pgtitle[] = gettext("DHCPv6 Server");
 $shortcut_section = "dhcp6";
 
 include("head.inc");

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -436,7 +436,7 @@ if ($_GET['act'] == "del") {
 	}
 }
 
-$pgtitle = array(gettext("Services"), gettext("DHCPv6 Server/RA"));
+$pgtitle = array(gettext("Services"), htmlspecialchars(gettext("DHCPv6 Server & RA")));
 
 if (!empty($if) && !$dhcrelay_enabled && isset($iflist[$if])) {
 	$pgtitle[] = $iflist[$if];

--- a/src/usr/local/www/services_dhcpv6_edit.php
+++ b/src/usr/local/www/services_dhcpv6_edit.php
@@ -220,7 +220,7 @@ $ifname = '';
 if (!empty($if) && isset($iflist[$if])) {
 	$ifname = $iflist[$if];
 }
-$pgtitle = array(gettext("Services"), gettext("DHCPv6 Server/RA"), $ifname, gettext("DHCPv6 Server"), gettext("Edit Static Mapping"));
+$pgtitle = array(gettext("Services"), htmlspecialchars(gettext("DHCPv6 Server & RA")), $ifname, gettext("DHCPv6 Server"), gettext("Edit Static Mapping"));
 $shortcut_section = "dhcp6";
 
 include("head.inc");

--- a/src/usr/local/www/services_dhcpv6_edit.php
+++ b/src/usr/local/www/services_dhcpv6_edit.php
@@ -214,7 +214,13 @@ if ($_POST) {
 	}
 }
 
-$pgtitle = array(gettext("Services"), gettext("DHCPv6 Server"), gettext("Edit Static Mapping"));
+$iflist = get_configured_interface_with_descr();
+$ifname = '';
+
+if (!empty($if) && isset($iflist[$if])) {
+	$ifname = $iflist[$if];
+}
+$pgtitle = array(gettext("Services"), gettext("DHCPv6 Server/RA"), $ifname, gettext("DHCPv6 Server"), gettext("Edit Static Mapping"));
 $shortcut_section = "dhcp6";
 
 include("head.inc");

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -56,8 +56,8 @@
 
 ##|+PRIV
 ##|*IDENT=page-services-ntpd
-##|*NAME=Services: NTP
-##|*DESCR=Allow access to the 'Services: NTP' page.
+##|*NAME=Services: NTP Settings
+##|*DESCR=Allow access to the 'Services: NTP Settings' page.
 ##|*MATCH=services_ntpd.php*
 ##|-PRIV
 
@@ -251,7 +251,7 @@ if (empty($pconfig['interface'])) {
 } else {
 	$pconfig['interface'] = explode(",", $pconfig['interface']);
 }
-$pgtitle = array(gettext("Services"), gettext("NTP"), gettext("NTP"));
+$pgtitle = array(gettext("Services"), gettext("NTP"), gettext("Settings"));
 $shortcut_section = "ntp";
 include("head.inc");
 
@@ -263,7 +263,7 @@ if ($savemsg) {
 }
 
 $tab_array = array();
-$tab_array[] = array(gettext("NTP"), true, "services_ntpd.php");
+$tab_array[] = array(gettext("Settings"), true, "services_ntpd.php");
 $tab_array[] = array(gettext("Serial GPS"), false, "services_ntpd_gps.php");
 $tab_array[] = array(gettext("PPS"), false, "services_ntpd_pps.php");
 display_top_tabs($tab_array);

--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -227,7 +227,7 @@ $shortcut_section = "ntp";
 include("head.inc");
 
 $tab_array = array();
-$tab_array[] = array(gettext("NTP"), false, "services_ntpd.php");
+$tab_array[] = array(gettext("Settings"), false, "services_ntpd.php");
 $tab_array[] = array(gettext("Serial GPS"), true, "services_ntpd_gps.php");
 $tab_array[] = array(gettext("PPS"), false, "services_ntpd_pps.php");
 display_top_tabs($tab_array);
@@ -241,7 +241,7 @@ $section->addInput(new Form_StaticText(
 	'A GPS connected via a serial port may be used as a reference clock for NTP. If the GPS also supports PPS and is properly configured, ' .
 	'and connected, that GPS may also be used as a Pulse Per Second clock reference. NOTE: A USB GPS may work, but is not recommended due to USB bus timing issues.' . '<br />' .
 	'For the best results, NTP should have at least three sources of time. So it is best to configure at least 2 servers under ' .
-	'<a href="services_ntpd.php">Services > NTP</a>' .
+	'<a href="services_ntpd.php">Services > NTP > Settings</a>' .
 	' to minimize clock drift if the GPS data is not valid over time. Otherwise ntpd may only use values from the unsynchronized local clock when providing time to clients.'
 ));
 

--- a/src/usr/local/www/services_ntpd_pps.php
+++ b/src/usr/local/www/services_ntpd_pps.php
@@ -146,7 +146,7 @@ if ($savemsg) {
 }
 
 $tab_array = array();
-$tab_array[] = array(gettext("NTP"), false, "services_ntpd.php");
+$tab_array[] = array(gettext("Settings"), false, "services_ntpd.php");
 $tab_array[] = array(gettext("Serial GPS"), false, "services_ntpd_gps.php");
 $tab_array[] = array(gettext("PPS"), true, "services_ntpd_pps.php");
 display_top_tabs($tab_array);
@@ -161,7 +161,7 @@ $section->addInput(new Form_StaticText(
 	'A serial GPS may also be used, but the serial GPS driver would usually be the better option. ' .
 	'A PPS signal only provides a reference to the change of a second, so at least one other source to number the seconds is required.' . '<br /><br />' .
 	'At least 3 additional time sources should be configured under ' .
-	'<a href="services_ntpd.php">' . 'Services > NTP' . '</a>' . ' to reliably supply the time of each PPS pulse.'
+	'<a href="services_ntpd.php">' . 'Services > NTP > Settings' . '</a>' . ' to reliably supply the time of each PPS pulse.'
 ));
 
 $serialports = glob("/dev/cua?[0-9]{,.[0-9]}", GLOB_BRACE);

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -234,7 +234,12 @@ if ($_POST) {
 	}
 }
 
-$pgtitle = array(gettext("Services"), gettext("Router Advertisements"));
+$pgtitle = array(gettext("Services"), gettext("DHCPv6 Server/RA"));
+
+if (!empty($if) && isset($iflist[$if])) {
+	$pgtitle[] = $iflist[$if];
+}
+$pgtitle[] = gettext("Router Advertisements");
 
 include("head.inc");
 

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -234,7 +234,7 @@ if ($_POST) {
 	}
 }
 
-$pgtitle = array(gettext("Services"), gettext("DHCPv6 Server/RA"));
+$pgtitle = array(gettext("Services"), htmlspecialchars(gettext("DHCPv6 Server & RA")));
 
 if (!empty($if) && isset($iflist[$if])) {
 	$pgtitle[] = $iflist[$if];

--- a/src/usr/local/www/services_unbound_acls.php
+++ b/src/usr/local/www/services_unbound_acls.php
@@ -206,6 +206,10 @@ $actionHelp =
 					sprintf(gettext('%sAllow Snoop:%s Allow recursive and nonrecursive access from hosts within the netblock defined below. Used for cache snooping and ideally should only be configured for your administrative host.'), '<span class="text-success"><strong>', '</strong></span>'); 
 
 $pgtitle = array(gettext("Services"), gettext("DNS Resolver"), gettext("Access Lists"));
+
+if ($act == "new" || $act == "edit") {
+	$pgtitle[] = gettext('Edit');
+}
 $shortcut_section = "resolver";
 include("head.inc");
 

--- a/src/usr/local/www/status_captiveportal.php
+++ b/src/usr/local/www/status_captiveportal.php
@@ -124,7 +124,7 @@ if (!empty($cpzone)) {
 }
 
 if (!empty($cpzone) && isset($config['voucher'][$cpzone]['enable'])) {
-	$pgtitle = array(gettext("Status"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Active Users"));
+	$pgtitle = array(gettext("Status"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Active Users"));
 } else {
 	$pgtitle = array(gettext("Status"), gettext("Captive Portal"));
 }

--- a/src/usr/local/www/status_captiveportal_expire.php
+++ b/src/usr/local/www/status_captiveportal_expire.php
@@ -83,7 +83,7 @@ if (!is_array($config['captiveportal'])) {
 }
 $a_cp =& $config['captiveportal'];
 
-$pgtitle = array(gettext("Status"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Expire Vouchers"));
+$pgtitle = array(gettext("Status"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Expire Vouchers"));
 
 include("head.inc");
 

--- a/src/usr/local/www/status_captiveportal_test.php
+++ b/src/usr/local/www/status_captiveportal_test.php
@@ -83,7 +83,7 @@ if (!is_array($config['captiveportal'])) {
 }
 $a_cp =& $config['captiveportal'];
 
-$pgtitle = array(gettext("Status"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Test Vouchers"));
+$pgtitle = array(gettext("Status"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Test Vouchers"));
 $shortcut_section = "captiveportal-vouchers";
 
 include("head.inc");

--- a/src/usr/local/www/status_captiveportal_voucher_rolls.php
+++ b/src/usr/local/www/status_captiveportal_voucher_rolls.php
@@ -82,7 +82,7 @@ if (!is_array($config['captiveportal'])) {
 	$config['captiveportal'] = array();
 }
 $a_cp =& $config['captiveportal'];
-$pgtitle = array(gettext("Status"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Voucher Rolls"));
+$pgtitle = array(gettext("Status"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Voucher Rolls"));
 $shortcut_section = "captiveportal-vouchers";
 
 if (!is_array($config['voucher'][$cpzone]['roll'])) {

--- a/src/usr/local/www/status_captiveportal_vouchers.php
+++ b/src/usr/local/www/status_captiveportal_vouchers.php
@@ -82,7 +82,7 @@ if (!is_array($config['captiveportal'])) {
 	$config['captiveportal'] = array();
 }
 $a_cp =& $config['captiveportal'];
-$pgtitle = array(gettext("Status"), gettext("Captive Portal"), sprintf(gettext("Zone: %s"), $a_cp[$cpzone]['zone']), gettext("Active Vouchers"));
+$pgtitle = array(gettext("Status"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Active Vouchers"));
 $shortcut_section = "captiveportal-vouchers";
 
 function clientcmp($a, $b) {

--- a/src/usr/local/www/status_pkglogs.php
+++ b/src/usr/local/www/status_pkglogs.php
@@ -102,6 +102,10 @@ if (!$apkg) { // If we aren't looking for a specific package, locate the first p
 }
 
 $pgtitle = array(gettext("Status"), gettext("Package Logs"));
+
+if ($pkgwithlogging && !empty($apkg)) {
+	$pgtitle[] = $apkg;
+}
 include("head.inc");
 
 if ($pkgwithlogging == false) {

--- a/src/usr/local/www/system_advanced_admin.php
+++ b/src/usr/local/www/system_advanced_admin.php
@@ -326,7 +326,7 @@ if ($savemsg) {
 
 $tab_array = array();
 $tab_array[] = array(gettext("Admin Access"), true, "system_advanced_admin.php");
-$tab_array[] = array(gettext("Firewall & NAT"), false, "system_advanced_firewall.php");
+$tab_array[] = array(htmlspecialchars(gettext("Firewall & NAT")), false, "system_advanced_firewall.php");
 $tab_array[] = array(gettext("Networking"), false, "system_advanced_network.php");
 $tab_array[] = array(gettext("Miscellaneous"), false, "system_advanced_misc.php");
 $tab_array[] = array(gettext("System Tunables"), false, "system_advanced_sysctl.php");

--- a/src/usr/local/www/system_advanced_firewall.php
+++ b/src/usr/local/www/system_advanced_firewall.php
@@ -401,7 +401,7 @@ if ($_POST) {
 	}
 }
 
-$pgtitle = array(gettext("System"), gettext("Advanced"), gettext("Firewall & NAT"));
+$pgtitle = array(gettext("System"), gettext("Advanced"), htmlspecialchars(gettext("Firewall & NAT")));
 include("head.inc");
 
 if ($input_errors) {
@@ -413,7 +413,7 @@ if ($savemsg) {
 
 $tab_array = array();
 $tab_array[] = array(gettext("Admin Access"), false, "system_advanced_admin.php");
-$tab_array[] = array(gettext("Firewall & NAT"), true, "system_advanced_firewall.php");
+$tab_array[] = array(htmlspecialchars(gettext("Firewall & NAT")), true, "system_advanced_firewall.php");
 $tab_array[] = array(gettext("Networking"), false, "system_advanced_network.php");
 $tab_array[] = array(gettext("Miscellaneous"), false, "system_advanced_misc.php");
 $tab_array[] = array(gettext("System Tunables"), false, "system_advanced_sysctl.php");

--- a/src/usr/local/www/system_advanced_misc.php
+++ b/src/usr/local/www/system_advanced_misc.php
@@ -314,7 +314,7 @@ if ($savemsg) {
 
 $tab_array = array();
 $tab_array[] = array(gettext("Admin Access"), false, "system_advanced_admin.php");
-$tab_array[] = array(gettext("Firewall & NAT"), false, "system_advanced_firewall.php");
+$tab_array[] = array(htmlspecialchars(gettext("Firewall & NAT")), false, "system_advanced_firewall.php");
 $tab_array[] = array(gettext("Networking"), false, "system_advanced_network.php");
 $tab_array[] = array(gettext("Miscellaneous"), true, "system_advanced_misc.php");
 $tab_array[] = array(gettext("System Tunables"), false, "system_advanced_sysctl.php");

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -182,7 +182,7 @@ if ($savemsg) {
 
 $tab_array = array();
 $tab_array[] = array(gettext("Admin Access"), false, "system_advanced_admin.php");
-$tab_array[] = array(gettext("Firewall & NAT"), false, "system_advanced_firewall.php");
+$tab_array[] = array(htmlspecialchars(gettext("Firewall & NAT")), false, "system_advanced_firewall.php");
 $tab_array[] = array(gettext("Networking"), true, "system_advanced_network.php");
 $tab_array[] = array(gettext("Miscellaneous"), false, "system_advanced_misc.php");
 $tab_array[] = array(gettext("System Tunables"), false, "system_advanced_sysctl.php");

--- a/src/usr/local/www/system_advanced_notifications.php
+++ b/src/usr/local/www/system_advanced_notifications.php
@@ -226,7 +226,7 @@ if ($savemsg) {
 
 $tab_array = array();
 $tab_array[] = array(gettext("Admin Access"), false, "system_advanced_admin.php");
-$tab_array[] = array(gettext("Firewall & NAT"), false, "system_advanced_firewall.php");
+$tab_array[] = array(htmlspecialchars(gettext("Firewall & NAT")), false, "system_advanced_firewall.php");
 $tab_array[] = array(gettext("Networking"), false, "system_advanced_network.php");
 $tab_array[] = array(gettext("Miscellaneous"), false, "system_advanced_misc.php");
 $tab_array[] = array(gettext("System Tunables"), false, "system_advanced_sysctl.php");

--- a/src/usr/local/www/system_advanced_sysctl.php
+++ b/src/usr/local/www/system_advanced_sysctl.php
@@ -180,7 +180,7 @@ if (is_subsystem_dirty('sysctl') && ($act != "edit" )) {
 
 $tab_array = array();
 $tab_array[] = array(gettext("Admin Access"), false, "system_advanced_admin.php");
-$tab_array[] = array(gettext("Firewall & NAT"), false, "system_advanced_firewall.php");
+$tab_array[] = array(htmlspecialchars(gettext("Firewall & NAT")), false, "system_advanced_firewall.php");
 $tab_array[] = array(gettext("Networking"), false, "system_advanced_network.php");
 $tab_array[] = array(gettext("Miscellaneous"), false, "system_advanced_misc.php");
 $tab_array[] = array(gettext("System Tunables"), true, "system_advanced_sysctl.php");

--- a/src/usr/local/www/system_advanced_sysctl.php
+++ b/src/usr/local/www/system_advanced_sysctl.php
@@ -164,6 +164,10 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Advanced"), gettext("System Tunables"));
+
+if ($act == "edit") {
+	$pgtitle[] = gettext('Edit');
+}
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -64,9 +64,6 @@
 require("guiconfig.inc");
 require_once("auth.inc");
 
-$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Authentication Servers"));
-$shortcut_section = "authentication";
-
 if (is_numericint($_GET['id'])) {
 	$id = $_GET['id'];
 }
@@ -377,6 +374,12 @@ if($_POST && $input_errors) {
 	$pconfig['ldap_template'] = $_POST['ldap_tmpltype'];
 }
 
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Authentication Servers"));
+
+if ($act == "new" || $act == "edit" || $input_errors) {
+	$pgtitle[] = gettext('Edit');
+}
+$shortcut_section = "authentication";
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -501,7 +501,7 @@ if (empty($a_ca))
 {
 	$section->addInput(new Form_StaticText(
 		'Peer Certificate Authority',
-		'No Certificate Authorities defined.<br/>Create one under <a href="system_camanager.php">System &gt; Cert Manager</a>.'
+		'No Certificate Authorities defined.<br/>Create one under <a href="system_camanager.php">System &gt; Cert. Manager</a>.'
 	));
 }
 else

--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -72,8 +72,6 @@ $ca_methods = array(
 $ca_keylens = array("512", "1024", "2048", "4096");
 $openssl_digest_algs = array("sha1", "sha224", "sha256", "sha384", "sha512");
 
-$pgtitle = array(gettext("System"), gettext("Certificate Manager"), gettext("CAs"));
-
 if (is_numericint($_GET['id'])) {
 	$id = $_GET['id'];
 }
@@ -350,6 +348,11 @@ if ($_POST) {
 	}
 }
 
+$pgtitle = array(gettext("System"), gettext("Certificate Manager"), gettext("CAs"));
+
+if ($act == "new" || $act == "edit" || $act == gettext("Save") || $input_errors) {
+	$pgtitle[] = gettext('Edit');
+}
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -79,8 +79,6 @@ $cert_types = array(
 $altname_types = array("DNS", "IP", "email", "URI");
 $openssl_digest_algs = array("sha1", "sha224", "sha256", "sha384", "sha512");
 
-$pgtitle = array(gettext("System"), gettext("Certificate Manager"), gettext("Certificates"));
-
 if (is_numericint($_GET['userid'])) {
 	$userid = $_GET['userid'];
 }
@@ -559,6 +557,11 @@ if ($_POST) {
 	}
 }
 
+$pgtitle = array(gettext("System"), gettext("Certificate Manager"), gettext("Certificates"));
+
+if (($act == "new" || ($_POST['save'] == gettext("Save") && $input_errors)) || ($act == "csr" || ($_POST['save'] == gettext("Update") && $input_errors))) {
+	$pgtitle[] = gettext('Edit');
+}
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_crlmanager.php
+++ b/src/usr/local/www/system_crlmanager.php
@@ -67,8 +67,6 @@ require_once("vpn.inc");
 
 global $openssl_crl_status;
 
-$pgtitle = array(gettext("System"), gettext("Certificate Manager"), gettext("Certificate Revocation"));
-
 $crl_methods = array(
 	"internal" => gettext("Create an internal Certificate Revocation List"),
 	"existing" => gettext("Import an existing Certificate Revocation List"));
@@ -292,6 +290,11 @@ if ($_POST) {
 	}
 }
 
+$pgtitle = array(gettext("System"), gettext("Certificate Manager"), gettext("Certificate Revocation"));
+
+if ($act == "new" || $act == gettext("Save") || $input_errors || $act == "edit") {
+	$pgtitle[] = gettext('Edit');
+}
 include("head.inc");
 ?>
 

--- a/src/usr/local/www/system_groupmanager.php
+++ b/src/usr/local/www/system_groupmanager.php
@@ -67,8 +67,6 @@
 
 require("guiconfig.inc");
 
-$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Groups"));
-
 if (!is_array($config['system']['group'])) {
 	$config['system']['group'] = array();
 }
@@ -257,6 +255,11 @@ function build_priv_table() {
 	return($privhtml);
 }
 
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Groups"));
+
+if ($act == "new" || $act == "edit") {
+	$pgtitle[] = gettext('Edit');
+}
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_groupmanager_addprivs.php
+++ b/src/usr/local/www/system_groupmanager_addprivs.php
@@ -80,7 +80,7 @@ function admin_groups_sort() {
 
 require("guiconfig.inc");
 
-$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Groups"), gettext("Add Privileges"));
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Groups"), gettext("Edit"), gettext("Add Privileges"));
 
 if (is_numericint($_GET['groupid'])) {
 	$groupid = $_GET['groupid'];

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -69,8 +69,6 @@ require("certs.inc");
 require("guiconfig.inc");
 
 // start admin user code
-$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Users"));
-
 if (isset($_POST['userid']) && is_numericint($_POST['userid'])) {
 	$id = $_POST['userid'];
 }
@@ -466,6 +464,11 @@ function build_cert_table() {
 	return($certhtml);
 }
 
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Users"));
+
+if ($act == "new" || $act == "edit" || $input_errors) {
+	$pgtitle[] = gettext('Edit');
+}
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_usermanager_addprivs.php
+++ b/src/usr/local/www/system_usermanager_addprivs.php
@@ -67,7 +67,7 @@ function admusercmp($a, $b) {
 
 require("guiconfig.inc");
 
-$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Users"), gettext("Add Privileges"));
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Users"), gettext("Edit"), gettext("Add Privileges"));
 
 if (is_numericint($_GET['userid'])) {
 	$userid = $_GET['userid'];

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -67,9 +67,6 @@ require_once("pkg-utils.inc");
 
 global $openvpn_topologies;
 
-$pgtitle = array(gettext("VPN"), gettext("OpenVPN"), gettext("Clients"));
-$shortcut_section = "openvpn";
-
 if (!is_array($config['openvpn']['openvpn-client'])) {
 	$config['openvpn']['openvpn-client'] = array();
 }
@@ -425,6 +422,13 @@ if ($_POST) {
 		exit;
 	}
 }
+
+$pgtitle = array(gettext("VPN"), gettext("OpenVPN"), gettext("Clients"));
+
+if ($act=="new" || $act=="edit") {
+	$pgtitle[] = gettext('Edit');
+}
+$shortcut_section = "openvpn";
 
 include("head.inc");
 

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -615,7 +615,7 @@ if ($act=="new" || $act=="edit"):
 	} else {
 		$section->addInput(new Form_StaticText(
 			'Peer Certificate Authority',
-			sprintf('No Certificate Authorities defined. You may create one here: %s', '<a href="system_camanager.php">System &gt; Cert Manager</a>')
+			sprintf('No Certificate Authorities defined. You may create one here: %s', '<a href="system_camanager.php">System &gt; Cert. Manager</a>')
 		));
 	}
 
@@ -629,7 +629,7 @@ if ($act=="new" || $act=="edit"):
 	} else {
 		$section->addInput(new Form_StaticText(
 			'Peer Certificate Revocation list',
-			sprintf('No Certificate Revocation Lists defined. You may create one here: %s', '<a href="system_crlmanager.php">System &gt; Cert Manager &gt; Certificate Revocation</a>')
+			sprintf('No Certificate Revocation Lists defined. You may create one here: %s', '<a href="system_crlmanager.php">System &gt; Cert. Manager &gt; Certificate Revocation</a>')
 		));
 	}
 

--- a/src/usr/local/www/vpn_openvpn_csc.php
+++ b/src/usr/local/www/vpn_openvpn_csc.php
@@ -67,9 +67,6 @@ require_once("pkg-utils.inc");
 
 global $openvpn_tls_server_modes;
 
-$pgtitle = array(gettext("VPN"), gettext("OpenVPN"), gettext("Client Specific Overrides"));
-$shortcut_section = "openvpn";
-
 if (!is_array($config['openvpn']['openvpn-csc'])) {
 	$config['openvpn']['openvpn-csc'] = array();
 }
@@ -307,6 +304,13 @@ if ($_POST) {
 		exit;
 	}
 }
+
+$pgtitle = array(gettext("VPN"), gettext("OpenVPN"), gettext("Client Specific Overrides"));
+
+if ($act=="new" || $act=="edit") {
+	$pgtitle[] = gettext('Edit');
+}
+$shortcut_section = "openvpn";
 
 include("head.inc");
 

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -738,7 +738,7 @@ if ($act=="new" || $act=="edit"):
 	} else {
 		$section->addInput(new Form_StaticText(
 			'Peer Certificate Authority',
-			sprintf('No Certificate Authorities defined. You may create one here: %s', '<a href="system_camanager.php">System &gt; Cert Manager</a>')
+			sprintf('No Certificate Authorities defined. You may create one here: %s', '<a href="system_camanager.php">System &gt; Cert. Manager</a>')
 		));
 	}
 
@@ -752,7 +752,7 @@ if ($act=="new" || $act=="edit"):
 	} else {
 		$section->addInput(new Form_StaticText(
 			'Peer Certificate Revocation list',
-			sprintf('No Certificate Revocation Lists defined. You may create one here: %s', '<a href="system_camanager.php">System &gt; Cert Manager</a>')
+			sprintf('No Certificate Revocation Lists defined. You may create one here: %s', '<a href="system_camanager.php">System &gt; Cert. Manager</a>')
 		));
 	}
 
@@ -766,7 +766,7 @@ if ($act=="new" || $act=="edit"):
 			}
 		}
 	} else {
-		$certhelp = sprintf('%s%s%s$s', '<span id="certtype">', gettext('No Certificates defined. You may create one here: '), '<a href="system_camanager.php">' . gettext("System &gt; Cert Manager") . '</a>', '</span>');
+		$certhelp = sprintf('%s%s%s$s', '<span id="certtype">', gettext('No Certificates defined. You may create one here: '), '<a href="system_camanager.php">' . gettext("System &gt; Cert. Manager") . '</a>', '</span>');
 	}
 
 	$cl = openvpn_build_cert_list(false, true);
@@ -786,7 +786,7 @@ if ($act=="new" || $act=="edit"):
 		'DH Parameter length (bits)',
 		$pconfig['dh_length'],
 		array_combine($openvpn_dh_lengths, $openvpn_dh_lengths)
-		))->setHelp(count($a_cert) ? '':sprintf('No Certificates defined. You may create one here: %s', '<a href="system_camanager.php">System &gt; Cert Manager</a>'));
+		))->setHelp(count($a_cert) ? '':sprintf('No Certificates defined. You may create one here: %s', '<a href="system_camanager.php">System &gt; Cert. Manager</a>'));
 
 	if (!$pconfig['shared_key']) {
 		$section->addInput(new Form_Checkbox(

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -590,6 +590,10 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("VPN"), gettext("OpenVPN"), gettext("Servers"));
+
+if ($act=="new" || $act=="edit") {
+	$pgtitle[] = gettext('Edit');
+}
 $shortcut_section = "openvpn";
 
 include("head.inc");


### PR DESCRIPTION
Last follow up to pulls #2622 and #2629

 - Renamed some titles that had / in them so they don't clash with breadcrumb separator
 - Renamed some titles to make things more consistent
 - Removed "headline" from package manager breadcrumb since it is redundant
 - Removed "Zone:" prefix from captive portal zone name in the breadcrumb
 - Added missing breadcrumb items on some pages