### PR TITLE
Translate submit button name

### DIFF
--- a/src/usr/local/www/classes/Form.class.php
+++ b/src/usr/local/www/classes/Form.class.php
@@ -47,7 +47,7 @@ class Form extends Form_Element
 		if (gettype($submit) == 'string') {
 			$submit = new Form_Button(
 				'save',
-				$submit,
+				gettext($submit),
 				null,
 				'fa-save'
 			);


### PR DESCRIPTION
I noticed that the submit button 'Save' did not appear as 'Salvar' in pt_BR, even though that translation is there for pt_BR.
This change here makes the buttons have translated text.
But maybe there is a deeper place that the gettext() should be done - inside Form_Button() itself?
And maybe there are other places in the whole bootstrap/classes/... where strings still need to get translated?

Note: This change causes breakage to services_dhcpv6.php because that has code which explicitly compares to the untranslated string "Save":

```
if ($_POST['apply'] == "Apply Changes") {
	$savemsg = dhcpv6_apply_changes(false);
} elseif ($_POST['save'] == "Save") {
```
So whatever solution is done to make button text translate, code like the above will also need to be fixed at the same time.