### PR TITLE
Add field to specify source-hash key

### DIFF
--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -126,7 +126,13 @@ if (isset($id) && $a_out[$id]) {
 	$pconfig['target'] = $a_out[$id]['target'];
 	$pconfig['targetip'] = $a_out[$id]['targetip'];
 	$pconfig['targetip_subnet'] = $a_out[$id]['targetip_subnet'];
-	$pconfig['poolopts'] = $a_out[$id]['poolopts'];
+	if (substr($a_out[$id]['poolopts'],0,11) == 'source-hash'){
+		list($opts, $key) = split(" ",$a_out[$id]['poolopts']);
+		$pconfig['source-hash-key']=$key;
+		$pconfig['poolopts']=$opts;
+	}else{
+		$pconfig['poolopts']=$a_out[$id]['poolopts'];
+	}
 	$pconfig['interface'] = $a_out[$id]['interface'];
 
 	if (!$pconfig['interface']) {
@@ -267,6 +273,9 @@ if ($_POST) {
 				$input_errors[] = gettext("Only Round Robin pool options may be chosen when selecting an alias.");
 			}
 		}
+		if ($_POST['source-hash-key']){
+			$source_hash_key = $_POST['source-hash-key'];
+		}
 	}
 
 	/* if user has selected any as source, set it here */
@@ -308,7 +317,11 @@ if ($_POST) {
 		$natent['targetip'] = (!isset($_POST['nonat'])) ? $_POST['targetip'] : "";
 		$natent['targetip_subnet'] = (!isset($_POST['nonat'])) ? $_POST['targetip_subnet'] : "";
 		$natent['interface'] = $_POST['interface'];
-		$natent['poolopts'] = $poolopts;
+		if($poolopts == 'source-hash' && isset($source_hash_key)){
+			$natent['poolopts'] = $poolopts." ".$source_hash_key;
+		}else{
+			$natent['poolopts'] = $poolopts;
+		}
 
 		/* static-port */
 		if (isset($_POST['staticnatport']) && $protocol_uses_ports && !isset($_POST['nonat'])) {
@@ -601,6 +614,13 @@ $section->addInput(new Form_Select(
 				'<li>' . 'Sticky Address: The Sticky Address option can be used with the Random and Round Robin pool types to ensure that a particular source address is always mapped to the same translation address.' . '</li>' .
 			'</ul><span class="help-block">');
 
+$section->addInput(new Form_Input(
+	'source-hash-key',
+	'Source Hash Key',
+	'text',
+	$pconfig['source-hash-key']
+))->setHelp('The key that is fed to the hashing algorithm in hex format or as a string, defaults to a randomly generated value.')->setWidth(10)->addClass('othersubnet');
+
 $group = new Form_Group('Port');
 $group->addClass('natportgrp');
 
@@ -749,10 +769,16 @@ events.push(function() {
 		} else if ($('#target option:selected').text().trim().substring(0,5) == "Other") {
 			hideInput('poolopts', false);
 			hideGroupClass('othersubnet', false);
+			if ($('#poolopts option:selected').text().trim().substring(0,6) == "Source") {
+				hideInput('source-hash-key', false);
+			}else {
+				hideInput('source-hash-key', true);
+			}
 		} else {
 			$('#poolopts').prop('selectedIndex',0);
 			hideInput('poolopts', true);
 			hideGroupClass('othersubnet', true);
+			hideInput('source-hash-key', true);
 			$('#targetip').val('');
 			$('#targetip_subnet').val('0');
 		}
@@ -780,6 +806,10 @@ events.push(function() {
 	});
 
 	$('#target').on('change', function() {
+		poolopts_change();
+	});
+
+	$('#poolopts').on('change', function() {
 		poolopts_change();
 	});
 


### PR DESCRIPTION
The source-hash pool option uses a hash of the source address to
determine the translation address. This hashing algorithm is also fed a
key, which unless specified defaults to a random value. This random
value is then generated each time pf is reloaded.

This commit adds the ability to specify the key in order to provide
consistent hashing, even when pf is reloaded.

I welcome feedback as I am primarily a systems/network engineer, not a programmer. We have however been developing a larger NAT-solution based on pfsense when we ran into issues with inconsistent hashing, especially when trying to configure high-availability.