### PR TITLE
HTML Compliance - Diagnostics / States / States

### DIFF
--- a/src/usr/local/www/diag_dump_states.php
+++ b/src/usr/local/www/diag_dump_states.php
@@ -253,7 +253,7 @@ print $form;
 			$info = $res[$i]['dst'];
 			if ($res[$i]['dst-orig'])
 				$info .= " (" . $res[$i]['dst-orig'] . ")";
-			$info .= " <- ";
+			$info .= " &lt;- ";
 			$info .= $res[$i]['src'];
 			if ($res[$i]['src-orig'])
 				$info .= " (" . $res[$i]['src-orig'] . ")";


### PR DESCRIPTION
Bad character - after <. Probable cause: Unescaped <. Try escaping it as &lt;.