### PR TITLE
fix dhcpd-rrd error on boot

### DIFF
--- a/src/etc/inc/rrd.inc
+++ b/src/etc/inc/rrd.inc
@@ -979,7 +979,7 @@ function enable_rrd_graphing() {
 
 					/* enter UNKNOWN values in the RRD so it knows we rebooted. */
 					if (platform_booting()) {
-						mwexec("$rrdtool update $rrddbpath$dhcpif$dhcpd N:U:U:U:U:U:U:U:U");
+						mwexec("$rrdtool update $rrddbpath$dhcpif$dhcpd N:U:U:U");
 					}
 
 					$rrdupdatesh .= "\n";


### PR DESCRIPTION
Seems there is a copy/paste error from when i initially created the dhcpd rrd thingy. Just noticed this now ;)

Mar 17 22:33:34 	php-cgi 		rc.bootup: The command '/usr/bin/nice -n20 /usr/local/bin/rrdtool update /var/db/rrd/opt3-dhcpd.rrd N:U:U:U:U:U:U:U:U' returned exit code '1', the output was 'ERROR: /var/db/rrd/opt3-dhcpd.rrd: found extra data on update argument: U:U:U:U:U'