### PR TITLE
Simplify convert_seconds_to_hms() and show days for large numbers of hours

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1144,27 +1144,17 @@ function is_pppoe_server_enabled() {
 	return $pppoeenable;
 }
 
-function convert_seconds_to_hms($sec) {
-	$min = $hrs = 0;
-	if ($sec != 0) {
-		$min = floor($sec/60);
-		$sec %= 60;
+function convert_seconds_to_dhms($sec) {
+	if (!is_numericint($sec)) {
+		return '-';
 	}
-	if ($min != 0) {
-		$hrs = floor($min/60);
-		$min %= 60;
-	}
-	if ($sec < 10) {
-		$sec = "0".$sec;
-	}
-	if ($min < 10) {
-		$min = "0".$min;
-	}
-	if ($hrs < 10) {
-		$hrs = "0".$hrs;
-	}
-	$result = $hrs.":".$min.":".$sec;
-	return $result;
+	// FIXME: When we move to PHP 7 we can use "intdiv($sec % X, Y)" etc
+	list($d, $h, $m, $s) = array(	(int)($sec/86400),
+					(int)(($sec % 86400)/3600),
+					(int)(($sec % 3600)/60),
+					$sec % 60
+				);
+	return ($d > 0 ? $d . 'd ' : '') . sprintf('%02d:%02d:%02d', $h, $m, $s);
 }
 
 /* Compute the total uptime from the ppp uptime log file in the conf directory */
@@ -1177,7 +1167,7 @@ function get_ppp_uptime($port) {
 		foreach ($uptime_data as $upt) {
 			$sec += substr($upt, 1 + strpos($upt, " "));
 		}
-		return convert_seconds_to_hms($sec);
+		return convert_seconds_to_dhms($sec);
 	} else {
 		$total_time = gettext("No history data found!");
 		return $total_time;
@@ -1351,7 +1341,7 @@ function get_interface_info($ifdescr) {
 
 	if (file_exists("{$g['varrun_path']}/{$link_type}_{$ifdescr}.pid")) {
 		$sec = trim(`/usr/local/sbin/ppp-uptime.sh {$ifinfo['if']}`);
-		$ifinfo['ppp_uptime'] = convert_seconds_to_hms($sec);
+		$ifinfo['ppp_uptime'] = convert_seconds_to_dhms($sec);
 	}
 
 	if ($ifinfo['status'] == "up") {

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1144,13 +1144,14 @@ function is_pppoe_server_enabled() {
 	return $pppoeenable;
 }
 
-function convert_seconds_to_dhms($sec) {
+/* Optional arg forces hh:mm:ss without days */
+function convert_seconds_to_dhms($sec, $showhoursonly = false) {
 	if (!is_numericint($sec)) {
 		return '-';
 	}
 	// FIXME: When we move to PHP 7 we can use "intdiv($sec % X, Y)" etc
-	list($d, $h, $m, $s) = array(	(int)($sec/86400),
-					(int)(($sec % 86400)/3600),
+	list($d, $h, $m, $s) = array(	(int)($showhoursonly ? 0 : $sec/86400),
+					(int)($showhoursonly ? $sec : $sec % 86400)/3600),
 					(int)(($sec % 3600)/60),
 					$sec % 60
 				);

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1151,7 +1151,7 @@ function convert_seconds_to_dhms($sec, $showhoursonly = false) {
 	}
 	// FIXME: When we move to PHP 7 we can use "intdiv($sec % X, Y)" etc
 	list($d, $h, $m, $s) = array(	(int)($showhoursonly ? 0 : $sec/86400),
-					(int)($showhoursonly ? $sec : $sec % 86400)/3600),
+					(int)(($showhoursonly ? $sec : $sec % 86400)/3600),
 					(int)(($sec % 3600)/60),
 					$sec % 60
 				);

--- a/src/usr/local/www/status_ipsec.php
+++ b/src/usr/local/www/status_ipsec.php
@@ -223,7 +223,7 @@ function print_ipsec_body() {
 
 			print("</td>\n");
 			print("<td>\n");
-			print(htmlspecialchars($ikesa['reauth-time']) . gettext(" seconds (") . convert_seconds_to_hms($ikesa['reauth-time']) . ")");
+			print(htmlspecialchars($ikesa['reauth-time']) . gettext(" seconds (") . convert_seconds_to_dhms($ikesa['reauth-time']) . ")");
 			print("</td>\n");
 			print("<td>\n");
 			print(htmlspecialchars($ikesa['encr-alg']));
@@ -245,7 +245,7 @@ function print_ipsec_body() {
 			print(ucfirst(htmlspecialchars($ikesa['state'])));
 
 			if ($ikesa['state'] == 'ESTABLISHED') {
-				print("<br/>" . htmlspecialchars($ikesa['established']) . gettext(" seconds (") . convert_seconds_to_hms($ikesa['established']) . gettext(") ago"));
+				print("<br/>" . htmlspecialchars($ikesa['established']) . gettext(" seconds (") . convert_seconds_to_dhms($ikesa['established']) . gettext(") ago"));
 			}
 
 			print("</span>");
@@ -333,9 +333,9 @@ function print_ipsec_body() {
 					print("</td>\n");
 					print("<td>\n");
 
-					print(gettext("Rekey: ") . htmlspecialchars($childsa['rekey-time']) . gettext(" seconds (") . convert_seconds_to_hms($childsa['rekey-time']) . ")");
-					print('<br/>' . gettext('Life: ') . htmlspecialchars($childsa['life-time']) . gettext(" seconds (") . convert_seconds_to_hms($childsa['life-time']) . ")");
-					print('<br/>' . gettext('Install: ') .htmlspecialchars($childsa['install-time']) . gettext(" seconds (") . convert_seconds_to_hms($childsa['install-time']) . ")");
+					print(gettext("Rekey: ") . htmlspecialchars($childsa['rekey-time']) . gettext(" seconds (") . convert_seconds_to_dhms($childsa['rekey-time']) . ")");
+					print('<br/>' . gettext('Life: ') . htmlspecialchars($childsa['life-time']) . gettext(" seconds (") . convert_seconds_to_dhms($childsa['life-time']) . ")");
+					print('<br/>' . gettext('Install: ') .htmlspecialchars($childsa['install-time']) . gettext(" seconds (") . convert_seconds_to_dhms($childsa['install-time']) . ")");
 
 
 					print("</td>\n");


### PR DESCRIPTION
If the time represented is large (eg uptime might be several months) then hours becomes unhelpful, Put simply, it's clearer and more intuitive/meaningful to show "4921:02:06" as "205d 01:02:06". (Leading "days" value isn't shown unless >=1 for simplicity)

Optional arg added forcing HH:MM:SS without days (old behaviour) even when it's a large number of hours, in case it's useful in some contexts.

Notes -

1) Function  simplified and all "if" statements removed
2) Input validity check before trying to convert format
3) Renamed to convert_seconds_to_dhms()