### PR TITLE
Allow namecheap dynamic dns host to start with *.

### DIFF
--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -146,8 +146,8 @@ if ($_POST) {
 	}
 
 	if (isset($_POST['host']) && in_array("host", $reqdfields)) {
-		/* Namecheap can have a @. in hostname */
-		if ($pconfig['type'] == "namecheap" && substr($_POST['host'], 0, 2) == '@.') {
+		/* Namecheap can have @. and *. in hostname */
+		if ($pconfig['type'] == "namecheap" && in_array(substr($_POST['host'], 0, 2), array('@.', '*.')) {
 			$host_to_check = substr($_POST['host'], 2);
 		} else {
 			$host_to_check = $_POST['host'];


### PR DESCRIPTION
Namecheap allows wildcard subdomains in their dynamic dns update url by providing the host as *.example.com. This commit allows hosts that start with *. to pass validation if the provider is namecheap.