### PR TITLE
ICMPv6 Firewall Log Display - Fixes 5933 - RELENG_2_2

### DIFF
--- a/etc/inc/filter_log.inc
+++ b/etc/inc/filter_log.inc
@@ -190,7 +190,7 @@ function parse_filter_line($line) {
 				$flent['urg'] = $rule_data[$field++];
 				$flent['options'] = explode(";",$rule_data[$field++]);
 			}
-		} else if ($flent['protoid'] == '1') { // ICMP
+		} else if ($flent['protoid'] == '1' || $flent['protoid'] == '58') { // ICMP (IPv4 & IPv6)
 			$flent['src'] = $flent['srcip'];
 			$flent['dst'] = $flent['dstip'];
 


### PR DESCRIPTION
ICMPv6 logging was not being displayed in firewall log.