### PR TITLE
replace apparently pointless function in 2 files 

### DIFF
--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -74,18 +74,6 @@ $do_ping = false;
 $host = '';
 $count = DEFAULT_COUNT;
 
-function create_sourceaddresslist() {
-	$sourceips = get_possible_traffic_source_addresses(true);
-
-	$list = array("" => gettext('Default'));
-
-	foreach ($sourceips as $sipvalue => $sipname) {
-		$list[$sipvalue] = $sipname;
-	}
-
-	return $list;
-}
-
 if ($_POST || $_REQUEST['host']) {
 	unset($input_errors);
 	unset($do_ping);
@@ -190,7 +178,7 @@ $section->addInput(new Form_Select(
 	'sourceip',
 	'Source address',
 	$sourceip,
-	create_sourceaddresslist()
+	array('' => gettext('Automatically selected (default)')) + get_possible_traffic_source_addresses(true)
 ))->setHelp('Select source address for the ping');
 
 $section->addInput(new Form_Select(

--- a/src/usr/local/www/diag_traceroute.php
+++ b/src/usr/local/www/diag_traceroute.php
@@ -80,18 +80,6 @@ $ttl = DEFAULT_TTL;
 $ipproto = 'ipv4';
 $sourceip = 'any';
 
-function create_sourceaddresslist() {
-	$list = array('any' => gettext('Any'));
-
-	$sourceips = get_possible_traffic_source_addresses(true);
-
-	foreach ($sourceips as $sipvalue => $sipname) {
-		$list[$sipvalue] = $sipname;
-	}
-
-	return($list);
-}
-
 if ($_POST || $_REQUEST['host']) {
 	unset($input_errors);
 
@@ -178,7 +166,7 @@ $section->addInput(new Form_Select(
 	'sourceip',
 	'Source Address',
 	$sourceip,
-	create_sourceaddresslist()
+	array('any' => gettext('Any')) + get_possible_traffic_source_addresses(true);
 ))->setHelp('Select source address for the trace');
 
 $section->addInput(new Form_Select(


### PR DESCRIPTION
Code loops through all return values of get_possible_traffic_source_addresses(true) to create a list of key=>descript list, but the original function returned exactly such a list anyhow with no other data associated with the keys. So the code seems pointless as it replicates exactly the original return value from possible_traffic_source_addresses(). 

A quick search shows the rewritten code in this PR is already used in diag_testport.php line 287 and status_logs_settings.php line 356 (relevant repo search link: https://github.com/pfsense/pfsense/search?utf8=%E2%9C%93&q=get_possible_traffic_source_addresses ), confirming that this function isn't needed.