### PR TITLE
Load actual value of webguihostnamemenu

### DIFF
--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -97,7 +97,7 @@ $pconfig['dashboardavailablewidgetspanel'] = isset($config['system']['webgui']['
 $pconfig['systemlogsfilterpanel'] = isset($config['system']['webgui']['systemlogsfilterpanel']);
 $pconfig['systemlogsmanagelogpanel'] = isset($config['system']['webgui']['systemlogsmanagelogpanel']);
 $pconfig['statusmonitoringsettingspanel'] = isset($config['system']['webgui']['statusmonitoringsettingspanel']);
-$pconfig['webguihostnamemenu'] = isset($config['system']['webgui']['webguihostnamemenu']);
+$pconfig['webguihostnamemenu'] = $config['system']['webgui']['webguihostnamemenu'];
 $pconfig['dnslocalhost'] = isset($config['system']['dnslocalhost']);
 
 if (!$pconfig['timezone']) {


### PR DESCRIPTION
This is a string from a list of valid values (empty, "hostonly", "fqdn"). So it is not correct to just gather a true/false value here.