### PR TITLE
HTML Compliance - Diagnostics / Configuration History

### DIFF
--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -304,7 +304,7 @@ endif;
 ?>
 			</tbody>
 		</table>
-	</form>
-</div>
+	</div>
+</form>
 
 <?php include("foot.inc");


### PR DESCRIPTION
End tag form seen, but there were open elements. Unclosed element div.
Swap places between closing div and form tag.