### PR TITLE
Simplify config backup cache settings

### DIFF
--- a/src/etc/inc/config.lib.inc
+++ b/src/etc/inc/config.lib.inc
@@ -792,7 +792,7 @@ function cleanup_backupcache($lock = false) {
 	global $g;
 	$i = false;
 
-	$revisions = get_config_backup_count();
+	$revisions = intval(is_numericint($config['system']['backupcount']) ? $config['system']['backupcount'] : $g['default_config_backup_count']);
 
 	if (!$lock) {
 		$lockkey = lock('config');
@@ -995,17 +995,6 @@ function make_config_revision_entry($desc = null, $override_user = null) {
 	}
 	$revision['username'] = $username;
 	return $revision;
-}
-
-function get_config_backup_count() {
-	global $config, $g;
-	if (isset($config['system']['backupcount']) && is_numeric($config['system']['backupcount']) && ($config['system']['backupcount'] >= 0)) {
-		return intval($config['system']['backupcount']);
-	} elseif ($g['platform'] == "nanobsd") {
-		return 5;
-	} else {
-		return 30;
-	}
 }
 
 function pfSense_clear_globals() {

--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -151,11 +151,17 @@ if (file_exists("/etc/platform")) {
 	if ($g['platform'] == "nanobsd") {
 		$g['firmware_update_text']="pfSense-*.img.gz";
 		$g['hidebackupbeforeupgrade'] = true;
-
+		$g['default_config_backup_count'] = 5;
 	} else {
 		$g['firmware_update_text']="pfSense-*.tgz";
+		$g['default_config_backup_count'] = 30;
 	}
-}
+} else { 
+	// shouldn't happen but "just in case" no platform were detected 
+	$g['platform'] = 'undetected'; 
+	$g['default_config_backup_count'] = 30; 
+} 
+
 
 if (file_exists("{$g['etc_path']}/default-config-flavor")) {
 	$flavor_array = file("{$g['etc_path']}/default-config-flavor");

--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -186,14 +186,14 @@ if ($diff) {
 
 $form = new Form(false);
 
-$section = new Form_Section('Saved Configurations', 'savedconfig', COLLAPSIBLE|SEC_CLOSED);
+$section = new Form_Section('Configuration Backup Cache Settings', 'configsettings', COLLAPSIBLE|SEC_CLOSED);
 
 $section->addInput(new Form_Input(
 	'backupcount',
 	'Backup Count',
 	'number',
 	$config['system']['backupcount']
-))->setHelp('Maximum number of old configurations to keep. By default this is 30 for a full install or 5 on NanoBSD. ');
+))->setHelp('Maximum number of old configurations to keep in the cache. By default this is 30 for a full install or 5 on NanoBSD. ');
 
 $space = exec("/usr/bin/du -sh /conf/backup | /usr/bin/awk '{print $1;}'");
 

--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -64,7 +64,7 @@
 require("guiconfig.inc");
 
 if (isset($_POST['backupcount'])) {
-	if (is_numericint($_POST['backupcount']) && ($_POST['backupcount'] >= 0)) {
+	if (is_numericint($_POST['backupcount'])) {
 		$config['system']['backupcount'] = $_POST['backupcount'];
 		$changedescr = $config['system']['backupcount'];
 	} else {

--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -64,7 +64,7 @@
 require("guiconfig.inc");
 
 if (isset($_POST['backupcount'])) {
-	if (is_numeric($_POST['backupcount']) && ($_POST['backupcount'] >= 0)) {
+	if (is_numericint($_POST['backupcount']) && ($_POST['backupcount'] >= 0)) {
 		$config['system']['backupcount'] = $_POST['backupcount'];
 		$changedescr = $config['system']['backupcount'];
 	} else {
@@ -193,7 +193,7 @@ $section->addInput(new Form_Input(
 	'Backup Count',
 	'number',
 	$config['system']['backupcount']
-))->setHelp('Maximum number of old configurations to keep in the cache. By default this is 30 for a full install or 5 on NanoBSD. ');
+))->setHelp('Maximum number of old configurations to keep in the cache, 0 for no backups, or leave blank for the default value (' . $g['default_config_backup_count'] . ' for the current platform).');
 
 $space = exec("/usr/bin/du -sh /conf/backup | /usr/bin/awk '{print $1;}'");
 


### PR DESCRIPTION
 - Instead of hardcoded values of # of backups calculated at various points based on $g['platform'], we can set the correct value at the same time $g['platform'] is set. (Also ensures easy to modify in future)
 - Use is_numericint() at a couple of places where we are doing unnecessarily messy input checking of an expected int >= 0
 - function get_config_backup_count() redundant / removed from config.lib.inc (no need for it now revisions doesn't need calculating, and it was only used once in the codebase)
 - Better title for GUI config backup settings. Most pages call these tabs "Settings".  The hidden "Saved Configs" section looks like saved configs, it isn't obvious that it's actually a hidden settings tab
