### PR TITLE
Relax Suhosin to allow a 512M memory limit

### DIFF
--- a/src/etc/rc.php_ini_setup
+++ b/src/etc/rc.php_ini_setup
@@ -273,7 +273,7 @@ suhosin.post.max_value_length = 500000
 suhosin.request.max_array_index_length = 256
 suhosin.request.max_vars = 5000
 suhosin.request.max_value_length = 500000
-suhosin.memory_limit = 512435456
+suhosin.memory_limit = 536870912
 
 EOF
 


### PR DESCRIPTION
Because b20c7ef13d47d058bdea845c3b28503529e153fd and PHP uses 1024 multiples.