### PR TITLE
Allow IPs in althostnames

### DIFF
--- a/src/usr/local/www/system_advanced_admin.php
+++ b/src/usr/local/www/system_advanced_admin.php
@@ -123,7 +123,7 @@ if ($_POST) {
 	if ($_POST['althostnames']) {
 		$althosts = explode(" ", $_POST['althostnames']);
 		foreach ($althosts as $ah) {
-			if (!is_hostname($ah)) {
+			if (!is_ipaddr($ah) && !is_hostname($ah)) {
 				$input_errors[] = sprintf(gettext("Alternate hostname %s is not a valid hostname."), htmlspecialchars($ah));
 			}
 		}


### PR DESCRIPTION
This change will allow implementation of workarounds for bugs involving 'An HTTP_REFERER was detected other than what is defined in System' by adding the IP address to the alternate hostnames list, without having to disable protection completely.

This is useful to workaround things like Redmine #5939 and/or enabling access to WebGUI over IPv6 linklocal (fe80::1:1) by adding IPs manually.

Thanks.