### PR TITLE
Do not allow empty elements in IPv6 addresses

### DIFF
--- a/src/etc/inc/IPv6.inc
+++ b/src/etc/inc/IPv6.inc
@@ -901,7 +901,7 @@ class Net_IPv6
 
             for ($i = 0; $i < count($ipv6); $i++) {
 
-                if(4 < strlen($ipv6[$i])) {
+                if ((4 < strlen($ipv6[$i])) || (0 == strlen($ipv6[$i]))) {
 
                     return false;
 


### PR DESCRIPTION
Redmine #6024
Upstream pull request https://github.com/pear/Net_IPv6/pull/14
At this point in the checkIPv6 processing the string should be an uncompressed IPv6 addressed - all the elements should have something in them, a "0" if that element is zero. So any zero-length element is a problem.