### PR TITLE
Alias Tables RAM Disk Store

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2151,7 +2151,7 @@ function pfs_version_compare($cur_time, $cur_text, $remote) {
 	return $v;
 }
 function process_alias_urltable($name, $url, $freq, $forceupdate=false, $validateonly=false) {
-	global $config;
+	global $g, $config;
 
 	$urltable_prefix = "/var/db/aliastables/";
 	$urltable_filename = $urltable_prefix . $name . ".txt";
@@ -2186,6 +2186,13 @@ function process_alias_urltable($name, $url, $freq, $forceupdate=false, $validat
 				if (is_array($urltable)) {
 					file_put_contents($urltable_filename, implode("\n", $urltable));
 				}
+			}
+			/* If this backup is still there on a full install, but we aren't going to use ram disks, remove the archive since this is a transition. */
+			if (($g['platform'] == $g['product_name']) && !isset($config['system']['use_mfs_tmpvar'])) {
+				unlink_if_exists("{$g['cf_conf_path']}/RAM_Disk_Store{$urltable_filename}.tgz");
+			} else {
+				/* Update the RAM disk store with the new/updated table file. */
+				mwexec("cd / && /usr/bin/tar -czf \"{$g['cf_conf_path']}/RAM_Disk_Store{$urltable_filename}.tgz\" -C / \"{$urltable_filename}\"");
 			}
 			unlink_if_exists($tmp_urltable_filename);
 		} else {
@@ -3083,6 +3090,38 @@ function pkg_call_plugins($plugin_type, $plugin_params) {
 		}
 	}
 	return $results;
+}
+
+function restore_aliastables() {
+	global $g, $config;
+
+	$dbpath = "{$g['vardb_path']}/aliastables/";
+
+	/* restore the alias tables, if we have them */
+	$files = glob("{$g['cf_conf_path']}/RAM_Disk_Store{$dbpath}*.tgz");
+	if (count($files)) {
+		echo "Restoring alias tables...";
+		foreach ($files as $file) {
+			if (file_exists($file)) {
+				$aliastablesrestore = "";
+				$aliastablesreturn = "";
+				exec("cd /;LANG=C /usr/bin/tar -xzf {$file} 2>&1", $aliastablesrestore, $aliastablesreturn);
+				$aliastablesrestore = implode(" ", $aliastablesrestore);
+				if ($aliastablesreturn <> 0) {
+					log_error(sprintf(gettext('Alias table restore failed exited with %1$s, the error is: %2$s %3$s%4$s'), $aliastablesreturn, $aliastablesrestore, $file, "\n"));
+				} else {
+					log_error(sprintf(gettext('Alias table restore succeeded exited with %1$s, the result is: %2$s %3$s%4$s'), $aliastablesreturn, $aliastablesrestore, $dbpath.basename($file, ".tgz"), "\n"));
+				}
+			}
+			/* If this backup is still there on a full install, but we aren't going to use ram disks, remove the archive since this is a transition. */
+			if (($g['platform'] == $g['product_name']) && !isset($config['system']['use_mfs_tmpvar'])) {
+				unlink_if_exists("{$file}");
+			}
+		}
+		echo "done.\n";
+		return true;
+	}
+	return false;
 }
 
 ?>

--- a/src/etc/rc.backup_aliastables.sh
+++ b/src/etc/rc.backup_aliastables.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+: ${DBPATH:=/var/db/aliastables}
+: ${CF_CONF_PATH:=/cf/conf}
+
+: ${RAM_Disk_Store:=${CF_CONF_PATH}/RAM_Disk_Store/${DBPATH}}
+
+# Save the alias tables database to the RAM disk store.
+if [ -d "${DBPATH}" ]; then
+	[ -z "$NO_REMOUNT" ] && /etc/rc.conf_mount_rw
+
+	if [ ! -d "${RAM_Disk_Store}" ]; then
+		mkdir -p "${RAM_Disk_Store}"
+	fi
+
+	for aliastablefile in "${DBPATH}"/* ; do
+		filename="$(basename ${aliastablefile})"
+		if [ ! -f "${RAM_Disk_Store}/${filename}.tgz" ]; then
+			cd / && /usr/bin/tar -czf "${RAM_Disk_Store}/${filename}.tgz" -C / "${DBPATH}/${filename}"
+		fi
+	done
+
+	[ -z "$NO_REMOUNT" ] && /etc/rc.conf_mount_ro
+fi

--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -230,6 +230,9 @@ interfaces_loopback_configure();
 /* start syslogd */
 system_syslogd_start();
 
+/* restore alias tables */
+restore_aliastables();
+
 echo "Starting Secure Shell Services...";
 send_event("service reload sshd");
 echo "done.\n";

--- a/src/etc/rc.reboot
+++ b/src/etc/rc.reboot
@@ -24,6 +24,7 @@ DISK_NAME=`/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}'`
 DISK_TYPE=`/usr/bin/basename ${DISK_NAME} | /usr/bin/cut -c1-2`
 # If we are not on a full install, or if the full install wants RAM disks, or if the full install _was_ using RAM disks, but isn't for the next boot...
 if [ "${PLATFORM}" != "${product}" ] || [ "${USE_MFS_TMPVAR}" = "true" ] || [ "${DISK_TYPE}" = "md" ]; then
+	/etc/rc.backup_aliastables.sh
 	/etc/rc.backup_rrd.sh
 	/etc/rc.backup_dhcpleases.sh
 fi

--- a/src/etc/rc.shutdown
+++ b/src/etc/rc.shutdown
@@ -33,6 +33,7 @@ DISK_NAME=`/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}'`
 DISK_TYPE=`/usr/bin/basename ${DISK_NAME} | /usr/bin/cut -c1-2`
 # If we are not on a full install, or if the full install wants RAM disks, or if the full install _was_ using RAM disks, but isn't for the next boot...
 if [ "${PLATFORM}" != "${product}" ] || [ "${USE_MFS_TMPVAR}" = "true" ] || [ "${DISK_TYPE}" = "md" ]; then
+	/etc/rc.backup_aliastables.sh
 	/etc/rc.backup_rrd.sh
 	/etc/rc.backup_dhcpleases.sh
 fi


### PR DESCRIPTION
Fixes 6189
If ramdisk is enabled keep a copy of the alias tables to restore at boot time.  Otherwise unpredictable behavior may occur due to some aliases not being  available when the firewall rules load.