### PR TITLE
Title Bar Shortcuts Privileges

### DIFF
--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -505,7 +505,7 @@ if (($pagename === "index.php") && ($numColumns > 2)) {
 	<?php endif ?>
 
 <?php
-if (!$hide_service_status && !empty($shortcuts[$shortcut_section]['service'])) {
+if (!$hide_service_status && !empty($shortcuts[$shortcut_section]['service']) && isAllowedPage('status_services.php')) {
 	$ssvc = array();
 	switch ($shortcut_section) {
 		case "openvpn":
@@ -523,15 +523,15 @@ if (!$hide_service_status && !empty($shortcuts[$shortcut_section]['service'])) {
 	}
 }
 
-if ('' != ($link = get_shortcut_main_link($shortcut_section, false))) {
+if (('' != ($link = get_shortcut_main_link($shortcut_section, false))) && (isAllowedPage($shortcuts[$shortcut_section]['main']))) {
 	echo '<li>' . $link . '</li>';
 }
 
-if ('' != ($link = get_shortcut_status_link($shortcut_section, false))) {
+if (('' != ($link = get_shortcut_status_link($shortcut_section, false))) && (isAllowedPage($shortcuts[$shortcut_section]['status']))) {
 	echo '<li>' . $link . '</li>';
 }
 
-if ('' != ($link = get_shortcut_log_link($shortcut_section, false))) {
+if (('' != ($link = get_shortcut_log_link($shortcut_section, false))) && (isAllowedPage($shortcuts[$shortcut_section]['log']))) {
 	echo '<li>' . $link . '</li>';
 }
 


### PR DESCRIPTION
Only display title bar shortcuts the user has privileges for.
Confusing and inconvenient being sent to the home page when clicking on those.  Then have to browse back to where you were.