### PR TITLE
print_callout class setting

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -359,7 +359,7 @@ function print_callout($msg, $class = 'info', $heading = '') {
 	$class = strtolower($class);
 	$callout = '';
 
-	if ($class != 'default' && $class != 'danger' && $class != 'warning' && $class = 'info') {
+	if ($class != 'default' && $class != 'danger' && $class != 'warning' && $class != 'info') {
 		$class = 'info';
 	}
 	$callout .= '<div class="bs-callout bs-callout-' . $class . '">';


### PR DESCRIPTION
The last test here looks not good having just a single equals sign - if the interpreter evaluates this then $class will always get set to 'info'.
In practice it should work OK, because the evaluation of boolean conditions left to right should stop when any of the other tests to the left evaluates false. So $class will only be set to 'info' if it is not already 'default' 'danger' or 'warning'.

Actually the code could be:
a) Obfuscated version with empty if block content:
if ($class != 'default' && $class != 'danger' && $class != 'warning' && $class = 'info') {
    // Noop - the if test above has already set $class to 'info' as required.
}

or

b) Clearer version without bothering with any test for $class != 'info' :
if ($class != 'default' && $class != 'danger' && $class != 'warning') {
    $class = 'info';
}