### PR TITLE
Fix Redmine #6011

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -205,8 +205,9 @@ if (function_exists("display_error_form") && !isset($config['system']['webgui'][
 						break;
 					}
 				}
-				$interface_list_ipv6s = get_configured_ipv6_addresses();
+				$interface_list_ipv6s = get_configured_ipv6_addresses(true);
 				foreach ($interface_list_ipv6s as $ilipv6s) {
+					$ilipv6s = explode('%', $ilipv6s)[0];
 					if (strcasecmp($referrer_host, $ilipv6s) == 0) {
 						$found_host = true;
 						break;

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -5376,7 +5376,7 @@ function get_interface_ip($interface = "wan") {
 	}
 }
 
-function get_interface_ipv6($interface = "wan", $flush = false) {
+function get_interface_ipv6($interface = "wan", $flush = false, $linklocal_fallback = false) {
 	global $config;
 
 	if (substr($interface, 0, 4) == '_vip') {
@@ -5425,7 +5425,7 @@ function get_interface_ipv6($interface = "wan", $flush = false) {
 		 * NOTE: On the case when only the prefix is requested,
 		 * the communication on WAN will be done over link-local.
 		 */
-		if (is_array($config['interfaces'][$interface]) && isset($config['interfaces'][$interface]['dhcp6prefixonly'])) {
+		if ($linklocal_fallback || (is_array($config['interfaces'][$interface]) && isset($config['interfaces'][$interface]['dhcp6prefixonly']))) {
 			$curip = find_interface_ipv6_ll($realif, $flush);
 			if ($curip && is_ipaddrv6($curip) && ($curip != "::")) {
 				return $curip;

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1469,13 +1469,13 @@ function get_configured_ip_addresses() {
  *   IPv6 addresses.
  *
  */
-function get_configured_ipv6_addresses() {
+function get_configured_ipv6_addresses($linklocal_fallback = false) {
 	require_once("interfaces.inc");
 	$ipv6_array = array();
 	$interfaces = get_configured_interface_list();
 	if (is_array($interfaces)) {
 		foreach ($interfaces as $int) {
-			$ipaddrv6 = get_interface_ipv6($int);
+			$ipaddrv6 = get_interface_ipv6($int, false, $linklocal_fallback);
 			$ipv6_array[$int] = $ipaddrv6;
 		}
 	}


### PR DESCRIPTION
This will add linklocal fallback where no IPv6 is otherwise configured to allow login using this IPs.
See: https://redmine.pfsense.org/issues/6011