### PR TITLE
Reduce maximum length of string to gettext()

### DIFF
--- a/src/usr/local/www/classes/Form/Input.class.php
+++ b/src/usr/local/www/classes/Form/Input.class.php
@@ -246,7 +246,7 @@ class Form_Input extends Form_Element
 		if (isset($this->_help))
 		{
 			/* Strings longer than this will break gettext. */
-			if (strlen($this->_help) < 7620) {
+			if (strlen($this->_help) < 4096) {
 				$help = gettext($this->_help);
 			} else {
 				$help = $this->_help;


### PR DESCRIPTION
This limit is set at 4096 on PHP 5.6: http://lxr.php.net/xref/PHP_5_6/ext/gettext/gettext.c#139

Bug report on forum: https://forum.pfsense.org/index.php?topic=110088.0

Thanks!