### PR TITLE
Collapsible Panels JavaScript Error - Fixes 5926

### DIFF
--- a/src/usr/local/www/bootstrap/css/pfSense.css
+++ b/src/usr/local/www/bootstrap/css/pfSense.css
@@ -790,7 +790,7 @@ a[href]:after {
 }
 
 /** Eliminate overflow in available widgets, log filter, and manage log panels. (cause of scroll bar) */
-#widget-available_panel-body>.content>.row,
+#widgets-available_panel-body>.content>.row,
 #filter-panel_panel-body>.form-group,
 #manage-log-panel_panel-body>.form-group,
 /** optionally prevent more globally by using the class hierarchy */

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -327,13 +327,13 @@ pfSense_handle_custom_code("/usr/local/pkg/dashboard/pre_dashboard");
 	<div class="panel-heading">
 		<h2 class="panel-title"><?=gettext("Available Widgets"); ?>
 			<span class="widget-heading-icon">
-				<a data-toggle="collapse" href="#widget-available_panel-body" id="widgets-available">
+				<a data-toggle="collapse" href="#widgets-available_panel-body" id="widgets-available">
 					<i class="fa fa-plus-circle"></i>
 				</a>
 			</span>
 		</h2>
 	</div>
-	<div id="widget-available_panel-body" class="panel-body collapse <?=$panel_body_state?>">
+	<div id="widgets-available_panel-body" class="panel-body collapse <?=$panel_body_state?>">
 		<div class="content">
 			<div class="row">
 <?php

--- a/src/usr/local/www/jquery/pfSenseHelpers.js
+++ b/src/usr/local/www/jquery/pfSenseHelpers.js
@@ -451,8 +451,7 @@ $('.container .panel-heading a[data-toggle="collapse"]').each(function (idx, el)
 		$(el).children('i').toggleClass('fa-minus-circle', true);
 		$(el).children('i').toggleClass('fa-plus-circle', false);
 
-		if(($(el).closest('a').attr('id') != 'widgets-available') && 
-		   ($(el).closest('a').attr('href').match(/widget-.*?_panel-body/i))) {
+		if($(el).attr('href').match(/widget-.*?_panel-body/i)) {
 			updateWidgets();
 		}
 	});
@@ -461,8 +460,7 @@ $('.container .panel-heading a[data-toggle="collapse"]').each(function (idx, el)
 		$(el).children('i').toggleClass('fa-minus-circle', false);
 		$(el).children('i').toggleClass('fa-plus-circle', true);
 
-		if(($(el).closest('a').attr('id') != 'widgets-available') && 
-		   ($(el).closest('a').attr('href').match(/widget-.*?_panel-body/i))) {
+		if($(el).attr('href').match(/widget-.*?_panel-body/i)) {
 			updateWidgets();
 		}
 	});

--- a/src/usr/local/www/jquery/pfSenseHelpers.js
+++ b/src/usr/local/www/jquery/pfSenseHelpers.js
@@ -451,7 +451,8 @@ $('.container .panel-heading a[data-toggle="collapse"]').each(function (idx, el)
 		$(el).children('i').toggleClass('fa-minus-circle', true);
 		$(el).children('i').toggleClass('fa-plus-circle', false);
 
-		if($(el).closest('a').attr('id') != 'widgets-available') {
+		if(($(el).closest('a').attr('id') != 'widgets-available') && 
+		   ($(el).closest('a').attr('href').match(/widget-.*?_panel-body/i))) {
 			updateWidgets();
 		}
 	});
@@ -460,7 +461,8 @@ $('.container .panel-heading a[data-toggle="collapse"]').each(function (idx, el)
 		$(el).children('i').toggleClass('fa-minus-circle', false);
 		$(el).children('i').toggleClass('fa-plus-circle', true);
 
-		if($(el).closest('a').attr('id') != 'widgets-available') {
+		if(($(el).closest('a').attr('id') != 'widgets-available') && 
+		   ($(el).closest('a').attr('href').match(/widget-.*?_panel-body/i))) {
 			updateWidgets();
 		}
 	});


### PR DESCRIPTION
Not the most elegant solution but should be functional.
Would prefer each widget to have an id attribute with something unique to match that identifies it as a widget panel.  Or test if 'updateWidgets' is defined as a function since it should only be so on the index page (dashboard).  But that seems sort of a hackish means.

Changing the widgets available panel href to "#widgets-available_panel-body" (note the added 's' to widget) may be the next best thing so that only the one if match test would be needed.

Is a call to updateWidgets even need here?  It's not readily obvious to me what it's accomplishing here when collapsing/expanding a widget panel.  My guess is that the intention is to save the panel collapsible state.  But I'm not experiencing that.