### PR TITLE
Add missing recommended key lengths/digest to Cert system

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -56,7 +56,7 @@ define("OPEN_SSL_CONF_PATH", "/etc/ssl/openssl.cnf");
 require_once("functions.inc");
 
 global $openssl_digest_algs;
-$openssl_digest_algs = array("sha1", "sha224", "sha256", "sha384", "sha512");
+$openssl_digest_algs = array("sha1", "sha224", "sha256", "sha384", "sha512", "whirlpool");
 
 global $openssl_crl_status;
 $openssl_crl_status = array(

--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -69,8 +69,8 @@ $ca_methods = array(
 	"internal" => gettext("Create an internal Certificate Authority"),
 	"intermediate" => gettext("Create an intermediate Certificate Authority"));
 
-$ca_keylens = array("512", "1024", "2048", "4096");
-$openssl_digest_algs = array("sha1", "sha224", "sha256", "sha384", "sha512");
+$ca_keylens = array("512", "1024", "2048", "3072", "4096", "7680", "8192", "15360", "16384");
+$openssl_digest_algs = array("sha1", "sha224", "sha256", "sha384", "sha512", "whirlpool");
 
 if (is_numericint($_GET['id'])) {
 	$id = $_GET['id'];

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -70,13 +70,13 @@ $cert_methods = array(
 	"external" => gettext("Create a Certificate Signing Request"),
 );
 
-$cert_keylens = array("512", "1024", "2048", "4096");
+$cert_keylens = array("512", "1024", "2048", "3072", "4096", "7680", "8192", "15360", "16384");
 $cert_types = array(
 	"server" => "Server Certificate",
 	"user" => "User Certificate");
 
 $altname_types = array("DNS", "IP", "email", "URI");
-$openssl_digest_algs = array("sha1", "sha224", "sha256", "sha384", "sha512");
+$openssl_digest_algs = array("sha1", "sha224", "sha256", "sha384", "sha512", "whirlpool");
 
 if (is_numericint($_GET['userid'])) {
 	$userid = $_GET['userid'];

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -805,9 +805,14 @@ if ($act == "new" || $act == "edit" || $input_errors):
 					512 => '512 bits',
 					1024 => '1024 bits',
 					2048 => '2048 bits',
+					3072 => '3072 bits',
 					4096 => '4096 bits',
+					7680 => '7680 bits',
+					8192 => '8192 bits',
+					15360 => '15360 bits',
+					16384 => '16384 bits'
 				)
-			));
+			))->setHelp('The larger the key, the more security it offers, but larger keys take considerably more time to generate, and take slightly longer to validate leading to a slight slowdown in setting up new sessions (not always noticeable). As of 2016, 2048 bit is the minimum and most common selection and 4096 is the maximum in common use. For more information see &lt;a href="https://keylength.com"&gt;keylength.com&lt;/a&gt;.');
 
 			$section->addInput(new Form_Input(
 				'lifetime',


### PR DESCRIPTION
Add missing key lengths to the certificate management pages, for keys of size 3072 (for current use), 7680, 15360 (for long term resistance), 8192 and 16384 (common binary exponents), and the missing digest "whirlpool".

The key lengths are supported by OpenSSL and for certain uses are currently recommended (eg long term resistance to replay/decryption). See keylength.com for citations.

The "whirlpool" digest is the only non-SHA1/2/3 family digest to be recommended and is especially valuable for users wishing to avoid the SHA families (for whatever reason).

Files changed - user manager, cert manager, ca manager, certs.inc