### PR TITLE
Handle alias from CNAME in diag_dns

### DIFF
--- a/src/usr/local/www/diag_dns.php
+++ b/src/usr/local/www/diag_dns.php
@@ -100,7 +100,13 @@ if (isset($_POST['create_alias']) && (is_hostname($host) || is_ipaddr($host))) {
 					$addresses .= " ";
 				}
 				$re = rtrim($re);
-				$sn = is_ipaddrv6($re) ? '/128' : '/32';
+				if (is_ipaddr($re)) {
+					$sn = is_ipaddrv6($re) ? '/128' : '/32';
+				} else {
+					// The name was a CNAME and resolved to another name, rather than an address.
+					// In this case the alias entry will have a FQDN, so do not put a CIDR after it.
+					$sn = "";
+				}
 				$addresses .= $re . $sn;
 				$isfirst = false;
 			}


### PR DESCRIPTION
If I resolve a CNAME with diag_dns, it gives back the translated FQDNs - e.g. www.inf.org translates to inf.org. Then press "Add Alias".
Problem: The existing code puts a "/32" CIDR after that in the alias "www_inf_org" in the config - "inf.org./32" - and if you then edit the "www_inf_org" alias it shows as "inf.org./32" in the Network or FQDN Address field. Normally when putting an FQDN into an alias, no CIDR is inserted.

This change fixes it.