### PR TITLE
Fix hardcoded pfSense on login page

### DIFF
--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -264,7 +264,7 @@ if (isset($config['system']['webgui']['webguicss'])) {
 
 				<div class="panel panel-default">
 					<div class="panel-heading">
-						<h2 class="panel-title"><?=gettext("Login to pfSense")?></h2>
+						<h2 class="panel-title"><?=sprintf(gettext("Login to %s"), $g['product_name'])?></h2>
 					</div>
 
 					<div class="panel-body">


### PR DESCRIPTION
I guess this hard-coded mention of pfSense should use the value from $g ?