### PR TITLE
Fix regression on system page preventing save with blank DNS servers

### DIFF
--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -201,7 +201,7 @@ if ($_POST) {
 		}
 	}
 
-	if (count($dnslist) != count(array_unique($dnslist))) {
+	if (count(array_filter($dnslist)) != count(array_unique(array_filter($dnslist)))) {
 		$input_errors[] = gettext('Each configured DNS server must have a unique IP address. Remove the duplicated IP.');
 	}
 


### PR DESCRIPTION
Introduced in f700dc9 for ticket #5915.
Fixes ticket #5916.

Blank DNS slots will always cause the count check to return false so you can't save the page with less than 3 DNS servers listed.