### PR TITLE
Add Actions column heading for CRL Manager

### DIFF
--- a/src/usr/local/www/system_crlmanager.php
+++ b/src/usr/local/www/system_crlmanager.php
@@ -615,7 +615,7 @@ if ($act == "new" || $act == gettext("Save") || $input_errors) {
 						<th><?=gettext("Internal")?></th>
 						<th><?=gettext("Certificates")?></th>
 						<th><?=gettext("In Use")?></th>
-						<th></th>
+						<th><?=gettext("Actions")?></th>
 					</tr>
 				</thead>
 				<tbody>


### PR DESCRIPTION
To be consistent with everywhere else that has a heading for the Actions column.