### PR TITLE
services_ntpd_gps fix handling of initcmd

### DIFF
--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -389,7 +389,7 @@ $section->addInput(new Form_StaticText(
 $section->addInput(new Form_Textarea(
 	'gpsinitcmd',
 	null,
-	$pconfig['initcmd']
+	base64_decode($pconfig['initcmd'])
 ))->setHelp('Commands entered here will be sent to the GPS during initialization. Please read and understand your GPS documentation before making any changes here');
 
 $group = new Form_Group('NMEA Checksum Calculator');
@@ -525,7 +525,7 @@ events.push(function() {
 		$('#result').val(NMEAChecksum($('#nmeastring').val()));
 	});
 
-	// When the 'GPS' selector is changed, we set tth gps defaults
+	// When the 'GPS' selector is changed, we set the gps defaults
 	$('#gpstype').on('change', function() {
 		set_gps_default($(this).val());
 	});
@@ -533,7 +533,9 @@ events.push(function() {
 	hideInput('gpsinitcmd', true);
 	hideClass('calculator', true);
 
-	set_gps_default('<?=$pconfig['type']?>');
+	if ('<?=$pconfig['initcmd']?>' == '') {
+		set_gps_default('<?=$pconfig['type']?>');
+	}
 
 	//	Checkboxes gpsprefer and gpsnoselect are mutually exclusive
 	$('#gpsprefer').click(function() {


### PR DESCRIPTION
1) When reading the (encoded) initcmd string into Form_Textarea(), decode it.
Previously the encoded value was displaying in the text area and when the user presses save, that encode string is itself encoded again in the config and thus stuffs things up.
2) When loading the page, only use set_gps_default() to set initcmd if initcmd is currently empty.
Previously the initcmd value would be set to the default string for the GPS type every time the page loaded, which would override any change that the user had made.
Note: After this is fixed, then I will also submit changes to make the Advanced button work in the new ways.