### PR TITLE
Diagnostics / Tables - URL Table Aliases

### DIFF
--- a/src/usr/local/www/diag_tables.php
+++ b/src/usr/local/www/diag_tables.php
@@ -226,7 +226,7 @@ if ($bogons || $urltable || !empty($entries)) {
 	}
 
 	if ($table_comments) {
-		print_info_box($last_update_msg . " &nbsp; &nbsp; " . $records_count_msg . " &nbsp; &nbsp; " . 
+		print_info_box($last_update_msg . " &nbsp; &nbsp; " . $records_count_msg . "<br />" .
 		'<span style="display:none" class="infoblock">' . ' ' . gettext("Hide table comments.") . '<br />' . $table_comments . '</span>' .
 		'<span style="display:none"   id="showtblcom">' . ' ' . gettext("Show table comments.") . '</span>' .
 		'' , 'info', false);


### PR DESCRIPTION
Think you are saying to put the second info block on a new line.  Though I could live with that.  I'm not fond of the extra dedicated line.  Consuming vertical space when there is plenty of unused horizontal space available in which it flows well.

Seems like maybe the the browser is not honoring something about the info block css, such as a width, or perhaps something that hasn't been specified in the css, and causing it to line wrap.

Anyway here's a commit with the comments info block on a separate line.  I'll leave it up to you to use or not.