### PR TITLE
fix rowhelper select_source empty combo

### DIFF
--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -301,7 +301,7 @@ function bootstrapTable($text) {
  * the specified element to $group
  */
 function display_row($trc, $value, $fieldname, $type, $rowhelper, $description, $ewidth = null) {
-	global $text, $group;
+	global $text, $group, $config;
 
 	switch ($type) {
 		case "input":


### PR DESCRIPTION
while using $config['installedpackage']{['...'] as source