### PR TITLE
Initialize variables correctly

### DIFF
--- a/src/etc/inc/gmirror.inc
+++ b/src/etc/inc/gmirror.inc
@@ -284,7 +284,7 @@ function gmirror_get_consumer_metadata($consumer) {
 	if (!is_valid_consumer($consumer)) {
 		return array();
 	}
-	$output = "";
+	$output = array();
 	exec("/sbin/gmirror dump " . escapeshellarg($consumer), $output);
 	return array_map('trim', $output);
 }
@@ -341,7 +341,7 @@ function gmirror_get_all_unused_consumer_sizes_on_disk($disk) {
 	if (!is_valid_disk($disk) || !is_consumer_unused($disk)) {
 		return array();
 	}
-	$output = "";
+	$output = array();
 	exec("/sbin/geom part list " . escapeshellarg($disk) . " | /usr/bin/egrep '(Name:|Mediasize:)' | /usr/bin/cut -c4- | /usr/bin/sed -l -e 'N;s/\\nMediasize://;P;D;' | /usr/bin/cut -c7-", $output);
 	if (empty($output)) {
 		exec("/sbin/geom disk list " . escapeshellarg($disk) . " | /usr/bin/egrep '(Name:|Mediasize:)' | /usr/bin/cut -c4- | /usr/bin/sed -l -e 'N;s/\\nMediasize://;P;D;' | /usr/bin/cut -c7-", $output);

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -175,7 +175,7 @@ if ($_POST) {
 		$input_errors[] = gettext("The domain may only contain the characters a-z, 0-9, '-' and '.'.");
 	}
 
-	$ignore_posted_dnsgw = array();
+	$dnslist = $ignore_posted_dnsgw = array();
 
 	for ($dnscounter=1; $dnscounter<5; $dnscounter++) {
 		$dnsname="dns{$dnscounter}";


### PR DESCRIPTION
I have spotted and corrected the following:

1) gmirror.inc: there are two calls to exec(), those calls expect the 2nd parameter to be an array, this commit initializes the variables correctly.

2) system.php: variable dnslist is used as an array without prior type initialization. This is one of the causes for apparent PR #2680 problems (which led to its reversal).

Note: After this commit is merged, PR #2680 may be safely reapplied for more tough code if desired.