### PR TITLE
Services Status

### DIFF
--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -492,7 +492,7 @@ function get_service_status_icon($service, $withtext = true, $smallicon = false,
 	if (get_service_status($service)) {
 		$statustext = gettext("Running");
 		$text_class = "text-success";
-		$fa_class = "fa fa-circle-o-notch fa-spin";
+		$fa_class = "fa fa-play";
 		$fa_class_thumbs = "fa fa-thumbs-o-up";
 		$Thumbs_UpDown = "Thumbs up";
 	} else {

--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -486,27 +486,50 @@ function get_service_status($service) {
 	return $running;
 }
 
-function get_service_status_icon($service, $withtext = true, $smallicon = false) {
-	global $g;
+function get_service_status_icon($service, $withtext = true, $smallicon = false, $withthumbs = false, $title = "service_state") {
 	$output = "";
+
 	if (get_service_status($service)) {
 		$statustext = gettext("Running");
-		$output .= "<a title=\"" . sprintf(gettext("%s Service is"), $service["name"]) . " {$statustext}\" ><i class=\"";
-		$output .= ($smallicon) ? "fa fa-play" : "fa fa-lg fa-play";
-		$output .= "\" ></i></a>";
-		if ($withtext) {
-			$output .= "&nbsp;" . $statustext;
-		}
+		$text_class = "text-success";
+		$fa_class = "fa fa-circle-o-notch fa-spin";
+		$fa_class_thumbs = "fa fa-thumbs-o-up";
+		$Thumbs_UpDown = "Thumbs up";
 	} else {
-		$service_enabled = is_service_enabled($service['name']);
-		$statustext = ($service_enabled) ? gettext("Stopped") : gettext("Disabled");
-		$output .= "<a title=\"" . sprintf(gettext("%s Service is"), $service["name"]) . " {$statustext}\" ><i class=\"";
-		$output .= ($smallicon) ? "fa fa-times" : "fa fa-lg fa-times";
-		$output .= "\" ></i></a>";
-		if ($withtext) {
-			$output .= "&nbsp;" . $statustext;
+		if (is_service_enabled($service['name'])) {
+			$statustext = gettext("Stopped");
+			$text_class = "text-danger";
+			$fa_class = "fa fa-stop";
+		} else {
+			$statustext = gettext("Disabled");
+			$text_class = "text-warning";
+			$fa_class = "fa fa-ban";
 		}
+		$fa_class_thumbs = "fa fa-thumbs-o-down";
+		$Thumbs_UpDown = "Thumbs down";
 	}
+	$fa_size = ($smallicon) ? "fa-1x" : "fa-lg";
+
+	$spacer = ($withthumbs || $withtext) ? " " : "";
+	if ($title == "state") {
+		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"{$statustext}\"></i>{$spacer}";
+	} elseif ($title == "service_state") {
+		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"" . sprintf(gettext("%s Service is %s"), $service["name"], $statustext) . "\"></i>{$spacer}";
+	} elseif ($title == "description_state") {
+		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"" . sprintf(gettext("%s, %s Service is %s"), $service["description"], $statustext) . "\"></i>{$spacer}";
+	} elseif ($title == "description_service_state") {
+		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"" . sprintf(gettext("%s, %s Service is %s"), $service["description"], $service["name"], $statustext) . "\"></i>{$spacer}";
+	}
+
+	$spacer = ($withtext) ? " " : "";
+	if ($withthumbs) {
+		$output .= "<i class=\"{$text_class} {$fa_class_thumbs} {$fa_size}\" title=\"{$Thumbs_UpDown}\"></i>{$spacer}";
+	}
+
+	if ($withtext) {
+		$output .= "<span class=\"" . $text_class . "\">" . $statustext . "</span>";
+	}
+
 	return $output;
 }
 

--- a/src/usr/local/www/status_openvpn.php
+++ b/src/usr/local/www/status_openvpn.php
@@ -173,10 +173,12 @@ include("head.inc"); ?>
 						<td colspan="2">
 							<table>
 								<tr>
-									<td>
 										<?php $ssvc = find_service_by_openvpn_vpnid($server['vpnid']); ?>
-										<?= get_service_status_icon($ssvc, true, true); ?>
-										<?= get_service_control_links($ssvc); ?>
+									<td>
+										<?= gettext("Status") . ": " . get_service_status_icon($ssvc, false, true, false, "service_state"); ?>
+									</td>
+									<td>
+										<?= gettext("Actions") . ": " . get_service_control_links($ssvc); ?>
 									</td>
 								</tr>
 							</table>

--- a/src/usr/local/www/status_services.php
+++ b/src/usr/local/www/status_services.php
@@ -141,21 +141,11 @@ if (count($services) > 0) {
 						<td>
 							<?=$service['name']?>
 						</td>
-
 						<td>
 							<?=$service['description']?>
 						</td>
-<?php
-		// if service is running then listr else listbg
-		$bgclass = null;
-		$running = false;
-
-		if (get_service_status($service)) {
-			$running = true;
-		}
-?>
 						<td>
-							<?=$running ? '<span class="text-success">' . gettext("Running") . '</span>':'<span class="text-danger">' . gettext("Stopped") . '</span>'?>
+							<?= get_service_status_icon($service, false, true, false, "state"); ?>
 						</td>
 						<td>
 							<?=get_service_control_links($service)?>

--- a/src/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/services_status.widget.php
@@ -129,7 +129,7 @@ if (count($services) > 0) {
 		$service_desc = explode(".",$service['description']);
 ?>
 		<tr>
-			<td><i class="fa fa-<?=get_service_status($service) ? 'check-circle text-success' : 'times-circle text-warning'?>"></i></td>
+			<td><?=get_service_status_icon($service, false, true, false, "state")?></td>
 			<td><?=$service['dispname']?></td>
 			<td><?=$service_desc[0]?></td>
 			<td><?=get_service_control_links($service)?></td>


### PR DESCRIPTION
Get Service Status Function

Add option for thumbs up/down icon.
Add option to specify title contents.
Distinguish between Stopped and Disabled with icons and text classes.

Replace status indicator icon fa-play with animated fa-circle-notch.
Replace status indicator icon fa-times with fa-stop and fa-ban.

Re-factor code logic for greater output flexibility.  Can return many combinations of status icons and text based on the function call parameters.

Status / OpenVPN - Status Indicator

Add prefixes to Status and Actions.
Remove textual status.  Icon and title should be fine.

Status / Services - Status Indicator

Use status icon instead of text.  Icon and title should be fine.