### PR TITLE
Headers don't need HTML entities

### DIFF
--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -270,7 +270,7 @@ if ($_POST) {
 			if ($pkg['aftersaveredirect'] != "") {
 				pfSenseHeader($pkg['aftersaveredirect']);
 			} elseif (!$pkg['adddeleteeditpagefields']) {
-				pfSenseHeader("pkg_edit.php?xml={$xml}&amp;id=0");
+				pfSenseHeader("pkg_edit.php?xml={$xml}&id=0");
 			} elseif (!$pkg['preoutput']) {
 				pfSenseHeader("pkg.php?xml=" . $xml);
 			}


### PR DESCRIPTION
This commits fixes form submission on Services/UPnP redirecting to an URL with ```&amp;``` on it.