### PR TITLE
Miscellaneous  Textual Correction - System / Advanced / Networking

### DIFF
--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -215,7 +215,7 @@ $group->add(new Form_Input(
 	$pconfig['ipv6nat_ipaddr']
 ))->setHelp('Enable IPv4 NAT encapsulation of IPv6 packets. <br/>This provides an '.
 	'RFC 2893 compatibility mechanism that can be used to tunneling IPv6 packets over '.
-	'IPv4 routing infrastructures. If enabled, don"t forget to add a firewall rule to '.
+	'IPv4 routing infrastructures. If enabled, don\'t forget to add a firewall rule to '.
 	'permit IPv6 packets.');
 
 $section->add($group);


### PR DESCRIPTION
Use apostrophe instead of quote.