### PR TITLE
HTML Compliance - Firewall / Aliases / Bulk Import

### DIFF
--- a/src/usr/local/www/firewall_aliases_import.php
+++ b/src/usr/local/www/firewall_aliases_import.php
@@ -219,9 +219,9 @@ $section->addInput(new Form_Textarea(
 	'import separated by a carriage return. Common examples are lists of IPs, '.
 	'networks, blacklists, etc.The list may contain IP addresses, with or without '.
 	'CIDR prefix, IP ranges, blank lines (ignored) and an optional description after '.
-	'each IP. e.g.:<ul><li>172.16.1.2</li><li>172.16.0.0/24</li><li>10.11.12.100-'.
+	'each IP. e.g.:</span><ul><li>172.16.1.2</li><li>172.16.0.0/24</li><li>10.11.12.100-'.
 	'10.11.12.200</li><li>192.168.1.254 Home router</li><li>10.20.0.0/16 Office '.
-	'network</li><li>10.40.1.10-10.40.1.19 Managed switches</li></ul>');
+	'network</li><li>10.40.1.10-10.40.1.19 Managed switches</li></ul><span class="help-block">');
 
 $form->add($section);
 print $form;


### PR DESCRIPTION
Error: Element ul not allowed as child of element span in this context. (Suppressing further errors from this subtree.)