### PR TITLE
Bug #6364 Memory increase, Bug#6367 LDAP timeout

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -881,7 +881,7 @@ function ldap_test_bind($authcfg) {
 		$ldapbindun = $authcfg['ldap_binddn'];
 		$ldapbindpw = $authcfg['ldap_bindpw'];
 		$ldapver = $authcfg['ldap_protver'];
-		$ldaptimeout = is_numeric($authcfg['ldap_timeout']) ? $authcfg['ldap_timeout'] : 25;
+		$ldaptimeout = is_numeric($authcfg['ldap_timeout']) ? $authcfg['ldap_timeout'] : 5;
 		if (empty($ldapbndun) || empty($ldapbindpw)) {
 			$ldapanon = true;
 		} else {
@@ -965,7 +965,7 @@ function ldap_get_user_ous($show_complete_ou=true, $authcfg) {
 		$ldapname = $authcfg['name'];
 		$ldapfallback = false;
 		$ldapscope = $authcfg['ldap_scope'];
-		$ldaptimeout = is_numeric($authcfg['ldap_timeout']) ? $authcfg['ldap_timeout'] : 25;
+		$ldaptimeout = is_numeric($authcfg['ldap_timeout']) ? $authcfg['ldap_timeout'] : 5;
 	} else {
 		return false;
 	}
@@ -1098,7 +1098,7 @@ function ldap_get_groups($username, $authcfg) {
 		$ldapname = $authcfg['name'];
 		$ldapfallback = false;
 		$ldapscope = $authcfg['ldap_scope'];
-		$ldaptimeout = is_numeric($authcfg['ldap_timeout']) ? $authcfg['ldap_timeout'] : 25;
+		$ldaptimeout = is_numeric($authcfg['ldap_timeout']) ? $authcfg['ldap_timeout'] : 5;
 	} else {
 		return false;
 	}
@@ -1241,7 +1241,7 @@ function ldap_backed($username, $passwd, $authcfg) {
 		$ldapver = $authcfg['ldap_protver'];
 		$ldapname = $authcfg['name'];
 		$ldapscope = $authcfg['ldap_scope'];
-		$ldaptimeout = is_numeric($authcfg['ldap_timeout']) ? $authcfg['ldap_timeout'] : 25;
+		$ldaptimeout = is_numeric($authcfg['ldap_timeout']) ? $authcfg['ldap_timeout'] : 5;
 	} else {
 		return false;
 	}

--- a/src/etc/inc/config.inc
+++ b/src/etc/inc/config.inc
@@ -69,11 +69,11 @@ if (!$ARCH) {
 	$ARCH = php_uname("m");
 }
 
-// Set memory limit to 256M on amd64.
+// Set memory limit to 512M on amd64.
 if ($ARCH == "amd64") {
-	ini_set("memory_limit", "256M");
+	ini_set("memory_limit", "512M"); //Change is required to accomodate pfsense 2.3.1
 } else {
-	ini_set("memory_limit", "128M");
+	ini_set("memory_limit", "256M");
 }
 
 /* include globals from notices.inc /utility/XML parser files */


### PR DESCRIPTION
PHP Fatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 32 bytes) in /usr/local/www/status_carp.php on line 261

So increasing the memory in the includes php file might solve the issue.