### PR TITLE
system.inc - improve package info to syslog.conf

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -899,14 +899,23 @@ function system_syslogd_start() {
 	if (isset($syslogcfg)) {
 		$separatelogfacilities = array('ntp', 'ntpd', 'ntpdate', 'charon', 'ipsec_starter', 'openvpn', 'pptps', 'poes', 'l2tps', 'relayd', 'hostapd', 'dnsmasq', 'filterdns', 'unbound', 'dhcpd', 'dhcrelay', 'dhclient', 'dhcp6c', 'dpinger', 'radvd', 'routed', 'olsrd', 'zebra', 'ospfd', 'bgpd', 'miniupnpd', 'filterlog');
 		$syslogconf = "";
+		$default_mail_info="mail.crit";		
 		if ($config['installedpackages']['package']) {
 			foreach ($config['installedpackages']['package'] as $package) {
 				if ($package['logging']) {
-					array_push($separatelogfacilities, $package['logging']['facilityname']);
-					if (!is_file($g['varlog_path'].'/'.$package['logging']['logfilename'])) {
-						mwexec("{$log_create_directive} {$log_size} {$g['varlog_path']}/{$package['logging']['logfilename']}");
+					// check if package needs to change default mail info on syslog
+					if (preg_match ("/mail/",$package['logging']['default_mail_info'])) {
+						$default_mail_info=$package['logging']['default_mail_info'];
 					}
-					$syslogconf .= "!{$package['logging']['facilityname']}\n*.*\t\t\t\t\t\t {$log_directive}{$g['varlog_path']}/{$package['logging']['logfilename']}\n";
+					if ($package['logging']['clog'] == 'no') {
+						$noclog_directives.="{$package['logging']['facilityname']}.*\t\t\t\t\t\t {$g['varlog_path']}/{$package['logging']['logfilename']}\n";
+					} else {
+						array_push($separatelogfacilities, $package['logging']['facilityname']);
+						if (!is_file($g['varlog_path'].'/'.$package['logging']['logfilename'])) {
+							mwexec("{$log_create_directive} {$log_size} {$g['varlog_path']}/{$package['logging']['logfilename']}");
+						}
+						$syslogconf .= "!{$package['logging']['facilityname']}\n*.*\t\t\t\t\t\t {$log_directive}{$g['varlog_path']}/{$package['logging']['logfilename']}\n";
+					}
 				}
 			}
 		}
@@ -1010,7 +1019,8 @@ local3.*							{$log_directive}{$g['varlog_path']}/vpn.log
 local4.*							{$log_directive}{$g['varlog_path']}/portalauth.log
 local5.*							{$log_directive}{$g['varlog_path']}/nginx.log
 local7.*							{$log_directive}{$g['varlog_path']}/dhcpd.log
-*.notice;kern.debug;lpr.info;mail.crit;daemon.none;news.err;local0.none;local3.none;local4.none;local7.none;security.*;auth.info;authpriv.info;daemon.info	{$log_directive}{$g['varlog_path']}/system.log
+{$noclog_directives}
+*.notice;kern.debug;lpr.info;{$default_mail_info};daemon.none;news.err;local0.none;local3.none;local4.none;local7.none;security.*;auth.info;authpriv.info;daemon.info	{$log_directive}{$g['varlog_path']}/system.log
 auth.info;authpriv.info 					|exec /usr/local/sbin/sshlockout_pf 15
 *.emerg								*
 


### PR DESCRIPTION
packages like postfix needs some custom settings to syslog.conf. As it is dangerous to be done by file hacking.(https://github.com/pfsense/FreeBSD-ports/pull/23) I'm sending this code change to improve system.inc tests on package logging config.