### PR TITLE
Fix checking of config.cache validity

### DIFF
--- a/src/etc/inc/config.lib.inc
+++ b/src/etc/inc/config.lib.inc
@@ -138,7 +138,7 @@ function parse_config($parse = false) {
 	if (!$parse) {
 		if (file_exists($g['tmp_path'] . '/config.cache')) {
 			$config = unserialize(file_get_contents($g['tmp_path'] . '/config.cache'));
-			if (is_null($config)) {
+			if (!is_array($config)) {
 				$parse = true;
 			}
 		} else {


### PR DESCRIPTION
Make sure $config contains something other than NULL or FALSE. Previously code would only check for NULL.

On previous implementation: If, for any reason, config.cache were corrupted, then unserialize would return FALSE and configuration would be considered parsed anyway.