### PR TITLE
Deletes Even if Say Cancel - Fixes 5907

### DIFF
--- a/src/usr/local/www/bootstrap/css/pfSense.css
+++ b/src/usr/local/www/bootstrap/css/pfSense.css
@@ -859,3 +859,9 @@ a[href]:after {
 .bs-callout-info h4 {
     color: #01579B;
 }
+
+/* Disable 300 ms click delay so event handlers are effective. */
+/* Makes posible for non-touch compatible features to work; e.g. double tap rule to edit. */
+body{
+	touch-action: manipulation;
+}


### PR DESCRIPTION
Touch Action CSS
Bootstrap is applying this to the .btn class.  But that doesn't cover everything for us nor does it make possible to double tap firewall rules (table rows & cells) to edit.

"W3C added a new value for touch-action to the pointer events specification: manipulation."
https://w3c.github.io/pointerevents/#the-touch-action-css-property

Background:
What Exactly Is..... The 300ms Click Delay - November 21, 2013
http://www.telerik.com/blogs/what-exactly-is.....-the-300ms-click-delay

"From a practical point of view, touch-action determines whether you can pinch to zoom or double tap to zoom after touching the targeted element.  Therefore this is perfect for solving our 300ms click delay."