### PR TITLE
Minor tweaks to simplify code

### DIFF
--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -54,12 +54,12 @@
 // Global defines
 
 // Automatic panel collapse
-define(COLLAPSIBLE, 0x08);
-define(SEC_CLOSED, 0x04);
-define(SEC_OPEN, 0x00);
+define('COLLAPSIBLE', 0x08);
+define('SEC_CLOSED', 0x04);
+define('SEC_OPEN', 0x00);
 
 // AddPassword method defines
-define(DMYPWD, "********");
+define('DMYPWD', "********");
 
 global $g;
 $g = array(

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -56,9 +56,9 @@
  *
  */
 
-define(VIP_ALL, 1);
-define(VIP_CARP, 2);
-define(VIP_IPALIAS, 3);
+define('VIP_ALL', 1);
+define('VIP_CARP', 2);
+define('VIP_IPALIAS', 3);
 
 /* kill a process by pid file */
 function killbypid($pidfile) {

--- a/src/usr/local/www/diag_halt.php
+++ b/src/usr/local/www/diag_halt.php
@@ -85,7 +85,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	print_info_box(gettext("The system is halting now. This may take one minute or so."), 'success', false);
 
 	if (DEBUG) {
-	   print(sprintf(gettext("Not actually halting (DEBUG is set true)%s"), "<br />"));
+	   printf(gettext("Not actually halting (DEBUG is set true)%s"), "<br />");
 	} else {
 		print('<pre>');
 		system_halt();

--- a/src/usr/local/www/diag_nanobsd.php
+++ b/src/usr/local/www/diag_nanobsd.php
@@ -69,7 +69,7 @@ require_once("config.inc");
 
 // Setting DEBUG to true causes the dangerous stuff on this page to be simulated rather than executed.
 // MUST be set to false for production of course
-define(DEBUG, false);
+define('DEBUG', false);
 
 $pgtitle = array(gettext("Diagnostics"), gettext("NanoBSD"));
 include("head.inc");

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -61,7 +61,7 @@
 ##|*MATCH=services_ntpd.php*
 ##|-PRIV
 
-define(NUMTIMESERVERS, 10);		// The maximum number of configurable time servers
+define('NUMTIMESERVERS', 10);		// The maximum number of configurable time servers
 require("guiconfig.inc");
 require_once('rrd.inc');
 require_once("shaper.inc");

--- a/src/usr/local/www/status_ipsec_spd.php
+++ b/src/usr/local/www/status_ipsec_spd.php
@@ -63,8 +63,8 @@
 ##|*MATCH=status_ipsec_spd.php*
 ##|-PRIV
 
-define(RIGHTARROW, '&#x25ba;');
-define(LEFTARROW,  '&#x25c0;');
+define('RIGHTARROW', '&#x25ba;');
+define('LEFTARROW',  '&#x25c0;');
 
 require("guiconfig.inc");
 require("ipsec.inc");

--- a/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
@@ -177,7 +177,7 @@ if ($_REQUEST['getdyndnsstatus']) {
 		<?php endif; ?>
 		</td>
 		<td>
-		<?php print(htmlspecialchars($hostname)); ?>
+		<?=htmlspecialchars($hostname);?>
 		</td>
 		<td>
 		<div id="dyndnsstatus<?= $dyndnsid;?>"><?= gettext("Checking ...");?></div>

--- a/src/usr/local/www/wizard.php
+++ b/src/usr/local/www/wizard.php
@@ -69,7 +69,7 @@ require_once("rrd.inc");
 require_once("system.inc");
 
 // This causes the step #, field type and field name to be printed at the top of the page
-define(DEBUG, false);
+define('DEBUG', false);
 
 global $g;
 


### PR DESCRIPTION
Calling ```print(sprintf(...))``` can be simplified to ```printf(...)```.
```<?php print``` can be simplified to ```<?=```.

**edit**
added a commit that deals with define() calls with unquoted 1st parameter.