### PR TITLE
Echo boolean value instead of string

### DIFF
--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -406,7 +406,7 @@ events.push(function() {
 		var text;
 		// On page load decide the initial state based on the data.
 		if (ispageload) {
-			showadvcustom = "<?=$customoptions?>";
+			showadvcustom = <?=($customoptions ? 'true' : 'false');?>;
 		} else {
 			// It was a click, swap the state.
 			showadvcustom = !showadvcustom;


### PR DESCRIPTION
Prior to this change, code would echo an empty string if false and 1 if true. While this shouldn't cause any harm, echoing boolean representation is cleaner as done in all other files with similar code.

This PR puts code in line, while simplifying it with a ternary expression.

In other places it happens as:
```<?php if (is_aoadv_used($pconfig)) {echo 'true';} else {echo 'false';} ?>``` and
```<?php if ($showadv) {echo 'true';} else {echo 'false';} ?>```
Which could be optimized, respectively, to:
```<?=(is_aoadv_used($pconfig) ? 'true' : 'false');?>``` and
```<?=($showadv ? 'true' : 'false');?>``` if desired.

Thanks.