### PR TITLE
Remove "we" personalizations

### DIFF
--- a/src/usr/local/www/crash_reporter.php
+++ b/src/usr/local/www/crash_reporter.php
@@ -150,7 +150,7 @@ exec("/usr/bin/grep -vi warning /tmp/PHP_errors.log", $php_errors);
 		}
 ?>
 	<div class="panel panel-default">
-		<div class="panel-heading"><h2 class="panel-title"><?=gettext("Unfortunately We Have Detected a Programming Bug")?></h2></div>
+		<div class="panel-heading"><h2 class="panel-title"><?=gettext("Unfortunately a Programming Bug has been detected")?></h2></div>
 		<div class="panel-body">
 			<div class="content">
 				<p>

--- a/src/usr/local/www/diag_limiter_info.php
+++ b/src/usr/local/www/diag_limiter_info.php
@@ -68,7 +68,7 @@ $shortcut_section = "trafficshaper-limiters";
 if ($_REQUEST['getactivity']) {
 	$text = `/sbin/ipfw pipe show`;
 	if ($text == "") {
-		$text = gettext("We could not find any limiters on this system.");
+		$text = gettext("No limiters were found on this system.");
 	}
 	echo gettext("Limiters:") . "\n";
 	echo $text;

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -215,7 +215,7 @@ if (file_exists('/conf/trigger_initial_wizard')) {
 			<div class="col-sm-offset-3 col-sm-6 col-xs-12">
 				<font color="white">
 				<p><h3><?=sprintf(gettext("Welcome to %s!\n"), $g['product_name'])?></h3></p>
-				<p><?=gettext("One moment while we start the initial setup wizard.")?></p>
+				<p><?=gettext("One moment while the initial setup wizard starts.")?></p>
 				<p><?=gettext("Embedded platform users: Please be patient, the wizard takes a little longer to run than the normal GUI.")?></p>
 				<p><?=sprintf(gettext("To bypass the wizard, click on the %s logo on the initial page."), $g['product_name'])?></p>
 				</font>

--- a/src/usr/local/www/system_gateway_groups_edit.php
+++ b/src/usr/local/www/system_gateway_groups_edit.php
@@ -346,7 +346,7 @@ $section->addInput(new Form_StaticText(
 	'Link Priority',
 	'The priority selected here defines in what order failover and balancing of links will be done. ' .
 	'Multiple links of the same priority will balance connections until all links in the priority will be exhausted. ' .
-	'If all links in a priority level are exhausted we will use the next available link(s) in the next priority level.'
+	'If all links in a priority level are exhausted then the next available link(s) in the next priority level will be used.'
 ));
 
 $section->addInput(new Form_StaticText(

--- a/src/usr/local/www/system_hasync.php
+++ b/src/usr/local/www/system_hasync.php
@@ -170,7 +170,7 @@ $section->addInput(new Form_Select(
 	$pconfig['pfsyncinterface'],
 	$iflist
 ))->setHelp('If Synchronize States is enabled this interface will be used for communication.<br />' .
-			'We recommend setting this to an interface other than LAN! A dedicated interface works the best.<br />' .
+			'It is recommended to set this to an interface other than LAN! A dedicated interface works the best.<br />' .
 			'An IP must be defined on each machine participating in this failover group.<br />' .
 			'An IP must be assigned to the interface on any participating sync nodes.');
 

--- a/src/usr/local/www/wizards/setup_wizard.xml
+++ b/src/usr/local/www/wizards/setup_wizard.xml
@@ -85,7 +85,7 @@
 <step>
 	<id>3</id>
 	<title>General Information</title>
-	<description>On this screen you will set the general pfSense parameters.</description>
+	<description>On this screen the general pfSense parameters will be set.</description>
 	<fields>
 		<field>
 			<name>Hostname</name>
@@ -149,28 +149,28 @@
 		<![CDATA[
 		if(empty($_POST['hostname']) || !is_unqualified_hostname($_POST['hostname'])) {
 			include("head.inc");
-			$input_errors[] = "Hostname is invalid. Please press back in your browser window and correct.";
+			$input_errors[] = "Hostname is invalid. Please press back in the browser window and correct.";
 			print_input_errors($input_errors);
 			include("foot.inc");
 			die;
 		}
 		if(empty($_POST['domain']) || !is_domain($_POST['domain'])) {
 			include("head.inc");
-			$input_errors[] = "Domain is invalid. Please press back in your browser window and correct.";
+			$input_errors[] = "Domain is invalid. Please press back in the browser window and correct.";
 			print_input_errors($input_errors);
 			include("foot.inc");
 			die;
 		}
 		if(!empty($_POST['primarydnsserver']) && !is_ipaddr($_POST['primarydnsserver'])) {
 			include("head.inc");
-			$input_errors[] = "Primary DNS server is invalid. Please press back in your browser window and correct.";
+			$input_errors[] = "Primary DNS server is invalid. Please press back in the browser window and correct.";
 			print_input_errors($input_errors);
 			include("foot.inc");
 			die;
 		}
 		if(!empty($_POST['secondarydnsserver']) && !is_ipaddr($_POST['secondarydnsserver'])) {
 			include("head.inc");
-			$input_errors[] = "Second DNS server is invalid. Please press back in your browser window and correct.";
+			$input_errors[] = "Second DNS server is invalid. Please press back in the browser window and correct.";
 			print_input_errors($input_errors);
 			include("foot.inc");
 			die;
@@ -203,7 +203,7 @@
 		<![CDATA[
 		foreach (explode(' ', $_POST['timeserverhostname']) as $ts) {
 			if (!is_domain($ts)) {
-				$input_errors[] = gettext("NTP Time Server names may only contain the characters a-z, 0-9, '-' and '.'. Entries may be separated by spaces. Please press back in your browser window and correct.");
+				$input_errors[] = gettext("NTP Time Server names may only contain the characters a-z, 0-9, '-' and '.'. Entries may be separated by spaces. Please press back in the browser window and correct.");
 				print_input_errors($input_errors);
 				include("foot.inc");
 				die;
@@ -216,7 +216,7 @@
 	<id>5</id>
 	<disableallfieldsbydefault>true</disableallfieldsbydefault>
 	<title>Configure WAN Interface</title>
-	<description>On this screen we will configure the Wide Area Network information.</description>
+	<description>On this screen the Wide Area Network information will be configured.</description>
 	<javascriptafterformdisplay>
 		var selectedItem = 0;
 		if(document.forms[0].ipaddress.value == 'dhcp') {
@@ -302,14 +302,14 @@
 			<name>MTU</name>
 			<type>input</type>
 			<bindstofield>interfaces->wan->mtu</bindstofield>
-			<description> Set the MTU of the WAN interface. If you leave this field blank, an MTU of 1492 bytes for PPPoE and 1500 bytes for all other connection types will be assumed.</description>
+			<description> Set the MTU of the WAN interface. If this field is left blank, an MTU of 1492 bytes for PPPoE and 1500 bytes for all other connection types will be assumed.</description>
 		</field>
 		<field>
 			<donotdisable>true</donotdisable>
 			<name>MSS</name>
 			<type>input</type>
 			<bindstofield>interfaces->wan->mss</bindstofield>
-			<description> If you enter a value in this field, then MSS clamping for TCP connections to the value entered above minus 40 (TCP/IP header size) will be in effect. If you leave this field blank, an MSS of 1492 bytes for PPPoE and 1500 bytes for all other connection types will be assumed. This should match the above MTU value in most all cases.</description>
+			<description> If a value is entered in this field, then MSS clamping for TCP connections to the value entered above minus 40 (TCP/IP header size) will be in effect. If this field is left blank, an MSS of 1492 bytes for PPPoE and 1500 bytes for all other connection types will be assumed. This should match the above MTU value in most all cases.</description>
 		</field>
 		<field>
 			<name>Static IP Configuration</name>
@@ -378,7 +378,7 @@
 			<name>PPPoE Dial on demand</name>
 			<typehint>Enable Dial-On-Demand mode</typehint>
 			<type>checkbox</type>
-			<description>This option causes the interface to operate in dial-on-demand mode, allowing you to have a virtual full time connection. The interface is configured, but the actual connection of the link is delayed until qualifying outgoing traffic is detected.</description>
+			<description>This option causes the interface to operate in dial-on-demand mode, allowing a virtual full time connection. The interface is configured, but the actual connection of the link is delayed until qualifying outgoing traffic is detected.</description>
 			<bindstofield>wizardtemp->wan->ondemand</bindstofield>
 		</field>
 		<field>
@@ -435,7 +435,7 @@
 			<typehint>Enable Dial-On-Demand mode</typehint>
 			<type>checkbox</type>
 			<bindstofield>wizardtemp->wan->pptpondemand</bindstofield>
-			<description>This option causes the interface to operate in dial-on-demand mode, allowing you to have a virtual full time connection. The interface is configured, but the actual connection of the link is delayed until qualifying outgoing traffic is detected.</description>
+			<description>This option causes the interface to operate in dial-on-demand mode, allowing a virtual full time connection. The interface is configured, but the actual connection of the link is delayed until qualifying outgoing traffic is detected.</description>
 		</field>
 		<field>
 			<name>PPTP Idle timeout</name>
@@ -450,7 +450,7 @@
 		<field>
 			<donotdisable>true</donotdisable>
 			<name>Block RFC1918 Private Networks</name>
-			<description> When set, this option blocks traffic from IP addresses that are reserved for private networks as per RFC 1918 (10/8, 172.16/12, 192.168/16) as well as loopback addresses (127/8). You should generally leave this option turned on, unless your WAN network lies in such a private address space, too.</description>
+			<description> When set, this option blocks traffic from IP addresses that are reserved for private networks as per RFC 1918 (10/8, 172.16/12, 192.168/16) as well as loopback addresses (127/8). This option should generally be left turned on, unless the WAN network lies in such a private address space, too.</description>
 			<type>checkbox</type>
 			<bindstofield>interfaces->wan->blockpriv</bindstofield>
 			<typehint>Block private networks from entering via WAN</typehint>
@@ -462,7 +462,7 @@
 		<field>
 			<donotdisable>true</donotdisable>
 			<name>Block bogon networks</name>
-			<description>When set, this option blocks traffic from IP addresses that are reserved (but not RFC 1918) or not yet assigned by IANA. Bogons are prefixes that should never appear in the Internet routing table, and obviously should not appear as the source address in any packets you receive.</description>
+			<description>When set, this option blocks traffic from IP addresses that are reserved (but not RFC 1918) or not yet assigned by IANA. Bogons are prefixes that should never appear in the Internet routing table, and obviously should not appear as the source address in any packets received.</description>
 			<type>checkbox</type>
 			<bindstofield>interfaces->wan->blockbogons</bindstofield>
 			<typehint>Block non-Internet routed networks from entering via WAN</typehint>
@@ -489,14 +489,14 @@
 		<![CDATA[
 		if(!empty($_POST['mtu']) && ($_POST['mtu'] < 576)) {
 			include("head.inc");
-			$input_errors[] = "MTU Must be at least 576 (Per RFC 791). Please press back in your browser window and correct.";
+			$input_errors[] = "MTU Must be at least 576 (Per RFC 791). Please press back in the browser window and correct.";
 			print_input_errors($input_errors);
 			include("foot.inc");
 			die;
 		}
 		if(!empty($_POST['macaddress']) && !is_macaddr($_POST['macaddress'])) {
 			include("head.inc");
-			$input_errors[] = "Invalid MAC Address. Please press back in your browser window and correct.";
+			$input_errors[] = "Invalid MAC Address. Please press back in the browser window and correct.";
 			print_input_errors($input_errors);
 			include("foot.inc");
 			die;
@@ -504,7 +504,7 @@
 		if(!empty($_POST['ipaddress']) && ($_POST['selectedtype'] == "Static")) {
 			if (!is_ipaddr($_POST['ipaddress'])) {
 				include("head.inc");
-				$input_errors[] = "Invalid WAN IP Address. Please press back in your browser window and correct.";
+				$input_errors[] = "Invalid WAN IP Address. Please press back in the browser window and correct.";
 				print_input_errors($input_errors);
 				include("foot.inc");
 				die;
@@ -513,7 +513,7 @@
 			    ($_POST['ipaddress'] == gen_subnet($_POST['ipaddress'], $_POST['subnetmask']) ||
 			     $_POST['ipaddress'] == gen_subnet_max($_POST['ipaddress'], $_POST['subnetmask']))) {
 			    include("head.inc");
-				$input_errors[] = "Invalid WAN IP Address. Please press back in your browser window and correct.";
+				$input_errors[] = "Invalid WAN IP Address. Please press back in the browser window and correct.";
 				print_input_errors($input_errors);
 				include("foot.inc");
 				die;
@@ -521,21 +521,21 @@
 		}
 		if(!empty($_POST['dhcphostname']) && !is_hostname($_POST['dhcphostname'])) {
 			include("head.inc");
-			$input_errors[] = "Invalid DHCP Hostname. Please press back in your browser window and correct.";
+			$input_errors[] = "Invalid DHCP Hostname. Please press back in the browser window and correct.";
 			print_input_errors($input_errors);
 			include("foot.inc");
 			die;
 		}
 		if(!empty($_POST['pptplocalipaddress']) && !is_ipaddr($_POST['pptplocalipaddress'])) {
 		    include("head.inc");
-			$input_errors[] = "Invalid PPTP Local IP Address. Please press back in your browser window and correct.";
+			$input_errors[] = "Invalid PPTP Local IP Address. Please press back in the browser window and correct.";
 			print_input_errors($input_errors);
 			include("foot.inc");
 			die;
 		}
 		if(!empty($_POST['pptpremoteipaddress']) && !is_ipaddr($_POST['pptpremoteipaddress'])) {
 			include("head.inc");
-			$input_errors[] = "Invalid PPTP Remote IP Address. Please press back in your browser window and correct.";
+			$input_errors[] = "Invalid PPTP Remote IP Address. Please press back in the browser window and correct.";
 			print_input_errors($input_errors);
 			include("foot.inc");
 			die;
@@ -598,7 +598,7 @@
 <step>
 	<id>6</id>
 	<title>Configure LAN Interface</title>
-	<description>On this screen we will configure the Local Area Network information.</description>
+	<description>On this screen the Local Area Network information will be configured.</description>
 	<fields>
 		<field>
 			<name>LAN IP Address</name>
@@ -621,7 +621,7 @@
 	<stepsubmitphpaction>
 		<![CDATA[
 		if(empty($_POST['lanipaddress']) || !is_ipaddr($_POST['lanipaddress'])) {
-			print_info_box("Invalid LAN IP address. Please press back in your browser window and correct.");
+			print_info_box("Invalid LAN IP address. Please press back in the browser window and correct.");
 			die;
 		}
 
@@ -631,21 +631,21 @@
 		if ($_POST['subnetmask'] < 31) {
 			if ($_POST['lanipaddress'] == $lowestip) {
 				include("head.inc");
-				$input_errors[] = "LAN IP Address equals subnet network address. This is not allowed. Please press back in your browser window and correct.";
+				$input_errors[] = "LAN IP Address equals subnet network address. This is not allowed. Please press back in the browser window and correct.";
 				print_input_errors($input_errors);
 				include("foot.inc");
 				die;
 			}
 			if ($_POST['lanipaddress'] == $highestip) {
 				include("head.inc");
-				$input_errors[] = "LAN IP Address equals subnet broadcast address. This is not allowed. Please press back in your browser window and correct.";
+				$input_errors[] = "LAN IP Address equals subnet broadcast address. This is not allowed. Please press back in the browser window and correct.";
 				print_input_errors($input_errors);
 				include("foot.inc");
 				die;
 			}
 		} else {
 			include("head.inc");
-			$input_errors[] = "Invalid subnet mask, choose a mask less than 31. Please press back in your browser window and correct.";
+			$input_errors[] = "Invalid subnet mask, choose a mask less than 31. Please press back in the browser window and correct.";
 			print_input_errors($input_errors);
 			include("foot.inc");
 			die;
@@ -685,7 +685,7 @@
 <step>
 	<id>7</id>
 	<title>Set Admin WebGUI Password</title>
-	<description>On this screen we will set the admin password, which is used to access the WebGUI and also SSH services if you wish to enable them.</description>
+	<description>On this screen the admin password will be set, which is used to access the WebGUI and also SSH services if enabled.</description>
 	<fields>
 		<field>
 			<name>Admin Password</name>
@@ -709,7 +709,7 @@
 			local_user_set($admin_user);
 			write_config();
 		} else {
-			print_info_box("Passwords do not match! Please press back in your browser window and correct.");
+			print_info_box("Passwords do not match! Please press back in the browser window and correct.");
 			die;
 		}
 	}


### PR DESCRIPTION
Did some "you" in setup wizard also, while I was there. But I did leave a couple because they seem appropriate in the context of first-time setup.