### PR TITLE
Add missing recommended key lengths to OpenVPN options

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -103,7 +103,8 @@ $openvpn_verbosity_level = array(
 
 global $openvpn_dh_lengths;
 $openvpn_dh_lengths = array(
-	1024, 2048, 4096);
+	1024, 2048, 3072, 4096, 7680, 8192, 15360, 16384
+);
 
 global $openvpn_cert_depths;
 $openvpn_cert_depths = array(

--- a/src/usr/local/www/wizards/openvpn_wizard.xml
+++ b/src/usr/local/www/wizards/openvpn_wizard.xml
@@ -367,7 +367,7 @@
 		<field>
 			<name>keylength</name>
 			<displayname>Key length</displayname>
-			<description>&lt;br/&gt;Size of the key which will be generated. The larger the key, the more security it offers, but larger keys are generally slower to use.</description>
+			<description>&lt;br/&gt;Size of the key which will be generated. The larger the key, the more security it offers, but larger keys are generally slower to use. As of 2016, 2048 bit is the minimum and most common selection and 4096 is the maximum in common use. For more information see &lt;a href="https://keylength.com"&gt;keylength.com&lt;/a&gt;</description>
 			<type>select</type>
 			<value>2048</value>
 			<bindstofield>ovpnserver->step6->keylength</bindstofield>
@@ -385,8 +385,28 @@
 					<value>2048</value>
 				</option>
 				<option>
-					<name>4096 bit</name>
+					<name>3072 bit</name>
+					<value>3072</value>
+				</option>
+				<option>
+					<name>4096 bit (maximum commonly used as of 2016)</name>
 					<value>4096</value>
+				</option>
+				<option>
+					<name>7680 bit</name>
+					<value>7680</value>
+				</option>
+				<option>
+					<name>8192 bit</name>
+					<value>8192</value>
+				</option>
+				<option>
+					<name>15360 bit</name>
+					<value>15360</value>
+				</option>
+				<option>
+					<name>16384 bit</name>
+					<value>16384</value>
 				</option>
 			</options>
 		</field>

--- a/src/usr/local/www/wizards/openvpn_wizard.xml
+++ b/src/usr/local/www/wizards/openvpn_wizard.xml
@@ -367,7 +367,7 @@
 		<field>
 			<name>keylength</name>
 			<displayname>Key length</displayname>
-			<description>&lt;br/&gt;Size of the key which will be generated. The larger the key, the more security it offers, but larger keys are generally slower to use. As of 2016, 2048 bit is the minimum and most common selection and 4096 is the maximum in common use. For more information see &lt;a href="https://keylength.com"&gt;keylength.com&lt;/a&gt;</description>
+			<description>&lt;br/&gt;Size of the key which will be generated. The larger the key, the more security it offers, but larger keys are slower to generate and at the start of a session. As of 2016, 2048 bit is the minimum and most common selection and 4096 is the maximum in common use. For more information see &lt;a href="https://keylength.com"&gt;keylength.com&lt;/a&gt;</description>
 			<type>select</type>
 			<value>2048</value>
 			<bindstofield>ovpnserver->step6->keylength</bindstofield>

--- a/src/usr/local/www/wizards/openvpn_wizard.xml
+++ b/src/usr/local/www/wizards/openvpn_wizard.xml
@@ -389,7 +389,7 @@
 					<value>3072</value>
 				</option>
 				<option>
-					<name>4096 bit (maximum commonly used as of 2016)</name>
+					<name>4096 bit</name>
 					<value>4096</value>
 				</option>
 				<option>

--- a/src/usr/local/www/wizards/openvpn_wizard.xml
+++ b/src/usr/local/www/wizards/openvpn_wizard.xml
@@ -367,7 +367,7 @@
 		<field>
 			<name>keylength</name>
 			<displayname>Key length</displayname>
-			<description>&lt;br/&gt;Size of the key which will be generated. The larger the key, the more security it offers, but larger keys are slower to generate and at the start of a session. As of 2016, 2048 bit is the minimum and most common selection and 4096 is the maximum in common use. For more information see &lt;a href="https://keylength.com"&gt;keylength.com&lt;/a&gt;</description>
+			<description>&lt;br/&gt;Size of the key which will be generated. The larger the key, the more security it offers, but larger keys take considerably more time to generate, and take slightly longer to validate leading to a slight slowdown in setting up new sessions (not always noticeable). As of 2016, 2048 bit is the minimum and most common selection and 4096 is the maximum in common use. For more information see &lt;a href="https://keylength.com"&gt;keylength.com&lt;/a&gt;</description>
 			<type>select</type>
 			<value>2048</value>
 			<bindstofield>ovpnserver->step6->keylength</bindstofield>


### PR DESCRIPTION
Add key lengths to the OpenVPN options, for asymmetric keys of size 3072 (for current use), 7680, 15360 (for long term resistance), 8192 and 16384 (common binary exponents).

These are both supported by OpenVPN anyhow, and for certain uses are currently recommended (eg  long term resistance to replay/decryption). See keylength.com for citations. 

This PR would only affect OpenVPN, and OpenVPN supports these key sizes, so should not cause any issue.