### PR TITLE
Fix #6173 Use correct list of special nets

### DIFF
--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -631,16 +631,14 @@ function dsttype_selected() {
 	global $pconfig, $config;
 
 	$selected = "";
-
-	$sel = is_specialnet($pconfig['dst']);
-	if (!$sel) {
+	if (array_key_exists($pconfig['dst'], build_dsttype_list())) {
+		$selected = $pconfig['dst'];
+	} else {
 		if ($pconfig['dstmask'] == 32) {
 			$selected = 'single';
 		} else {
 			$selected = 'network';
 		}
-	} else {
-		$selected = $pconfig['dst'];
 	}
 
 	return($selected);


### PR DESCRIPTION
is_specialnet() was only using a smaller list of "special nets", so when you have a VIP as the selected special destination it was not matching it up on edit, and thus "forgetting" the special VIP selection.
build_dsttype_list() already makes a good list of special destination types. That list includes all the "special" VIPs.