### PR TITLE
Status / System Logs - Manage Logs Panel Error

### DIFF
--- a/src/usr/local/www/status_logs_common.inc
+++ b/src/usr/local/www/status_logs_common.inc
@@ -785,7 +785,7 @@ function manage_log_section() {
 		$manage_log_active = true;
 	}
 
-	if ($filter_active) {
+	if ($manage_log_active) {
 		$panel_state = 'in';
 		$panel_body_state = SEC_OPEN;
 	} else {


### PR DESCRIPTION
Change test to use the correct variable.  Otherwise it will never be true and form will not be kept open when there is input error.