### PR TITLE
HTML Compliance - Login Form

### DIFF
--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -277,7 +277,7 @@ if (isset($config['system']['webgui']['webguicss'])) {
 <?php if (!empty($_SESSION['Login_Error'])): ?>
 						<div class="alert alert-danger" role="alert"><?=$_SESSION['Login_Error'];?></div>
 <?php endif ?>
-						<div class="alert alert-warning" class="hidden" id="no_cookies"><?= gettext("Your browser must support cookies to login."); ?></div>
+						<div class="alert alert-warning hidden" id="no_cookies"><?= gettext("Your browser must support cookies to login."); ?></div>
 
 						<form method="post" <?= $loginautocomplete ?> action="<?=$_SERVER['SCRIPT_NAME'];?>" class="form-horizontal">
 							<div class="form-group">


### PR DESCRIPTION
Error: Duplicate attribute class.
<div class=alert alert-warning class=hidden id=no_cookies>Your browser must support cookies to login.</div>
Consolidate multiple class attributes.

Error: Attribute autocorrect not allowed on element input at this point.
<input type=text class=form-control name=usernamefld id=usernamefld placeholder=Enter your username autocorrect=off autocapitalize=none spellcheck=false>
Non standard IOs Safari, Android Chrome attribute.

Error: Attribute autocapitalize not allowed on element input at this point.
<input type=text class=form-control name=usernamefld id=usernamefld placeholder=Enter your username autocorrect=off autocapitalize=none spellcheck=false>
Non standard IOs Safari, Android Chrome attribute.