### PR TITLE
Redmine #5994 Enhance test for PPP advanced defaults

### DIFF
--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -1001,6 +1001,10 @@ events.push(function() {
 			    ($pconfig['pppoe_pr_preset_val'] == "") &&
 			    (!$pconfig['ondemand']) &&
 			    ($pconfig['idletimeout'] == "") &&
+			    (!$pconfig['pppoe_monthly']) &&
+			    (!$pconfig['pppoe_weekly']) &&
+			    (!$pconfig['pppoe_daily']) &&
+			    (!$pconfig['pppoe_hourly']) &&
 			    (!$pconfig['vjcomp']) &&
 			    (!$pconfig['tcpmssfix']) &&
 			    (!$pconfig['shortseq']) &&


### PR DESCRIPTION
If pppoe_monthly, pppoe_weekly, pppeo_daily or pppoe_hourly was already set, then when editing the PPP interface the advanced fields were not automagically displayed. They should be, because the user needs to see these settings if they are there.

Add these extra checks to the test makes the Advanced fields automagically open correctly in this case.