### PR TITLE
Allow moving last pool entry

### DIFF
--- a/src/usr/local/www/load_balancer_pool_edit.php
+++ b/src/usr/local/www/load_balancer_pool_edit.php
@@ -243,7 +243,7 @@ events.push(function() {
 		var len = From.length;
 		var option;
 
-		if (len > 1) {
+		if (len > 0) {
 			for (i=0; i<len; i++) {
 				if (From.eq(i).is(':selected')) {
 					option = From.eq(i).val();


### PR DESCRIPTION
If you are moving load balancer pool entries back and forth between the enabled and disabled pools, you can't move the last entry in the disabled pool back to the enabled pool, which you should be able to do.
This change also gives the user flexibility to move the last enabled entry to the disabled, that is helpful if the user is just moving entries around - e.g. putting everything into disabled then adding 1 or 2 back to the enabled. On save, the validation checks that the enabled list has something in it, so the user can;t actually save an empty load balancer pool anyway.