### PR TITLE
Services / DNS Resolver / General Settings

### DIFF
--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -378,7 +378,7 @@ $btnadv = new Form_Button(
 	'fa-cog'
 );
 
-$btnadv->addClass('btn-info btn-sm');
+$btnadv->setAttribute('type','button')->addClass('btn-info btn-sm');
 
 $section->addInput(new Form_StaticText(
 	'Display Custom Options',
@@ -436,9 +436,6 @@ events.push(function() {
 		hideInput('btnadvcustom', hide);
 		hideInput('custom_options', hide || !showadvcustom);
 	}
-
-	// Make the 'additional options' button a plain button, not a submit button
-	$("#btnadvcustom").prop('type','button');
 
 	// Un-hide additional controls
 	$('#btnadvcustom').click(function(event) {


### PR DESCRIPTION
Static should be static.
Elements that don't need to be dynamic should be static.
More robust than depending on client-side processing to set them.