### PR TITLE
Interfaces - Adv DHCP Options Str to Array

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4035,7 +4035,7 @@ function DHCP6_Config_File_Advanced($interface, $wancfg, $wanif) {
 
 	$send_options = "";
 	if ($wancfg['adv_dhcp6_interface_statement_send_options'] != '') {
-		$options = explode(',', $wancfg['adv_dhcp6_interface_statement_send_options']);
+		$options = str_to_array($wancfg['adv_dhcp6_interface_statement_send_options']);
 		foreach ($options as $option) {
 			$send_options .= "\tsend " . trim($option) . ";\n";
 		}
@@ -4313,7 +4313,7 @@ function DHCP_Config_File_Advanced($interface, $wancfg, $wanif) {
 
 	$send_options = "";
 	if ($wancfg['adv_dhcp_send_options'] != '') {
-		$options = explode(',', $wancfg['adv_dhcp_send_options']);
+		$options = str_to_array($wancfg['adv_dhcp_send_options']);
 		foreach ($options as $option) {
 			$send_options .= "\tsend " . trim($option) . ";\n";
 		}
@@ -4331,7 +4331,7 @@ function DHCP_Config_File_Advanced($interface, $wancfg, $wanif) {
 
 	$option_modifiers = "";
 	if ($wancfg['adv_dhcp_option_modifiers'] != '') {
-		$modifiers = explode(',', $wancfg['adv_dhcp_option_modifiers']);
+		$modifiers = str_to_array($wancfg['adv_dhcp_option_modifiers']);
 		foreach ($modifiers as $modifier) {
 			$option_modifiers .= "\t" . trim($modifier) . ";\n";
 		}
@@ -4429,6 +4429,21 @@ function DHCP_Config_File_Substitutions($wancfg, $wanif, $dhclientconf) {
 	}
 
 	return $dhclientconf;
+}
+
+function str_to_array($str, $delim = ',', $enclosure = '"', $delim_sub = "*c^o#m?m@a*") {
+
+	// Apply temporary delimiter substitutions to enclosed portions of string.
+	$str = preg_replace_callback(
+		'|'.$enclosure.'.*?'.$enclosure.'|',
+		function ($matches) use ($delim, $delim_sub) {
+			return str_replace($delim, $delim_sub, $matches[0]);
+		}, $str);
+
+	// Make array with temporary delimiter substitutions reverted.
+	$array = str_replace($delim_sub, $delim, array_map('trim', explode($delim, $str)));
+
+	return $array;
 }
 
 function interfaces_group_setup() {


### PR DESCRIPTION
Add function to convert DHCP options strings to array that maintains comma's within the double quoted enclosed declaration portions.