### PR TITLE
Status Monitoring - Settings Panel Collapsible

### DIFF
--- a/src/usr/local/www/bootstrap/css/pfSense.css
+++ b/src/usr/local/www/bootstrap/css/pfSense.css
@@ -793,6 +793,7 @@ a[href]:after {
 #widget-available_panel-body>.content>.row,
 #filter-panel_panel-body>.form-group,
 #manage-log-panel_panel-body>.form-group,
+#monitoring-settings-panel_panel-body>.form-group,
 /** optionally prevent more globally by using the class hierarchy */
 .panel-body.collapse.in>.content>.row,
 .panel-body.collapse.in>.form-group

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -544,6 +544,22 @@ if (($pagename === "index.php") && ($numColumns > 2)) {
 		endif
 	?>
 
+	<?php if ($monitoring_settings_form_hidden): ?>
+		<li>
+			<a onclick="$('#monitoring-settings-form').toggle(360);" title="<?=gettext("Settings")?>">
+				<i class="fa fa-wrench icon-pointer"></i>
+			</a>
+		</li>
+	<?php endif?>
+
+	<?php if ($status_monitoring): ?>
+		<li>
+			<a id="update" title="<?=gettext("Refresh Graph")?>">
+				<i class="fa fa-repeat icon-pointer"></i>
+			</a>
+		</li>
+	<?php endif?>
+
 <?php
 if (!$hide_service_status && !empty($shortcuts[$shortcut_section]['service']) && isAllowedPage('status_services.php')) {
 	$ssvc = array();

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -96,6 +96,7 @@ $pconfig['webguileftcolumnhyper'] = isset($config['system']['webgui']['webguilef
 $pconfig['dashboardavailablewidgetspanel'] = isset($config['system']['webgui']['dashboardavailablewidgetspanel']);
 $pconfig['systemlogsfilterpanel'] = isset($config['system']['webgui']['systemlogsfilterpanel']);
 $pconfig['systemlogsmanagelogpanel'] = isset($config['system']['webgui']['systemlogsmanagelogpanel']);
+$pconfig['statusmonitoringsettingspanel'] = isset($config['system']['webgui']['statusmonitoringsettingspanel']);
 $pconfig['dnslocalhost'] = isset($config['system']['dnslocalhost']);
 
 if (!$pconfig['timezone']) {
@@ -252,6 +253,9 @@ if ($_POST) {
 
 		unset($config['system']['webgui']['systemlogsmanagelogpanel']);
 		$config['system']['webgui']['systemlogsmanagelogpanel'] = $_POST['systemlogsmanagelogpanel'] ? true : false;
+
+		unset($config['system']['webgui']['statusmonitoringsettingspanel']);
+		$config['system']['webgui']['statusmonitoringsettingspanel'] = $_POST['statusmonitoringsettingspanel'] ? true : false;
 
 		/* XXX - billm: these still need updating after figuring out how to check if they actually changed */
 		$olddnsservers = $config['system']['dnsserver'];
@@ -546,6 +550,13 @@ $group->add(new Form_Checkbox(
 	'Manage Log',
 	$pconfig['systemlogsmanagelogpanel']
 ))->setHelp('Show the Manage Log panel in System Logs.');
+
+$group->add(new Form_Checkbox(
+	'statusmonitoringsettingspanel',
+	null,
+	'Monitoring Settings',
+	$pconfig['statusmonitoringsettingspanel']
+))->setHelp('Show the Settings panel in Status Monitoring.');
 
 $group->setHelp('These options allow certain panels to be automatically hidden on page load. A control is provided in the title bar to un-hide the panel.
 <br /><span class="badge" title="This feature is in BETA">BETA</span>');


### PR DESCRIPTION
Make the status monitoring settings panel collapsible with page load state configurable in general setup associated panels show/hide.
Replace Update button with refresh icon on title bar.

Required by FreeBSD-Ports pull request # 78 Status Monitoring - Settings Panel Collapsible.
https://github.com/pfsense/FreeBSD-ports/pull/78