### PR TITLE
Allow to restore any areas of config

### DIFF
--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -683,7 +683,7 @@ $section->addInput(new Form_Select(
 	'restorearea',
 	'Restore area',
 	'',
-	build_area_list(false)
+	build_area_list(true)
 ));
 
 $section->addInput(new Form_Input(


### PR DESCRIPTION
If the existing config does not have a particular area in it, then the user should still be able to restore it from another config.
Redmine #6144