### PR TITLE
Feature 4923: update to rfc2307 filter and group name length

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -1084,7 +1084,7 @@ function ldap_get_groups($username, $authcfg) {
 		$ldapnameattribute = strtolower($authcfg['ldap_attr_user']);
 		$ldapgroupattribute = strtolower($authcfg['ldap_attr_member']);
 		if (isset($authcfg['ldap_rfc2307'])) {
-			$ldapfilter         = "(&(objectClass={$authcfg['ldap_attr_groupobj']})({$ldapgroupattribute}={$username}))";
+			$ldapfilter         = "(&(objectClass={$authcfg['ldap_attr_groupobj']})(|({$ldapgroupattribute}={$username})({$ldapgroupattribute}={$ldapnameattribute}={$username},{$ldapauthcont})))";
 		} else {
 			$ldapfilter         = "({$ldapnameattribute}={$username})";
 		}

--- a/src/usr/local/www/system_groupmanager.php
+++ b/src/usr/local/www/system_groupmanager.php
@@ -189,8 +189,8 @@ if (isset($_POST['save'])) {
 	}
 
 
-	if (strlen($_POST['groupname']) > 16) {
-		$input_errors[] = gettext("The group name is longer than 16 characters.");
+	if (strlen($_POST['groupname']) > 32) {
+		$input_errors[] = gettext("The group name is longer than 32 characters.");
 	}
 
 	if (!$input_errors && !(isset($id) && $a_group[$id])) {


### PR DESCRIPTION
- The rfc2307 filter currently doesn't account for the situation where a member is added only via their DN.  This filter extension simply adds the capability to search via DN "or" user_attr.  I would think a wildcard search would be acceptable in some situations as well, but less secure depending on existing hierarchy of the tree.
- The other commit extends the group length requirement to allow 32 characters opposed to 16.  LDAP group names can get quite long in length and BSD isn't impacted by this, so I'd think that 32 would be acceptable.
