### PR TITLE
services_ntpd fix leaptext array key name

### DIFF
--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -169,8 +169,8 @@ if ($_POST) {
 			enable_rrd_graphing();
 		}
 
-		if (!empty($_POST['leaptxt'])) {
-			$config['ntpd']['leapsec'] = base64_encode($_POST['leaptxt']);
+		if (!empty($_POST['leaptext'])) {
+			$config['ntpd']['leapsec'] = base64_encode($_POST['leaptext']);
 		} elseif (isset($config['ntpd']['leapsec'])) {
 			unset($config['ntpd']['leapsec']);
 		}


### PR DESCRIPTION
Use leaptext everywhere - some references were to leaptext and some to leaptxt, so it didn't work.