### PR TITLE
Improve track6-prefix-id handling

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -2454,14 +2454,14 @@ if ($pconfig['track6-prefix-id'] == "") {
 }
 
 $section->addInput(new Form_Input(
-	'track6-prefix-id--hex' . $iface,
+	'track6-prefix-id--hex',
 	'IPv6 Prefix ID',
 	'text',
 	sprintf("%x", $pconfig['track6-prefix-id'])
 ))->setHelp('<span id="track6-prefix-id-range"></span>The value in this field is the (Delegated) IPv6 prefix ID. This determines the configurable network ID based on the dynamic IPv6 connection. The default value is 0.');
 
 $section->addInput(new Form_Input(
-	'track6-prefix-id-max' . $iface,
+	'track6-prefix-id-max',
 	null,
 	'hidden',
 	0
@@ -3620,6 +3620,10 @@ events.push(function() {
 
 	$('#type6').on('change', function() {
 		updateTypeSix(this.value);
+	});
+
+	$('#track6-interface').on('change', function() {
+		update_track6_prefix();
 	});
 
 	$('#pppoe-reset-type').on('change', function() {


### PR DESCRIPTION
1) The var $iface is not set at lines 2457 or 2464. It is a var that was used higher up local to build_ipv6interface_list() - it is not relevant to the single fields track6-prefix-id--hex and track6-prefix-id-max
2) When the user selects a different track6-interface then trigger update_track6_prefix() which will update the help text track6-prefix-id-range.

Related to forum https://forum.pfsense.org/index.php?topic=107962.msg601309#msg601309
This pull request does not directly address the reported issue of the track6-prefix-id not "taking". It just fixes up some code issues that I noticed.