### PR TITLE
Fix $POST checks so they do not depend on string Save

### DIFF
--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -220,9 +220,9 @@ if (is_array($dhcrelaycfg) && isset($dhcrelaycfg['enable']) && isset($dhcrelaycf
 	}
 }
 
-if ($_POST['apply'] == "Apply Changes") {
+if (isset($_POST['apply'])) {
 	$savemsg = dhcpv6_apply_changes(false);
-} elseif ($_POST['save'] == "Save") {
+} elseif (isset($_POST['save'])) {
 	unset($input_errors);
 
 	$old_dhcpdv6_enable = ($pconfig['enable'] == true);


### PR DESCRIPTION
This prevents problems when Save is translated to other languages.
Note: This is the only remaining place I could find with this issue.
There are other pieces of code that do:
```
if ($_POST['save'] == gettext("Save"))
```
which also works, but looks a bit ugly.
I left those alone, since they do work OK in any language.