### PR TITLE
Use consistent arrow colors on dashboard

### DIFF
--- a/src/usr/local/www/widgets/widgets/openvpn.widget.php
+++ b/src/usr/local/www/widgets/widgets/openvpn.widget.php
@@ -178,10 +178,10 @@ $clients = openvpn_get_active_clients();
 <?php
 					if ($sk_server['status'] == "up") {
 						/* tunnel is up */
-						echo '<i class="fa fa-arrow-up"></i>';
+						echo '<i class="fa fa-arrow-up text-success"></i>';
 					} else {
 						/* tunnel is down */
-						echo '<i class="fa fa-arrow-down"></i>';
+						echo '<i class="fa fa-arrow-down text-danger"></i>';
 					}
 ?>
 					</td>
@@ -228,10 +228,10 @@ $clients = openvpn_get_active_clients();
 <?php
 				if ($client['status'] == "up") {
 					/* tunnel is up */
-					echo '<i class="fa fa-arrow-up"></i>';
+					echo '<i class="fa fa-arrow-up text-success"></i>';
 				} else {
 					/* tunnel is down */
-					echo '<i class="fa fa-arrow-down"></i>';
+					echo '<i class="fa fa-arrow-down text-danger"></i>';
 				}
 
 ?>

--- a/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
+++ b/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
@@ -93,11 +93,11 @@ if (count($wolcomputers) > 0):
 			</td>
 			<td>
 		<?php if ($status == 'expires'): ?>
-				<i class="fa fa-arrow-up" data-toggle="tooltip" title="<?= gettext("Online") ?>"></i>
+				<i class="fa fa-arrow-up text-success" data-toggle="tooltip" title="<?= gettext("Online") ?>"></i>
 		<?php elseif ($status == 'permanent'): ?>
-				<i class="fa fa-arrow-up" data-toggle="tooltip" title="<?= gettext("Static ARP") ?>"></i>
+				<i class="fa fa-arrow-up text-success" data-toggle="tooltip" title="<?= gettext("Static ARP") ?>"></i>
 		<?php else: ?>
-				<i class="fa fa-arrow-down" data-toggle="tooltip" title="<?= gettext("Offline") ?>"></i>
+				<i class="fa fa-arrow-down text-danger" data-toggle="tooltip" title="<?= gettext("Offline") ?>"></i>
 		<?php endif; ?>
 			</td>
 			<td>


### PR DESCRIPTION

Redmine #6123
Interfaces widget and IPsec widget use text-success and text-danger to
make the up and down arrows be green and red.
This change does the same thing to OpenVPN and WoL widgets for
consistency.