### PR TITLE
Fix PHP Warning about invalid argument supplied for foreach

### DIFF
--- a/src/usr/local/www/system_groupmanager.php
+++ b/src/usr/local/www/system_groupmanager.php
@@ -193,9 +193,11 @@ if (isset($_POST['save'])) {
 	}
 
 	/* Check the POSTed members to ensure they are valid and exist */
-	foreach ($_POST['members'] as $newmember) {
-		if (!is_numeric($newmember) || empty(getUserEntryByUID($newmember))) {
-			$input_errors[] = gettext("One or more invalid group members was submitted.");
+	if(is_array($_POST['members'])) {
+		foreach ($_POST['members'] as $newmember) {
+			if (!is_numeric($newmember) || empty(getUserEntryByUID($newmember))) {
+				$input_errors[] = gettext("One or more invalid group members was submitted.");
+			}
 		}
 	}
 

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -214,9 +214,11 @@ if ($_POST['save']) {
 	}
 
 	/* Check the POSTed groups to ensure they are valid and exist */
-	foreach ($_POST['groups'] as $newgroup) {
-		if (empty(getGroupEntry($newgroup))) {
-			$input_errors[] = gettext("One or more invalid groups was submitted.");
+	if(is_array($_POST['groups'])) {
+		foreach ($_POST['groups'] as $newgroup) {
+			if (empty(getGroupEntry($newgroup))) {
+				$input_errors[] = gettext("One or more invalid groups was submitted.");
+			}
 		}
 	}
 


### PR DESCRIPTION
If _POST['members'] or _POST['groups'] is not set / none selected at GUI, it would give a warning on crash reporter (dev versions).

Here is the crash report prior to the fix (for reference purposes):
```
[13-Jun-2016 20:19:27 Etc/UTC] PHP Warning:  Invalid argument supplied for foreach() in /usr/local/www/system_usermanager.php on line 217
[13-Jun-2016 20:19:27 Etc/UTC] PHP Stack trace:
[13-Jun-2016 20:19:27 Etc/UTC] PHP   1. {main}() /usr/local/www/system_usermanager.php:0
[13-Jun-2016 20:19:41 Etc/UTC] PHP Warning:  Invalid argument supplied for foreach() in /usr/local/www/system_groupmanager.php on line 196
[13-Jun-2016 20:19:41 Etc/UTC] PHP Stack trace:
[13-Jun-2016 20:19:41 Etc/UTC] PHP   1. {main}() /usr/local/www/system_groupmanager.php:0
```

This PR fixes those problems.