### PR TITLE
Removed global variables used on the version 2.2

### DIFF
--- a/src/etc/inc/rrd.inc
+++ b/src/etc/inc/rrd.inc
@@ -54,23 +54,6 @@
 
 /* include all configuration functions */
 
-global $rrd_graph_list;
-$rrd_graph_list = array("eighthour", "day", "week", "month", "quarter", "year", "fouryear");
-global $rrd_period_list;
-$rrd_period_list = array("absolute" => gettext("Absolute Timespans"), "current" => gettext("Current Period"), "previous" => gettext("Previous Period"));
-global $rrd_graph_length_list;
-$rrd_graph_length_list = array(
-	"eighthour" => 28800,
-	"day" => 86400,
-	"week" => 604800,
-	"month" => 2678400,
-	"quarter" => 7948800,
-	"year" => 31622400,
-	"fouryear" => 126230400);
-global $rrd_style_list;
-$rrd_style_list = array('inverse' => gettext('Inverse'),
-		'absolute' => gettext('Absolute'));
-
 function dump_rrd_to_xml($rrddatabase, $xmldumpfile) {
 	$rrdtool = "/usr/bin/nice -n20 /usr/local/bin/rrdtool";
 	unlink_if_exists($xmldumpfile);


### PR DESCRIPTION
Removed global vars that is not more used on this version in the file rrd.inc