### PR TITLE
Bootstrap for outbound NAT port should accept a range.

### DIFF
--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -607,10 +607,9 @@ $group->addClass('natportgrp');
 $group->add(new Form_Input(
 	'natport',
 	null,
-	'number',
-	$pconfig['natport'],
-	['min' => '1', 'max' => '65536']
-))->setHelp('Enter the source port for the outbound NAT mapping.');
+	'text',
+	$pconfig['natport']
+))->setHelp('Enter the source port or range for the outbound NAT mapping.');
 
 $group->add(new Form_Checkbox(
 	'staticnatport',


### PR DESCRIPTION
The form validation still exists for a port range here but the form itself will not accept anything but a number 1 - 65536. Make like the other port/range fields.