### PR TITLE
Fix GUI timeout and csrf expiry handling when timeout=0 or unset

### DIFF
--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -112,7 +112,8 @@ $g = array(
 	"help_base_url" => "/help.php",
 	"pkg_prefix" => "pfSense-pkg-",
 	"default_timezone" => "Etc/UTC",
-	"language" => "en_US"
+	"language" => "en_US",
+	"default_gui_timeout" => 240
 );
 
 /* IP TOS flags */

--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -113,7 +113,7 @@ $g = array(
 	"pkg_prefix" => "pfSense-pkg-",
 	"default_timezone" => "Etc/UTC",
 	"language" => "en_US",
-	"default_gui_timeout" => 240
+	"default_gui_timeout_mins" => 240
 );
 
 /* IP TOS flags */

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -61,7 +61,7 @@
 if (!$nocsrf) {
 	function csrf_startup() {
 		csrf_conf('rewrite-js', '/csrf/csrf-magic.js');
-		$timeout_minutes = isset($config['system']['webgui']['session_timeout']) ? $config['system']['webgui']['session_timeout'] : 240;
+		$timeout_minutes = isset($config['system']['webgui']['session_timeout']) ? $config['system']['webgui']['session_timeout'] : $g['default_gui_timeout_mins'];
 		csrf_conf('expires', $timeout_minutes * 60);
 	}
 	require_once("csrf/csrf-magic.php");

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -56,9 +56,12 @@
  *
  */
 
-/* Include authentication routines */
-/* THIS MUST BE ABOVE ALL OTHER CODE */
-if (!$nocsrf) {
+/* Include authentication routines
+   THIS MUST BE ABOVE ALL OTHER CODE
+   $config currently uses: 
+   UNSET = default, 0 = no expiry, value > 0 for timeout in minutes 
+*/
+if (!$nocsrf && $config['system']['webgui']['session_timeout'] !== "0") {
 	function csrf_startup() {
 		csrf_conf('rewrite-js', '/csrf/csrf-magic.js');
 		$timeout_minutes = isset($config['system']['webgui']['session_timeout']) ? $config['system']['webgui']['session_timeout'] : $g['default_gui_timeout_mins'];

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -61,11 +61,15 @@
    $config currently uses: 
    UNSET = default, 0 = no expiry, value > 0 for timeout in minutes 
 */
-if (!$nocsrf && $config['system']['webgui']['session_timeout'] !== "0") {
+if (!$nocsrf) {
 	function csrf_startup() {
 		csrf_conf('rewrite-js', '/csrf/csrf-magic.js');
-		$timeout_minutes = isset($config['system']['webgui']['session_timeout']) ? max($config['system']['webgui']['session_timeout'], 1) : $g['default_gui_timeout_mins'];
-		csrf_conf('expires', $timeout_minutes * 60);
+		if (!isset($config['system']['webgui']['session_timeout'])) {
+			csrf_conf('expires', $g['default_gui_timeout_mins'] * 60);
+		} elseif ($config['system']['webgui']['session_timeout'] > 0) {
+			csrf_conf('expires', $config['system']['webgui']['session_timeout'] * 60);
+		}
+		// else it's set but zero, i.e. no gui timeout, so don't set csrf expiry
 	}
 	require_once("csrf/csrf-magic.php");
 }

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -68,8 +68,11 @@ if (!$nocsrf) {
 			csrf_conf('expires', $g['default_gui_timeout_mins'] * 60);
 		} elseif ($config['system']['webgui']['session_timeout'] > 0) {
 			csrf_conf('expires', $config['system']['webgui']['session_timeout'] * 60);
+		} else {
+			// else it's set but zero, i.e. no gui timeout, so set a very long csrf expiry of 50 years
+			// nsures no untoward side effects from alternatives of completely avoiding csrf_startup() or modifying csrf_magic.php
+			csrf_conf('expires', 50 * 31e6);
 		}
-		// else it's set but zero, i.e. no gui timeout, so don't set csrf expiry
 	}
 	require_once("csrf/csrf-magic.php");
 }

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -64,7 +64,7 @@
 if (!$nocsrf && $config['system']['webgui']['session_timeout'] !== "0") {
 	function csrf_startup() {
 		csrf_conf('rewrite-js', '/csrf/csrf-magic.js');
-		$timeout_minutes = isset($config['system']['webgui']['session_timeout']) ? $config['system']['webgui']['session_timeout'] : $g['default_gui_timeout_mins'];
+		$timeout_minutes = isset($config['system']['webgui']['session_timeout']) ? max($config['system']['webgui']['session_timeout'], 1) : $g['default_gui_timeout_mins'];
 		csrf_conf('expires', $timeout_minutes * 60);
 	}
 	require_once("csrf/csrf-magic.php");

--- a/src/usr/local/www/system_usermanager_settings.php
+++ b/src/usr/local/www/system_usermanager_settings.php
@@ -211,15 +211,22 @@ $form = new Form;
 
 $section = new Form_Section('Settings');
 
+// cope with non-exact hour timouts (for niceness!)
+$t  = $g['default_gui_timeout_mins'];
+if ($t >= 60) {
+	$t2 = intdiv($t, 60) . ' hours' . ($t % 60 <> 0 ? ' ' . ($t % 60) . ' minutes' : '') . ' (' . $t . ' minutes)';
+} else
+	$t2 = $t . ' minutes';
+}
+
 $section->addInput(new Form_Input(
 	'session_timeout',
 	'Session timeout',
 	'number',
 	$pconfig['session_timeout'],
 	[min => 0]
-))->setHelp('Time in minutes to expire idle management sessions. The default is 4 '.
-	'hours (240 minutes). Enter 0 to never expire sessions. NOTE: This is a security '.
-	'risk!');
+))->setHelp('Time in minutes to expire idle management sessions. Leave empty for the default timeout of ' . $t2 .
+	'. Enter 0 to never expire sessions. NOTE: Long and never-expiring sessions are a security risk!');
 
 $auth_servers = array();
 foreach (auth_get_authserver_list() as $auth_server) {


### PR DESCRIPTION
The gui timeout setting is handled inconsistently. 

- _system_usermanager_settings.php_ states that unset = default 240 mins and "0" = no timeout. But _guiconfig.inc_ treats "0" as zero minutes rather than a setting used to disable csrf expiry timeout
- _csrf_magic.php_ automatically sets the 'expires' variable = 7200. If guiconfig.inc doesn't explicitly set a value then this value might be used. This can never be correct handling (valid values are only default=240*60, user specified in $config or "never expire")

Fix:
 - add a $g['default_gui_timeout_mins'] = 240 to avoid a hard-coded value in multiple places;
 - ensure guiconfig.inc always sets a value for expiry, even if configured never to expire (in which case use 50 years or something) - see below. 
 - also clarify comment in system_usermanager_settings.php, and ensure it handles any possible future change to the default value displayed to the user (unlikely but still)

(**NOTE** - it could be changed more efficiently in csrf_magic.php where the expires default is first set, or by simply not calling csrf_start() in guiconfig.inc when non-expiry is configured. But the php file looks like a direct import from the csrf project so it's left unchanged, and it's not clear whether totally avoiding csrf_start() will have other side effects on session security, so I've instead chosen to set a very long timeout explicitly. If these are not issues then the handling should be changed from this PR for improved handling of never-expires and defaults)