### PR TITLE
service_dhcp include btnadvopts in section

### DIFF
--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1145,8 +1145,6 @@ $section->addInput(new Form_Input(
 	$pconfig['ldap']
 ))->setHelp('Leave blank to disable. Enter a full URI for the LDAP server in the form ldap://ldap.example.com/dc=example,dc=com ');
 
-$form->add($section);
-
 // Advanced Additional options
 $btnadv = new Form_Button(
 	'btnadvopts',
@@ -1161,6 +1159,8 @@ $section->addInput(new Form_StaticText(
 	'Additional BOOTP/DHCP Options',
 	$btnadv
 ));
+
+$form->add($section);
 
 $section = new Form_Section('Additional BOOTP/DHCP Options');
 $section->addClass('adnlopts');


### PR DESCRIPTION
Before this change, $section is added to $form before btnadvopts is put into $section. The previous code looked to me like btnadvopts would end up in a $section object that got overwritten by the new Form_Section at line 1165.
This change makes sure that the button is added to the section, and then the section is added to the form.

But actually the old code is working OK. (And the new code also works just the same)

So am I missing something?