### PR TITLE
Only add fake DHCPDv6 when not already enabled

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1249,7 +1249,7 @@ function services_dhcpdv6_configure($blacklist = array()) {
 		if (isset($blacklist[$ifname])) {
 			continue;
 		}
-		if (!empty($config['interfaces'][$ifname]['track6-interface']) && isset($dhcpdv6cfg[$ifname]['enable'])) {
+		if (!empty($config['interfaces'][$ifname]['track6-interface']) && !isset($dhcpdv6cfg[$ifname]['enable'])) {
 			$realif = get_real_interface($ifname, "inet6");
 			$ifcfgipv6 = get_interface_ipv6($ifname);
 			if (!is_ipaddrv6($ifcfgipv6)) {


### PR DESCRIPTION
The current code is adding the "fake" entry when track6-interface is defined, and the user has enabled DHCPv6 on the interface - that is causing the user-defined settings to be overridden by the hard-coded settings in this "if" block.
This change should make this code be executed only for track6-interface where DHCPv6 is not enabled by the user, as the comments above intended:
We add a fake entry for interfaces that are set to track6 another WAN unless DHCP has been configured.

Ref forum: https://forum.pfsense.org/index.php?topic=107537.msg600111#msg600111