### PR TITLE
Redmine #5994 Firewall Rules advanced buttons

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1363,7 +1363,7 @@ foreach (['src' => 'Source', 'dst' => 'Destination'] as $type => $name) {
 	if ($type == 'src') {
 		$section->addInput(new Form_Button(
 			'btnsrcadv',
-			'Show advanced',
+			'Display Advanced',
 			null,
 			'fa-cog'
 		))->addClass('btn-info');
@@ -1744,7 +1744,7 @@ events.push(function() {
 	var portsenabled = 1;
 	var editenabled = 1;
 	var optionsvisible = 0;
-	var srcportsvisible = 0;
+	var srcportsvisible = false;
 
 	function ext_change() {
 
@@ -1805,6 +1805,13 @@ events.push(function() {
 
 	function show_source_port_range() {
 		hideClass('srcprtr', !srcportsvisible);
+
+		if (srcportsvisible) {
+			text = "<?=gettext('Hide Advanced');?>";
+		} else {
+			text = "<?=gettext('Display Advanced');?>";
+		}
+		$('#btnsrcadv').html('<i class="fa fa-cog"></i> ' + text);
 	}
 
 	function typesel_change() {
@@ -1890,14 +1897,19 @@ events.push(function() {
 
 		if ($('#proto').find(":selected").index() <= 2) {
 			hideClass('dstprtr', false);
-			hideClass('srcprtr', !srcportsvisible);
-			$("#btnsrcadv").prop('value', srcportsvisible ? 'Hide advanced':'Show advanced');
+			hideInput('btnsrcadv', false);
+			if (($('#srcbeginport').val() == "any") && ($('#srcendport').val() == "any")) {
+				srcportsvisible = false;
+			} else {
+				srcportsvisible = true;
+			}
 		} else {
-			hideClass('srcprtr', true);
 			hideClass('dstprtr', true);
-			srcportsvisible = 0;
-			$("#btnsrcadv").prop('value', srcportsvisible ? 'Hide advanced':'Show advanced');
+			hideInput('btnsrcadv', true);
+			srcportsvisible = false;
 		}
+
+		show_source_port_range();
 	}
 
 	function src_rep_change() {
@@ -1921,7 +1933,6 @@ events.push(function() {
 	<?php if ((!empty($pconfig['srcbeginport']) && $pconfig['srcbeginport'] != "any") || (!empty($pconfig['srcendport']) && $pconfig['srcendport'] != "any")): ?>
 		srcportsvisible = true;
 		show_source_port_range();
-		hideInput('btnsrcadv', true);
 	<?php endif; ?>
 
 	// Make it a regular button, not a submit
@@ -1937,7 +1948,6 @@ events.push(function() {
 	$('#btnsrcadv').click(function() {
 		srcportsvisible = !srcportsvisible;
 		show_source_port_range();
-		$("#btnsrcadv").prop('value', srcportsvisible ? 'Hide advanced':'Show advanced');
 	});
 
 	$('#srcendport').on('change', function() {

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1366,7 +1366,7 @@ foreach (['src' => 'Source', 'dst' => 'Destination'] as $type => $name) {
 			'Display Advanced',
 			null,
 			'fa-cog'
-		))->addClass('btn-info');
+		))->addClass('btn-info btn-sm');
 	}
 
 	$portValues = ['' => gettext('(other)'), 'any' => gettext('any')];
@@ -1441,23 +1441,19 @@ $section->addInput(new Form_Input(
 	$pconfig['descr']
 ))->setHelp('You may enter a description here for your reference.');
 
-$adv_open = is_aoadv_used($pconfig);
-
-$btnadvanced = new Form_Button(
-	'toggle-advanced',
-	'Advanced Options',
+$btnadv = new Form_Button(
+	'btnadvopts',
+	'Display Advanced',
 	null,
 	'fa-cog'
 );
 
-$btnadvanced->addClass('btn-info');
+$btnadv->addClass('btn-info btn-sm');
 
-if (!$adv_open) {
-	$section->addInput(new Form_StaticText(
-		null,
-		$btnadvanced
-	));
-}
+$section->addInput(new Form_StaticText(
+	'Advanced Options',
+	$btnadv
+));
 
 $form->add($section);
 
@@ -1743,8 +1739,39 @@ events.push(function() {
 
 	var portsenabled = 1;
 	var editenabled = 1;
-	var optionsvisible = 0;
 	var srcportsvisible = false;
+
+	// Show advanced additional opts options ======================================================
+	var showadvopts = false;
+
+	function show_advopts(ispageload) {
+		var text;
+		// On page load decide the initial state based on the data.
+		if (ispageload) {
+			showadvopts = <?php if (is_aoadv_used($pconfig)) {echo 'true';} else {echo 'false';} ?>;
+		} else {
+			// It was a click, swap the state.
+			showadvopts = !showadvopts;
+		}
+
+		hideClass('advanced-options', !showadvopts);
+		if ($('#tcpflags_any').prop('checked')) {
+			$('.table-flags').addClass('hidden');
+		}
+
+		if (showadvopts) {
+			text = "<?=gettext('Hide Advanced');?>";
+		} else {
+			text = "<?=gettext('Display Advanced');?>";
+		}
+		$('#btnadvopts').html('<i class="fa fa-cog"></i> ' + text);
+	}
+
+	$('#btnadvopts').prop('type', 'button');
+
+	$('#btnadvopts').click(function(event) {
+		show_advopts();
+	});
 
 	function ext_change() {
 
@@ -1927,7 +1954,7 @@ events.push(function() {
 
 	typesel_change();
 
-	hideClass('advanced-options',  ! "<?=$adv_open?>");
+	show_advopts(true);
 	hideClass('srcportrange', true);
 
 	<?php if ((!empty($pconfig['srcbeginport']) && $pconfig['srcbeginport'] != "any") || (!empty($pconfig['srcendport']) && $pconfig['srcendport'] != "any")): ?>
@@ -1936,7 +1963,6 @@ events.push(function() {
 	<?php endif; ?>
 
 	// Make it a regular button, not a submit
-	$('#toggle-advanced').prop('type','button');
 	$("#btnsrcadv").prop('type','button');
 
 	// on click . .
@@ -1981,14 +2007,6 @@ events.push(function() {
 
 	$('#ipprotocol').on('change', function() {
 		proto_change();
-	});
-
-	$('#toggle-advanced').click(function() {
-		optionsvisible = 1;
-		hideClass('advanced-options', false);
-		if ($('#tcpflags_any').prop('checked')) {
-			$('.table-flags').addClass('hidden');
-		}
 	});
 
 	$('#tcpflags_any').click(function () {


### PR DESCRIPTION
Standardize the source port advanced button:
1) Put some common code fragments into show_source_port_range() and use code that actually successfully changes the button text Display/Hide. Around line 1808.
2) Make the button itself be hidden when a protocol is selected that does not use source port range (as well as the source port fields being hidden) - line 1908-1909
3) When the user re-selects a protocol that can use source port range, unhide the button and set the button text and hide/unhide of source port fields appropriately depending on the run-time values in the source port fields - line 1900-1905

This standardizes the behavior of the source port Advanced button.

I will do the other general advanced button separately.