### PR TITLE
Feature #6388 custom GUI preference settings per user

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -1513,6 +1513,66 @@ function is_account_disabled($username) {
 	return false;
 }
 
+function get_user_settings($username) {
+	global $config;
+	$settings = array();
+	$settings['widgets'] = $config['widgets'];
+	$settings['webgui']['dashboardcolumns'] = $config['system']['webgui']['dashboardcolumns'];
+	$settings['webgui']['webguihostnamemenu'] = $config['system']['webgui']['webguihostnamemenu'];
+	$settings['webgui']['webguicss'] = $config['system']['webgui']['webguicss'];
+	$settings['webgui']['dashboardavailablewidgetspanel'] = isset($config['system']['webgui']['dashboardavailablewidgetspanel']);
+	$settings['webgui']['webguifixedmenu'] = isset($config['system']['webgui']['webguifixedmenu']);
+	$settings['webgui']['webguileftcolumnhyper'] = isset($config['system']['webgui']['webguileftcolumnhyper']);
+	$settings['webgui']['systemlogsfilterpanel'] = isset($config['system']['webgui']['systemlogsfilterpanel']);
+	$settings['webgui']['systemlogsmanagelogpanel'] = isset($config['system']['webgui']['systemlogsmanagelogpanel']);
+	$settings['webgui']['statusmonitoringsettingspanel'] = isset($config['system']['webgui']['statusmonitoringsettingspanel']);
+	$settings['webgui']['pagenamefirst'] = isset($config['system']['webgui']['pagenamefirst']);
+	$user = getUserEntry($username);
+	if (isset($user['customsettings'])) {
+		$settings['customsettings'] = true;
+		if (isset($user['widgets'])) {
+			// This includes the 'sequence', and any widgetname-config per-widget settings.
+			$settings['widgets'] = $user['widgets'];
+		}
+		if (isset($user['dashboardcolumns'])) {
+			$settings['webgui']['dashboardcolumns'] = $user['dashboardcolumns'];
+		}
+		if (isset($user['webguicss'])) {
+			$settings['webgui']['webguicss'] = $user['webguicss'];
+		}
+		if (isset($user['webguihostnamemenu'])) {
+			$settings['webgui']['webguihostnamemenu'] = $user['webguihostnamemenu'];
+		}
+		$settings['webgui']['dashboardavailablewidgetspanel'] = isset($user['dashboardavailablewidgetspanel']);
+		$settings['webgui']['webguifixedmenu'] = isset($user['webguifixedmenu']);
+		$settings['webgui']['webguileftcolumnhyper'] = isset($user['webguileftcolumnhyper']);
+		$settings['webgui']['systemlogsfilterpanel'] = isset($user['systemlogsfilterpanel']);
+		$settings['webgui']['systemlogsmanagelogpanel'] = isset($user['systemlogsmanagelogpanel']);
+		$settings['webgui']['statusmonitoringsettingspanel'] = isset($user['statusmonitoringsettingspanel']);
+		$settings['webgui']['pagenamefirst'] = isset($user['pagenamefirst']);
+	} else {
+		$settings['customsettings'] = false;
+	}
+
+	if ($settings['webgui']['dashboardcolumns'] < 1) {
+		$settings['webgui']['dashboardcolumns'] = 2;
+	}
+
+	return $settings;
+}
+
+function save_widget_settings($username, $settings) {
+	global $config, $userindex;
+	$user = getUserEntry($username);
+	if (isset($user['customsettings'])) {
+		$config['system']['user'][$userindex[$username]]['widgets'] = $settings;
+		write_config(sprintf(gettext("Widget configuration has been changed for user %s."), $username));
+	} else {
+		$config['widgets'] = $settings;
+		write_config(gettext("Widget configuration has been changed."));
+	}
+}
+
 function auth_get_authserver($name) {
 	global $config;
 

--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -72,6 +72,11 @@ if (!session_auth()) {
 $allowedpages = getAllowedPages($_SESSION['Username'], $_SESSION['user_radius_attributes']);
 
 /*
+ * Get user-based preference settings so they can be easily referenced.
+ */
+$user_settings = get_user_settings($_SESSION['Username']);
+
+/*
  * redirect to first allowed page if requesting a wrong url
  */
 
@@ -123,7 +128,7 @@ session_commit();
  * determine if the user is allowed access to the requested page
  */
 function display_error_form($http_code, $desc) {
-	global $config, $g;
+	global $config, $user_settings, $g;
 
 	if (isAjax()) {
 		printf(gettext('Error: %1$s Description: %2$s'), $http_code, $desc);
@@ -132,11 +137,11 @@ function display_error_form($http_code, $desc) {
 
 	$cssfile = "/css/pfSense.css";
 
-	if (isset($config['system']['webgui']['webguicss'])) {
-	if (file_exists("/usr/local/www/css/" . $config['system']['webgui']['webguicss'])) {
-		$cssfile = "/css/" . $config['system']['webgui']['webguicss'];
+	if (isset($user_settings['webgui']['webguicss'])) {
+		if (file_exists("/usr/local/www/css/" . $user_settings['webgui']['webguicss'])) {
+			$cssfile = "/css/" . $user_settings['webgui']['webguicss'];
+		}
 	}
-}
 
 ?>
 <!DOCTYPE html>
@@ -234,11 +239,14 @@ if ($local_ip == false) {
 	}
 }
 
+// For the login form, get the settings of no particular user.
+// That ensures we will use the system default theme for the login form.
+$user_settings = get_user_settings("");
 $cssfile = "/css/pfSense.css";
 
-if (isset($config['system']['webgui']['webguicss'])) {
-	if (file_exists("/usr/local/www/css/" . $config['system']['webgui']['webguicss'])) {
-		$cssfile = "/css/" . $config['system']['webgui']['webguicss'];
+if (isset($user_settings['webgui']['webguicss'])) {
+	if (file_exists("/usr/local/www/css/" . $user_settings['webgui']['webguicss'])) {
+		$cssfile = "/css/" . $user_settings['webgui']['webguicss'];
 	}
 }
 

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -162,6 +162,242 @@ function get_dns_servers() {
 	return array_unique($dns_servers);
 }
 
+/****f* pfsense-utils/get_css_files
+ * NAME
+ *   get_css_files - get a list of the available CSS files (themes)
+ * INPUTS
+ *   none
+ * RESULT
+ *   $csslist - an array of the CSS files
+ ******/
+function get_css_files() {
+	$csslist = array();
+
+	// List pfSense files, then any BETA files followed by any user-contributed files
+	$cssfiles = glob("/usr/local/www/css/*.css");
+
+	if (is_array($cssfiles)) {
+		arsort($cssfiles);
+		$usrcss = $pfscss = $betacss = array();
+
+		foreach ($cssfiles as $css) {
+			if (strpos($css, "BETA") != 0) {
+				array_push($betacss, $css);
+			} else if (strpos($css, "pfSense") != 0) {
+				array_push($pfscss, $css);
+			} else {
+				array_push($usrcss, $css);
+			}
+		}
+
+		$css = array_merge($pfscss, $betacss, $usrcss);
+
+		foreach ($css as $file) {
+			$file = basename($file);
+			$csslist[$file] = pathinfo($file, PATHINFO_FILENAME);
+		}
+	}
+	return $csslist;
+}
+
+/****f* pfsense-utils/gen_webguicss_field
+ * NAME
+ *   gen_webguicss_field
+ * INPUTS
+ *   Pointer to section object
+ *   Initial value for the field
+ * RESULT
+ *   no return value, section object is updated
+ ******/
+function gen_webguicss_field(&$section, $value) {
+
+	$csslist = get_css_files();
+
+	if (!isset($csslist[$value])) {
+		$value = "pfSense.css";
+	}
+
+	$section->addInput(new Form_Select(
+		'webguicss',
+		'Theme',
+		$value,
+		$csslist
+	))->setHelp(sprintf(gettext('Choose an alternative css file (if installed) to change the appearance of the webConfigurator. css files are located in /usr/local/www/css/%s'), '<span id="csstxt"></span>'));
+}
+
+/****f* pfsense-utils/gen_webguifixedmenu_field
+ * NAME
+ *   gen_webguifixedmenu_field
+ * INPUTS
+ *   Pointer to section object
+ *   Initial value for the field
+ * RESULT
+ *   no return value, section object is updated
+ ******/
+function gen_webguifixedmenu_field(&$section, $value) {
+
+	$section->addInput(new Form_Select(
+		'webguifixedmenu',
+		'Top Navigation',
+		$value,
+		["" => gettext("Scrolls with page"), "fixed" => gettext("Fixed (Remains visible at top of page)")]
+	))->setHelp("The fixed option is intended for large screens only.");
+}
+
+/****f* pfsense-utils/gen_webguihostnamemenu_field
+ * NAME
+ *   gen_webguihostnamemenu_field
+ * INPUTS
+ *   Pointer to section object
+ *   Initial value for the field
+ * RESULT
+ *   no return value, section object is updated
+ ******/
+function gen_webguihostnamemenu_field(&$section, $value) {
+
+	$section->addInput(new Form_Select(
+		'webguihostnamemenu',
+		'Hostname in Menu',
+		$value,
+		["" => gettext("Default (No hostname)"), "hostonly" => gettext("Hostname only"), "fqdn" => gettext("Fully Qualified Domain Name")]
+	))->setHelp("Replaces the Help menu title in the Navbar with the system hostname or FQDN.");
+}
+
+/****f* pfsense-utils/gen_dashboardcolumns_field
+ * NAME
+ *   gen_dashboardcolumns_field
+ * INPUTS
+ *   Pointer to section object
+ *   Initial value for the field
+ * RESULT
+ *   no return value, section object is updated
+ ******/
+function gen_dashboardcolumns_field(&$section, $value) {
+
+	if (($value < 1) || ($value > 4)) {
+		$value = 2;
+	}
+
+	$section->addInput(new Form_Input(
+		'dashboardcolumns',
+		'Dashboard Columns',
+		'number',
+		$value,
+		[min => 1, max => 4]
+	));
+}
+
+/****f* pfsense-utils/gen_associatedpanels_fields
+ * NAME
+ *   gen_associatedpanels_fields
+ * INPUTS
+ *   Pointer to section object
+ *   Initial value for each of the fields
+ * RESULT
+ *   no return value, section object is updated
+ ******/
+function gen_associatedpanels_fields(&$section, $value1, $value2, $value3, $value4) {
+
+	$group = new Form_Group('Associated Panels Show/Hide');
+
+	$group->add(new Form_Checkbox(
+		'dashboardavailablewidgetspanel',
+		null,
+		'Available Widgets',
+		$value1
+		))->setHelp('Show the Available Widgets panel on the Dashboard.');
+
+	$group->add(new Form_Checkbox(
+		'systemlogsfilterpanel',
+		null,
+		'Log Filter',
+		$value2
+	))->setHelp('Show the Log Filter panel in System Logs.');
+
+	$group->add(new Form_Checkbox(
+		'systemlogsmanagelogpanel',
+		null,
+		'Manage Log',
+		$value3
+	))->setHelp('Show the Manage Log panel in System Logs.');
+
+	$group->add(new Form_Checkbox(
+		'statusmonitoringsettingspanel',
+		null,
+		'Monitoring Settings',
+		$value4
+	))->setHelp('Show the Settings panel in Status Monitoring.');
+
+	$group->setHelp('These options allow certain panels to be automatically hidden on page load. A control is provided in the title bar to un-hide the panel.');
+
+	$section->add($group);
+}
+
+/****f* pfsense-utils/gen_webguileftcolumnhyper_field
+ * NAME
+ *   gen_webguileftcolumnhyper_field
+ * INPUTS
+ *   Pointer to section object
+ *   Initial value for the field
+ * RESULT
+ *   no return value, section object is updated
+ ******/
+function gen_webguileftcolumnhyper_field(&$section, $value) {
+
+	$section->addInput(new Form_Checkbox(
+		'webguileftcolumnhyper',
+		'Left Column Labels',
+		'Active',
+		$value
+	))->setHelp('If selected, clicking a label in the left column will select/toggle the first item of the group.');
+}
+
+/****f* pfsense-utils/gen_pagenamefirst_field
+ * NAME
+ *   gen_pagenamefirst_field
+ * INPUTS
+ *   Pointer to section object
+ *   Initial value for the field
+ * RESULT
+ *   no return value, section object is updated
+ ******/
+function gen_pagenamefirst_field(&$section, $value) {
+
+	$section->addInput(new Form_Checkbox(
+		'pagenamefirst',
+		'Browser tab text',
+		'Display page name first in browser tab',
+		$value
+	))->setHelp('When this is unchecked, the browser tab shows the host name followed '.
+		'by the current page. Check this box to display the current page followed by the '.
+		'host name.');
+}
+
+/****f* pfsense-utils/gen_user_settings_fields
+ * NAME
+ *   gen_user_settings_fields
+ * INPUTS
+ *   Pointer to section object
+ *   Array of initial values for the fields
+ * RESULT
+ *   no return value, section object is updated
+ ******/
+function gen_user_settings_fields(&$section, $pconfig) {
+
+	gen_webguicss_field($section, $pconfig['webguicss']);
+	gen_webguifixedmenu_field($section, $pconfig['webguifixedmenu']);
+	gen_webguihostnamemenu_field($section, $pconfig['webguihostnamemenu']);
+	gen_dashboardcolumns_field($section, $pconfig['dashboardcolumns']);
+	gen_associatedpanels_fields(
+		$section,
+		$pconfig['dashboardavailablewidgetspanel'],
+		$pconfig['systemlogsfilterpanel'],
+		$pconfig['systemlogsmanagelogpanel'],
+		$pconfig['statusmonitoringsettingspanel']);
+	gen_webguileftcolumnhyper_field($section, $pconfig['webguileftcolumnhyper']);
+	gen_pagenamefirst_field($section, $pconfig['pagenamefirst']);
+}
+
 function hardware_offloading_applyflags($iface) {
 	global $config;
 

--- a/src/etc/inc/priv.defs.inc
+++ b/src/etc/inc/priv.defs.inc
@@ -1167,6 +1167,12 @@ $priv_list['page-system-update-settings']['descr'] = gettext("Allow access to th
 $priv_list['page-system-update-settings']['match'] = array();
 $priv_list['page-system-update-settings']['match'][] = "system_update_settings.php*";
 
+$priv_list['page-system-user-settings'] = array();
+$priv_list['page-system-user-settings']['name'] = gettext("WebCfg - System: User Settings");
+$priv_list['page-system-user-settings']['descr'] = gettext("Allow access to the 'System: User Settings' page.");
+$priv_list['page-system-user-settings']['match'] = array();
+$priv_list['page-system-user-settings']['match'][] = "system_user_settings.php*";
+
 $priv_list['page-system-usermanager'] = array();
 $priv_list['page-system-usermanager']['name'] = gettext("WebCfg - System: User Manager");
 $priv_list['page-system-usermanager']['descr'] = gettext("Allow access to the 'System: User Manager' page.");

--- a/src/usr/local/www/classes/Form/Group.class.php
+++ b/src/usr/local/www/classes/Form/Group.class.php
@@ -108,7 +108,7 @@ EOT;
 
 	public function __toString()
 	{
-		global $config;
+		global $config, $user_settings;
 
 		$element = parent::__toString();
 
@@ -142,7 +142,7 @@ EOT;
 		$inputs = implode('', $this->_inputs);
 		$help = $this->_getHelp();
 
-		if (!isset($config['system']['webgui']['webguileftcolumnhyper']))
+		if (!$user_settings['webgui']['webguileftcolumnhyper'])
 			$target = null;
 
 		$label = new Form_Element('label', false, ['for' => $target]);

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -60,7 +60,7 @@ header('Content-Type: text/html; charset=utf-8');
 
 $pagetitle = gentitle($pgtitle);
 
-if (isset($config['system']['webgui']['pagenamefirst'])) {
+if ($user_settings['webgui']['pagenamefirst']) {
 	$tabtitle = $pagetitle . " - " . htmlspecialchars($config['system']['hostname'] . "." . $config['system']['domain']);
 } else {
 	$tabtitle = htmlspecialchars($config['system']['hostname'] . "." . $config['system']['domain']) . " - " . $pagetitle;
@@ -68,9 +68,9 @@ if (isset($config['system']['webgui']['pagenamefirst'])) {
 
 $cssfile = "/css/pfSense.css";
 
-if (isset($config['system']['webgui']['webguicss'])) {
-	if (file_exists("/usr/local/www/css/" . $config['system']['webgui']['webguicss'])) {
-		$cssfile = "/css/" . $config['system']['webgui']['webguicss'];
+if (isset($user_settings['webgui']['webguicss'])) {
+	if (file_exists("/usr/local/www/css/" . $user_settings['webgui']['webguicss'])) {
+		$cssfile = "/css/" . $user_settings['webgui']['webguicss'];
 	}
 }
 
@@ -255,6 +255,10 @@ if (!isAllowedPage("system_usermanager.php*")) {
 	$system_menu[] = array(gettext("User Manager"), "/system_usermanager.php");
 }
 
+if ($user_settings['customsettings'] && isAllowedPage("system_user_settings.php*")) {
+	$system_menu[] = array(gettext("User Settings"), "/system_user_settings.php");
+}
+
 $system_menu = msort(array_merge($system_menu, return_ext_menu("System")), 0);
 
 // Interfaces
@@ -425,11 +429,11 @@ if (!$g['disablehelpmenu']) {
 
 $menuclass = "static";
 
-if (isset($config['system']['webgui']['webguifixedmenu'])) {
+if ($user_settings['webgui']['webguifixedmenu'] == "fixed") {
 	$menuclass = "fixed";
 }
 
-$numColumns = $config['system']['webgui']['dashboardcolumns'];
+$numColumns = $user_settings['webgui']['dashboardcolumns'];
 
 if (($pagename === "index.php") && ($numColumns > 2)) {
 	$columnsContainer = 'style="max-width: ' . 585*$numColumns . 'px;width: 100%"';
@@ -450,10 +454,10 @@ if (($pagename === "index.php") && ($numColumns > 2)) {
 		<div class="collapse navbar-collapse" id="pf-navbar">
 			<ul class="nav navbar-nav">
 			<?php
-                if ($config['system']['webgui']['webguihostnamemenu'] == 'hostonly') {
+                if ($user_settings['webgui']['webguihostnamemenu'] == 'hostonly') {
                     $help_menu_title = htmlspecialchars($config['system']['hostname']);
                 }
-                elseif ($config['system']['webgui']['webguihostnamemenu'] == 'fqdn') {
+                elseif ($user_settings['webgui']['webguihostnamemenu'] == 'fqdn') {
                     $help_menu_title = htmlspecialchars($config['system']['hostname'] . "." . $config['system']['domain']);
                 }
                 else {

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -155,15 +155,16 @@ if (!is_array($config['widgets'])) {
 
 if ($_POST && $_POST['sequence']) {
 
-	$config['widgets']['sequence'] = rtrim($_POST['sequence'], ',');
+	$widget_settings = array();
+	$widget_settings['sequence'] = rtrim($_POST['sequence'], ',');
 
 	foreach ($widgets as $widgetname => $widgetconfig) {
 		if ($_POST[$widgetname . '-config']) {
-			$config['widgets'][$widgetname . '-config'] = $_POST[$widgetname . '-config'];
+			$widget_settings[$widgetname . '-config'] = $_POST[$widgetname . '-config'];
 		}
 	}
 
-	write_config(gettext("Widget configuration has been changed."));
+	save_widget_settings($_SESSION['Username'], $widget_settings);
 	header("Location: /");
 	exit;
 }
@@ -251,9 +252,9 @@ if ($fd) {
 }
 
 ##build widget saved list information
-if ($config['widgets'] && $config['widgets']['sequence'] != "") {
-	$dashboardcolumns = isset($config['system']['webgui']['dashboardcolumns']) ? $config['system']['webgui']['dashboardcolumns'] : 2;
-	$pconfig['sequence'] = $config['widgets']['sequence'];
+if ($user_settings['widgets']['sequence'] != "") {
+	$dashboardcolumns = isset($user_settings['webgui']['dashboardcolumns']) ? $user_settings['webgui']['dashboardcolumns'] : 2;
+	$pconfig['sequence'] = $user_settings['widgets']['sequence'];
 	$widgetsfromconfig = array();
 
 	foreach (explode(',', $pconfig['sequence']) as $line) {
@@ -307,7 +308,7 @@ if ($config['widgets'] && $config['widgets']['sequence'] != "") {
 }
 
 ## Get the configured options for Show/Hide available widgets panel.
-$dashboard_available_widgets_hidden = isset($config['system']['webgui']['dashboardavailablewidgetspanel']) ? false : true;
+$dashboard_available_widgets_hidden = !$user_settings['webgui']['dashboardavailablewidgetspanel'];
 
 if ($dashboard_available_widgets_hidden) {
 	$panel_state = 'out';

--- a/src/usr/local/www/status_logs_common.inc
+++ b/src/usr/local/www/status_logs_common.inc
@@ -62,7 +62,7 @@ require_once("filter_log.inc");
 
 // Status Logs Common - Code
 function status_logs_common_code() {
-	global $g, $config, $specific_log, $nentries, $rawfilter, $filterlogentries_qty, $logfile_path, $shortcut_section, $allowed_logs, $logfile;
+	global $g, $config, $user_settings, $specific_log, $nentries, $rawfilter, $filterlogentries_qty, $logfile_path, $shortcut_section, $allowed_logs, $logfile;
 	global $system_logs_filter_form_hidden, $system_logs_manage_log_form_hidden, $view;
 
 	$logfile_path = "{$g['varlog_path']}/" . basename($logfile) . ".log";
@@ -91,8 +91,8 @@ function status_logs_common_code() {
 	}
 
 	// Get the configured options for Show/Hide Log Filter and Manage Log panels.
-	$system_logs_filter_form_hidden = isset($config['system']['webgui']['systemlogsfilterpanel']) ? false : true;
-	$system_logs_manage_log_form_hidden = isset($config['system']['webgui']['systemlogsmanagelogpanel']) ? false : true;
+	$system_logs_filter_form_hidden = !$user_settings['webgui']['systemlogsfilterpanel'];
+	$system_logs_manage_log_form_hidden = !$user_settings['webgui']['systemlogsmanagelogpanel'];
 
 	if ($logfile == 'filter' && $view == 'summary') {
 		$system_logs_filter_form_hidden = false;

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -97,7 +97,7 @@ $pconfig['dashboardavailablewidgetspanel'] = isset($config['system']['webgui']['
 $pconfig['systemlogsfilterpanel'] = isset($config['system']['webgui']['systemlogsfilterpanel']);
 $pconfig['systemlogsmanagelogpanel'] = isset($config['system']['webgui']['systemlogsmanagelogpanel']);
 $pconfig['statusmonitoringsettingspanel'] = isset($config['system']['webgui']['statusmonitoringsettingspanel']);
-$pconfig['webguihostnamemenu'] = isset($config['system']['webgui']['webguihostnamemenu']);
+$pconfig['webguihostnamemenu'] = $config['system']['webgui']['webguihostnamemenu'];
 $pconfig['dnslocalhost'] = isset($config['system']['dnslocalhost']);
 
 if (!$pconfig['timezone']) {
@@ -496,108 +496,19 @@ $section->addInput(new Form_Select(
 
 $form->add($section);
 
-$csslist = array();
-
-// List pfSense files, then any BETA files followed by any user-contributed files
-$cssfiles = glob("/usr/local/www/css/*.css");
-
-if(is_array($cssfiles)) {
-	arsort($cssfiles);
-	$usrcss = $pfscss = $betacss = array();
-
-	foreach ($cssfiles as $css) {
-	    if (strpos($css, "BETA") != 0) {
-	        array_push($betacss, $css);
-	    } else if (strpos($css, "pfSense") != 0) {
-	        array_push($pfscss, $css);
-	    } else {
-	        array_push($usrcss, $css);
-	    }
-	}
-
-	$css = array_merge($pfscss, $betacss, $usrcss);
-
-	foreach ($css as $file) {
-		$file = basename($file);
-		$csslist[$file] = pathinfo($file, PATHINFO_FILENAME);
-	}
-}
-
-if (!isset($pconfig['webguicss']) || !isset($csslist[$pconfig['webguicss']])) {
-	$pconfig['webguicss'] = "pfSense.css";
-}
-
 $section = new Form_Section('webConfigurator');
 
-$section->addInput(new Form_Select(
-	'webguicss',
-	'Theme',
-	$pconfig['webguicss'],
-	$csslist
-))->setHelp(sprintf(gettext('Choose an alternative css file (if installed) to change the appearance of the webConfigurator. css files are located in /usr/local/www/css/%s'), '<span id="csstxt"></span>'));
-
-$section->addInput(new Form_Select(
-	'webguifixedmenu',
-	'Top Navigation',
-	$pconfig['webguifixedmenu'],
-	["" => gettext("Scrolls with page"), "fixed" => gettext("Fixed (Remains visible at top of page)")]
-))->setHelp("The fixed option is intended for large screens only.");
-
-$section->addInput(new Form_Select(
-	'webguihostnamemenu',
-	'Hostname in Menu',
-	$pconfig['webguihostnamemenu'],
-	["" => gettext("Default (No hostname)"), "hostonly" => gettext("Hostname only"), "fqdn" => gettext("Fully Qualified Domain Name")]
-))->setHelp("Replaces the Help menu title in the Navbar with the system hostname or FQDN.");
-
-$section->addInput(new Form_Input(
-	'dashboardcolumns',
-	'Dashboard Columns',
-	'number',
-	$pconfig['dashboardcolumns'],
-	[min => 1, max => 4]
-));
-
-$group = new Form_Group('Associated Panels Show/Hide');
-
-$group->add(new Form_Checkbox(
-	'dashboardavailablewidgetspanel',
-	null,
-	'Available Widgets',
-	$pconfig['dashboardavailablewidgetspanel']
-	))->setHelp('Show the Available Widgets panel on the Dashboard.');
-
-$group->add(new Form_Checkbox(
-	'systemlogsfilterpanel',
-	null,
-	'Log Filter',
-	$pconfig['systemlogsfilterpanel']
-))->setHelp('Show the Log Filter panel in System Logs.');
-
-$group->add(new Form_Checkbox(
-	'systemlogsmanagelogpanel',
-	null,
-	'Manage Log',
-	$pconfig['systemlogsmanagelogpanel']
-))->setHelp('Show the Manage Log panel in System Logs.');
-
-$group->add(new Form_Checkbox(
-	'statusmonitoringsettingspanel',
-	null,
-	'Monitoring Settings',
-	$pconfig['statusmonitoringsettingspanel']
-))->setHelp('Show the Settings panel in Status Monitoring.');
-
-$group->setHelp('These options allow certain panels to be automatically hidden on page load. A control is provided in the title bar to un-hide the panel.');
-
-$section->add($group);
-
-$section->addInput(new Form_Checkbox(
-	'webguileftcolumnhyper',
-	'Left Column Labels',
-	'Active',
-	$pconfig['webguileftcolumnhyper']
-))->setHelp('If selected, clicking a label in the left column will select/toggle the first item of the group.');
+gen_webguicss_field($section, $pconfig['webguicss']);
+gen_webguifixedmenu_field($section, $pconfig['webguifixedmenu']);
+gen_webguihostnamemenu_field($section, $pconfig['webguihostnamemenu']);
+gen_dashboardcolumns_field($section, $pconfig['dashboardcolumns']);
+gen_associatedpanels_fields(
+	$section,
+	$pconfig['dashboardavailablewidgetspanel'],
+	$pconfig['systemlogsfilterpanel'],
+	$pconfig['systemlogsmanagelogpanel'],
+	$pconfig['statusmonitoringsettingspanel']);
+gen_webguileftcolumnhyper_field($section, $pconfig['webguileftcolumnhyper']);
 
 $form->add($section);
 

--- a/src/usr/local/www/system_advanced_admin.php
+++ b/src/usr/local/www/system_advanced_admin.php
@@ -472,14 +472,7 @@ $section->addInput(new Form_Checkbox(
 	'information on HTTP_REFERER is available from <a target="_blank" '.
 	'href="http://en.wikipedia.org/wiki/HTTP_referrer">Wikipedia</a>.');
 
-$section->addInput(new Form_Checkbox(
-	'pagenamefirst',
-	'Browser tab text',
-	'Display page name first in browser tab',
-	$pconfig['pagenamefirst']
-))->setHelp('When this is unchecked, the browser tab shows the host name followed '.
-	'by the current page. Check this box to display the current page followed by the '.
-	'host name.');
+gen_pagenamefirst_field($section, $pconfig['pagenamefirst']);
 
 $form->add($section);
 $section = new Form_Section('Secure Shell');

--- a/src/usr/local/www/system_user_settings.php
+++ b/src/usr/local/www/system_user_settings.php
@@ -1,0 +1,212 @@
+<?php
+/*
+	system_user_settings.php
+*/
+/* ====================================================================
+ *	Copyright (c)  2004-2015  Electric Sheep Fencing, LLC. All rights reserved.
+ *
+ *	Redistribution and use in source and binary forms, with or without modification,
+ *	are permitted provided that the following conditions are met:
+ *
+ *	1. Redistributions of source code must retain the above copyright notice,
+ *		this list of conditions and the following disclaimer.
+ *
+ *	2. Redistributions in binary form must reproduce the above copyright
+ *		notice, this list of conditions and the following disclaimer in
+ *		the documentation and/or other materials provided with the
+ *		distribution.
+ *
+ *	3. All advertising materials mentioning features or use of this software
+ *		must display the following acknowledgment:
+ *		"This product includes software developed by the pfSense Project
+ *		 for use in the pfSense software distribution. (http://www.pfsense.org/).
+ *
+ *	4. The names "pfSense" and "pfSense Project" must not be used to
+ *		 endorse or promote products derived from this software without
+ *		 prior written permission. For written permission, please contact
+ *		 coreteam@pfsense.org.
+ *
+ *	5. Products derived from this software may not be called "pfSense"
+ *		nor may "pfSense" appear in their names without prior written
+ *		permission of the Electric Sheep Fencing, LLC.
+ *
+ *	6. Redistributions of any form whatsoever must retain the following
+ *		acknowledgment:
+ *
+ *	"This product includes software developed by the pfSense Project
+ *	for use in the pfSense software distribution (http://www.pfsense.org/).
+ *
+ *	THIS SOFTWARE IS PROVIDED BY THE pfSense PROJECT ``AS IS'' AND ANY
+ *	EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *	IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *	PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE pfSense PROJECT OR
+ *	ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ *	STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ *	OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *	====================================================================
+ *
+ */
+
+##|+PRIV
+##|*IDENT=page-system-user-settings
+##|*NAME=System: User Settings
+##|*DESCR=Allow access to the 'System: User Settings' page.
+##|*MATCH=system_user_settings.php*
+##|-PRIV
+
+ require_once("auth.inc");
+ require_once("guiconfig.inc");
+
+$pgtitle = array(gettext("System"), gettext("User Settings"));
+
+$a_user = &$config['system']['user'];
+
+if (isset($_SESSION['Username']) && isset($userindex[$_SESSION['Username']])) {
+	$id = $userindex[$_SESSION['Username']];
+}
+
+if (isset($id) && $a_user[$id]) {
+	$pconfig['webguicss'] = $a_user[$id]['webguicss'];
+	$pconfig['webguifixedmenu'] = $a_user[$id]['webguifixedmenu'];
+	$pconfig['webguihostnamemenu'] = $a_user[$id]['webguihostnamemenu'];
+	$pconfig['dashboardcolumns'] = $a_user[$id]['dashboardcolumns'];
+	$pconfig['dashboardavailablewidgetspanel'] = isset($a_user[$id]['dashboardavailablewidgetspanel']);
+	$pconfig['systemlogsfilterpanel'] = isset($a_user[$id]['systemlogsfilterpanel']);
+	$pconfig['systemlogsmanagelogpanel'] = isset($a_user[$id]['systemlogsmanagelogpanel']);
+	$pconfig['statusmonitoringsettingspanel'] = isset($a_user[$id]['statusmonitoringsettingspanel']);
+	$pconfig['webguileftcolumnhyper'] = isset($a_user[$id]['webguileftcolumnhyper']);
+	$pconfig['pagenamefirst'] = isset($a_user[$id]['pagenamefirst']);
+} else {
+	echo gettext("The settings cannot be managed for a non-local user.");
+	include("foot.inc");
+	exit;
+}
+
+if (isset($_POST['save'])) {
+	unset($input_errors);
+	/* input validation */
+
+	$reqdfields = explode(" ", "webguicss dashboardcolumns");
+	$reqdfieldsn = array(gettext("Theme"), gettext("Dashboard Columns"));
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
+
+	$userent = $a_user[$id];
+
+	if (!$input_errors) {
+		$pconfig['webguicss'] = $userent['webguicss'] = $_POST['webguicss'];
+
+		if ($_POST['webguifixedmenu']) {
+			$pconfig['webguifixedmenu'] = $userent['webguifixedmenu'] = $_POST['webguifixedmenu'];
+		} else {
+			$pconfig['webguifixedmenu'] = "";
+			unset($userent['webguifixedmenu']);
+		}
+
+		if ($_POST['webguihostnamemenu']) {
+			$pconfig['webguihostnamemenu'] = $userent['webguihostnamemenu'] = $_POST['webguihostnamemenu'];
+		} else {
+			$pconfig['webguihostnamemenu'] = "";
+			unset($userent['webguihostnamemenu']);
+		}
+
+		$pconfig['dashboardcolumns'] = $userent['dashboardcolumns'] = $_POST['dashboardcolumns'];
+
+		if ($_POST['dashboardavailablewidgetspanel']) {
+			$pconfig['dashboardavailablewidgetspanel'] = $userent['dashboardavailablewidgetspanel'] = true;
+		} else {
+			$pconfig['dashboardavailablewidgetspanel'] = false;
+			unset($userent['dashboardavailablewidgetspanel']);
+		}
+
+		if ($_POST['systemlogsfilterpanel']) {
+			$pconfig['systemlogsfilterpanel'] = $userent['systemlogsfilterpanel'] = true;
+		} else {
+			$pconfig['systemlogsfilterpanel'] = false;
+			unset($userent['systemlogsfilterpanel']);
+		}
+
+		if ($_POST['systemlogsmanagelogpanel']) {
+			$pconfig['systemlogsmanagelogpanel'] = $userent['systemlogsmanagelogpanel'] = true;
+		} else {
+			$pconfig['systemlogsmanagelogpanel'] = false;
+			unset($userent['systemlogsmanagelogpanel']);
+		}
+
+		if ($_POST['statusmonitoringsettingspanel']) {
+			$pconfig['statusmonitoringsettingspanel'] = $userent['statusmonitoringsettingspanel'] = true;
+		} else {
+			$pconfig['statusmonitoringsettingspanel'] = false;
+			unset($userent['statusmonitoringsettingspanel']);
+		}
+
+		if ($_POST['webguileftcolumnhyper']) {
+			$pconfig['webguileftcolumnhyper'] = $userent['webguileftcolumnhyper'] = true;
+		} else {
+			$pconfig['webguileftcolumnhyper'] = false;
+			unset($userent['webguileftcolumnhyper']);
+		}
+
+		if ($_POST['pagenamefirst']) {
+			$pconfig['pagenamefirst'] = $userent['pagenamefirst'] = true;
+		} else {
+			$pconfig['pagenamefirst'] = false;
+			unset($userent['pagenamefirst']);
+		}
+
+		$a_user[$id] = $userent;
+		$savemsg = sprintf(gettext("User settings successfully changed for user %s."), $_SESSION['Username']);
+		write_config($savemsg);
+	}
+}
+
+include("head.inc");
+
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+
+if ($savemsg) {
+	print_info_box($savemsg, 'success');
+}
+
+$form = new Form();
+
+$section = new Form_Section('User Settings for ' . $_SESSION['Username']);
+
+gen_user_settings_fields($section, $pconfig);
+
+$form->add($section);
+print($form);
+$csswarning = sprintf(gettext("%sUser-created themes are unsupported, use at your own risk."), "<br />");
+?>
+<script type="text/javascript">
+//<![CDATA[
+events.push(function() {
+
+	// Handle displaying a warning message if a user-created theme is selected.
+	function setThemeWarning() {
+		if ($('#webguicss').val().startsWith("pfSense")) {
+			$('#csstxt').html("").addClass("text-default");
+		} else {
+			$('#csstxt').html("<?=$csswarning?>").addClass("text-danger");
+		}
+	}
+
+	$('#webguicss').change(function() {
+		setThemeWarning();
+	});
+
+	// ---------- On initial page load ------------------------------------------------------------
+	setThemeWarning();
+
+});
+//]]>
+</script>
+<?php
+include("foot.inc");

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -94,6 +94,17 @@ if (isset($id) && $a_user[$id]) {
 	$pconfig['usernamefld'] = $a_user[$id]['name'];
 	$pconfig['descr'] = $a_user[$id]['descr'];
 	$pconfig['expires'] = $a_user[$id]['expires'];
+	$pconfig['customsettings'] = isset($a_user[$id]['customsettings']);
+	$pconfig['webguicss'] = $a_user[$id]['webguicss'];
+	$pconfig['webguifixedmenu'] = $a_user[$id]['webguifixedmenu'];
+	$pconfig['webguihostnamemenu'] = $a_user[$id]['webguihostnamemenu'];
+	$pconfig['dashboardcolumns'] = $a_user[$id]['dashboardcolumns'];
+	$pconfig['dashboardavailablewidgetspanel'] = isset($a_user[$id]['dashboardavailablewidgetspanel']);
+	$pconfig['systemlogsfilterpanel'] = isset($a_user[$id]['systemlogsfilterpanel']);
+	$pconfig['systemlogsmanagelogpanel'] = isset($a_user[$id]['systemlogsmanagelogpanel']);
+	$pconfig['statusmonitoringsettingspanel'] = isset($a_user[$id]['statusmonitoringsettingspanel']);
+	$pconfig['webguileftcolumnhyper'] = isset($a_user[$id]['webguileftcolumnhyper']);
+	$pconfig['pagenamefirst'] = isset($a_user[$id]['pagenamefirst']);
 	$pconfig['groups'] = local_user_get_groups($a_user[$id]);
 	$pconfig['utype'] = $a_user[$id]['scope'];
 	$pconfig['uid'] = $a_user[$id]['uid'];
@@ -330,6 +341,7 @@ if ($_POST['save']) {
 
 		$userent['name'] = $_POST['usernamefld'];
 		$userent['expires'] = $_POST['expires'];
+		$userent['dashboardcolumns'] = $_POST['dashboardcolumns'];
 		$userent['authorizedkeys'] = base64_encode($_POST['authorizedkeys']);
 		$userent['ipsecpsk'] = $_POST['ipsecpsk'];
 
@@ -337,6 +349,66 @@ if ($_POST['save']) {
 			$userent['disabled'] = true;
 		} else {
 			unset($userent['disabled']);
+		}
+
+		if ($_POST['customsettings']) {
+			$userent['customsettings'] = true;
+		} else {
+			unset($userent['customsettings']);
+		}
+
+		if ($_POST['webguicss']) {
+			$userent['webguicss'] = $_POST['webguicss'];
+		} else {
+			unset($userent['webguicss']);
+		}
+
+		if ($_POST['webguifixedmenu']) {
+			$userent['webguifixedmenu'] = $_POST['webguifixedmenu'];
+		} else {
+			unset($userent['webguifixedmenu']);
+		}
+
+		if ($_POST['webguihostnamemenu']) {
+			$userent['webguihostnamemenu'] = $_POST['webguihostnamemenu'];
+		} else {
+			unset($userent['webguihostnamemenu']);
+		}
+
+		if ($_POST['dashboardavailablewidgetspanel']) {
+			$userent['dashboardavailablewidgetspanel'] = true;
+		} else {
+			unset($userent['dashboardavailablewidgetspanel']);
+		}
+
+		if ($_POST['systemlogsfilterpanel']) {
+			$userent['systemlogsfilterpanel'] = true;
+		} else {
+			unset($userent['systemlogsfilterpanel']);
+		}
+
+		if ($_POST['systemlogsmanagelogpanel']) {
+			$userent['systemlogsmanagelogpanel'] = true;
+		} else {
+			unset($userent['systemlogsmanagelogpanel']);
+		}
+
+		if ($_POST['statusmonitoringsettingspanel']) {
+			$userent['statusmonitoringsettingspanel'] = true;
+		} else {
+			unset($userent['statusmonitoringsettingspanel']);
+		}
+
+		if ($_POST['webguileftcolumnhyper']) {
+			$userent['webguileftcolumnhyper'] = true;
+		} else {
+			unset($userent['webguileftcolumnhyper']);
+		}
+
+		if ($_POST['pagenamefirst']) {
+			$userent['pagenamefirst'] = true;
+		} else {
+			unset($userent['pagenamefirst']);
 		}
 
 		if (isset($id) && $a_user[$id]) {
@@ -710,6 +782,15 @@ if ($act == "new" || $act == "edit" || $input_errors):
 	))->setHelp('Leave blank if the account shouldn\'t expire, otherwise enter '.
 		'the expiration date');
 
+	$section->addInput(new Form_Checkbox(
+		'customsettings',
+		'Custom Settings',
+		'Use individual customized GUI options and dashboard layout for this user.',
+		$pconfig['customsettings']
+	));
+
+	gen_user_settings_fields($section, $pconfig);
+
 	// ==== Group membership ==================================================
 	$group = new Form_Group('Group membership');
 
@@ -883,12 +964,48 @@ $section->addInput(new Form_Input(
 $form->add($section);
 
 print $form;
+
+$csswarning = sprintf(gettext("%sUser-created themes are unsupported, use at your own risk."), "<br />");
 ?>
 <script type="text/javascript">
 //<![CDATA[
 events.push(function() {
 
+	function setcustomoptions() {
+		var adv = $('#customsettings').prop('checked');
+
+		hideInput('webguicss', !adv);
+		hideInput('webguifixedmenu', !adv);
+		hideInput('webguihostnamemenu', !adv);
+		hideInput('dashboardcolumns', !adv);
+		hideCheckbox('dashboardavailablewidgetspanel', !adv);
+		hideCheckbox('systemlogsfilterpanel', !adv);
+		hideCheckbox('systemlogsmanagelogpanel', !adv);
+		hideCheckbox('statusmonitoringsettingspanel', !adv);
+		hideCheckbox('webguileftcolumnhyper', !adv);
+		hideCheckbox('pagenamefirst', !adv);
+	}
+
+	// Handle displaying a warning message if a user-created theme is selected.
+	function setThemeWarning() {
+		if ($('#webguicss').val().startsWith("pfSense")) {
+			$('#csstxt').html("").addClass("text-default");
+		} else {
+			$('#csstxt').html("<?=$csswarning?>").addClass("text-danger");
+		}
+	}
+
+	$('#webguicss').change(function() {
+		setThemeWarning();
+	});
+
+	setThemeWarning();
+
 	// On click . .
+	$('#customsettings').click(function () {
+		setcustomoptions();
+	});
+
 	$("#movetodisabled").click(function() {
 		moveOptions($('[name="groups[]"] option'), $('[name="sysgroups[]"]'));
 	});
@@ -931,6 +1048,7 @@ events.push(function() {
 	hideClass('cert-options', true);
 	//hideInput('authorizedkeys', true);
 	hideCheckbox('showkey', true);
+	setcustomoptions();
 
 	// On submit mark all the user's groups as "selected"
 	$('form').submit(function() {


### PR DESCRIPTION
This allows the admin to create/edit a user and check the new
customprofile checkbox. The various GUI preferences are then displayed. The
admin can choose the various GUI preferences for that user (or can leave them as-is and let the user chose):
- CSS file (theme)
- top navigation
- hostname in menu
- dashboard columns
- Show the Available Widgets panel on the Dashboard (on/off)
- Show the Log Filter panel in System Logs (on/off)
- Show the Manage Log panel in System Logs (on/off)
- Show the Settings panel in Status Monitoring (on/off)
- Left Column Labels (on/off)
- Display page name first in browser tab (on/off)

That user then gets the specified GUI preferences, rather than the
system settings.
When that user changes their dashboard widgets and widget layout, that
is saved for that individual user also.
If the user has been granted the "WebCfg - System: User Settings" privilege/page then they can go to System->User Settings and choose/change the user settings for themselves.

So user preference settings can be managed in 3 general places:
a) Where they are now for system-wide settings (mostly in System->General Setup, webConfigurator section)
b) System->User Manager - for an admin to set user preference settings for particular user/s.
c) System->User Settings - for the user themselves to choose their preferred settings.

In addition, the dashboard widgets and their layout are saved using the same UI as at present. If the user has customsettings enabled, then those settings are saved just for them, otherwise they are saved as system-wide settings like now.

Note: This feature is only for local users. If a user is authenticated
remotely then this code provides no way to specify custom options for
the user.