### PR TITLE
Internationalize Form_Button text

### DIFF
--- a/src/usr/local/www/diag_authentication.php
+++ b/src/usr/local/www/diag_authentication.php
@@ -147,7 +147,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Test',
+	gettext('Test'),
 	null,
 	'fa-wrench'
 ))->addClass('btn-primary');

--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -664,7 +664,7 @@ $group = new Form_Group('');
 // Note: ID attribute of each element created is to be unique.  Not being used, suppressing it.
 $group->add(new Form_Button(
 	'Submit',
-	'Download configuration as XML',
+	gettext('Download configuration as XML'),
 	null,
 	'fa-download'
 ))->setAttribute('id')->addClass('btn-primary');
@@ -712,7 +712,7 @@ $group = new Form_Group('');
 // Note: ID attribute of each element created is to be unique.  Not being used, suppressing it.
 $group->add(new Form_Button(
 	'Submit',
-	'Restore Configuration',
+	gettext('Restore Configuration'),
 	null,
 	'fa-undo'
 ))->setHelp('The firewall will reboot after restoring the configuration.')->addClass('btn-danger restore')->setAttribute('id');
@@ -729,7 +729,7 @@ if (($config['installedpackages']['package'] != "") || (is_subsystem_dirty("pack
 		// Note: ID attribute of each element created is to be unique.  Not being used, suppressing it.
 		$group->add(new Form_Button(
 			'Submit',
-			'Reinstall Packages',
+			gettext('Reinstall Packages'),
 			null,
 			'fa-retweet'
 		))->setHelp('Click this button to reinstall all system packages.  This may take a while.')->addClass('btn-success')->setAttribute('id');
@@ -742,7 +742,7 @@ if (($config['installedpackages']['package'] != "") || (is_subsystem_dirty("pack
 		// Note: ID attribute of each element created is to be unique.  Not being used, suppressing it.
 		$group->add(new Form_Button(
 			'Submit',
-			'Clear Package Lock',
+			gettext('Clear Package Lock'),
 			null,
 			'fa-wrench'
 		))->setHelp('Click this button to clear the package lock if a package fails to reinstall properly after an upgrade.')->addClass('btn-warning')->setAttribute('id');

--- a/src/usr/local/www/diag_dns.php
+++ b/src/usr/local/www/diag_dns.php
@@ -233,7 +233,7 @@ $section->addInput(new Form_Input(
 if (!empty($resolved)) {
 	$form->addGlobal(new Form_Button(
 		'create_alias',
-		'Add alias',
+		gettext('Add alias'),
 		null,
 		'fa-plus'
 	))->removeClass('btn-primary')->addClass('btn-success');
@@ -243,7 +243,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Lookup',
+	gettext('Lookup'),
 	null,
 	'fa-search'
 ))->addClass('btn-primary');

--- a/src/usr/local/www/diag_dump_states.php
+++ b/src/usr/local/www/diag_dump_states.php
@@ -175,7 +175,7 @@ $section->addInput(new Form_Input(
 
 $filterbtn = new Form_Button(
 	'filterbtn',
-	'Filter',
+	gettext('Filter'),
 	null,
 	'fa-filter'
 );
@@ -188,7 +188,7 @@ $section->addInput(new Form_StaticText(
 if (isset($_POST['filter']) && (is_ipaddr($_POST['filter']) || is_subnet($_POST['filter']))) {
 	$killbtn = new Form_Button(
 		'killfilter',
-		'Kill States',
+		gettext('Kill States'),
 		null,
 		'fa-trash'
 	);

--- a/src/usr/local/www/diag_dump_states_sources.php
+++ b/src/usr/local/www/diag_dump_states_sources.php
@@ -136,7 +136,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Filter',
+	gettext('Filter'),
 	null,
 	'fa-filter'
 ))->addClass('btn-primary');

--- a/src/usr/local/www/diag_nanobsd.php
+++ b/src/usr/local/www/diag_nanobsd.php
@@ -156,7 +156,7 @@ $section->addInput(new Form_StaticText(
 
 $slicebtn = new Form_Button(
 	'bootslice',
-	'Switch Slice',
+	gettext('Switch Slice'),
 	null,
 	'fa-retweet'
 );
@@ -213,7 +213,7 @@ $section->addInput(new Form_Checkbox(
 
 $permbtn = new Form_Button(
 	'setrw',
-	'Save',
+	gettext('Save'),
 	null,
 	'fa-save'
 );
@@ -233,7 +233,7 @@ $section->addInput(new Form_Input(
 
 $dupbtn = new Form_Button(
 	'duplicateslice',
-	'Duplicate ' . $COMPLETE_BOOT_PATH . ' -> ' . $TOFLASH,
+	gettext('Duplicate') . ' ' . $COMPLETE_BOOT_PATH . ' -> ' . $TOFLASH,
 	null,
 	'fa-clone'
 );
@@ -252,7 +252,7 @@ $section->addInput(new Form_StaticText(
 if (file_exists("/conf/upgrade_log.txt")) {
 	$viewbtn = new Form_Button(
 		'viewupgradelog',
-		'View log',
+		gettext('View log'),
 		null,
 		'fa-file-text-o'
 	);

--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -393,14 +393,14 @@ $processisrunning = ($processcheck != "");
 if (($action == gettext("Stop") or $action == "") and $processisrunning != true) {
 	$form->addGlobal(new Form_Button(
 		'startbtn',
-		'Start',
+		gettext('Start'),
 		null,
 		'fa-play-circle'
 	))->addClass('btn-success');
 } else {
 	$form->addGlobal(new Form_Button(
 		'stopbtn',
-		'Stop',
+		gettext('Stop'),
 		null,
 		'fa-stop-circle'
 	))->addClass('btn-warning');
@@ -409,14 +409,14 @@ if (($action == gettext("Stop") or $action == "") and $processisrunning != true)
 if (file_exists($fp.$fn) and $processisrunning != true) {
 	$form->addGlobal(new Form_Button(
 		'viewbtn',
-		'View Capture',
+		gettext('View Capture'),
 		null,
 		'fa-file-text-o'
 	))->addClass('btn-primary');
 
 	$form->addGlobal(new Form_Button(
 		'downloadbtn',
-		'Download Capture',
+		gettext('Download Capture'),
 		null,
 		'fa-download'
 	))->addClass('btn-primary');

--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -204,7 +204,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Ping',
+	gettext('Ping'),
 	null,
 	'fa-rss'
 ))->addClass('btn-primary');

--- a/src/usr/local/www/diag_resetstate.php
+++ b/src/usr/local/www/diag_resetstate.php
@@ -143,7 +143,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Reset',
+	gettext('Reset'),
 	null,
 	'fa-trash'
 ))->addClass('btn-danger');

--- a/src/usr/local/www/diag_routes.php
+++ b/src/usr/local/www/diag_routes.php
@@ -135,7 +135,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Update',
+	gettext('Update'),
 	null,
 	'fa-refresh'
 ))->addClass('btn-primary');

--- a/src/usr/local/www/diag_smart.php
+++ b/src/usr/local/www/diag_smart.php
@@ -294,7 +294,7 @@ switch ($action) {
 	if (!empty($pconfig['smartmonemail'])) {
 		$form->addGlobal(new Form_Button(
 			'test',
-			'Send test email',
+			gettext('Send test email'),
 			null,
 			'fa-send'
 		))->addClass('btn-info');
@@ -314,7 +314,7 @@ switch ($action) {
 
 		$btnview = new Form_Button(
 			'submit',
-			'View',
+			gettext('View'),
 			null,
 			'fa-file-o'
 		);
@@ -394,7 +394,7 @@ switch ($action) {
 
 		$btntest = new Form_Button(
 			'submit',
-			'Test',
+			gettext('Test'),
 			null,
 			'fa-wrench'
 		);
@@ -467,7 +467,7 @@ switch ($action) {
 
 		$btnview =  new Form_Button(
 			'submit',
-			'View',
+			gettext('View'),
 			null,
 			'fa-file-o'
 		);
@@ -521,7 +521,7 @@ switch ($action) {
 // Abort
 		$btnabort = new Form_Button(
 			'submit',
-			'Abort',
+			gettext('Abort'),
 			null,
 			'fa-times'
 		);

--- a/src/usr/local/www/diag_tables.php
+++ b/src/usr/local/www/diag_tables.php
@@ -177,14 +177,14 @@ if ($bogons || $urltable || !empty($entries)) {
 	if ($bogons || $urltable) {
 		$group->add(new Form_Button(
 			'Download',
-			'Update',
+			gettext('Update'),
 			null,
 			'fa-refresh'
 		))->addClass('btn-success btn-sm');
 	} elseif (!empty($entries)) {
 		$group->add(new Form_Button(
 			'clearall',
-			'Clear Table',
+			gettext('Clear Table'),
 			null,
 			'fa-undo'
 		))->addClass('btn-danger btn-sm');

--- a/src/usr/local/www/diag_testport.php
+++ b/src/usr/local/www/diag_testport.php
@@ -299,7 +299,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Test',
+	gettext('Test'),
 	null,
 	'fa-wrench'
 ))->addClass('btn-primary');

--- a/src/usr/local/www/diag_traceroute.php
+++ b/src/usr/local/www/diag_traceroute.php
@@ -206,7 +206,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Traceroute',
+	gettext('Traceroute'),
 	null,
 	'fa-rss'
 ))->addClass('btn-primary');

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -743,7 +743,7 @@ while ($counter < count($addresses)) {
 
 	$group->add(new Form_Button(
 		'deleterow' . $counter,
-		'Delete',
+		gettext('Delete'),
 		null,
 		'fa-trash'
 	))->addClass('btn-warning');

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -721,7 +721,7 @@ $section->addInput(new Form_Select(
 
 $btnsrcadv = new Form_Button(
 	'srcadv',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1363,7 +1363,7 @@ foreach (['src' => 'Source', 'dst' => 'Destination'] as $type => $name) {
 	if ($type == 'src') {
 		$section->addInput(new Form_Button(
 			'btnsrcadv',
-			'Show advanced',
+			gettext('Show advanced'),
 			null,
 			'fa-cog'
 		))->addClass('btn-info');
@@ -1445,7 +1445,7 @@ $adv_open = is_aoadv_used($pconfig);
 
 $btnadvanced = new Form_Button(
 	'toggle-advanced',
-	'Advanced Options',
+	gettext('Advanced Options'),
 	null,
 	'fa-cog'
 );

--- a/src/usr/local/www/firewall_schedule_edit.php
+++ b/src/usr/local/www/firewall_schedule_edit.php
@@ -468,14 +468,14 @@ $group = new Form_Group(null);
 
 $group->add(new Form_Button(
 	'btnaddtime',
-	'Add Time',
+	gettext('Add Time'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success btn-sm');
 
 $group->add(new Form_Button(
 	'btnclrsel',
-	'Clear selection',
+	gettext('Clear selection'),
 	null,
 	'fa-undo'
 ))->addClass('btn-info btn-sm');
@@ -654,7 +654,7 @@ if ($getSchedule) {
 
 			$group->add(new Form_Button(
 				'Delete' . $counter,
-				'Delete',
+				gettext('Delete'),
 				null,
 				'fa-trash'
 			))->addClass('btn-xs btn-warning');

--- a/src/usr/local/www/firewall_shaper.php
+++ b/src/usr/local/www/firewall_shaper.php
@@ -476,7 +476,7 @@ if (!$dfltmsg && $sform)  {
 
 			$sform->addGlobal(new Form_Button(
 				'add',
-				'Add new Queue',
+				gettext('Add new Queue'),
 				$url,
 				'fa-plus'
 			))->addClass('btn-success');
@@ -491,7 +491,7 @@ if (!$dfltmsg && $sform)  {
 
 		$sform->addGlobal(new Form_Button(
 			'delete',
-			$queue ? 'Delete this queue':'Disable shaper on interface',
+			$queue ? gettext('Delete this queue'):gettext('Disable shaper on interface'),
 			$url,
 			'fa-trash'
 		))->addClass('btn-danger');

--- a/src/usr/local/www/firewall_shaper_vinterface.php
+++ b/src/usr/local/www/firewall_shaper_vinterface.php
@@ -446,7 +446,7 @@ if ($dfltmsg) {
 
 			$sform->addGlobal(new Form_Button(
 				'add',
-				'Add new Queue',
+				gettext('Add new Queue'),
 				$url,
 				'fa-plus'
 			))->addClass('btn-success');
@@ -461,7 +461,7 @@ if ($dfltmsg) {
 
 			$sform->addGlobal(new Form_Button(
 				'delete',
-				($queue && ($qname != $pipe)) ? 'Delete this queue':'Delete Limiter',
+				($queue && ($qname != $pipe)) ? gettext('Delete this queue'):gettext('Delete Limiter'),
 				$url,
 				'fa-trash'
 			))->addClass('btn-danger');

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -1754,7 +1754,7 @@ $macaddress = new Form_Input(
 
 $btnmymac = new Form_Button(
 	'btnmymac',
-	'Copy My MAC',
+	gettext('Copy My MAC'),
 	null,
 	'fa-clone'
 	);
@@ -1816,7 +1816,7 @@ $group->add(new Form_Select(
 
 $group->add(new Form_Button(
 	'addgw',
-	'Add a new gateway',
+	gettext('Add a new gateway'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success')->setAttribute('data-target', '#newgateway')->setAttribute('data-toggle', 'modal');
@@ -1849,7 +1849,7 @@ $group->add(new Form_Select(
 
 $group->add(new Form_Button(
 	'addgw6',
-	'Add a new gateway',
+	gettext('Add a new gateway'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success')->setAttribute('data-target', '#newgateway6')->setAttribute('data-toggle', 'modal');
@@ -1891,7 +1891,7 @@ $modal->addInput(new Form_Input(
 
 $btnaddgw6 = new Form_Button(
 	'add6',
-	'Add',
+	gettext('Add'),
 	null,
 	'fa-plus'
 );
@@ -1900,7 +1900,7 @@ $btnaddgw6->addClass('btn-success');
 
 $btncnxgw6 = new Form_Button(
 	'cnx6',
-	'Cancel',
+	gettext('Cancel'),
 	null,
 	'fa-undo'
 );
@@ -2558,7 +2558,7 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_Button(
 	'btnadvppp',
-	'Advanced PPP',
+	gettext('Advanced PPP'),
 	isset($pconfig['pppid']) ? 'interfaces_ppps_edit.php?id=' . htmlspecialchars($pconfig['pppid']) : 'interfaces_ppps_edit.php',
 	'fa-cog'
 ))->addClass('btn-info')->setHelp('Create a new PPP configuration');
@@ -2684,7 +2684,7 @@ $section->add($group);
 
 $section->addInput(new Form_Button(
 	'btnadvppp',
-	'Advanced and MLPPP',
+	gettext('Advanced and MLPPP'),
 	isset($pconfig['pppid']) ? 'interfaces_ppps_edit.php?id=' . htmlspecialchars($pconfig['pppid']) : 'interfaces_ppps_edit.php',
 	'fa-cog'
 ))->addClass('btn-info')->setHelp('Click for additional PPPoE configuration options. Save first if changes have been made.');
@@ -2747,7 +2747,7 @@ if (isset($pconfig['pptp_localip'][1]) || isset($pconfig['pptp_subnet'][1]) || i
 
 $section->addInput(new Form_Button(
 	'btnadvppp',
-	'Advanced and MLPPP',
+	gettext('Advanced and MLPPP'),
 	isset($pconfig['pppid']) ? 'interfaces_ppps_edit.php?id=' . htmlspecialchars($pconfig['pppid']) : 'interfaces_ppps_edit.php',
 	'fa-cog'
 ))->addClass('btn-info')->setHelp($mlppp_text . 'Click for additional PPTP and L2TP configuration options. Save first if changes have been made.');
@@ -3198,7 +3198,7 @@ $modal->addInput(new Form_Input(
 
 $btnaddgw = new Form_Button(
 	'add',
-	'Add',
+	gettext('Add'),
 	null,
 	'fa-plus'
 );
@@ -3207,7 +3207,7 @@ $btnaddgw->addClass('btn-success');
 
 $btncnxgw = new Form_Button(
 	'cnx',
-	'Cancel',
+	gettext('Cancel'),
 	null,
 	'fa-undo'
 );

--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -819,7 +819,7 @@ $section->add($group);
 
 $btnadvanced = new Form_Button(
 		'btnadvanced',
-		'Advanced',
+		gettext('Advanced'),
 		null,
 		'fa-cog'
 );

--- a/src/usr/local/www/interfaces_qinq_edit.php
+++ b/src/usr/local/www/interfaces_qinq_edit.php
@@ -329,7 +329,7 @@ foreach ($item as $ww) {
 
 	$group->add(new Form_Button(
 		'deleterow' . $counter,
-		'Delete',
+		gettext('Delete'),
 		null,
 		'fa-trash'
 	))->addClass('btn-warning');
@@ -341,7 +341,7 @@ foreach ($item as $ww) {
 
 $form->addGlobal(new Form_Button(
 	'addrow',
-	'Add Tag',
+	gettext('Add Tag'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success addbtn');

--- a/src/usr/local/www/load_balancer_pool_edit.php
+++ b/src/usr/local/www/load_balancer_pool_edit.php
@@ -412,7 +412,7 @@ $group->add(new Form_IpAddress(
 
 $group->add(new Form_Button(
 	'btnaddtopool',
-	'Add to pool',
+	gettext('Add to pool'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success');
@@ -457,14 +457,14 @@ $group = new Form_Group('');
 
 $group->add(new Form_Button(
 	'removedisabled',
-	'Remove',
+	gettext('Remove'),
 	null,
 	'fa-trash'
 ))->addClass('btn-danger btn-sm');
 
 $group->add(new Form_Button(
 	'removeenabled',
-	'Remove',
+	gettext('Remove'),
 	null,
 	'fa-trash'
 ))->addClass('btn-danger btn-sm');
@@ -475,14 +475,14 @@ $group = new Form_Group('');
 
 $group->add(new Form_Button(
 	'movetoenabled',
-	'Move to enabled list',
+	gettext('Move to enabled list'),
 	null,
 	'fa-angle-double-right'
 ))->addClass('btn-info btn-sm');
 
 $group->add(new Form_Button(
 	'movetodisabled',
-	'Move to disabled list',
+	gettext('Move to disabled list'),
 	null,
 	'fa-angle-double-left'
 ))->addClass('btn-info btn-sm');

--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -1457,7 +1457,7 @@ foreach ($pkg['fields']['field'] as $pkga) {
 					// Delete row button
 					$group->add(new Form_Button(
 						'deleterow' . $rowcounter,
-						'Delete',
+						gettext('Delete'),
 						null,
 						'fa-trash'
 					))->removeClass('btn-primary')->addClass('btn-warning btn-sm');
@@ -1469,7 +1469,7 @@ foreach ($pkg['fields']['field'] as $pkga) {
 			// Add row button
 			$section->addInput(new Form_Button(
 				'addrow',
-				'Add',
+				gettext('Add'),
 				null,
 				'fa-plus'
 			))->addClass('btn-success');
@@ -1510,7 +1510,7 @@ $form->addGlobal(new Form_Input(
 if (!empty($advanced)) {
 	$form->addGlobal(new Form_Button(
 		'showadv',
-		'Show Advanced Options',
+		gettext('Show Advanced Options'),
 		null,
 		'fa-cog'
 	))->addClass('btn-info');

--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -1105,21 +1105,21 @@ if ($pconfig['page']['htmltext']) {
 	$group = new Form_Group('Current Portal Page');
 	$group->add(new Form_Button(
 		'btnview',
-		'View',
+		gettext('View'),
 		$href,
 		'fa-file-text-o'
 	))->addClass('btn btn-info btn-xs')->setAttribute("target", "_blank");
 
 	$group->add(new Form_Button(
 		'btndownload',
-		'Download',
+		gettext('Download'),
 		'?zone=' . $cpzone . '&act=gethtmlhtml',
 		'fa-download'
 	))->addClass('btn btn-primary btn-xs')->setAttribute("target", "_blank");
 
 	$group->add(new Form_Button(
 		'btndownload',
-		'Restore Default Page',
+		gettext('Restore Default Page'),
 		'?zone=' . $cpzone . '&act=delhtmlhtml',
 		'fa-undo'
 	))->addClass('btn btn-danger btn-xs')->setAttribute("target", "_blank");
@@ -1139,21 +1139,21 @@ if ($pconfig['page']['errtext']) {
 	$group = new Form_Group('Current Auth Error Page');
 	$group->add(new Form_Button(
 		'btnview',
-		'View',
+		gettext('View'),
 		'?zone=' . $cpzone . '&act=viewerrhtml',
 		'fa-file-text-o'
 	))->addClass('btn btn-info btn-xs')->setAttribute("target", "_blank");
 
 	$group->add(new Form_Button(
 		'btndownload',
-		'Download',
+		gettext('Download'),
 		'?zone=' . $cpzone . '&act=geterrhtml',
 		'fa-download'
 	))->addClass('btn btn-primary btn-xs')->setAttribute("target", "_blank");
 
 	$group->add(new Form_Button(
 		'btndownload',
-		'Restore Default Page',
+		gettext('Restore Default Page'),
 		'?zone=' . $cpzone . '&act=delerrhtml',
 		'fa-undo'
 	))->addClass('btn btn-danger btn-xs')->setAttribute("target", "_blank");
@@ -1171,21 +1171,21 @@ if ($pconfig['page']['logouttext']) {
 	$group = new Form_Group('Current Logout Page');
 	$group->add(new Form_Button(
 		'btnview',
-		'View',
+		gettext('View'),
 		'?zone=' . $cpzone . '&act=viewlogouthtml',
 		'fa-file-text-o'
 	))->addClass('btn btn-info btn-xs')->setAttribute("target", "_blank");
 
 	$group->add(new Form_Button(
 		'btndownload',
-		'Download',
+		gettext('Download'),
 		'?zone=' . $cpzone . '&act=getlogouthtml',
 		'fa-download'
 	))->addClass('btn btn-primary btn-xs')->setAttribute("target", "_blank");
 
 	$group->add(new Form_Button(
 		'btndownload',
-		'Restore Default Page',
+		gettext('Restore Default Page'),
 		'?zone=' . $cpzone . '&act=dellogouthtml',
 		'fa-undo'
 	))->addClass('btn btn-danger btn-xs')->setAttribute("target", "_blank");

--- a/src/usr/local/www/services_captiveportal_filemanager.php
+++ b/src/usr/local/www/services_captiveportal_filemanager.php
@@ -202,7 +202,7 @@ if ($_GET['act'] == 'add') {
 
 	$form->addGlobal(new Form_Button(
 		'Submit',
-		'Upload',
+		gettext('Upload'),
 		null,
 		'fa-upload'
 	))->addClass('btn-primary');

--- a/src/usr/local/www/services_captiveportal_mac_edit.php
+++ b/src/usr/local/www/services_captiveportal_mac_edit.php
@@ -246,7 +246,7 @@ $macaddress = new Form_Input(
 
 $btnmymac = new Form_Button(
 	'btnmymac',
-	'Copy My MAC',
+	gettext('Copy My MAC'),
 	null,
 	'fa-clone'
 	);

--- a/src/usr/local/www/services_captiveportal_zones_edit.php
+++ b/src/usr/local/www/services_captiveportal_zones_edit.php
@@ -132,7 +132,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Save & Continue',
+	gettext('Save & Continue'),
 	null,
 	'fa-save'
 ))->addClass('btn-primary');

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -882,7 +882,7 @@ if (!is_numeric($pool) && !($act == "newpool")) {
 
 	$btnaddpool = new Form_Button(
 		'btnaddpool',
-		'Add pool',
+		gettext('Add pool'),
 		'services_dhcp.php?if=' . htmlspecialchars($if) . '&act=newpool',
 		'fa-plus'
 	);
@@ -999,7 +999,7 @@ if (!is_numeric($pool) && !($act == "newpool")) {
 // DDNS
 $btnadv = new Form_Button(
 	'btnadvdns',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -1049,7 +1049,7 @@ $section->addInput(new Form_Input(
 // Advanced MAC
 $btnadv = new Form_Button(
 	'btnadvmac',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -1078,7 +1078,7 @@ $section->addInput(new Form_Input(
 // Advanced NTP
 $btnadv = new Form_Button(
 	'btnadvntp',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -1105,7 +1105,7 @@ $section->addInput(new Form_IpAddress(
 // Advanced TFTP
 $btnadv = new Form_Button(
 	'btnadvtftp',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -1126,7 +1126,7 @@ $section->addInput(new Form_IpAddress(
 // Advanced LDAP
 $btnadv = new Form_Button(
 	'btnadvldap',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -1150,7 +1150,7 @@ $form->add($section);
 // Advanced Additional options
 $btnadv = new Form_Button(
 	'btnadvopts',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -1218,7 +1218,7 @@ foreach ($pconfig['numberoptions']['item'] as $item) {
 
 	$group->add(new Form_Button(
 		'deleterow' . $counter,
-		'Delete',
+		gettext('Delete'),
 		null,
 		'fa-trash'
 	))->addClass('btn-warning');
@@ -1230,7 +1230,7 @@ foreach ($pconfig['numberoptions']['item'] as $item) {
 
 $section->addInput(new Form_Button(
 	'addrow',
-	'Add',
+	gettext('Add'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success');

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -434,7 +434,7 @@ $macaddress = new Form_Input(
 
 $btnmymac = new Form_Button(
 	'btnmymac',
-	'Copy My MAC',
+	gettext('Copy My MAC'),
 	null,
 	'fa-clone'
 	);
@@ -592,7 +592,7 @@ $section->addInput(new Form_Input(
 
 $btndyndns = new Form_Button(
 	'btndyndns',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -640,7 +640,7 @@ $section->addInput(new Form_Input(
 
 $btnntp = new Form_Button(
 	'btnntp',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -676,7 +676,7 @@ $section->add($group);
 
 $btntftp = new Form_Button(
 	'btntftp',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -754,7 +754,7 @@ $section->addInput(new Form_Checkbox(
 
 $btndyndns = new Form_Button(
 	'btndyndns',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -822,7 +822,7 @@ $section->addInput(new Form_Checkbox(
 
 $btnntp = new Form_Button(
 	'btnntp',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -858,7 +858,7 @@ $section->add($group);
 
 $btnldap = new Form_Button(
 	'btnldap',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -879,7 +879,7 @@ $section->addInput(new Form_Input(
 
 $btnnetboot = new Form_Button(
 	'btnnetboot',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -907,7 +907,7 @@ $section->addInput(new Form_Input(
 
 $btnadnl = new Form_Button(
 	'btnadnl',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -954,7 +954,7 @@ foreach ($pconfig['numberoptions']['item'] as $item) {
 
 	$btn = new Form_Button(
 		'deleterow' . $counter,
-		'Delete',
+		gettext('Delete'),
 		null,
 		'fa-trash'
 	);
@@ -968,7 +968,7 @@ foreach ($pconfig['numberoptions']['item'] as $item) {
 
 $btnaddopt = new Form_Button(
 	'addrow',
-	'Add Option',
+	gettext('Add Option'),
 	null,
 	'fa-plus'
 );

--- a/src/usr/local/www/services_dnsmasq_edit.php
+++ b/src/usr/local/www/services_dnsmasq_edit.php
@@ -319,7 +319,7 @@ if ($pconfig['aliases']['item']) {
 
 		$group->add(new Form_Button(
 			'deleterow' . $counter,
-			'Delete',
+			gettext('Delete'),
 			null,
 			'fa-trash'
 		))->addClass('btn-warning');
@@ -331,7 +331,7 @@ if ($pconfig['aliases']['item']) {
 
 $form->addGlobal(new Form_Button(
 	'addrow',
-	'Add Host Name',
+	gettext('Add Host Name'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success addbtn');

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -444,7 +444,7 @@ if (isset($id) && $a_dyndns[$id]) {
 
 	$form->addGlobal(new Form_Button(
 		'force',
-		'Save & Force Update',
+		gettext('Save & Force Update'),
 		null,
 		'fa-refresh'
 	))->removeClass('btn-primary')->addClass('btn-info');

--- a/src/usr/local/www/services_igmpproxy_edit.php
+++ b/src/usr/local/www/services_igmpproxy_edit.php
@@ -261,7 +261,7 @@ foreach ($item as $ww) {
 
 	$group->add(new Form_Button(
 		'deleterow' . $counter,
-		'Delete',
+		gettext('Delete'),
 		null,
 		'fa-trash'
 	))->removeClass('btn-primary')->addClass('btn-warning');
@@ -272,7 +272,7 @@ foreach ($item as $ww) {
 
 $section->addInput(new Form_Button(
 	'addrow',
-	'Add network',
+	gettext('Add network'),
 	null,
 	'fa-plus'
 ))->removeClass('btn-primary')->addClass('btn-success addbtn');

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -279,7 +279,7 @@ for ($counter=0; $counter < $maxrows; $counter++) {
 
 	$group->add(new Form_Button(
 		'deleterow' . $counter,
-		'Delete',
+		gettext('Delete'),
 		null,
 		'fa-trash'
 	))->addClass('btn-warning');
@@ -289,7 +289,7 @@ for ($counter=0; $counter < $maxrows; $counter++) {
 
 $section->addInput(new Form_Button(
 	'addrow',
-	'Add',
+	gettext('Add'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success');
@@ -335,7 +335,7 @@ $section->addInput(new Form_Checkbox(
 // Statistics logging section
 $btnadvstats = new Form_Button(
 	'btnadvstats',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -371,7 +371,7 @@ $section->addInput(new Form_Checkbox(
 // Leap seconds section
 $btnleap = new Form_Button(
 	'btnleap',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );

--- a/src/usr/local/www/services_ntpd_acls.php
+++ b/src/usr/local/www/services_ntpd_acls.php
@@ -317,7 +317,7 @@ foreach ($networkacl as $item) {
 
 	$group->add(new Form_Button(
 		'deleterow' . $counter,
-		'Delete',
+		gettext('Delete'),
 		null,
 		'fa-trash'
 	))->addClass('btn-warning');
@@ -330,7 +330,7 @@ foreach ($networkacl as $item) {
 
 $section->addInput(new Form_Button(
 	'addrow',
-	'Add',
+	gettext('Add'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success');

--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -374,7 +374,7 @@ $section->addInput(new Form_Input(
 // Statistics logging section
 $btnadvgps = new Form_Button(
 	'btnadvgps',
-	'Advanced',
+	gettext('Advanced'),
 	null,
 	'fa-cog'
 );
@@ -401,7 +401,7 @@ $group->add(new Form_Input(
 
 $btncalc = new Form_Button(
 	'btncalc',
-	'Calculate',
+	gettext('Calculate'),
 	null,
 	'fa-calculator'
 );

--- a/src/usr/local/www/services_pppoe_edit.php
+++ b/src/usr/local/www/services_pppoe_edit.php
@@ -554,7 +554,7 @@ if ($usernames != "") {
 
 		$group->add(new Form_Button(
 			'deleterow' . $counter,
-			'Delete',
+			gettext('Delete'),
 			null,
 			'fa-trash'
 		))->addClass('btn-warning');
@@ -567,7 +567,7 @@ if ($usernames != "") {
 
 $btnaddrow = new Form_Button(
 	'addrow',
-	'Add user',
+	gettext('Add user'),
 	null,
 	'fa-plus'
 );

--- a/src/usr/local/www/services_rfc2136_edit.php
+++ b/src/usr/local/www/services_rfc2136_edit.php
@@ -334,7 +334,7 @@ if (isset($id) && $a_rfc2136[$id]) {
 
 	$form->addGlobal(new Form_Button(
 		'force',
-		'Save & Force Update',
+		gettext('Save & Force Update'),
 		null,
 		'fa-refresh'
 	))->addClass('btn-info');

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -355,7 +355,7 @@ foreach ($pconfig['subnets'] as $subnet) {
 
 	$group->add(new Form_Button(
 		'deleterow' . $counter,
-		'Delete',
+		gettext('Delete'),
 		null,
 		'fa-trash'
 	))->removeClass('btn-primary')->addClass('btn-warning');
@@ -369,7 +369,7 @@ foreach ($pconfig['subnets'] as $subnet) {
 
 $section->addInput(new Form_Button(
 	'addrow',
-	'Add',
+	gettext('Add'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success');

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -367,7 +367,7 @@ $section->addInput(new Form_Checkbox(
 
 $btnadvdns = new Form_Button(
 	'btnadvdns',
-	'Custom options',
+	gettext('Custom options'),
 	null,
 	'fa-cog'
 );

--- a/src/usr/local/www/services_unbound_acls.php
+++ b/src/usr/local/www/services_unbound_acls.php
@@ -297,7 +297,7 @@ if ($act == "new" || $act == "edit") {
 
 		$group->add(new Form_Button(
 			'deleterow' . $counter,
-			'Delete',
+			gettext('Delete'),
 			null,
 			'fa-trash'
 		))->addClass('btn-warning');
@@ -310,7 +310,7 @@ if ($act == "new" || $act == "edit") {
 
 	$form->addGlobal(new Form_Button(
 		'addrow',
-		'Add Network',
+		gettext('Add Network'),
 		null,
 		'fa-plus'
 	))->addClass('btn-success');

--- a/src/usr/local/www/services_unbound_host_edit.php
+++ b/src/usr/local/www/services_unbound_host_edit.php
@@ -320,7 +320,7 @@ if ($pconfig['aliases']['item']) {
 
 		$group->add(new Form_Button(
 			'deleterow' . $counter,
-			'Delete',
+			gettext('Delete'),
 			null,
 			'fa-trash'
 		))->addClass('btn-warning');
@@ -332,7 +332,7 @@ if ($pconfig['aliases']['item']) {
 
 $form->addGlobal(new Form_Button(
 	'addrow',
-	'Add Host Name',
+	gettext('Add Host Name'),
 	null,
 	'fa-plus'
 ))->removeClass('btn-primary')->addClass('btn-success addbtn');

--- a/src/usr/local/www/services_wol.php
+++ b/src/usr/local/www/services_wol.php
@@ -184,7 +184,7 @@ $section->addInput(new Form_Input(
 
 $section->addInput(new Form_Button(
 	'Submit',
-	'Send',
+	gettext('Send'),
 	null,
 	'fa-power-off'
 ))->addClass('btn-primary');

--- a/src/usr/local/www/status_captiveportal_expire.php
+++ b/src/usr/local/www/status_captiveportal_expire.php
@@ -126,7 +126,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Expire',
+	gettext('Expire'),
 	null,
 	'fa-trash'
 ))->addClass('btn-warning');

--- a/src/usr/local/www/status_captiveportal_test.php
+++ b/src/usr/local/www/status_captiveportal_test.php
@@ -134,7 +134,7 @@ $form->add($section);
 
 $form->addGlobal(new Form_Button(
 	'Submit',
-	'Test',
+	gettext('Test'),
 	null,
 	'fa-wrench'
 ))->addClass('btn-primary');

--- a/src/usr/local/www/status_logs_settings.php
+++ b/src/usr/local/www/status_logs_settings.php
@@ -333,7 +333,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Button(
 	'resetlogs',
-	'Reset Log Files',
+	gettext('Reset Log Files'),
 	null,
 	'fa-trash'
 ))->addClass('btn-danger btn-sm')->setHelp('Clears all local log files and reinitializes them as empty logs. This also restarts the DHCP daemon. Use the Save button first if you have made any setting changes.');

--- a/src/usr/local/www/system_advanced_notifications.php
+++ b/src/usr/local/www/system_advanced_notifications.php
@@ -279,7 +279,7 @@ $section->addPassword(new Form_Input(
 
 $section->addInput(new Form_Button(
 	'test-growl',
-	'Test Growl Settings',
+	gettext('Test Growl Settings'),
 	null,
 	'fa-rss'
 ))->addClass('btn-info')->setHelp('A test notification will be sent even if the service is '.
@@ -370,7 +370,7 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_Button(
 	'test-smtp',
-	'Test SMTP Settings',
+	gettext('Test SMTP Settings'),
 	null,
 	'fa-send'
 ))->addClass('btn-info')->setHelp('A test notification will be sent even if the service is '.

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -571,7 +571,7 @@ $group->add(new Form_Input(
 
 $group->add(new Form_Button(
 	'Select',
-	'Select a container',
+	gettext('Select a container'),
 	null,
 	'fa-search'
 ))->addClass('btn-info');

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -826,7 +826,7 @@ foreach ($pconfig['altnames']['item'] as $item) {
 
 	$group->add(new Form_Button(
 		'deleterow' . $counter,
-		'Delete',
+		gettext('Delete'),
 		null,
 		'fa-trash'
 	))->addClass('btn-warning');
@@ -840,7 +840,7 @@ foreach ($pconfig['altnames']['item'] as $item) {
 
 $section->addInput(new Form_Button(
 	'addrow',
-	'Add',
+	gettext('Add'),
 	null,
 	'fa-plus'
 ))->addClass('btn-success');
@@ -997,7 +997,7 @@ print $form;
 
 	$form->addGlobal(new Form_Button(
 		'save',
-		'Update',
+		gettext('Update'),
 		null,
 		'fa-save'
 	))->addClass('btn-primary');

--- a/src/usr/local/www/system_crlmanager.php
+++ b/src/usr/local/www/system_crlmanager.php
@@ -572,7 +572,7 @@ if ($act == "new" || $act == gettext("Save") || $input_errors) {
 
 		$group->add(new Form_Button(
 			'submit',
-			'Add',
+			gettext('Add'),
 			null,
 			'fa-plus'
 			))->addClass('btn-success btn-sm');

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -713,7 +713,7 @@ if (!(!empty($pconfig['latencylow']) || !empty($pconfig['latencyhigh']) ||
 
 	$btnadvanced = new Form_Button(
 		'toggle-advanced',
-		'Advanced Options',
+		gettext('Advanced Options'),
 		null,
 		'fa-cog'
 	);

--- a/src/usr/local/www/system_groupmanager.php
+++ b/src/usr/local/www/system_groupmanager.php
@@ -449,14 +449,14 @@ if ($pconfig['gid'] != 1998) { // all users group
 
 	$group->add(new Form_Button(
 		'movetoenabled',
-		'Move to "Members"',
+		gettext('Move to "Members"'),
 		null,
 		'fa-angle-double-right'
 	))->removeClass('btn-primary')->addClass('btn-info btn-sm');
 
 	$group->add(new Form_Button(
 		'movetodisabled',
-		'Move to "Not members',
+		gettext('Move to "Not members'),
 		null,
 		'fa-angle-double-left'
 	))->removeClass('btn-primary')->addClass('btn-info btn-sm');

--- a/src/usr/local/www/system_groupmanager_addprivs.php
+++ b/src/usr/local/www/system_groupmanager_addprivs.php
@@ -212,7 +212,7 @@ $section->addInput(new Form_Input(
 
 $btnfilter = new Form_Button(
 	'btnfilter',
-	'Filter',
+	gettext('Filter'),
 	null,
 	'fa-filter'
 );
@@ -223,7 +223,7 @@ $form->addGlobal($btnfilter);
 
 $btnclear = new Form_Button(
 	'btnclear',
-	'Clear',
+	gettext('Clear'),
 	null,
 	'fa-times'
 );

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -716,14 +716,14 @@ if ($act == "new" || $act == "edit" || $input_errors):
 
 	$group->add(new Form_Button(
 		'movetoenabled',
-		'Move to "Member of" list',
+		gettext('Move to "Member of" list'),
 		null,
 		'fa-angle-double-right'
 	))->removeClass('btn-primary')->addClass('btn-info btn-sm');
 
 	$group->add(new Form_Button(
 		'movetodisabled',
-		'Move to "Not member of" list',
+		gettext('Move to "Not member of" list'),
 		null,
 		'fa-angle-double-left'
 	))->removeClass('btn-primary')->addClass('btn-info btn-sm');

--- a/src/usr/local/www/system_usermanager_addprivs.php
+++ b/src/usr/local/www/system_usermanager_addprivs.php
@@ -206,7 +206,7 @@ $section->addInput(new Form_Input(
 
 $btnfilter = new Form_Button(
 	'btnfilter',
-	'Filter',
+	gettext('Filter'),
 	null,
 	'fa-filter'
 );
@@ -217,7 +217,7 @@ $form->addGlobal($btnfilter);
 
 $btnclear = new Form_Button(
 	'btnclear',
-	'Clear',
+	gettext('Clear'),
 	null,
 	'fa-times'
 );

--- a/src/usr/local/www/system_usermanager_settings.php
+++ b/src/usr/local/www/system_usermanager_settings.php
@@ -179,7 +179,7 @@ $section->addInput(new Form_Select(
 
 $form->addGlobal(new Form_Button(
 	'savetest',
-	'Save & Test',
+	gettext('Save & Test'),
 	null,
 	'fa-wrench'
 ))->addClass('btn-info');


### PR DESCRIPTION
The text of a Form_Button is not translated internally. Some Form_Button
calls already had the button text enclosed in gettext(), this does it
for the remaining ones.
So now all buttons have the chance to have a translation.