### PR TITLE
Bug fixes to Route53 DynDNS

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -594,7 +594,7 @@
 
 					/* Setting Variables */
 					$hostname = "{$this->_dnsHost}.";
-					$ZoneID = $this->_dnsZoneID;
+					$ZoneID = trim($this->_dnsZoneID);
 					$AccessKeyId = $this->_dnsUser;
 					$SecretAccessKey = $this->_dnsPass;
 					$NewIP = $this->_dnsIP;
@@ -630,7 +630,7 @@
 					}
 
 					/* Check if we need to update DNS Record */
-					if ($OldIP !== $NewIP) {
+					if ($OldIP !== $NewIP || $OldTTL !== $NewTTL) {
 						if (!empty($OldIP)) {
 							/* Your Hostname already exists, deleting and creating it again */
 							$changes = array();


### PR DESCRIPTION
Fixed a bug regarding a leading space in $ZoneID that causes an AWS 505 error. Also adds support for updating DNS if TTL changes.