### PR TITLE
HTML Compliance - Diagnostics / Test Port

### DIFF
--- a/src/usr/local/www/diag_testport.php
+++ b/src/usr/local/www/diag_testport.php
@@ -71,6 +71,8 @@ $allowautocomplete = true;
 $pgtitle = array(gettext("Diagnostics"), gettext("Test Port"));
 require("guiconfig.inc");
 
+include("head.inc");
+
 define('NC_TIMEOUT', 10);
 $do_testport = false;
 $retval = 1;
@@ -215,8 +217,6 @@ if ($_POST || $_REQUEST['host']) {
 		}
 	}
 }
-
-include("head.inc");
 
 // Handle the display of all messages here where the user can readily see them
 if ($input_errors) {


### PR DESCRIPTION
Error: Start tag seen without seeing a doctype first.
Expected e.g. <!DOCTYPE html>.
Error: Stray doctype.
Error: Stray start tag html.
Fatal Error: Cannot recover after last error. Any further errors will be ignored.