### PR TITLE
Make QinQ interfaces work again

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -318,17 +318,17 @@ function interface_qinq_configure(&$vlan, $fd = NULL) {
 
 	pfSense_ngctl_attach(".", $qinqif);
 	if (!empty($vlanif) && does_interface_exist($vlanif)) {
-		fwrite($fd, "shutdown {$qinqif}qinq:\n");
-		exec("/usr/sbin/ngctl msg {$qinqif}qinq: gettable", $result);
+		fwrite($fd, "shutdown {$vlanif}qinq:\n");
+		exec("/usr/sbin/ngctl msg {$vlanif}qinq: gettable", $result);
 		if (empty($result)) {
-			fwrite($fd, "mkpeer {$qinqif}: vlan lower downstream\n");
-			fwrite($fd, "name {$qinqif}:lower {$vlanif}qinq\n");
-			fwrite($fd, "connect {$qinqif}: {$vlanif}qinq: upper nomatch\n");
+			fwrite($fd, "mkpeer {$vlanif}: vlan lower downstream\n");
+			fwrite($fd, "name {$vlanif}:lower {$vlanif}qinq\n");
+			fwrite($fd, "connect {$vlanif}: {$vlanif}qinq: upper nomatch\n");
 		}
 	} else {
-		fwrite($fd, "mkpeer {$qinqif}: vlan lower downstream\n");
-		fwrite($fd, "name {$qinqif}:lower {$vlanif}qinq\n");
-		fwrite($fd, "connect {$qinqif}: {$vlanif}qinq: upper nomatch\n");
+		fwrite($fd, "mkpeer {$vlanif}: vlan lower downstream\n");
+		fwrite($fd, "name {$vlanif}:lower {$vlanif}qinq\n");
+		fwrite($fd, "connect {$vlanif}: {$vlanif}qinq: upper nomatch\n");
 	}
 
 	/* invalidate interface cache */

--- a/src/usr/local/www/interfaces_assign.php
+++ b/src/usr/local/www/interfaces_assign.php
@@ -191,13 +191,13 @@ if (is_array($config['laggs']['lagg']) && count($config['laggs']['lagg'])) {
 /* add QinQ interfaces */
 if (is_array($config['qinqs']['qinqentry']) && count($config['qinqs']['qinqentry'])) {
 	foreach ($config['qinqs']['qinqentry'] as $qinq) {
-		$portlist["vlan{$qinq['tag']}"]['descr'] = "VLAN {$qinq['tag']}";
-		$portlist["vlan{$qinq['tag']}"]['isqinq'] = true;
+		$portlist["{$qinq['vlanif']}"]['descr'] = "VLAN {$qinq['tag']} on {$qinq['if']}";
+		$portlist["{$qinq['vlanif']}"]['isqinq'] = true;
 		/* QinQ members */
 		$qinqifs = explode(' ', $qinq['members']);
 		foreach ($qinqifs as $qinqif) {
-			$portlist["vlan{$qinq['tag']}_{$qinqif}"]['descr'] = "QinQ {$qinqif}";
-			$portlist["vlan{$qinq['tag']}_{$qinqif}"]['isqinq'] = true;
+			$portlist["{$qinq['vlanif']}_{$qinqif}"]['descr'] = "QinQ {$qinqif} on VLAN {$qinq['tag']} on {$qinq['if']}";
+			$portlist["{$qinq['vlanif']}_{$qinqif}"]['isqinq'] = true;
 		}
 	}
 }


### PR DESCRIPTION
QinQ interfaces are fundamentally broken at the moment. The interface pfsense is trying to address in the php code doesn't match the interface name in ifconfig . This commit allows pfsense to correctly assign QinQ interfaces again. 

Also fixes names in the interface assignment screen so instead of showing just QinQ10, which isn't descriptive enough, it'll show "QinQ10 on VLAN1 on em1".

See https://forum.pfsense.org/index.php?topic=110459.0 and https://redmine.pfsense.org/issues/4669