### PR TITLE
Change invalid use of $iface in interfaces.php

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -803,7 +803,7 @@ if ($_POST['apply']) {
 	if (($_POST['pptp_subnet0'] && !is_numeric($_POST['pptp_subnet0']))) {
 		$input_errors[] = gettext("A valid PPTP subnet bit count must be specified.");
 	}
-	if (($_POST['pptp_remote0'] && !is_ipaddrv4($_POST['pptp_remote0']) && !is_hostname($_POST['gateway'][$iface]))) {
+	if (($_POST['pptp_remote0'] && !is_ipaddrv4($_POST['pptp_remote0']) && !is_hostname($_POST['pptp_remote0']))) {
 		$input_errors[] = gettext("A valid PPTP remote IP address must be specified.");
 	}
 	if (($_POST['pptp_idletimeout'] != "") && !is_numericint($_POST['pptp_idletimeout'])) {


### PR DESCRIPTION
At this point $iface is an undefined var. So the last test of this "if" statement is useless.
That code fragment was introduced in commit https://github.com/pfsense/pfsense/commit/e4d40f41aafe00353c0069b457a0b1b0d6c20987
I think that code fragment came from a similar thing that is inside a "foreach $iface" loop in interfaces_ppps_edit.php
https://github.com/pfsense/pfsense/blob/master/src/usr/local/www/interfaces_ppps_edit.php#L300
and was pasted into the condition here back in 2011 without being changed.

What I have done to the test here seems what would have been intended. Any better ideas are welcome.