### PR TITLE
Add resetwebgui to developer shell

### DIFF
--- a/src/etc/phpshellsessions/resetwebgui
+++ b/src/etc/phpshellsessions/resetwebgui
@@ -1,0 +1,26 @@
+global $config;
+
+$config = parse_config(true);
+$default_theme = "pfSense.css";
+$default_columns = 2;
+$default_widgets = "system_information:col1:show,interfaces:col2:show";
+
+echo "Resetting webGUI:\n";
+echo "  Theme to " . $default_theme . "\n";
+echo "  Dashboard columns to " . $default_columns . "\n";
+echo "  Top navigation to scroll\n";
+echo "  Widgets to System Information and Interfaces\n";
+echo "...";
+
+$config['system']['webgui']['webguicss'] = $default_theme;
+$config['system']['webgui']['dashboardcolumns'] = $default_columns;
+
+if (isset($config['system']['webgui']['webguifixedmenu'])) {
+	unset($config['system']['webgui']['webguifixedmenu']);
+}
+
+$config['widgets']['sequence'] = $default_widgets;
+
+write_config("pfSsh.php reset webGUI");
+
+echo "done.\n";


### PR DESCRIPTION
This might be helpful to people if they have set the theme to something
that they are having trouble displaying, reading... or enabled some
widget that is not good or...
It allows them to get back to a known-working dashboard state, from
where they can try again with customizations.
Having something like this was suggested by stilez in amongst discussion
of features for https://github.com/pfsense/pfsense/pull/2989