### PR TITLE
System / User Manager / Groups / Edit / Add Privileges

### DIFF
--- a/src/usr/local/www/system_groupmanager_addprivs.php
+++ b/src/usr/local/www/system_groupmanager_addprivs.php
@@ -88,7 +88,6 @@ if (!is_array($a_group['priv'])) {
 
 // Make a local copy and sort it
 $spriv_list = $priv_list;
-uasort($spriv_list, "cpusercmp");
 
 if ($_POST) {
 


### PR DESCRIPTION
Not certain that the list needs to be sorted here.  Looks like it is already in order.  If it does then a valid callback function will need to be accessible.

Error: Non-space characters found without seeing a doctype first. Expected e.g. <!DOCTYPE html>.

Warning: uasort() expects parameter 2 to be a valid callback, function 'cpusercmp' not found or invalid function name in /usr/local/www/system_groupmanager_addprivs.php on line 91

Error: Element head is missing a required instance of child element title.

Warning: uasort() expects parameter 2 to be a valid callback, function 'cpusercmp' not found or invalid function name in /usr/local/www/system_groupmanager_addprivs.php on line 91

Error: Stray doctype.

Error: Stray start tag html.