### PR TITLE
Firewall NAT - Remove Pencil Icon From Aliases

### DIFF
--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -375,7 +375,7 @@ foreach ($a_nat as $natent):
 <?php
 	if (isset($alias['dst'])):
 ?>
-							</i></a>
+							</a>
 <?php
 	endif;
 ?>
@@ -392,7 +392,7 @@ foreach ($a_nat as $natent):
 <?php
 	if (isset($alias['dstport'])):
 ?>
-							</i></a>
+							</a>
 <?php
 	endif;
 ?>

--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -340,7 +340,7 @@ foreach ($a_nat as $natent):
 <?php
 	if (isset($alias['src'])):
 ?>
-							<i class='fa fa-pencil'></i></a>
+							</a>
 <?php
 	endif;
 ?>
@@ -357,7 +357,7 @@ foreach ($a_nat as $natent):
 <?php
 	if (isset($alias['srcport'])):
 ?>
-							<i class='fa fa-pencil'></i></a>
+							</a>
 <?php
 	endif;
 ?>
@@ -375,7 +375,7 @@ foreach ($a_nat as $natent):
 <?php
 	if (isset($alias['dst'])):
 ?>
-							<i class='fa fa-pencil'></i></a>
+							</i></a>
 <?php
 	endif;
 ?>
@@ -392,7 +392,7 @@ foreach ($a_nat as $natent):
 <?php
 	if (isset($alias['dstport'])):
 ?>
-							<i class='fa fa-pencil'></i></a>
+							</i></a>
 <?php
 	endif;
 ?>


### PR DESCRIPTION
Don't see the icon adding any value. Consumes space and clutters page. Make consistent with the firewall rules page.