### PR TITLE
Fix the IPsec SPD arrows

### DIFF
--- a/src/usr/local/www/status_ipsec_spd.php
+++ b/src/usr/local/www/status_ipsec_spd.php
@@ -64,7 +64,7 @@
 ##|-PRIV
 
 define('RIGHTARROW', '&#x25ba;');
-define('LEFTARROW',  '&#x25c0;');
+define('LEFTARROW',  '&#x25c4;');
 
 require("guiconfig.inc");
 require("ipsec.inc");


### PR DESCRIPTION
Currently, a `BLACK RIGHT-POINTING POINTER` and a `BLACK LEFT-POINTING
TRIANGLE` are used to display the direction.

This commit changes both arrows to be `POINTER`s.