### PR TITLE
Initialize output var in firewall_shaper_queues

### DIFF
--- a/src/usr/local/www/firewall_shaper_queues.php
+++ b/src/usr/local/www/firewall_shaper_queues.php
@@ -91,6 +91,7 @@ foreach ($qlist as $queue => $qkey) {
 	}
 }
 $tree .= "</ul>";
+$output = "";
 
 if ($_GET) {
 	if ($_GET['queue']) {


### PR DESCRIPTION
To clear any previous use of the var elsewhere in included files.
Forum: https://forum.pfsense.org/index.php?topic=111852.0