### PR TITLE
Allow user to dismiss diag_edit messages

### DIFF
--- a/src/usr/local/www/diag_edit.php
+++ b/src/usr/local/www/diag_edit.php
@@ -70,21 +70,21 @@ if ($_POST['action']) {
 		case 'load':
 			if (strlen($_POST['file']) < 1) {
 				print('|5|');
-				print_info_box(gettext("No file name specified."), 'danger', false);
+				print_info_box(gettext("No file name specified."), 'danger');
 				print('|');
 			} elseif (is_dir($_POST['file'])) {
 				print('|4|');
-				print_info_box(gettext("Loading a directory is not supported."), 'danger', false);
+				print_info_box(gettext("Loading a directory is not supported."), 'danger');
 				print('|');
 			} elseif (!is_file($_POST['file'])) {
 				print('|3|');
-				print_info_box(gettext("File does not exist or is not a regular file."), 'danger', false);
+				print_info_box(gettext("File does not exist or is not a regular file."), 'danger');
 				print('|');
 			} else {
 				$data = file_get_contents(urldecode($_POST['file']));
 				if ($data === false) {
 					print('|1|');
-					print_info_box(gettext("Failed to read file."), 'danger', false);
+					print_info_box(gettext("Failed to read file."), 'danger');
 					print('|');
 				} else {
 					$data = base64_encode($data);
@@ -96,7 +96,7 @@ if ($_POST['action']) {
 		case 'save':
 			if (strlen($_POST['file']) < 1) {
 				print('|');
-				print_info_box(gettext("No file name specified."), 'danger', false);
+				print_info_box(gettext("No file name specified."), 'danger');
 				print('|');
 			} else {
 				conf_mount_rw();
@@ -111,15 +111,15 @@ if ($_POST['action']) {
 				}
 				if ($ret === false) {
 					print('|');
-					print_info_box(gettext("Failed to write file."), 'danger', false);
+					print_info_box(gettext("Failed to write file."), 'danger');
 					print('|');
 				} elseif ($ret != strlen($_POST['data'])) {
 					print('|');
-					print_info_box(gettext("Error while writing file."), 'danger', false);
+					print_info_box(gettext("Error while writing file."), 'danger');
 					print('|');
 				} else {
 					print('|');
-					print_info_box(gettext("File saved successfully."), 'success', false);
+					print_info_box(gettext("File saved successfully."), 'success');
 					print('|');
 				}
 			}


### PR DESCRIPTION
Previously the close 'x' was displayed, but after this code was changed to use print_info_box() the close 'x' was not being displayed.