### PR TITLE
Miscellanous Textual Corrections - Add missing dots, normalize case

### DIFF
--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1030,21 +1030,21 @@ $section->addInput(new Form_IpAddress(
 	'ddnsdomainprimary',
 	'Primary DDNS address',
 	$pconfig['ddnsdomainprimary']
-))->setHelp('Primary domain name server IP address for the dynamic domain name');
+))->setHelp('Primary domain name server IP address for the dynamic domain name.');
 
 $section->addInput(new Form_Input(
 	'ddnsdomainkeyname',
 	'DNS Domain key',
 	'text',
 	$pconfig['ddnsdomainkeyname']
-))->setHelp('Dynamic DNS domain key name which will be used to register client names in the DNS server');
+))->setHelp('Dynamic DNS domain key name which will be used to register client names in the DNS server.');
 
 $section->addInput(new Form_Input(
 	'ddnsdomainkey',
 	'DNS Domain key secret',
 	'text',
 	$pconfig['ddnsdomainkey']
-))->setHelp('Dynamic DNS domain key secret which will be used to register client names in the DNS server');
+))->setHelp('Dynamic DNS domain key secret which will be used to register client names in the DNS server.');
 
 // Advanced MAC
 $btnadv = new Form_Button(

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -718,7 +718,7 @@ $section->add($group);
 
 $section->addInput(new Form_Input(
 	'domain',
-	'Domain Name',
+	'Domain name',
 	'text',
 	$pconfig['domain']
 ))->setHelp('The default is to use the domain name of this system as the default domain name provided by DHCP. An alternate domain name may be specified here. ');

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -132,7 +132,7 @@ if ($_POST) {
 		$reqdfieldsn[] = gettext("Username");
 		if ($pconfig['type'] == "namecheap") {
 			$reqdfields[] = "domainname";
-			$reqdfieldsn[] = gettext("Domain Name");
+			$reqdfieldsn[] = gettext("Domain name");
 		}
 	} else {
 		$reqdfields[] = "updateurl";
@@ -327,7 +327,7 @@ $group->add(new Form_Input(
 ));
 $group->add(new Form_Input(
 	'domainname',
-	'Domain Name',
+	'Domain name',
 	'text',
 	$pconfig['domainname']
 ));


### PR DESCRIPTION
Further tweaks in continuation of PR #2953

Additionally, I've spotted some cases where the letter casing of ```Domain Name``` was inconsistent, so I have changed all to ```Domain name```. Hopefully that is correct.
See: [services_dhcp_edit](https://github.com/pfsense/pfsense/blob/RELENG_2_3_0/src/usr/local/www/services_dhcp_edit.php#L567) and [services_dhcp](https://github.com/pfsense/pfsense/blob/RELENG_2_3_0/src/usr/local/www/services_dhcp.php#L941) on 2.3.0

Thanks!