### PR TITLE
Fix Bug #6394 - Incorrect Output of Translation

### DIFF
--- a/src/usr/local/www/classes/Form/Checkbox.class.php
+++ b/src/usr/local/www/classes/Form/Checkbox.class.php
@@ -63,7 +63,7 @@ class Form_Checkbox extends Form_Input
 	{
 		$input = parent::_getInput();
 
-		if (!isset($this->_description))
+		if (empty($this->_description))
 			return $input;
 
 		return '<label class="chkboxlbl">'. $input .' '. htmlspecialchars(gettext($this->_description)) .'</label>';

--- a/src/usr/local/www/classes/Form/Group.class.php
+++ b/src/usr/local/www/classes/Form/Group.class.php
@@ -86,7 +86,7 @@ class Form_Group extends Form_Element
 
 	protected function _getHelp()
 	{
-		if (!isset($this->_help))
+		if (empty($this->_help))
 			return null;
 
 		$group = new Form_Element;

--- a/src/usr/local/www/classes/Form/Input.class.php
+++ b/src/usr/local/www/classes/Form/Input.class.php
@@ -243,7 +243,7 @@ class Form_Input extends Form_Element
 		if (!isset($this->_help) && '<div>' == $column)
 			return (string)$input;
 
-		if (isset($this->_help))
+		if (!empty($this->_help))
 		{
 			/* Strings longer than this will break gettext. */
 			if (strlen($this->_help) < 4096) {

--- a/src/usr/local/www/classes/Form/Section.class.php
+++ b/src/usr/local/www/classes/Form/Section.class.php
@@ -92,7 +92,12 @@ class Form_Section extends Form_Element
 	public function __toString()
 	{
 		$element = parent::__toString();
-		$title = htmlspecialchars(gettext($this->_title));
+
+		if (!empty(trim($this->_title)) || is_numeric($this->_title))
+			$title = htmlspecialchars(gettext($this->_title));
+		else
+			$title = '';
+
 		$body = implode('', $this->_groups);
 		$hdricon = "";
 		$bodyclass = '<div class="panel-body">';


### PR DESCRIPTION
Apparently gettext() does not behave correctly when passed an empty string, this commit ensures gettext() is called only with non-empty strings