### PR TITLE
Redmine #6081 do not reuse index var

### DIFF
--- a/src/usr/local/www/services_dnsmasq.php
+++ b/src/usr/local/www/services_dnsmasq.php
@@ -403,7 +403,7 @@ foreach ($a_hosts as $i => $hostent):
 
 <?php
 	if ($hostent['aliases']['item'] && is_array($hostent['aliases']['item'])):
-		foreach ($hostent['aliases']['item'] as $i => $alias):
+		foreach ($hostent['aliases']['item'] as $alias):
 ?>
 				<tr>
 					<td>


### PR DESCRIPTION
The value of $i needs to be kept constant from the outer loop - do not reuse it here.