### PR TITLE
 Display hostname on header

### DIFF
--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -484,6 +484,11 @@ if (($pagename === "index.php") && ($numColumns > 2)) {
 					endif;
 				?>
 					<li class="dropdown">
+                                                <a href="/index.php">
+                                                        <b class="dropdown"><?=$config['system']['hostname'] . "." . $config['system']['domain']?></b>
+                                                </a>
+                                        </li>
+					<li class="dropdown">
 						<a href="/index.php?logout">
 							<i class="fa fa-sign-out" title="<?=gettext("Log out")?>"></i>
 						</a>


### PR DESCRIPTION
It includes the hostname in the header next to the logout button.
This will facilitate the recognition of pfsense is operating.
![selecao_001](https://cloud.githubusercontent.com/assets/6098562/15084653/4e1e162c-13ab-11e6-99d4-dc762a48f232.png)

I had a similar feature in previous versions, so I brought it to the latest version.