### PR TITLE
Fix #6251 Temperature on System Information Widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -242,9 +242,12 @@ $filesystems = get_mounted_filesystems();
 		<tr>
 			<th><?=gettext("Temperature");?></th>
 			<td>
-				<?php $TempMeter = $temp = get_temp(); ?>
-				<div id="tempPB"></div>
-				<span id="tempmeter"><?= $temp."&#176;C"; ?></span>
+				<?php $temp_deg_c = get_temp(); ?>
+				<div class="progress">
+					<div id="tempPB" class="progress-bar progress-bar-striped" role="progressbar" aria-valuenow="<?=$temp_deg_c?>" aria-valuemin="0" aria-valuemax="100" style="width: <?=$temp_deg_c?>%">
+					</div>
+				</div>
+				<span id="tempmeter"><?= $temp_deg_c . "&deg;C"; ?></span>
 			</td>
 		</tr>
 		<?php endif; ?>
@@ -429,10 +432,10 @@ function updateCPU(x) {
 
 function updateTemp(x) {
 	if ($("#tempmeter")) {
-		$("#tempmeter").html(x + '\u00B0' + 'C');
+		$("#tempmeter").html(x + '&deg;' + 'C');
 	}
 	if ($('#tempPB')) {
-		$("#tempPB").progressbar( { value: parseInt(x) } );
+		setProgress('tempPB', parseInt(x));
 	}
 }
 


### PR DESCRIPTION
It just seems that some infrastructure for a temperature bar had been put in place, but the code never finished to actually do it. But I am a bit surprised that it has taken so long for someone to report this.
The temperature is in deg Celsius, so a 0 to 100 "progress bar" works nicely for the typical reasonable temperature range. I have not tried to make it have any sort of good/warning/really hot color indications... - that is for the Temperature Sensors widget.
I also changed to using the &deg way to get a degree symbol, rather than the various special character codes that were there. Hopefully &deg should be a fully portable way to specify this.