### PR TITLE
Add basic PHP info dump

### DIFF
--- a/src/usr/local/www/status.php
+++ b/src/usr/local/www/status.php
@@ -287,6 +287,13 @@ defCmdT("Installed OS Packages", "/usr/sbin/pkg info");
 defCmdT("System Devices-PCI", "/usr/sbin/pciconf -lvb");
 defCmdT("System Devices-USB", "/usr/sbin/usbconfig dump_device_desc");
 
+/* Basic PHP config + modules */
+defCmdT("PHP general config", "/usr/local/bin/php -r 'phpinfo(INFO_GENERAL | INFO-CONFIGURATION);'");
+defCmdT("PHP modules", "/usr/local/bin/php -r 'phpinfo(INFO_MODULES);'");
+
+
+/* generate page */
+
 exec("/bin/date", $dateOutput, $dateStatus);
 $currentDate = $dateOutput[0];
 


### PR DESCRIPTION
Although a "hidden" file, status.php is useful for debugging and development. 

With pfSense using a lot of PHP functionality, probably should include a section that dumps the key parts of phpinfo() for debugging/checking. Add at the end.