### PR TITLE
Display NAT advanced source settings if defined

### DIFF
--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -1276,7 +1276,9 @@ events.push(function() {
 	typesel_change();
 	proto_change();
 	nordr_change();
-	hideSource(true);
+
+	var source_defined = <?= ($pconfig['srcnot'] || ($pconfig['src'] != "any") || ($pconfig['srcbeginport'] != "any") || ($pconfig['srcendport'] != "any"))? 1:0 ?>;
+	hideSource(!source_defined);
 
 	// --------- Autocomplete -----------------------------------------------------------------------------------------
 	var addressarray = <?= json_encode(get_alias_list(array("host", "network", "openvpn", "urltable"))) ?>;


### PR DESCRIPTION
On NAT Port Forward Edit, if any of the source port settings are different to the defaults then display the source fields, rather than just the Advanced button.
Otherwise when editing a NAT port forward with source address/port settings, it is not obvious to the user that there are existing source settings "hiding" under the Advanced button.