### PR TITLE
Status / System Logs - Manage Logs Panel Access

### DIFF
--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -496,13 +496,18 @@ if (($pagename === "index.php") && ($numColumns > 2)) {
 		</li>
 	<?php endif ?>
 
-	<?php if ($system_logs_manage_log_form_hidden): ?>
+	<?php if ($system_logs_manage_log_form_hidden): 
+			/* If the user does not have access to status logs settings page, then exclude the manage log panel icon from the title bar. */
+			if (isAllowedPage("status_logs_settings.php")) {
+	?>
 		<li>
 			<a onclick="$('#manage-log-form').toggle(360)" title="<?=gettext("Manage log")?>">
 				<i class="fa fa-wrench icon-pointer"></i>
 			</a>
 		</li>
-	<?php endif ?>
+	<?php	}
+		endif
+	?>
 
 <?php
 if (!$hide_service_status && !empty($shortcuts[$shortcut_section]['service'])) {

--- a/src/usr/local/www/status_logs_common.inc
+++ b/src/usr/local/www/status_logs_common.inc
@@ -777,6 +777,11 @@ function manage_log_code() {
 # Manage Log Section/Form
 function manage_log_section() {
 
+	/* If the user does not have access to status logs settings page, then exclude the manage log panel from the page. */
+	if (!isAllowedPage("status_logs_settings.php")) {
+		return;
+	}
+
 	global $input_errors, $allowed_logs, $logfile, $config, $pconfig;
 	global $system_logs_manage_log_form_hidden;
 


### PR DESCRIPTION
If the user does not have access to status logs settings page, then exclude the manage log panel from the page.