### PR TITLE
Add field to specify source-hash key

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2067,7 +2067,7 @@ function filter_nat_rules_generate() {
 				$poolopts = (is_subnet($obtarget) || is_alias($obtarget)) ? $obent['poolopts'] : "";
 
 				/* pool option source-hash allows specification of an optional source-hash key */
-				if ($poolopts == "source-hash" && isset($obent['source_hash_key'])) {
+				if ($poolopts == "source-hash" && !empty($obent['source_hash_key'])) {
 					$poolopts = "source-hash ".$obent['source_hash_key'];
 				}
 

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2066,6 +2066,11 @@ function filter_nat_rules_generate() {
 				$obtarget = ($obent['target'] == "other-subnet") ? $obent['targetip'] . '/' . $obent['targetip_subnet']: $obent['target'];
 				$poolopts = (is_subnet($obtarget) || is_alias($obtarget)) ? $obent['poolopts'] : "";
 
+				/* pool option source-hash allows specification of an optional source-hash key */
+				if ($poolopts == "source-hash" && isset($obent['source_hash_key'])) {
+					$poolopts = "source-hash ".$obent['source_hash_key'];
+				}
+
 				$natrules .= filter_nat_rules_generate_if($obent['interface'],
 					$src,
 					$obent['sourceport'],

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -126,13 +126,8 @@ if (isset($id) && $a_out[$id]) {
 	$pconfig['target'] = $a_out[$id]['target'];
 	$pconfig['targetip'] = $a_out[$id]['targetip'];
 	$pconfig['targetip_subnet'] = $a_out[$id]['targetip_subnet'];
-	if (substr($a_out[$id]['poolopts'],0,11) == 'source-hash'){
-		list($opts, $key) = split(" ",$a_out[$id]['poolopts']);
-		$pconfig['source-hash-key']=$key;
-		$pconfig['poolopts']=$opts;
-	}else{
-		$pconfig['poolopts']=$a_out[$id]['poolopts'];
-	}
+	$pconfig['poolopts'] = $a_out[$id]['poolopts'];
+	$pconfig['source_hash_key'] = $a_out[$id]['source_hash_key'];
 	$pconfig['interface'] = $a_out[$id]['interface'];
 
 	if (!$pconfig['interface']) {
@@ -263,6 +258,7 @@ if ($_POST) {
 
 	/* Verify Pool Options */
 	$poolopts = "";
+	$source_hash_key = "";
 	if ($_POST['poolopts']) {
 		if (is_subnet($_POST['target']) || ($_POST['target'] == "other-subnet")) {
 			$poolopts = $_POST['poolopts'];
@@ -273,8 +269,17 @@ if ($_POST) {
 				$input_errors[] = gettext("Only Round Robin pool options may be chosen when selecting an alias.");
 			}
 		}
-		if ($_POST['source-hash-key']){
-			$source_hash_key = $_POST['source-hash-key'];
+		/* If specified, verify valid source-hash key or generate a valid key using md5 */
+		if ($_POST['source_hash_key']) {
+			if (substr($_POST['source_hash_key'],0,2) == "0x") {
+				if (ctype_xdigit(substr($_POST['source_hash_key'],2)) && strlen($_POST['source_hash_key']) == 34) {
+					$source_hash_key = $_POST['source_hash_key'];
+				} else {
+					$input_errors[] = gettext("Incorrect format for source-hash key, \"0x\" must be followed by exactly 32 hexadecimal characters.");
+				}
+			} else {
+				$source_hash_key = "0x".md5($_POST['source_hash_key']);
+			}
 		}
 	}
 
@@ -317,11 +322,8 @@ if ($_POST) {
 		$natent['targetip'] = (!isset($_POST['nonat'])) ? $_POST['targetip'] : "";
 		$natent['targetip_subnet'] = (!isset($_POST['nonat'])) ? $_POST['targetip_subnet'] : "";
 		$natent['interface'] = $_POST['interface'];
-		if($poolopts == 'source-hash' && isset($source_hash_key)){
-			$natent['poolopts'] = $poolopts." ".$source_hash_key;
-		}else{
-			$natent['poolopts'] = $poolopts;
-		}
+		$natent['poolopts'] = $poolopts;
+		$natent['source_hash_key'] = $source_hash_key;
 
 		/* static-port */
 		if (isset($_POST['staticnatport']) && $protocol_uses_ports && !isset($_POST['nonat'])) {
@@ -615,11 +617,11 @@ $section->addInput(new Form_Select(
 			'</ul><span class="help-block">');
 
 $section->addInput(new Form_Input(
-	'source-hash-key',
+	'source_hash_key',
 	'Source Hash Key',
 	'text',
-	$pconfig['source-hash-key']
-))->setHelp('The key that is fed to the hashing algorithm in hex format or as a string, defaults to a randomly generated value.')->setWidth(10)->addClass('othersubnet');
+	$pconfig['source_hash_key']
+))->setHelp('The key that is fed to the hashing algorithm in hex format, preceeded by "0x", or any string. A non-hex string is hashed using md5 to a hexadecimal key. Defaults to a randomly generated value.')->setWidth(10)->addClass('othersubnet');
 
 $group = new Form_Group('Port');
 $group->addClass('natportgrp');
@@ -770,15 +772,15 @@ events.push(function() {
 			hideInput('poolopts', false);
 			hideGroupClass('othersubnet', false);
 			if ($('#poolopts option:selected').text().trim().substring(0,6) == "Source") {
-				hideInput('source-hash-key', false);
+				hideInput('source_hash_key', false);
 			}else {
-				hideInput('source-hash-key', true);
+				hideInput('source_hash_key', true);
 			}
 		} else {
 			$('#poolopts').prop('selectedIndex',0);
 			hideInput('poolopts', true);
 			hideGroupClass('othersubnet', true);
-			hideInput('source-hash-key', true);
+			hideInput('source_hash_key', true);
 			$('#targetip').val('');
 			$('#targetip_subnet').val('0');
 		}

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -126,7 +126,13 @@ if (isset($id) && $a_out[$id]) {
 	$pconfig['target'] = $a_out[$id]['target'];
 	$pconfig['targetip'] = $a_out[$id]['targetip'];
 	$pconfig['targetip_subnet'] = $a_out[$id]['targetip_subnet'];
-	$pconfig['poolopts'] = $a_out[$id]['poolopts'];
+	if (substr($a_out[$id]['poolopts'],0,11) == 'source-hash'){
+		list($opts, $key) = split(" ",$a_out[$id]['poolopts']);
+		$pconfig['source-hash-key']=$key;
+		$pconfig['poolopts']=$opts;
+	}else{
+		$pconfig['poolopts']=$a_out[$id]['poolopts'];
+	}
 	$pconfig['interface'] = $a_out[$id]['interface'];
 
 	if (!$pconfig['interface']) {
@@ -267,6 +273,9 @@ if ($_POST) {
 				$input_errors[] = gettext("Only Round Robin pool options may be chosen when selecting an alias.");
 			}
 		}
+		if ($_POST['source-hash-key']){
+			$source_hash_key = $_POST['source-hash-key'];
+		}
 	}
 
 	/* if user has selected any as source, set it here */
@@ -308,7 +317,11 @@ if ($_POST) {
 		$natent['targetip'] = (!isset($_POST['nonat'])) ? $_POST['targetip'] : "";
 		$natent['targetip_subnet'] = (!isset($_POST['nonat'])) ? $_POST['targetip_subnet'] : "";
 		$natent['interface'] = $_POST['interface'];
-		$natent['poolopts'] = $poolopts;
+		if($poolopts == 'source-hash' && isset($source_hash_key)){
+			$natent['poolopts'] = $poolopts." ".$source_hash_key;
+		}else{
+			$natent['poolopts'] = $poolopts;
+		}
 
 		/* static-port */
 		if (isset($_POST['staticnatport']) && $protocol_uses_ports && !isset($_POST['nonat'])) {
@@ -601,6 +614,13 @@ $section->addInput(new Form_Select(
 				'<li>' . 'Sticky Address: The Sticky Address option can be used with the Random and Round Robin pool types to ensure that a particular source address is always mapped to the same translation address.' . '</li>' .
 			'</ul><span class="help-block">');
 
+$section->addInput(new Form_Input(
+	'source-hash-key',
+	'Source Hash Key',
+	'text',
+	$pconfig['source-hash-key']
+))->setHelp('The key that is fed to the hashing algorithm in hex format or as a string, defaults to a randomly generated value.')->setWidth(10)->addClass('othersubnet');
+
 $group = new Form_Group('Port');
 $group->addClass('natportgrp');
 
@@ -749,10 +769,16 @@ events.push(function() {
 		} else if ($('#target option:selected').text().trim().substring(0,5) == "Other") {
 			hideInput('poolopts', false);
 			hideGroupClass('othersubnet', false);
+			if ($('#poolopts option:selected').text().trim().substring(0,6) == "Source") {
+				hideInput('source-hash-key', false);
+			}else {
+				hideInput('source-hash-key', true);
+			}
 		} else {
 			$('#poolopts').prop('selectedIndex',0);
 			hideInput('poolopts', true);
 			hideGroupClass('othersubnet', true);
+			hideInput('source-hash-key', true);
 			$('#targetip').val('');
 			$('#targetip_subnet').val('0');
 		}
@@ -780,6 +806,10 @@ events.push(function() {
 	});
 
 	$('#target').on('change', function() {
+		poolopts_change();
+	});
+
+	$('#poolopts').on('change', function() {
 		poolopts_change();
 	});
 


### PR DESCRIPTION
Resubmission of https://github.com/pfsense/pfsense/pull/2743 with corrections. CLA has been submitted and should be on file.

The source-hash pool option uses a hash of the source address to
determine the translation address. This hashing algorithm is also fed a
key, which unless specified defaults to a random value. This random
value is then generated each time pf is reloaded.

This PR adds the ability to specify the key in order to provide
consistent hashing, even when pf is reloaded.

Validation in firewall_nat_out_edit.php, in filter.inc the value is assumed valid if set. Allowed values are 0x followed by 32 hexadecimal digits. If a random string is entered it will be converted to the allowed value using md5, which generates 32 hexadecimal digits.