### PR TITLE
Limit widget column to dashboardcolumns

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -252,6 +252,7 @@ if ($fd) {
 
 ##build widget saved list information
 if ($config['widgets'] && $config['widgets']['sequence'] != "") {
+	$dashboardcolumns = isset($config['system']['webgui']['dashboardcolumns']) ? $config['system']['webgui']['dashboardcolumns'] : 2;
 	$pconfig['sequence'] = $config['widgets']['sequence'];
 	$widgetsfromconfig = array();
 
@@ -267,6 +268,11 @@ if ($config['widgets'] && $config['widgets']['sequence'] != "") {
 			} else {
 				$col = "col2";
 			}
+		}
+
+		// Limit the column to the current dashboard columns.
+		if (substr($col, 3) > $dashboardcolumns) {
+			$col = "col" . $dashboardcolumns;
 		}
 
 		$offset = strpos($file, '-container');


### PR DESCRIPTION
Stops widgets from "going missing" when the user reduces the dashboard columns in System, General Setup.
If the user just lowers dashboard columns to see what happens, then increases it again, the actual column settings are preserved in the config, so the widgets go back where they were. That seems a good thing.
If the user lowers dashboard columns and then also saves the dashboard, the newly-limited column settings will be saved.

Forum: https://forum.pfsense.org/index.php?topic=107865.0