### PR TITLE
Fix syntax error in diag_traceroute

### DIFF
--- a/src/usr/local/www/diag_traceroute.php
+++ b/src/usr/local/www/diag_traceroute.php
@@ -166,7 +166,7 @@ $section->addInput(new Form_Select(
 	'sourceip',
 	'Source Address',
 	$sourceip,
-	array('any' => gettext('Any')) + get_possible_traffic_source_addresses(true);
+	array('any' => gettext('Any')) + get_possible_traffic_source_addresses(true)
 ))->setHelp('Select source address for the trace');
 
 $section->addInput(new Form_Select(


### PR DESCRIPTION
The semi-colon is not needed here.
Reported by forum: https://forum.pfsense.org/index.php?topic=108643.0