### PR TITLE
Customize limiter info message

### DIFF
--- a/src/etc/inc/shaper.inc
+++ b/src/etc/inc/shaper.inc
@@ -4667,9 +4667,14 @@ function build_iface_without_this_queue($iface, $qname) {
 }
 
 $default_shaper_msg = sprintf(gettext("Welcome to the %s Traffic Shaper."), $g['product_name']) . "<br />";
-$default_shaper_msg .= gettext("The tree on the left navigates through the queues.<br />"
-	. "Buttons at the bottom represent queue actions and are activated accordingly.");
-
 $dn_default_shaper_msg = $default_shaper_msg;
+
+$shaper_msg = gettext("The tree on the left navigates through the %s.");
+$default_shaper_msg .= sprintf($shaper_msg, gettext("queues")) . "<br />";
+$dn_default_shaper_msg .= sprintf($shaper_msg, gettext("limiters")) . "<br />";
+
+$shaper_msg = gettext("Buttons at the bottom represent %s actions and are activated accordingly.");
+$default_shaper_msg .= sprintf($shaper_msg, gettext("queue"));
+$dn_default_shaper_msg .= sprintf($shaper_msg, gettext("limiter"));
 
 ?>


### PR DESCRIPTION
The $dn_default_shaper_msg is what is displayed on the Limiters tab. It needs to talk about "limiter" rather than "queue".
This code builds up each message using the same base template sentences, inserting "queue" or "limiter" in the appropriate place.