### PR TITLE
Firewall / Aliases / Edit - New URL Table Alias Type

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -850,7 +850,7 @@ function filter_generate_aliases() {
 				// TODO: Change it when pf supports tables with ports
 				$urlfn = alias_expand_urltable($aliased['name']);
 				if ($urlfn) {
-					$ports_tmp = parse_aliases_file($urlfn, "url_ports", "-1", false);
+					$ports_tmp = parse_aliases_file($urlfn, "urltable_ports", "-1", false);
 					$aliases .= "{$aliased['name']} = \"{ " . preg_replace("/\n/", " ", implode("\n", $ports_tmp)) . " }\"\n";
 				}
 				break;

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2150,7 +2150,7 @@ function pfs_version_compare($cur_time, $cur_text, $remote) {
 	}
 	return $v;
 }
-function process_alias_urltable($name, $url, $freq, $forceupdate=false, $validateonly=false) {
+function process_alias_urltable($name, $type, $url, $freq, $forceupdate=false, $validateonly=false) {
 	global $g, $config;
 
 	$urltable_prefix = "/var/db/aliastables/";
@@ -2177,7 +2177,8 @@ function process_alias_urltable($name, $url, $freq, $forceupdate=false, $validat
 		if (download_file($url, $tmp_urltable_filename, $verify_ssl)) {
 			// Convert lines that begin with '$' or ';' to comments '#' instead of deleting them.
 			mwexec("/usr/bin/sed -i \"\" -E 's/^[[:space:]]*($|#|;)/#/g; /^#/!s/\;.*//g;' ". escapeshellarg($tmp_urltable_filename));
-			if (alias_get_type($name) == "urltable_ports") {
+			$type = ($type) ? $type : alias_get_type($name);	// If empty type passed, try to get it from config.
+			if ($type == "urltable_ports") {
 				$ports = parse_aliases_file($tmp_urltable_filename, "url_ports", "-1", true);
 				$ports = group_ports($ports, true);
 				file_put_contents($urltable_filename, implode("\n", $ports));

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2181,7 +2181,7 @@ function process_alias_urltable($name, $type, $url, $freq, $forceupdate=false, $
 			$type = ($type) ? $type : alias_get_type($name);	// If empty type passed, try to get it from config.
 
 			$parsed_contents = parse_aliases_file($tmp_urltable_filename, $type, "-1", true);
-			if ($type == "url_ports") {
+			if ($type == "urltable_ports") {
 				$parsed_contents = group_ports($parsed_contents, true);
 			}
 			if (is_array($parsed_contents)) {

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1957,8 +1957,8 @@ function parse_aliases_file($filename, $type = "url", $max_items = -1, $kflc = f
 			if (!empty($tmp_str)) {
 				$tmp = $tmp_str;
 			}
-			$valid = ($type == "url" && (is_ipaddr($tmp) || is_subnet($tmp))) ||
-				($type == "url_ports" && (is_port($tmp) || is_portrange($tmp)));
+			$valid = (($type == "url" || $type == "urltable") && (is_ipaddr($tmp) || is_subnet($tmp))) ||
+				(($type == "url_ports" || $type == "urltable_ports") && (is_port($tmp) || is_portrange($tmp)));
 			if ($valid) {
 				$items[] = $tmp;
 				if (count($items) == $max_items) {
@@ -2177,17 +2177,17 @@ function process_alias_urltable($name, $type, $url, $freq, $forceupdate=false, $
 		if (download_file($url, $tmp_urltable_filename, $verify_ssl)) {
 			// Convert lines that begin with '$' or ';' to comments '#' instead of deleting them.
 			mwexec("/usr/bin/sed -i \"\" -E 's/^[[:space:]]*($|#|;)/#/g; /^#/!s/\;.*//g;' ". escapeshellarg($tmp_urltable_filename));
+
 			$type = ($type) ? $type : alias_get_type($name);	// If empty type passed, try to get it from config.
-			if ($type == "urltable_ports") {
-				$ports = parse_aliases_file($tmp_urltable_filename, "url_ports", "-1", true);
-				$ports = group_ports($ports, true);
-				file_put_contents($urltable_filename, implode("\n", $ports));
-			} else {
-				$urltable = parse_aliases_file($tmp_urltable_filename, "url", "-1", true);
-				if (is_array($urltable)) {
-					file_put_contents($urltable_filename, implode("\n", $urltable));
-				}
+
+			$parsed_contents = parse_aliases_file($tmp_urltable_filename, $type, "-1", true);
+			if ($type == "url_ports") {
+				$parsed_contents = group_ports($parsed_contents, true);
 			}
+			if (is_array($parsed_contents)) {
+				file_put_contents($urltable_filename, implode("\n", $parsed_contents));
+			}
+
 			/* If this backup is still there on a full install, but we aren't going to use ram disks, remove the archive since this is a transition. */
 			if (($g['platform'] == $g['product_name']) && !isset($config['system']['use_mfs_tmpvar'])) {
 				unlink_if_exists("{$g['cf_conf_path']}/RAM_Disk_Store{$urltable_filename}.tgz");

--- a/src/etc/rc.update_urltables
+++ b/src/etc/rc.update_urltables
@@ -49,7 +49,7 @@ if (count($todo) > 0) {
 			continue;
 		}
 
-		$r = process_alias_urltable($t['name'], $t['url'], $t['freq'], $forceupdate);
+		$r = process_alias_urltable($t['name'], $t['type'], $t['url'], $t['freq'], $forceupdate);
 		if ($r == 1) {
 			$result = "";
 			// TODO: Change it when pf supports tables with ports

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -206,6 +206,7 @@ if ($_POST) {
 	$address = array();
 	$final_address_details = array();
 	$alias['name'] = $_POST['name'];
+	$alias['type'] = $_POST['type'];
 
 	if (preg_match("/urltable/i", $_POST['type'])) {
 		$address = "";
@@ -219,7 +220,7 @@ if ($_POST) {
 			$alias['updatefreq'] = $_POST['address_subnet0'] ? $_POST['address_subnet0'] : 7;
 			if (!is_URL($alias['url']) || empty($alias['url'])) {
 				$input_errors[] = gettext("A valid URL must be provided.");
-			} elseif (!process_alias_urltable($alias['name'], $alias['url'], 0, true, true)) {
+			} elseif (!process_alias_urltable($alias['name'], $alias['type'], $alias['url'], 0, true, true)) {
 				$input_errors[] = gettext("Unable to fetch usable data from URL") . " " . htmlspecialchars($alias['url']);
 			}
 			if ($_POST["detail0"] <> "") {


### PR DESCRIPTION
Need to pass alias type to process_alias_urltable() function when creating a new url table alias because it is not yet set/available from config.  So the alias_get_type() function can't be successfully used yet.