### PR TITLE
HTML Compliance - Diagnostics / Edit File

### DIFF
--- a/src/usr/local/www/diag_edit.php
+++ b/src/usr/local/www/diag_edit.php
@@ -145,7 +145,7 @@ require("head.inc");
 				<input type="button" class="btn btn-default btn-sm"	  id="fbOpen"		   value="<?=gettext('Browse')?>" />
 				<input type="button" class="btn btn-default btn-sm"	  onclick="saveFile();" value="<?=gettext('Save')?>" />
 				<span class="pull-right">
-					<button id="btngoto" class="btn btn-default btn-sm"><?=gettext("GoTo Line #")?></button> <input type="number" id="gotoline" width="6"></input>
+					<button id="btngoto" class="btn btn-default btn-sm"><?=gettext("GoTo Line #")?></button> <input type="number" id="gotoline" size="6" />
 				</span>
 			</form>
 
@@ -159,7 +159,7 @@ require("head.inc");
 				}
 				//]]>
 				</script>
-				<textarea id="fileContent" name="fileContent" class="form-control" rows="30" cols=""></textarea>
+				<textarea id="fileContent" name="fileContent" class="form-control" rows="30" cols="20"></textarea>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Attribute width not allowed on element input at this point.
<input type=number id=gotoline width=6>
Width attribute is only valid on input element for type image.
Changed to use size attribute.

Stray end tag input.

Bad value for attribute cols on element textarea: The empty string is not a valid positive integer.
<textarea id=fileContent name=fileContent class=form-control rows=30 cols=">
Syntax of positive integer: One or more digits (0-9), with at least one which is non-zero.
For example: 42 is valid, but 00 is not.
This is being handled by css so setting to default value.

Stray start tag script.
</html>↩↩<script type=text/javascript>↩$(doc
Scripts being placed after the page closing tags is bad form.
The scripts in foot.inc that are required by filebrowser/browse.js should be provide by other means such as a scripts include file so that browser.js, and others, can be placed before the page close tags of foot.inc. Foot.inc should be just that. Not the start of something more. This is a design issue. Leaving for another time.