### PR TITLE
URL Table (Ports) File Comments

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -850,7 +850,8 @@ function filter_generate_aliases() {
 				// TODO: Change it when pf supports tables with ports
 				$urlfn = alias_expand_urltable($aliased['name']);
 				if ($urlfn) {
-					$aliases .= "{$aliased['name']} = \"{ " . preg_replace("/\n/", " ", file_get_contents($urlfn)) . " }\"\n";
+					$ports_tmp = parse_aliases_file($urlfn, "url_ports", "-1", false);
+					$aliases .= "{$aliased['name']} = \"{ " . preg_replace("/\n/", " ", implode("\n", $ports_tmp)) . " }\"\n";
 				}
 				break;
 			case "port":


### PR DESCRIPTION
Fix for bug #6395 that keeps full line comments of the downloaded file but strips them for the pf rules load.