### PR TITLE
Redmine #5994 Fix test for default source port fields

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1925,7 +1925,8 @@ events.push(function() {
 		if ($('#proto').find(":selected").index() <= 2) {
 			hideClass('dstprtr', false);
 			hideInput('btnsrcadv', false);
-			if (($('#srcbeginport').val() == "any") && ($('#srcendport').val() == "any")) {
+			if ((($('#srcbeginport').val() == "any") || ($('#srcbeginport').val() == "")) &&
+			    (($('#srcendport').val() == "any") || ($('#srcendport').val() == ""))) {
 				srcportsvisible = false;
 			} else {
 				srcportsvisible = true;


### PR DESCRIPTION
Fixes the problem reported by @jimp where the Advanced button for the source port fields would show "Hide Advanced" when creating a new rule from scratch. Now when creating a new rule, it starts off as "Display Advanced" (with the source port fields hidden.