### PR TITLE
Make HTML conformant with standards

### DIFF
--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -245,7 +245,7 @@ if (is_array($confvers)):
 			</thead>
 			<tbody>
 				<!-- First row is the current configuration -->
-				<tr valign="top">
+				<tr style="vertical-align:top;">
 					<td></td>
 					<td>
 						<input type="radio" name="newtime" value="current" />

--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -173,7 +173,7 @@ if ($diff) {
 		}
 ?>
 			<tr>
-				<td class="diff-text" valign="middle" style="background-color:<?=$color;?>;white-space:pre-wrap;"><?=htmlentities($line)?></td>
+				<td class="diff-text" style="vertical-align:middle; background-color:<?=$color;?>; white-space:pre-wrap;"><?=htmlentities($line)?></td>
 			</tr>
 <?php
 	}

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -535,7 +535,7 @@ if (is_subsystem_dirty('packagelock') || file_exists('/conf/needs_package_sync' 
 	} else {
 		$pgtitle = array(gettext("System"), gettext("Package Manager"));
 		$warning_text = gettext("Packages are currently being reinstalled in the background.<p>Do not make changes in the GUI until this is complete.");
-		$warning_text .= gettext("<p>If the above message is still displayed after a couple of hours, use the 'Clear Package Lock' button on the <a href='diag_backup.php' title='Backup & Restore'>Backup & Restore page</a> and reinstall packages manually.");
+		$warning_text .= sprintf(gettext('<p>If the above message is still displayed after a couple of hours, use the \'Clear Package Lock\' button on the <a href="diag_backup.php" title="%1$s">%1$s page</a> and reinstall packages manually.'), htmlspecialchars(gettext('Backup & Restore')));
 	}
 
 	print_info_box($warning_text);

--- a/src/usr/local/www/load_balancer_monitor.php
+++ b/src/usr/local/www/load_balancer_monitor.php
@@ -160,8 +160,8 @@ foreach ($a_monitor as $monitor) {
 						</td>
 						<td>
 							<a class="fa fa-pencil"	title="<?=gettext('Edit monitor')?>"	href="load_balancer_monitor_edit.php?id=<?=$idx?>"></a>
-							<a class="fa fa-clone"	title="<?=gettext('Copy monitor')?>"	href="load_balancer_monitor_edit.php?act=dup&id=<?=$idx?>"></a>
-							<a class="fa fa-trash"	title="<?=gettext('Delete monitor')?>"	href="load_balancer_monitor.php?act=del&id=<?=$idx?>"></a>
+							<a class="fa fa-clone"	title="<?=gettext('Copy monitor')?>"	href="load_balancer_monitor_edit.php?act=dup&amp;id=<?=$idx?>"></a>
+							<a class="fa fa-trash"	title="<?=gettext('Delete monitor')?>"	href="load_balancer_monitor.php?act=del&amp;id=<?=$idx?>"></a>
 						</td>
 					</tr>
 <?php

--- a/src/usr/local/www/load_balancer_pool.php
+++ b/src/usr/local/www/load_balancer_pool.php
@@ -195,8 +195,8 @@ foreach ($a_pool as $pool) {
 						</td>
 						<td>
 							<a class="fa fa-pencil"	title="<?=gettext('Edit pool')?>"	href="load_balancer_pool_edit.php?id=<?=$idx?>"></a>
-							<a class="fa fa-clone"	title="<?=gettext('Copy pool')?>"	href="load_balancer_pool_edit.php?act=dup&id=<?=$idx?>"></a>
-							<a class="fa fa-trash"	title="<?=gettext('Delete pool')?>"	href="load_balancer_pool.php?act=del&id=<?=$idx?>"></a>
+							<a class="fa fa-clone"	title="<?=gettext('Copy pool')?>"	href="load_balancer_pool_edit.php?act=dup&amp;id=<?=$idx?>"></a>
+							<a class="fa fa-trash"	title="<?=gettext('Delete pool')?>"	href="load_balancer_pool.php?act=del&amp;id=<?=$idx?>"></a>
 						</td>
 					</tr>
 <?php

--- a/src/usr/local/www/load_balancer_virtual_server.php
+++ b/src/usr/local/www/load_balancer_virtual_server.php
@@ -177,8 +177,8 @@ if (!empty($a_vs)) {
 						<td><?=htmlspecialchars($a_v['descr'])?></td>
 						<td>
 							<a class="fa fa-pencil"	title="<?=gettext('Edit virtual server')?>"	href="load_balancer_virtual_server_edit.php?id=<?=$i?>"></a>
-							<a class="fa fa-clone"	title="<?=gettext('Copy virtual server')?>"	href="load_balancer_virtual_server_edit.php?act=dup&id=<?=$i?>"></a>
-							<a class="fa fa-trash"	title="<?=gettext('Delete virtual server')?>"	href="load_balancer_virtual_server.php?act=del&id=<?=$i?>"></a>
+							<a class="fa fa-clone"	title="<?=gettext('Copy virtual server')?>"	href="load_balancer_virtual_server_edit.php?act=dup&amp;id=<?=$i?>"></a>
+							<a class="fa fa-trash"	title="<?=gettext('Delete virtual server')?>"	href="load_balancer_virtual_server.php?act=del&amp;id=<?=$i?>"></a>
 						</td>
 					</tr>
 <?php


### PR DESCRIPTION
This should do the trick in order to escape '&' via htmlspecialchars.
Also edited another file, moving the valign to respective style attribute.