### PR TITLE
Status IPsec only show time if established

### DIFF
--- a/src/usr/local/www/status_ipsec.php
+++ b/src/usr/local/www/status_ipsec.php
@@ -243,17 +243,21 @@ function print_ipsec_body() {
 			}
 
 			print(ucfirst(htmlspecialchars($ikesa['state'])));
-			print("<br/>" . htmlspecialchars($ikesa['established']) . gettext(" seconds (" . convert_seconds_to_hms($ikesa['established']) . ") ago"));
+
+			if ($ikesa['state'] == 'ESTABLISHED') {
+				print("<br/>" . htmlspecialchars($ikesa['established']) . gettext(" seconds (") . convert_seconds_to_hms($ikesa['established']) . gettext(") ago"));
+			}
+
 			print("</span>");
 			print("</td>\n");
 			print("<td>\n");
 
 			if ($ikesa['state'] != 'ESTABLISHED') {
 
-			print('<a href="status_ipsec.php?act=connect&amp;ikeid=' . $con_id . '" class="btn btn-xs btn-success" data-toggle="tooltip" title="' . gettext("Connect VPN"). '" >');
-			print('<i class="fa fa-sign-in icon-embed-btn"></i>');
-			print(gettext("Connect VPN"));
-			print("</a>\n");
+				print('<a href="status_ipsec.php?act=connect&amp;ikeid=' . $con_id . '" class="btn btn-xs btn-success" data-toggle="tooltip" title="' . gettext("Connect VPN"). '" >');
+				print('<i class="fa fa-sign-in icon-embed-btn"></i>');
+				print(gettext("Connect VPN"));
+				print("</a>\n");
 
 			} else {
 


### PR DESCRIPTION
When in the connecting state, this was showing "seconds (0:00:00) ago" - which seems odd.
I also fixed up the gettext() calls so they do not enclose convert_seconds_to_hms(), because that would pose translation difficulties.
And a little bit of indenting while I am here.