### PR TITLE
Hide CIDR for alias types that do not use it

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -774,7 +774,17 @@ events.push(function() {
 
 		disable_subnets = (tab == 'host') || (tab == 'port') || (tab == 'url') || (tab == 'url_ports');
 
+		// Enable/disable address_subnet so its value gets POSTed or not, as appropriate.
 		$("[id^='address_subnet']").prop("disabled", disable_subnets);
+
+		// Show or hide the actual address_subnet field and put in the slash, or not.
+		if (disable_subnets) {
+			$("[id^='address_subnet']").hide();
+			$('.pfIpMask').html('');
+		} else {
+			$("[id^='address_subnet']").show();
+			$('.pfIpMask').html('/');
+		}
 
 		// Set the help text to match the tab
 		var helparray = <?=json_encode($help);?>;


### PR DESCRIPTION
Suggested/discussed in forum https://forum.pfsense.org/index.php?topic=111593.0
Note: This solution hides the CIDR entry dropdown and changes the grey-shaded box pfIpMask with the "/" to be empty. The grey-shaded box has a "span" which makes the preceding text box (for the port number, IP address, FQDN...) stretch out across the available column space - which is good.
If I hide the whole pfIpMask then both the slash and the whole grey-shaded box go away, but it the span effect is also lost.
So this solution leaves a little grey-shaded empty box between Port and Description fields.
If someone has an even better way to enhance this, go for it. I didn't want to mess with the underlying form class code.