### PR TITLE
Translate the default submit button text

### DIFF
--- a/src/usr/local/www/classes/Form.class.php
+++ b/src/usr/local/www/classes/Form.class.php
@@ -41,8 +41,9 @@ class Form extends Form_Element
 
 	public function __construct($submit = null)
 	{
-		if (!isset($submit))
-			$submit = 'Save';
+		if (!isset($submit)) {
+			$submit = gettext('Save');
+		}
 
 		if (gettype($submit) == 'string') {
 			$submit = new Form_Button(


### PR DESCRIPTION
Note: This will cause a problem for some code that does comparisons expecting this text to be exactly the string 'Save'. If the user has selected a different language then the button text will be translated and thus will be some different text.
That is discussed in forum https://forum.pfsense.org/index.php?topic=108116.0
I will followup with another pull request to fix the things I can find like that.