### PR TITLE
Allow mail.php to be used in shell with subject

### DIFF
--- a/src/usr/local/bin/mail.php
+++ b/src/usr/local/bin/mail.php
@@ -10,6 +10,9 @@ $message = "";
 if ($options['s'] <> "") {
 	$subject = $options['s'];
 }
+else if (!empty($_GET['subject'])) {
+        $subject = $_GET['subject'];
+}
 
 
 $in = file("php://stdin");


### PR DESCRIPTION
Permits scripts to use /usr/local/bin/mail.php with subject like:
```
echo "This mail has a subject" | /usr/local/bin/mail.php subject="My Subject"
```