### PR TITLE
Pass correct parameter to function

### DIFF
--- a/src/etc/inc/shaper.inc
+++ b/src/etc/inc/shaper.inc
@@ -215,7 +215,7 @@ function get_obj_bandwidth($obj) {
 
 	switch ($match[1]) {
 		case '%':
-			$objbw = ($bw / 100) * get_interface_bandwidth($object);
+			$objbw = ($bw / 100) * get_interface_bandwidth($obj);
 			break;
 		default:
 			$objbw = $bw * get_bandwidthtype_scale($scale);


### PR DESCRIPTION
$object is not set here. $obj is.

See: 2638ddec7fca4e4e31b934517c890bc12c44fd55