### PR TITLE
Bring all calls of print_info_box to same standard

### DIFF
--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -609,7 +609,7 @@ if (is_subsystem_dirty('restore')):
 	<br/>
 	<form action="diag_reboot.php" method="post">
 		<input name="Submit" type="hidden" value="Yes" />
-		<?=print_info_box(gettext("The firewall configuration has been changed.") . "<br />" . gettext("The firewall is now rebooting."))?>
+		<?php print_info_box(gettext("The firewall configuration has been changed.") . "<br />" . gettext("The firewall is now rebooting.")); ?>
 		<br />
 	</form>
 <?php

--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -213,12 +213,12 @@ if (is_array($confvers)) {
 ?>
 <div>
 	<div class="infoblock blockopen">
-		<?=print_info_box(
+		<?php print_info_box(
 			gettext(
 				'To view the differences between an older configuration and a newer configuration, ' .
 				'select the older configuration using the left column of radio options and select the newer configuration in the right column, ' .
 				'then press the "Diff" button.'),
-			'info', false)?>
+			'info', false); ?>
 	</div>
 </div>
 <?php

--- a/src/usr/local/www/firewall_aliases.php
+++ b/src/usr/local/www/firewall_aliases.php
@@ -316,10 +316,10 @@ display_top_tabs($tab_array);
 	 That way jQuery (in pfenseHelpers.js) will automatically take care of the display. -->
 <div>
 	<div class="infoblock">
-		<?=print_info_box(gettext('Aliases act as placeholders for real hosts, networks or ports. They can be used to minimize the number ' .
+		<?php print_info_box(gettext('Aliases act as placeholders for real hosts, networks or ports. They can be used to minimize the number ' .
 			'of changes that have to be made if a host, network or port changes. <br />' .
 			'You can enter the name of an alias instead of the host, network or port where indicated. The alias will be resolved according to the list above.' . '<br />' .
-			'If an alias cannot be resolved (e.g. because you deleted it), the corresponding element (e.g. filter/NAT/shaper rule) will be considered invalid and skipped.'), 'info', false)?>
+			'If an alias cannot be resolved (e.g. because you deleted it), the corresponding element (e.g. filter/NAT/shaper rule) will be considered invalid and skipped.'), 'info', false); ?>
 	</div>
 </div>
 

--- a/src/usr/local/www/firewall_nat_1to1.php
+++ b/src/usr/local/www/firewall_nat_1to1.php
@@ -285,12 +285,12 @@ display_top_tabs($tab_array);
 </form>
 
 <div class="infoblock">
-<?=print_info_box(gettext('Depending on the way your WAN connection is setup, you may also need a ') . '<a href="firewall_virtual_ip.php">' .
+<?php print_info_box(gettext('Depending on the way your WAN connection is setup, you may also need a ') . '<a href="firewall_virtual_ip.php">' .
 			   gettext("Virtual IP.") . '</a>' . '<br />' .
 			   gettext('If you add a 1:1 NAT entry for any of the interface IPs on this system, ' .
 					   'it will make this system inaccessible on that IP address. i.e. if ' .
 					   'you use your WAN IP address, any services on this system (IPsec, OpenVPN server, etc.) ' .
-					   'using the WAN IP address will no longer function.'), 'info', false)?>
+					   'using the WAN IP address will no longer function.'), 'info', false); ?>
 
 </div>
 

--- a/src/usr/local/www/firewall_schedule.php
+++ b/src/usr/local/www/firewall_schedule.php
@@ -280,7 +280,7 @@ endforeach;
 </nav>
 
 <div class="infoblock">
-	<?=print_info_box(gettext('Schedules act as placeholders for time ranges to be used in firewall rules.'), 'info', false)?>
+	<?php print_info_box(gettext('Schedules act as placeholders for time ranges to be used in firewall rules.'), 'info', false); ?>
 </div>
 
 <?php

--- a/src/usr/local/www/firewall_shaper.php
+++ b/src/usr/local/www/firewall_shaper.php
@@ -509,7 +509,7 @@ if ($dfltmsg) {
 ?>
 <div>
 	<div class="infoblock">
-		<?=print_info_box($default_shaper_msg, 'info', false)?>
+		<?php print_info_box($default_shaper_msg, 'info', false); ?>
 	</div>
 </div>
 <?php

--- a/src/usr/local/www/firewall_virtual_ip.php
+++ b/src/usr/local/www/firewall_virtual_ip.php
@@ -373,8 +373,8 @@ endforeach;
 </nav>
 
 <div class="infoblock">
-	<?=print_info_box(sprintf(gettext('The virtual IP addresses defined on this page may be used in %1$sNAT%2$s mappings.'), '<a href="firewall_nat.php">', '</a>') . '<br />' .
-		sprintf(gettext('You can check the status of your CARP Virtual IPs and interfaces %1$shere%2$s.'), '<a href="status_carp.php">', '</a>'), 'info', false)?>
+	<?php print_info_box(sprintf(gettext('The virtual IP addresses defined on this page may be used in %1$sNAT%2$s mappings.'), '<a href="firewall_nat.php">', '</a>') . '<br />' .
+		sprintf(gettext('You can check the status of your CARP Virtual IPs and interfaces %1$shere%2$s.'), '<a href="status_carp.php">', '</a>'), 'info', false); ?>
 </div>
 
 <?php

--- a/src/usr/local/www/firewall_virtual_ip_edit.php
+++ b/src/usr/local/www/firewall_virtual_ip_edit.php
@@ -483,8 +483,8 @@ print($form);
 ?>
 
 <div class="infoblock">
-	<?=print_info_box(gettext("Proxy ARP and Other type Virtual IPs cannot be bound to by anything running on the firewall, such as IPsec, OpenVPN, etc.  Use a CARP or IP Alias type address for these types.") . '<br />' .
-			   sprintf(gettext("For more information on CARP and the above values, visit the OpenBSD %s"), '<a href="http://www.openbsd.org/faq/pf/carp.html">CARP FAQ</a>.'), 'info', false)?>
+	<?php print_info_box(gettext("Proxy ARP and Other type Virtual IPs cannot be bound to by anything running on the firewall, such as IPsec, OpenVPN, etc.  Use a CARP or IP Alias type address for these types.") . '<br />' .
+			   sprintf(gettext("For more information on CARP and the above values, visit the OpenBSD %s"), '<a href="http://www.openbsd.org/faq/pf/carp.html">CARP FAQ</a>.'), 'info', false); ?>
 </div>
 
 <script type="text/javascript">

--- a/src/usr/local/www/interfaces_groups.php
+++ b/src/usr/local/www/interfaces_groups.php
@@ -162,8 +162,8 @@ display_top_tabs($tab_array);
 </nav>
 
 <div class="infoblock">
-	<?=print_info_box(gettext('Interface Groups allow you to setup rules for multiple interfaces without duplicating the rules.<br />' .
-					   'If you remove members from an interface group, the group rules are no longer applicable to that interface.'), 'info', false)?>
+	<?php print_info_box(gettext('Interface Groups allow you to setup rules for multiple interfaces without duplicating the rules.<br />' .
+					   'If you remove members from an interface group, the group rules are no longer applicable to that interface.'), 'info', false); ?>
 
 </div>
 <?php

--- a/src/usr/local/www/interfaces_qinq.php
+++ b/src/usr/local/www/interfaces_qinq.php
@@ -188,9 +188,9 @@ endforeach;
 </nav>
 
 <div class="infoblock">
-	<?=print_info_box(sprintf(gettext('Not all drivers/NICs support 802.1Q QinQ tagging properly. <br />On cards that do not explicitly support it, ' .
+	<?php print_info_box(sprintf(gettext('Not all drivers/NICs support 802.1Q QinQ tagging properly. <br />On cards that do not explicitly support it, ' .
 		'QinQ tagging will still work, but the reduced MTU may cause problems.<br />' .
-		'See the %s handbook for information on supported cards.'), $g['product_name']), 'info', false)?>
+		'See the %s handbook for information on supported cards.'), $g['product_name']), 'info', false); ?>
 </div>
 
 <?php

--- a/src/usr/local/www/interfaces_vlan.php
+++ b/src/usr/local/www/interfaces_vlan.php
@@ -180,10 +180,10 @@ display_top_tabs($tab_array);
 </form>
 
 <div class="infoblock">
-	<?=print_info_box(sprintf(gettext('Not all drivers/NICs support 802.1Q '.
+	<?php print_info_box(sprintf(gettext('Not all drivers/NICs support 802.1Q '.
 		'VLAN tagging properly. <br />On cards that do not explicitly support it, VLAN '.
 		'tagging will still work, but the reduced MTU may cause problems.<br />See the '.
-		'%s handbook for information on supported cards.'), $g['product_name']), 'info', false)?>
+		'%s handbook for information on supported cards.'), $g['product_name']), 'info', false); ?>
 </div>
 <script type="text/javascript">
 //<![CDATA[

--- a/src/usr/local/www/pkg_mgr.php
+++ b/src/usr/local/www/pkg_mgr.php
@@ -207,11 +207,11 @@ display_top_tabs($tab_array);
 	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Packages')?></h2></div>
 	<div id="pkgtbl" class="panel-body table-responsive">
 		<div id="waitmsg">
-			<?=print_info_box(gettext("Please wait while the list of packages is retrieved and formatted.") . '&nbsp;<i class="fa fa-cog fa-spin"></i>')?>
+			<?php print_info_box(gettext("Please wait while the list of packages is retrieved and formatted.") . '&nbsp;<i class="fa fa-cog fa-spin"></i>'); ?>
 		</div>
 
 		<div id="errmsg" style="display: none;">
-			<?=print_info_box("<ul><li>" . gettext("Unable to retrieve package information.") . "</li></ul>", 'danger')?>
+			<?php print_info_box("<ul><li>" . gettext("Unable to retrieve package information.") . "</li></ul>", 'danger'); ?>
 		</div>
 	</div>
 </div>

--- a/src/usr/local/www/services_captiveportal_hostname.php
+++ b/src/usr/local/www/services_captiveportal_hostname.php
@@ -197,7 +197,7 @@ endif;
 </nav>
 
 <div class="infoblock">
-	<?=print_info_box($notestr, 'info', false)?>
+	<?php print_info_box($notestr, 'info', false); ?>
 </div>
 
 <?php

--- a/src/usr/local/www/services_captiveportal_ip.php
+++ b/src/usr/local/www/services_captiveportal_ip.php
@@ -193,8 +193,8 @@ endif;
 </nav>
 
 <div class="infoblock">
-<?=print_info_box(gettext('Adding allowed IP addresses will allow IP access to/from these addresses through the captive portal without being taken to the portal page. ' .
-					   'This can be used for a web server serving images for the portal page or a DNS server on another network, for example.'), 'info', false)?>
+<?php print_info_box(gettext('Adding allowed IP addresses will allow IP access to/from these addresses through the captive portal without being taken to the portal page. ' .
+					   'This can be used for a web server serving images for the portal page or a DNS server on another network, for example.'), 'info', false); ?>
 </div>
 
 <?php

--- a/src/usr/local/www/services_captiveportal_mac.php
+++ b/src/usr/local/www/services_captiveportal_mac.php
@@ -256,7 +256,7 @@ endif;
 </nav>
 
 <div class="infoblock">
-	<?=print_info_box(gettext('Adding MAC addresses as "pass" MACs allows them access through the captive portal automatically without being taken to the portal page.'), 'info', false)?>
+	<?php print_info_box(gettext('Adding MAC addresses as "pass" MACs allows them access through the captive portal automatically without being taken to the portal page.'), 'info', false); ?>
 </div>
 <?php
 include("foot.inc");

--- a/src/usr/local/www/services_igmpproxy.php
+++ b/src/usr/local/www/services_igmpproxy.php
@@ -180,8 +180,8 @@ endforeach;
 </nav>
 
 <div class="infoblock">
-<?=print_info_box(gettext('Please add the interface for upstream, the allowed subnets, and the downstream interfaces you would like the proxy to allow. ' .
-					   'Only one "upstream" interface can be configured.'), 'info', false)?>
+<?php print_info_box(gettext('Please add the interface for upstream, the allowed subnets, and the downstream interfaces you would like the proxy to allow. ' .
+					   'Only one "upstream" interface can be configured.'), 'info', false); ?>
 </div>
 <?php
 include("foot.inc");

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -556,14 +556,14 @@ endforeach;
 </nav>
 
 <div class="infoblock">
-	<?=print_info_box(sprintf(gettext("If the DNS Resolver is enabled, the DHCP".
+	<?php print_info_box(sprintf(gettext("If the DNS Resolver is enabled, the DHCP".
 		" service (if enabled) will automatically serve the LAN IP".
 		" address as a DNS server to DHCP clients so they will use".
 		" the DNS Resolver. If Forwarding is enabled, the DNS Resolver will use the DNS servers".
 		" entered in %sSystem: General setup%s".
 		" or those obtained via DHCP or PPP on WAN if &quot;Allow".
 		" DNS server list to be overridden by DHCP/PPP on WAN&quot;".
-		" is checked."), '<a href="system.php">', '</a>'), 'info', false)?>
+		" is checked."), '<a href="system.php">', '</a>'), 'info', false); ?>
 </div>
 
 <?php include("foot.inc");

--- a/src/usr/local/www/status_logs_filter_summary.php
+++ b/src/usr/local/www/status_logs_filter_summary.php
@@ -158,7 +158,7 @@ $infomsg = sprintf(gettext('This is a summary of the last %1$s lines of the fire
 ?>
 <div>
 	<div class="infoblock blockopen">
-		<?=print_info_box($infomsg, 'info', false);?>
+		<?php print_info_box($infomsg, 'info', false); ?>
 	</div>
 </div>
 

--- a/src/usr/local/www/system_gateway_groups.php
+++ b/src/usr/local/www/system_gateway_groups.php
@@ -206,9 +206,9 @@ endforeach;
 </nav>
 
 <div class="infoblock">
-	<?=print_info_box(gettext('Remember to use these Gateway Groups in firewall rules in order to enable load balancing, failover, ' .
+	<?php print_info_box(gettext('Remember to use these Gateway Groups in firewall rules in order to enable load balancing, failover, ' .
 						   'or policy-based routing.' . '<br />' .
-						   'Without rules directing traffic into the Gateway Groups, they will not be used.'), 'info', false)?>
+						   'Without rules directing traffic into the Gateway Groups, they will not be used.'), 'info', false); ?>
 </div>
 <?php
 include("foot.inc");

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -553,13 +553,13 @@ foreach ($a_user as $i => $userent):
 </form>
 
 <div class="infoblock">
-	<?=print_info_box(gettext("Additional users can be added here. User permissions for accessing " .
+	<?php print_info_box(gettext("Additional users can be added here. User permissions for accessing " .
 	"the webConfigurator can be assigned directly or inherited from group memberships. " .
 	"An icon that appears grey indicates that it is a system defined object. " .
 	"Some system object properties can be modified but they cannot be deleted.") .
 	'<br /><br />' .
 	gettext("Accounts added here are also used for other parts of the system " .
-	"such as OpenVPN, IPsec, and Captive Portal."), 'info', false)?>
+	"such as OpenVPN, IPsec, and Captive Portal."), 'info', false); ?>
 </div>
 
 <?php

--- a/src/usr/local/www/vpn_ipsec.php
+++ b/src/usr/local/www/vpn_ipsec.php
@@ -557,9 +557,9 @@ display_top_tabs($tab_array);
 </form>
 
 <div class="infoblock">
-	<?=print_info_box(sprintf(gettext("You can check your IPsec status at %s%s%s."), '<a href="status_ipsec.php">', gettext("Status:IPsec"), '</a>') . '<br />' .
+	<?php print_info_box(sprintf(gettext("You can check your IPsec status at %s%s%s."), '<a href="status_ipsec.php">', gettext("Status:IPsec"), '</a>') . '<br />' .
 	sprintf(gettext("IPsec debug mode can be enabled at %s%s%s."), '<a href="vpn_ipsec_settings.php">', gettext("VPN:IPsec:Advanced Settings"), '</a>') . '<br />' .
-	sprintf(gettext("IPsec can be set to prefer older SAs at %s%s%s."), '<a href="vpn_ipsec_settings.php">', gettext("VPN:IPsec:Advanced Settings"), '</a>'), 'info', false)?>
+	sprintf(gettext("IPsec can be set to prefer older SAs at %s%s%s."), '<a href="vpn_ipsec_settings.php">', gettext("VPN:IPsec:Advanced Settings"), '</a>'), 'info', false); ?>
 </div>
 
 <script type="text/javascript">


### PR DESCRIPTION
The call itself to print_info_box already echoes the content. There is no need of additionally using the short-open-echo tag on those calls to echo return value.

The previous implementation shouldn't yell any visible issues as return is 'NULL' (undefined) which casts to an empty string when printing.

But, just for the sake of conformity, this changes are advisable in my opinion.