### PR TITLE
Make limiters info box work same as By Interface

### DIFF
--- a/src/usr/local/www/firewall_shaper_vinterface.php
+++ b/src/usr/local/www/firewall_shaper_vinterface.php
@@ -432,9 +432,7 @@ display_top_tabs($tab_array);
 				<td>
 <?php
 
-if ($dfltmsg) {
-	print_info_box($dn_default_shaper_msg, 'info');
-} else {
+if (!$dfltmsg) {
 	// Add global buttons
 	if (!$dontshow || $newqueue) {
 		if ($can_add && ($action != "add")) {
@@ -481,7 +479,17 @@ if ($dfltmsg) {
 		</tbody>
 	</table>
 </div>
-
+<?php
+if ($dfltmsg) {
+?>
+<div>
+	<div class="infoblock">
+		<?php print_info_box($dn_default_shaper_msg, 'info', false); ?>
+	</div>
+</div>
+<?php
+}
+?>
 <script type="text/javascript">
 //<![CDATA[
 events.push(function() {


### PR DESCRIPTION
The info box displayed on Firewall->Shaper, By Interface come down the bottom with and info icon and can be shown/hidden by the user.
The similar info box on Firewall->Shaper, Limiters sits in the main body with no info icon and cannot be shown/hidden, but can be dismissed.
Make the info box on Firewall->Shaper, Limiters dispaly and owrk the same as on "By Interface".