### PR TITLE
Fix #6463 Dest net alias matching on page load

### DIFF
--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -804,7 +804,7 @@ events.push(function() {
         source: addressarray
     });
 
-    $('#dstbeginport_cust, #sourceport, #destination, #dstport').autocomplete({
+    $('#sourceport, #dstport').autocomplete({
         source: customarray
     });
 });


### PR DESCRIPTION
Do not set destination field to use customarray
Note: dstbeginport_cust does not exist on this page, so I got removed it here also to avoid future confusion.