### PR TITLE
Do not start Unbound while configuring track interface during boot

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3558,7 +3558,10 @@ function interface_track6_configure($interface = "lan", $wancfg, $linkupevent = 
 			require_once("services.inc");
 		}
 
-		if (isset($config['unbound']['enable'])) {
+		/* restart dnsmasq or unbound */
+		if (isset($config['dnsmasq']['enable'])) {
+			services_dnsmasq_configure();
+		} elseif (isset($config['unbound']['enable'])) {
 			services_unbound_configure();
 		}
 

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3553,7 +3553,7 @@ function interface_track6_configure($interface = "lan", $wancfg, $linkupevent = 
 			break;
 	}
 
-	if ($linkupevent == false) {
+	if ($linkupevent == false && !platform_booting()) {
 		if (!function_exists('services_dhcpd_configure')) {
 			require_once("services.inc");
 		}


### PR DESCRIPTION
This is part of ticket #6186.

Unbound and dhcpd services are started while configuring vlan and/or track interface. If track interface is also vlan then Unbound is started and then restarted because same function is called twice. This happens early on in the boot process before rc.bootup begins starting services.

On one of the systems I have Unbound starts and then gets restarted 4 times during the boot process.
1. while configuring VLANs via **interfaces_configure()->interfaces_vlan_configure()->interface_vlan_configure()->interface_configure()->interface_track6_configure()**
2. while configuring track interface via 
**interfaces_configure()->interface_configure()->interface_track6_configure()**
3. direct call to services_unbound_configure() by rc.bootup
4. direct call to services_unbound_configure() by rc.newwanip
5. while configuring track interface by rc.newwanipv6 via **link_interface_to_track6()->interface_track6_configure()**

This patch will prevent items 1, 2 and 5 from being executed.

I also added support for dnsmasq while I was in here. 



