### PR TITLE
Remove dead note from OpenVPN widget

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1614,7 +1614,6 @@ function openvpn_get_client_status($client, $socket) {
 		fclose($fp);
 
 	} else {
-		$DisplayNote=true;
 		$client['remote_host'] = gettext("Unable to contact daemon");
 		$client['virtual_addr'] = gettext("Service not running?");
 		$client['bytes_recv'] = 0;

--- a/src/usr/local/www/widgets/widgets/openvpn.widget.php
+++ b/src/usr/local/www/widgets/widgets/openvpn.widget.php
@@ -255,10 +255,6 @@ $clients = openvpn_get_active_clients();
 <?php
 }
 
-if ($DisplayNote) {
-	echo "<br /><b>". gettext("NOTE") . ":</b> ". gettext("You need to bind each OpenVPN client to enable its management daemon: use 'Local port' setting in the OpenVPN client screen");
-}
-
 if ((empty($clients)) && (empty($servers)) && (empty($sk_servers))) {
 	echo gettext("No OpenVPN instances defined");
 }


### PR DESCRIPTION
This note is never going to display, because $DisplayNote is only set in
a function and is not global.
In any case, I don't think the message is true (maybe it was true in the
past?).