### PR TITLE
Make rule_columns_with_alias end params optional

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -1129,7 +1129,7 @@ function alias_info_popup($alias_id) {
 	return $content;
 }
 
-function rule_columns_with_alias($src, $srcport, $dst, $dstport, $target, $targetport) {
+function rule_columns_with_alias($src, $srcport, $dst, $dstport, $target="", $targetport="") {
 	global $config;
 
 	if ($config['aliases']['alias'] == "" || !is_array($config['aliases']['alias'])) {


### PR DESCRIPTION
Stops PHP warnings like reported in forum https://forum.pfsense.org/index.php?topic=111768.0