### PR TITLE
Firewall / Rules - Simplify Order-Store Loops

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -292,23 +292,30 @@ if (isset($_POST['del_x'])) {
 	if (is_array($_POST['rule']) && !empty($_POST['rule'])) {
 		$a_filter_new = array();
 
-		// get the rules of other interfaces listed in config before this interface.
-		for ($i = 0; (isset($a_filter[$i]) && 
-			(($a_filter[$i]['interface'] != $if && !isset($a_filter[$i]['floating'])) || (isset($a_filter[$i]['floating']) && "FloatingRules" != $if)) 
-			); $i++) {
-			$a_filter_new[] = $a_filter[$i];
+		// Include the rules of other interfaces listed in config before this (the selected) interface.
+		foreach ($a_filter as $filteri_before => $filterent) {
+			if (($filterent['interface'] == $if && !isset($filterent['floating'])) || (isset($filterent['floating']) && "FloatingRules" == $if)) {
+				break;
+			} else {
+				$a_filter_new[] = $filterent;
+			}
 		}
 
-		// include the rules of this interface.
-		// if a rule is not in POST[rule], it has been deleted by the user
+		// Include the rules of this (the selected) interface.
+		// If a rule is not in POST[rule], it has been deleted by the user
 		foreach ($_POST['rule'] as $id) {
 			$a_filter_new[] = $a_filter[$id];
 		}
 
-		// get the rules of other interfaces listed in config after this interface.
-		for ( ; (isset($a_filter[$i])); $i++) {
-			if (($a_filter[$i]['interface'] != $if && !isset($a_filter[$i]['floating'])) || (isset($a_filter[$i]['floating']) && "FloatingRules" != $if)) {
-				$a_filter_new[] = $a_filter[$i];
+		// Include the rules of other interfaces listed in config after this (the selected) interface.
+		foreach ($a_filter as $filteri_after => $filterent) {
+			if ($filteri_before > $filteri_after) {
+				continue;
+			}
+			if (($filterent['interface'] == $if && !isset($filterent['floating'])) || (isset($filterent['floating']) && "FloatingRules" == $if)) {
+				continue;
+			} else {
+				$a_filter_new[] = $filterent;
 			}
 		}
 


### PR DESCRIPTION
Replace indexing for loops with more easily readable key/value foreach loops.
Make the order-store rules selection logic consistent with the display rules selection logic.