### PR TITLE
Provide better messages for invalid alias name errors

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1058,25 +1058,61 @@ function is_macaddr($macaddr, $partial=false) {
 	return preg_match('/^[0-9A-F]{2}(?:[:][0-9A-F]{2}){'.$repeat.'}$/i', $macaddr) == 1 ? true : false;
 }
 
-/* returns true if $name is a valid name for an alias
-   returns NULL if a reserved word is used
-   returns FALSE for bad chars in the name - this allows calling code to determine what the problem was.
-   aliases cannot be:
-	bad chars: anything except a-z 0-9 and underscore
-	bad names: empty string, pure numeric, pure underscore
-	reserved words: pre-defined service/protocol/port names which should not be ambiguous, and the words "port" and  "pass" */
+/*
+	If $return_message is true then
+		returns a text message about the reason that the name is invalid.
+		the text includes the type of "thing" that is being checked, passed in $object. (e.g. "alias", "gateway group", "schedule")
+	else
+		returns true if $name is a valid name for an alias
+		returns false if $name is not a valid name for an alias
 
-function is_validaliasname($name) {
+	Aliases cannot be:
+		bad chars: anything except a-z 0-9 and underscore
+		bad names: empty string, pure numeric, pure underscore
+		reserved words: pre-defined service/protocol/port names which should not be ambiguous, and the words "port" and  "pass" */
+
+function is_validaliasname($name, $return_message = false, $object = "alias") {
 	/* Array of reserved words */
 	$reserved = array("port", "pass");
 
 	if (!is_string($name) || strlen($name) >= 32 || preg_match('/(^_*$|^\d*$|[^a-z0-9_])/i', $name)) {
-		return false;
+		if ($return_message) {
+			return sprintf(gettext('The %1$s name must be less than 32 characters long, may not consist of only numbers, may not consist of only underscores, and may only contain the following characters: %2$s'), $object, 'a-z, A-Z, 0-9, _');
+		} else {
+			return false;
+		}
 	}
-	if (in_array($name, $reserved, true) || getservbyname($name, "tcp") || getservbyname($name, "udp") || getprotobyname($name)) {
-		return; /* return NULL */
+	if (in_array($name, $reserved, true)) {
+		if ($return_message) {
+			return sprintf(gettext('The %1$s name must not be either of the reserved words %2$s or %3$s.'), $object, "'port'", "'pass'");
+		} else {
+			return false;
+		}
 	}
-	return true;
+	if (getprotobyname($name)) {
+		if ($return_message) {
+			return sprintf(gettext('The %1$s name must not be a well-known IP protocol name such as TCP, UDP, ICMP etc.'), $object);
+		} else {
+			return false;
+		}
+	}
+	if (getservbyname($name, "tcp") || getservbyname($name, "udp")) {
+		if ($return_message) {
+			return sprintf(gettext('The %1$s name must not be a well-known TCP or UDP port name such as ssh, smtp, pop3, tftp, http, openvpn etc.'), $object);
+		} else {
+			return false;
+		}
+	}
+	if ($return_message) {
+		return sprintf(gettext("The %1$s name is valid."), $object);
+	} else {
+		return true;
+	}
+}
+
+/* returns a text message indicating if the alias name is valid, or the reason it is not valid. */
+function invalidaliasnamemsg($name, $object = "alias") {
+	return is_validaliasname($name, true, $object);
 }
 
 /* returns true if $port is a valid TCP/UDP port */

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -175,16 +175,10 @@ if ($_POST) {
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
-	$x = is_validaliasname($_POST['name']);
-	if (!isset($x)) {
-		$input_errors[] = gettext("Reserved word used for alias name.");
-	} else if ($_POST['type'] == "port" && (getservbyname($_POST['name'], "tcp") || getservbyname($_POST['name'], "udp"))) {
-		$input_errors[] = gettext("Reserved word used for alias name.");
-	} else {
-		if (is_validaliasname($_POST['name']) == false) {
-			$input_errors[] = sprintf(gettext("The alias name must be less than 32 characters long, may not consist of only numbers, may not consist of only underscores, and may only contain the following characters: %s"), 'a-z, A-Z, 0-9, _');
-		}
+	if (!is_validaliasname($_POST['name'])) {
+		$input_errors[] = invalidaliasnamemsg($_POST['name']);
 	}
+
 	/* check for name conflicts */
 	foreach ($a_aliases as $key => $alias) {
 		if (($alias['name'] == $_POST['name']) && (empty($a_aliases[$id]) || ($key != $id))) {

--- a/src/usr/local/www/firewall_aliases_import.php
+++ b/src/usr/local/www/firewall_aliases_import.php
@@ -94,8 +94,8 @@ if ($_POST['aliasimport'] != "") {
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
-	if (is_validaliasname($_POST['name']) == false) {
-		$input_errors[] = sprintf(gettext("The alias name may only consist of the characters %s"), "a-z, A-Z, 0-9, _.");
+	if (!is_validaliasname($_POST['name'])) {
+		$input_errors[] = invalidaliasnamemsg($_POST['name']);
 	}
 
 	/* check for name duplicates */

--- a/src/usr/local/www/firewall_schedule_edit.php
+++ b/src/usr/local/www/firewall_schedule_edit.php
@@ -125,13 +125,8 @@ if ($_POST) {
 		$input_errors[] = gettext("Schedule name cannot be blank.");
 	}
 
-	$x = is_validaliasname($_POST['name']);
-	if (!isset($x)) {
-		$input_errors[] = gettext("Reserved word used for schedule name.");
-	} else {
-		if (is_validaliasname($_POST['name']) == false) {
-			$input_errors[] = sprintf(gettext("The schedule name must be less than 32 characters long, may not consist of only numbers, may not consist of only underscores, and may only contain the following characters: %s"), 'a-z, A-Z, 0-9, _');
-		}
+	if (!is_validaliasname($_POST['name'])) {
+		$input_errors[] = invalidaliasnamemsg($_POST['name'], gettext("schedule"));
 	}
 
 	/* check for name conflicts */

--- a/src/usr/local/www/system_gateway_groups_edit.php
+++ b/src/usr/local/www/system_gateway_groups_edit.php
@@ -115,7 +115,7 @@ if ($_POST) {
 		$input_errors[] = gettext("A valid gateway group name must be specified.");
 	}
 	if (!is_validaliasname($_POST['name'])) {
-		$input_errors[] = gettext("The gateway name must not contain invalid characters.");
+		$input_errors[] = invalidaliasnamemsg($_POST['name'], gettext("gateway group"));
 	}
 
 	if (isset($_POST['name'])) {

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -147,7 +147,7 @@ if ($_POST) {
 		$input_errors[] = "A valid gateway name must be specified.";
 	}
 	if (!is_validaliasname($_POST['name'])) {
-		$input_errors[] = gettext("The gateway name must not contain invalid characters.");
+		$input_errors[] = invalidaliasnamemsg($_POST['name'], gettext("gateway"));
 	} else if (isset($_POST['disabled'])) {
 		// We have a valid gateway name that the user wants to mark as disabled.
 		// Check if the gateway name is used in any gateway group.


### PR DESCRIPTION
This standardizes all the code that uses is_validaliasname() so that it can also provide a customized message to tell the user what the particular problem is with the proposed "alias" name.
Note: This name validation is used by aliases, schedules, gateways and gateway groups.

The suggestion came from discussion in redmine issue 6273.