### PR TITLE
Turning off verbose logging for igmpproxy

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1634,7 +1634,8 @@ EOD;
 	fclose($igmpfl);
 	unset($igmpconf);
 
-	mwexec_bg("/usr/local/sbin/igmpproxy -v {$g['tmp_path']}/igmpproxy.conf");
+	/* Logging is not enabled by default.  Add -v to enable verbose logging. */
+	mwexec_bg("/usr/local/sbin/igmpproxy {$g['tmp_path']}/igmpproxy.conf");
 	log_error(gettext("Started IGMP proxy service."));
 
 	return 0;


### PR DESCRIPTION
Igmpproxy currently has verbose logging enabled.  There were previous tickets for this in earlier versions of pfSense.  See e.g. https://redmine.pfsense.org/issues/1477.  There's also forum queries on how to turn it off: e.g. https://forum.pfsense.org/index.php?topic=109042.0

I suggest removing -v from the command line options for igmpproxy, so that igmpproxy doesn't spam the system log.