### PR TITLE
Fix #6482 OpenVPN Redirect Gateway Option Causes GUI Issue

### DIFF
--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -1497,8 +1497,10 @@ events.push(function() {
 					hideInput('local_networkv6', true);
 					hideInput('topology', true);
 				} else {
-					hideInput('local_network', false);
-					hideInput('local_networkv6', false);
+					// For tunnel mode that is not shared key,
+					// the display status of local network fields depends on
+					// the state of the gwredir checkbox.
+					gwredir_change();
 					hideInput('topology', false);
 				}
 				break;


### PR DESCRIPTION
This fixes the GUI inconsistency reported in the referenced bug. On edit of an OpenVPN server that has tun mode, not shared key, and the gwredir checkbox checked, the local_network fields are shown, but actually they should be hidden (because that is what happens on first data entry when gwredir is checked).
At least this makes the GUI consistent. Then the other issues mentioned in Redmine feature 6483 can be addressed separately.