### PR TITLE
Add brackets for clarity

### DIFF
--- a/src/etc/inc/upgrade_config.inc
+++ b/src/etc/inc/upgrade_config.inc
@@ -4766,7 +4766,7 @@ function upgrade_148_to_149() {
 	foreach ($altq_list_queues as $altq) {
 		$sum = $altq->GetTotalBw();
 		while ($sum > get_queue_bandwidth($altq)) {
-			if (intval(($sum / 1000) * 1.2) < 1024 * 1024)
+			if (intval(($sum / 1000) * 1.2) < (1024 * 1024))
 				/* 1Gb where possible. */
 				$bw = 1024 * 1024;
 			else

--- a/src/usr/local/www/wizards/traffic_shaper_wizard_dedicated.inc
+++ b/src/usr/local/www/wizards/traffic_shaper_wizard_dedicated.inc
@@ -1227,9 +1227,9 @@ function apply_all_chosen_items() {
 			}
 			else if ($sched == "HFSC") {
 				$tmpcf['upperlimit'] = "on";
-				$tmpcf['upperlimit3'] = $downqbw / 1000 . "Kb";
+				$tmpcf['upperlimit3'] = ($downqbw / 1000) . "Kb";
 				$tmpcf['linkshare'] = "on";
-				$tmpcf['linkshare3'] = $downqbw / 1000 . "Kb";
+				$tmpcf['linkshare3'] = ($downqbw / 1000) . "Kb";
 				$tmpcf['bandwidth'] =  $downqbw / 1000;
 				$tmpcf['bandwidthtype'] = "Kb";
 			}

--- a/src/usr/local/www/wizards/traffic_shaper_wizard_multi_all.inc
+++ b/src/usr/local/www/wizards/traffic_shaper_wizard_multi_all.inc
@@ -1306,8 +1306,8 @@ function apply_all_chosen_items() {
 				$tmpcf['bandwidthtype'] = "Kb";
 			}
 			else if ($sched == "HFSC") {
-				$tmpcf['linkshare3'] = $lanqbw/1000 . "Kb";
-				$tmpcf['upperlimit3'] = $lanqbw/1000 . "Kb";
+				$tmpcf['linkshare3'] = ($lanqbw/1000) . "Kb";
+				$tmpcf['upperlimit3'] = ($lanqbw/1000) . "Kb";
 				$tmpcf['upperlimit'] = "on";
 				$tmpcf['linkshare'] = "on";
 				$tmpcf['bandwidth'] =  $lanqbw/1000;


### PR DESCRIPTION
Add some extra brackets for clarity, rather than relying on the operator
precedence rules. IMHO this makes it more readable, and no need for the
reader to wonder if anything might go wrong with the operator
precedence.