### PR TITLE
Fix #6142 validate and adjust dpinger params on upgrade

### DIFF
--- a/src/etc/inc/upgrade_config.inc
+++ b/src/etc/inc/upgrade_config.inc
@@ -4147,6 +4147,12 @@ function upgrade_129_to_130() {
 function upgrade_130_to_131() {
 	global $config;
 
+	// Default dpinger parameters at time of this upgrade (2.3)
+	$default_interval = 500;
+	$default_alert_interval = 1000;
+	$default_loss_interval = 2000;
+	$default_time_period = 60000;
+
 	if (isset($config['syslog']['apinger'])) {
 		$config['syslog']['dpinger'] = true;
 		unset($config['syslog']['apinger']);
@@ -4167,10 +4173,49 @@ function upgrade_130_to_131() {
 		    is_numeric($gw['interval'])) {
 			$gw['interval'] = $gw['interval'] * 1000;
 		}
+
+		if (isset($gw['interval'])) {
+			$effective_interval = $gw['interval'];
+		} else {
+			$effective_interval = $default_interval;
+		}
+
 		if (isset($gw['down']) &&
 		    is_numeric($gw['down'])) {
-			$gw['loss_interval'] = $gw['down'] * 1000;
+			$gw['time_period'] = $gw['down'] * 1000;
 			unset($gw['down']);
+		}
+
+		if (isset($gw['time_period'])) {
+			$effective_time_period = $gw['time_period'];
+		} else {
+			$effective_time_period = $default_time_period;
+		}
+
+		if (isset($gw['latencyhigh'])) {
+			// Default loss_interval is 2000, but must be set
+			// higher if latencyhigh is higher.
+			if ($gw['latencyhigh'] > $default_loss_interval) {
+				$gw['loss_interval'] = $gw['latencyhigh'];
+			}
+		}
+
+		if (isset($gw['loss_interval'])) {
+			$effective_loss_interval = $gw['loss_interval'];
+		} else {
+			$effective_loss_interval = $default_loss_interval;
+		}
+
+		if (isset($gw['interval'])) {
+			// Default alert_interval is 1000, but must be set
+			// higher if interval is higher.
+			if ($gw['interval'] > $default_alert_interval) {
+				$gw['alert_interval'] = $gw['interval'];
+			}
+		}
+
+		if ((($effective_interval * 2) + $effective_loss_interval) >= $effective_time_period) {
+			$gw['time_period'] = ($effective_interval * 2) + $effective_loss_interval + 1;
 		}
 
 		if (isset($gw['avg_delay_samples'])) {


### PR DESCRIPTION
1) The previous "down" value was being converted to msec and put into
"loss_interval". It should go into "time_period".
2) loss_interval must always be at least latencyhigh - make it so if
latencyhigh is big.
3) alert_interval must always be at least probe interval - make it so if
the probe interval is high.
4) The time_period for averaging the results must be at least 2 probe
intervals plus loss_interval (ensuring there should always be 2 probe
results by the time_period expiry) - make it so.

These various conditions taken from the validation code in
system_gateways_edit.php

Note: I have explicitly put the necessary default dpinger parameter
values here, rather than calling return_dpinger_defaults() because at
this point in any future conversion we want to use these particular
numbers, not what the defaults happen to be in pfSense 2.4 or 3.0 or...