### PR TITLE
Always use require_once

### DIFF
--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -323,6 +323,6 @@ if (isset($config['system']['webgui']['webguicss'])) {
 		//]]>
 		</script>
 <?php
-require('foot.inc');
+require_once('foot.inc');
 
 } // end function

--- a/src/etc/inc/upgrade_config.inc
+++ b/src/etc/inc/upgrade_config.inc
@@ -54,10 +54,10 @@
  */
 
 if (!function_exists("dump_rrd_to_xml")) {
-	require("rrd.inc");
+	require_once("rrd.inc");
 }
 if (!function_exists("read_altq_config")) {
-	require("shaper.inc");
+	require_once("shaper.inc");
 }
 
 /* Upgrade functions must be named:

--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -1272,7 +1272,7 @@ EOD;
 
 								if (!empty($ealg_kl) && $ealg_kl == "auto") {
 									if (empty($p2_ealgos) || !is_array($p2_ealgos)) {
-										require("ipsec.inc");
+										require_once("ipsec.inc");
 									}
 									$key_hi = $p2_ealgos[$ealg_id]['keysel']['hi'];
 									$key_lo = $p2_ealgos[$ealg_id]['keysel']['lo'];

--- a/src/etc/rc.captiveportal_configure
+++ b/src/etc/rc.captiveportal_configure
@@ -28,11 +28,11 @@
 	POSSIBILITY OF SUCH DAMAGE.
 */
 
-require("config.inc");
-require("functions.inc");
+require_once("config.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 captiveportal_configure();
 

--- a/src/etc/rc.captiveportal_configure_mac
+++ b/src/etc/rc.captiveportal_configure_mac
@@ -28,11 +28,11 @@
 	POSSIBILITY OF SUCH DAMAGE.
 */
 
-require("config.inc");
-require("functions.inc");
+require_once("config.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 global $cpzone;
 

--- a/src/etc/rc.initial.password
+++ b/src/etc/rc.initial.password
@@ -32,7 +32,7 @@
 	/* parse the configuration and include all functions used below */
 
 	require_once("config.inc");
-	require("auth.inc");
+	require_once("auth.inc");
 	require_once("functions.inc");
 	require_once("shaper.inc");
 

--- a/src/etc/rc.restart_webgui
+++ b/src/etc/rc.restart_webgui
@@ -2,10 +2,10 @@
 
 <?php
 
-require("config.inc");
-require("functions.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("config.inc");
+require_once("functions.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 require_once("rrd.inc");
 
 echo "Restarting webConfigurator...";

--- a/src/usr/local/bin/dhcpd_gather_stats.php
+++ b/src/usr/local/bin/dhcpd_gather_stats.php
@@ -25,7 +25,7 @@
 */
 
 require_once("config.inc");
-require("interfaces.inc");
+require_once("interfaces.inc");
 /* echo the rrd required syntax */
 echo "N:";
 $result = array();

--- a/src/usr/local/www/crash_reporter.php
+++ b/src/usr/local/www/crash_reporter.php
@@ -60,9 +60,9 @@
 ##|*MATCH=crash_reporter.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
-require("captiveportal.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
+require_once("captiveportal.inc");
 
 define("FILE_SIZE", 450000);
 

--- a/src/usr/local/www/diag_arp.php
+++ b/src/usr/local/www/diag_arp.php
@@ -66,7 +66,7 @@
 @ini_set('zlib.output_compression', 0);
 @ini_set('implicit_flush', 1);
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 // delete arp entry
 if (isset($_GET['deleteentry'])) {

--- a/src/usr/local/www/diag_authentication.php
+++ b/src/usr/local/www/diag_authentication.php
@@ -60,7 +60,7 @@
 ##|*MATCH=diag_authentication.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("radius.inc");
 
 if ($_POST) {

--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -69,7 +69,7 @@ ini_set('max_input_time', '0');
 
 /* omit no-cache headers because it confuses IE with file downloads */
 $omit_nocacheheaders = true;
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/diag_command.php
+++ b/src/usr/local/www/diag_command.php
@@ -69,7 +69,7 @@
 
 $allowautocomplete = true;
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if ($_POST['submit'] == "DOWNLOAD" && file_exists($_POST['dlPath'])) {
 	session_cache_limiter('public');

--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -61,7 +61,7 @@
 ##|*MATCH=diag_confbak.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (isset($_POST['backupcount'])) {
 	if (is_numericint($_POST['backupcount'])) {

--- a/src/usr/local/www/diag_defaults.php
+++ b/src/usr/local/www/diag_defaults.php
@@ -63,7 +63,7 @@
 ##|*MATCH=diag_defaults.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if ($_POST['Submit'] == " " . gettext("No") . " ") {
 	header("Location: index.php");

--- a/src/usr/local/www/diag_dns.php
+++ b/src/usr/local/www/diag_dns.php
@@ -61,7 +61,7 @@
 ##|-PRIV
 
 $pgtitle = array(gettext("Diagnostics"), gettext("DNS Lookup"));
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $host = trim($_REQUEST['host'], " \t\n\r\0\x0B[];\"'");
 $host_esc = escapeshellarg($host);

--- a/src/usr/local/www/diag_edit.php
+++ b/src/usr/local/www/diag_edit.php
@@ -63,7 +63,7 @@
 ##|-PRIV
 
 $pgtitle = array(gettext("Diagnostics"), gettext("Edit File"));
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if ($_POST['action']) {
 	switch ($_POST['action']) {
@@ -128,7 +128,7 @@ if ($_POST['action']) {
 	exit;
 }
 
-require("head.inc");
+require_once("head.inc");
 
 print_callout(gettext("The capabilities offered here can be dangerous. No support is available. Use them at your own risk!"), 'danger', gettext('Advanced Users Only'));
 

--- a/src/usr/local/www/diag_gmirror.php
+++ b/src/usr/local/www/diag_gmirror.php
@@ -403,4 +403,4 @@ endif; ?>
 </form>
 
 <?php
-require("foot.inc");
+require_once("foot.inc");

--- a/src/usr/local/www/diag_halt.php
+++ b/src/usr/local/www/diag_halt.php
@@ -66,9 +66,9 @@
 // Set DEBUG to true to prevent the system_halt() function from being called
 define("DEBUG", false);
 
-require("guiconfig.inc");
-require("functions.inc");
-require("captiveportal.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
+require_once("captiveportal.inc");
 
 if ($_POST['save'] == 'No') {
 	header("Location: index.php");

--- a/src/usr/local/www/diag_limiter_info.php
+++ b/src/usr/local/www/diag_limiter_info.php
@@ -60,7 +60,7 @@
 ##|*MATCH=diag_limiter_info.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $pgtitle = array(gettext("Diagnostics"), gettext("Limiter Info"));
 $shortcut_section = "trafficshaper-limiters";

--- a/src/usr/local/www/diag_nanobsd.php
+++ b/src/usr/local/www/diag_nanobsd.php
@@ -283,4 +283,4 @@ if (file_exists("/conf/upgrade_log.txt") && $_POST['viewupgradelog']) {
 	</div>
 <?php
 }
-require("foot.inc");
+require_once("foot.inc");

--- a/src/usr/local/www/diag_ndp.php
+++ b/src/usr/local/www/diag_ndp.php
@@ -67,7 +67,7 @@
 @ini_set('zlib.output_compression', 0);
 @ini_set('implicit_flush', 1);
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 exec("/usr/sbin/ndp -na", $rawdata);
 

--- a/src/usr/local/www/diag_pf_info.php
+++ b/src/usr/local/www/diag_pf_info.php
@@ -60,7 +60,7 @@
 ##|*MATCH=diag_pf_info.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $pgtitle = array(gettext("Diagnostics"), gettext("pfInfo"));
 

--- a/src/usr/local/www/diag_pftop.php
+++ b/src/usr/local/www/diag_pftop.php
@@ -60,7 +60,7 @@
 ##|*MATCH=diag_pftop.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $pgtitle = array(gettext("Diagnostics"), gettext("pfTop"));
 

--- a/src/usr/local/www/diag_reboot.php
+++ b/src/usr/local/www/diag_reboot.php
@@ -66,9 +66,9 @@
 // Set DEBUG to true to prevent the system_reboot() function from being called
 define("DEBUG", false);
 
-require("guiconfig.inc");
-require("functions.inc");
-require("captiveportal.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
+require_once("captiveportal.inc");
 
 $guitimeout = 90;	// Seconds to wait before reloading the page after reboot
 $guiretry = 20;		// Seconds to try again if $guitimeout was not long enough

--- a/src/usr/local/www/diag_resetstate.php
+++ b/src/usr/local/www/diag_resetstate.php
@@ -63,7 +63,7 @@
 ##|*MATCH=diag_resetstate.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("filter.inc");
 
 if ($_POST) {

--- a/src/usr/local/www/diag_smart.php
+++ b/src/usr/local/www/diag_smart.php
@@ -61,7 +61,7 @@
 ##|*MATCH=diag_smart.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 // What page, aka. action is being wanted
 // If they "get" a page but don't pass all arguments, smartctl will throw an error

--- a/src/usr/local/www/diag_system_activity.php
+++ b/src/usr/local/www/diag_system_activity.php
@@ -60,7 +60,7 @@
 ##|*MATCH=diag_system_activity.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $pgtitle = array(gettext("Diagnostics"), gettext("System Activity"));
 

--- a/src/usr/local/www/diag_testport.php
+++ b/src/usr/local/www/diag_testport.php
@@ -69,7 +69,7 @@
 $allowautocomplete = true;
 
 $pgtitle = array(gettext("Diagnostics"), gettext("Test Port"));
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 include("head.inc");
 

--- a/src/usr/local/www/diag_traceroute.php
+++ b/src/usr/local/www/diag_traceroute.php
@@ -64,7 +64,7 @@
 ##|*MATCH=diag_traceroute.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $allowautocomplete = true;
 $pgtitle = array(gettext("Diagnostics"), gettext("Traceroute"));

--- a/src/usr/local/www/firewall_aliases.php
+++ b/src/usr/local/www/firewall_aliases.php
@@ -63,7 +63,7 @@
 ##|*MATCH=firewall_aliases.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -63,7 +63,7 @@
 ##|*MATCH=firewall_aliases_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_aliases_import.php
+++ b/src/usr/local/www/firewall_aliases_import.php
@@ -64,10 +64,10 @@
 // Keywords not allowed in names
 $reserved_keywords = array("all", "pass", "block", "out", "queue", "max", "min", "pptp", "pppoe", "L2TP", "OpenVPN", "IPsec");
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("util.inc");
 require_once("filter.inc");
-require("shaper.inc");
+require_once("shaper.inc");
 
 $pgtitle = array(gettext("Firewall"), gettext("Aliases"), gettext("Bulk import"));
 

--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -63,7 +63,7 @@
 ##|*MATCH=firewall_nat.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_nat_1to1.php
+++ b/src/usr/local/www/firewall_nat_1to1.php
@@ -63,7 +63,7 @@
 ##|*MATCH=firewall_nat_1to1.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -63,11 +63,11 @@
 ##|*MATCH=firewall_nat_1to1_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("interfaces.inc");
 require_once("filter.inc");
 require_once("ipsec.inc");
-require("shaper.inc");
+require_once("shaper.inc");
 
 $referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat_1to1.php');
 

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -63,11 +63,11 @@
 ##|*MATCH=firewall_nat_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("itemid.inc");
 require_once("ipsec.inc");
 require_once("filter.inc");
-require("shaper.inc");
+require_once("shaper.inc");
 
 $referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat.php');
 

--- a/src/usr/local/www/firewall_nat_npt.php
+++ b/src/usr/local/www/firewall_nat_npt.php
@@ -64,7 +64,7 @@
 ##|*MATCH=firewall_nat_npt.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_nat_npt_edit.php
+++ b/src/usr/local/www/firewall_nat_npt_edit.php
@@ -63,10 +63,10 @@
 
 require_once("ipsec.inc");
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("interfaces.inc");
 require_once("filter.inc");
-require("shaper.inc");
+require_once("shaper.inc");
 
 $ifdisp = get_configured_interface_with_descr();
 

--- a/src/usr/local/www/firewall_nat_out.php
+++ b/src/usr/local/www/firewall_nat_out.php
@@ -63,7 +63,7 @@
 ##|*MATCH=firewall_nat_out.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -63,10 +63,10 @@
 ##|*MATCH=firewall_nat_out_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("ipsec.inc");
 require_once("filter.inc");
-require("shaper.inc");
+require_once("shaper.inc");
 
 if (!is_array($config['nat']['outbound'])) {
 	$config['nat']['outbound'] = array();

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -63,7 +63,7 @@
 ##|*MATCH=firewall_rules.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("ipsec.inc");

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -63,10 +63,10 @@
 ##|*MATCH=firewall_rules_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("ipsec.inc");
 require_once("filter.inc");
-require("shaper.inc");
+require_once("shaper.inc");
 
 if (isset($_POST['referer'])) {
 	$referer = $_POST['referer'];

--- a/src/usr/local/www/firewall_schedule.php
+++ b/src/usr/local/www/firewall_schedule.php
@@ -68,9 +68,9 @@ define('CLOCK', '<i class="fa fa-clock-o icon-black"></i>');
 $dayArray = array (gettext('Mon'), gettext('Tues'), gettext('Wed'), gettext('Thur'), gettext('Fri'), gettext('Sat'), gettext('Sun'));
 $monthArray = array (gettext('January'), gettext('February'), gettext('March'), gettext('April'), gettext('May'), gettext('June'), gettext('July'), gettext('August'), gettext('September'), gettext('October'), gettext('November'), gettext('December'));
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("filter.inc");
-require("shaper.inc");
+require_once("shaper.inc");
 
 $pgtitle = array(gettext("Firewall"), gettext("Schedules"));
 

--- a/src/usr/local/www/firewall_schedule_edit.php
+++ b/src/usr/local/www/firewall_schedule_edit.php
@@ -77,7 +77,7 @@ function schedule_sort() {
 	usort($config['schedules']['schedule'], "schedulecmp");
 }
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_shaper.php
+++ b/src/usr/local/www/firewall_shaper.php
@@ -60,7 +60,7 @@
 ##|*MATCH=firewall_shaper.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_shaper_queues.php
+++ b/src/usr/local/www/firewall_shaper_queues.php
@@ -60,7 +60,7 @@
 ##|*MATCH=firewall_shaper_queues.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_shaper_vinterface.php
+++ b/src/usr/local/www/firewall_shaper_vinterface.php
@@ -60,7 +60,7 @@
 ##|*MATCH=firewall_shaper_vinterface.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_shaper_wizards.php
+++ b/src/usr/local/www/firewall_shaper_wizards.php
@@ -60,7 +60,7 @@
 ##|*MATCH=firewall_shaper_wizards.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_virtual_ip.php
+++ b/src/usr/local/www/firewall_virtual_ip.php
@@ -64,7 +64,7 @@
 ##|*MATCH=firewall_virtual_ip.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/firewall_virtual_ip_edit.php
+++ b/src/usr/local/www/firewall_virtual_ip_edit.php
@@ -64,9 +64,9 @@
 ##|*MATCH=firewall_virtual_ip_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("filter.inc");
-require("shaper.inc");
+require_once("shaper.inc");
 
 if (!is_array($config['virtualip']['vip'])) {
 		$config['virtualip']['vip'] = array();

--- a/src/usr/local/www/graph.php
+++ b/src/usr/local/www/graph.php
@@ -65,8 +65,8 @@
 ##|*MATCH=graph.php*
 ##|-PRIV
 
-require("globals.inc");
-require("guiconfig.inc");
+require_once("globals.inc");
+require_once("guiconfig.inc");
 
 header("Last-Modified: " . gmdate("D, j M Y H:i:s") . " GMT");
 header("Expires: " . gmdate("D, j M Y H:i:s", time()) . " GMT");

--- a/src/usr/local/www/interfaces_assign.php
+++ b/src/usr/local/www/interfaces_assign.php
@@ -67,13 +67,13 @@
 $pgtitle = array(gettext("Interfaces"), gettext("Interface Assignments"));
 $shortcut_section = "interfaces";
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("ipsec.inc");
-require("vpn.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("ipsec.inc");
+require_once("vpn.inc");
+require_once("captiveportal.inc");
 require_once("rrd.inc");
 
 function interface_assign_description($portinfo, $portname) {

--- a/src/usr/local/www/interfaces_bridge.php
+++ b/src/usr/local/www/interfaces_bridge.php
@@ -60,7 +60,7 @@
 ##|*MATCH=interfaces_bridge.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['bridges']['bridged'])) {
 	$config['bridges']['bridged'] = array();

--- a/src/usr/local/www/interfaces_bridge_edit.php
+++ b/src/usr/local/www/interfaces_bridge_edit.php
@@ -60,7 +60,7 @@
 ##|*MATCH=interfaces_bridge_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['bridges']['bridged'])) {
 	$config['bridges']['bridged'] = array();

--- a/src/usr/local/www/interfaces_gif.php
+++ b/src/usr/local/www/interfaces_gif.php
@@ -60,7 +60,7 @@
 ##|*MATCH=interfaces_gif.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['gifs']['gif'])) {
 	$config['gifs']['gif'] = array();

--- a/src/usr/local/www/interfaces_gif_edit.php
+++ b/src/usr/local/www/interfaces_gif_edit.php
@@ -60,7 +60,7 @@
 ##|*MATCH=interfaces_gif_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['gifs']['gif'])) {
 	$config['gifs']['gif'] = array();

--- a/src/usr/local/www/interfaces_gre.php
+++ b/src/usr/local/www/interfaces_gre.php
@@ -60,7 +60,7 @@
 ##|*MATCH=interfaces_gre.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 
 if (!is_array($config['gres']['gre'])) {

--- a/src/usr/local/www/interfaces_gre_edit.php
+++ b/src/usr/local/www/interfaces_gre_edit.php
@@ -60,7 +60,7 @@
 ##|*MATCH=interfaces_gre_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 
 if (!is_array($config['gres']['gre'])) {

--- a/src/usr/local/www/interfaces_groups.php
+++ b/src/usr/local/www/interfaces_groups.php
@@ -60,7 +60,7 @@
 ##|*MATCH=interfaces_groups.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 
 if (!is_array($config['ifgroups']['ifgroupentry'])) {

--- a/src/usr/local/www/interfaces_groups_edit.php
+++ b/src/usr/local/www/interfaces_groups_edit.php
@@ -61,7 +61,7 @@
 ##|-PRIV
 
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 
 $pgtitle = array(gettext("Interfaces"), gettext("Interface Groups"), gettext("Edit"));

--- a/src/usr/local/www/interfaces_lagg.php
+++ b/src/usr/local/www/interfaces_lagg.php
@@ -60,7 +60,7 @@
 ##|*MATCH=interfaces_lagg.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['laggs']['lagg'])) {
 	$config['laggs']['lagg'] = array();

--- a/src/usr/local/www/interfaces_lagg_edit.php
+++ b/src/usr/local/www/interfaces_lagg_edit.php
@@ -60,7 +60,7 @@
 ##|*MATCH=interfaces_lagg_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['laggs']['lagg'])) {
 	$config['laggs']['lagg'] = array();

--- a/src/usr/local/www/interfaces_ppps.php
+++ b/src/usr/local/www/interfaces_ppps.php
@@ -63,7 +63,7 @@
 ##|*MATCH=interfaces_ppps.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 
 function ppp_inuse($num) {

--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -65,8 +65,8 @@
 ##|*MATCH=interfaces_ppps_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 
 define("CRON_MONTHLY_PATTERN", "0 0 1 * *");
 define("CRON_WEEKLY_PATTERN", "0 0 * * 0");

--- a/src/usr/local/www/interfaces_qinq.php
+++ b/src/usr/local/www/interfaces_qinq.php
@@ -60,7 +60,7 @@
 ##|*MATCH=interfaces_qinq.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 
 if (!is_array($config['qinqs']['qinqentry'])) {

--- a/src/usr/local/www/interfaces_qinq_edit.php
+++ b/src/usr/local/www/interfaces_qinq_edit.php
@@ -63,7 +63,7 @@
 $pgtitle = array(gettext("Interfaces"), gettext("QinQs"), gettext("Edit"));
 $shortcut_section = "interfaces";
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['qinqs']['qinqentry'])) {
 	$config['qinqs']['qinqentry'] = array();

--- a/src/usr/local/www/interfaces_vlan.php
+++ b/src/usr/local/www/interfaces_vlan.php
@@ -63,7 +63,7 @@
 ##|*MATCH=interfaces_vlan.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['vlans']['vlan'])) {
 	$config['vlans']['vlan'] = array();

--- a/src/usr/local/www/interfaces_vlan_edit.php
+++ b/src/usr/local/www/interfaces_vlan_edit.php
@@ -63,7 +63,7 @@
 ##|*MATCH=interfaces_vlan_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['vlans']['vlan'])) {
 	$config['vlans']['vlan'] = array();

--- a/src/usr/local/www/interfaces_wireless.php
+++ b/src/usr/local/www/interfaces_wireless.php
@@ -61,7 +61,7 @@
 ##|*MATCH=interfaces_wireless.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['wireless'])) {
 	$config['wireless'] = array();

--- a/src/usr/local/www/interfaces_wireless_edit.php
+++ b/src/usr/local/www/interfaces_wireless_edit.php
@@ -61,7 +61,7 @@
 ##|*MATCH=interfaces_wireless_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['wireless'])) {
 	$config['wireless'] = array();

--- a/src/usr/local/www/license.php
+++ b/src/usr/local/www/license.php
@@ -60,7 +60,7 @@
 ##|*MATCH=license.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 include("head.inc");
 ?>
 <div class="panel panel-default">

--- a/src/usr/local/www/load_balancer_monitor_edit.php
+++ b/src/usr/local/www/load_balancer_monitor_edit.php
@@ -61,7 +61,7 @@
 ##|*MATCH=load_balancer_monitor_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/load_balancer_monitor.php');
 

--- a/src/usr/local/www/load_balancer_pool_edit.php
+++ b/src/usr/local/www/load_balancer_pool_edit.php
@@ -61,7 +61,7 @@
 ##|*MATCH=load_balancer_pool_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("filter.inc");
 require_once("util.inc");
 

--- a/src/usr/local/www/load_balancer_virtual_server_edit.php
+++ b/src/usr/local/www/load_balancer_virtual_server_edit.php
@@ -61,7 +61,7 @@
 ##|*MATCH=load_balancer_virtual_server_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (isset($_POST['referer'])) {
 	$referer = $_POST['referer'];

--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -62,7 +62,7 @@
 
 ini_set('max_execution_time', '0');
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/pkg_mgr_install.php
+++ b/src/usr/local/www/pkg_mgr_install.php
@@ -63,7 +63,7 @@
 
 ini_set('max_execution_time', '0');
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/services_captiveportal_filemanager.php
+++ b/src/usr/local/www/services_captiveportal_filemanager.php
@@ -75,11 +75,11 @@ function cpelements_sort() {
 	usort($config['captiveportal'][$cpzone]['element'], "cpelementscmp");
 }
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 $cpzone = $_GET['zone'];
 if (isset($_POST['zone'])) {

--- a/src/usr/local/www/services_captiveportal_hostname.php
+++ b/src/usr/local/www/services_captiveportal_hostname.php
@@ -67,11 +67,11 @@ $notestr =
 	'This can be used for a web server serving images for the portal page, or a DNS server on another network, for example. ' .
 	'By specifying <em>from</em> addresses, it may be used to always allow pass-through access from a client behind the captive portal.');
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 $cpzone = $_GET['zone'];
 if (isset($_POST['zone'])) {

--- a/src/usr/local/www/services_captiveportal_hostname_edit.php
+++ b/src/usr/local/www/services_captiveportal_hostname_edit.php
@@ -69,11 +69,11 @@ function allowedhostnames_sort() {
 	usort($config['captiveportal'][$cpzone]['allowedhostname'], "allowedhostnamescmp");
 }
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 global $cpzone, $cpzoneid;
 

--- a/src/usr/local/www/services_captiveportal_ip.php
+++ b/src/usr/local/www/services_captiveportal_ip.php
@@ -66,11 +66,11 @@
 
 $directionicons = array('to' => '&#x2192;', 'from' => '&#x2190;', 'both' => '&#x21c4;');
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 $cpzone = $_GET['zone'];
 if (isset($_POST['zone'])) {

--- a/src/usr/local/www/services_captiveportal_ip_edit.php
+++ b/src/usr/local/www/services_captiveportal_ip_edit.php
@@ -74,11 +74,11 @@ function allowedips_sort() {
 	usort($config['captiveportal'][$cpzone]['allowedip'], "allowedipscmp");
 }
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 $cpzone = $_GET['zone'];
 if (isset($_POST['zone'])) {

--- a/src/usr/local/www/services_captiveportal_mac.php
+++ b/src/usr/local/www/services_captiveportal_mac.php
@@ -64,11 +64,11 @@
 ##|*MATCH=services_captiveportal_mac.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 global $cpzone;
 global $cpzoneid;

--- a/src/usr/local/www/services_captiveportal_mac_edit.php
+++ b/src/usr/local/www/services_captiveportal_mac_edit.php
@@ -74,11 +74,11 @@ function passthrumacs_sort() {
 	usort($config['captiveportal'][$cpzone]['passthrumac'], "passthrumacscmp");
 }
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 global $cpzone;
 global $cpzoneid;

--- a/src/usr/local/www/services_captiveportal_vouchers.php
+++ b/src/usr/local/www/services_captiveportal_vouchers.php
@@ -65,11 +65,11 @@ if ($_POST['postafterlogin']) {
 	$nocsrf= true;
 }
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 require_once("voucher.inc");
 
 $cpzone = $_GET['zone'];

--- a/src/usr/local/www/services_captiveportal_vouchers_edit.php
+++ b/src/usr/local/www/services_captiveportal_vouchers_edit.php
@@ -61,11 +61,11 @@
 ##|*MATCH=services_captiveportal_vouchers_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 require_once("voucher.inc");
 
 $cpzone = $_GET['zone'];

--- a/src/usr/local/www/services_captiveportal_zones.php
+++ b/src/usr/local/www/services_captiveportal_zones.php
@@ -60,11 +60,11 @@
 ##|*MATCH=services_captiveportal_zones.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 global $cpzone;
 global $cpzoneid;

--- a/src/usr/local/www/services_captiveportal_zones_edit.php
+++ b/src/usr/local/www/services_captiveportal_zones_edit.php
@@ -60,11 +60,11 @@
 ##|*MATCH=services_captiveportal_zones_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), gettext("Add Zone"));
 $shortcut_section = "captiveportal";

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -63,7 +63,7 @@
 ##|*MATCH=services_dhcp.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("filter.inc");
 require_once('rrd.inc');
 require_once("shaper.inc");

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -80,7 +80,7 @@ if (!$g['services_dhcp_server_enable']) {
 	exit;
 }
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $if = $_GET['if'];
 

--- a/src/usr/local/www/services_dhcp_relay.php
+++ b/src/usr/local/www/services_dhcp_relay.php
@@ -61,7 +61,7 @@
 ##|*MATCH=services_dhcp_relay.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("filter.inc");
 $pconfig['enable'] = isset($config['dhcrelay']['enable']);
 

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -64,7 +64,7 @@
 ##|*MATCH=services_dhcpv6.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("filter.inc");
 
 function dhcpv6_apply_changes($dhcpdv6_enable_changed) {

--- a/src/usr/local/www/services_dhcpv6_edit.php
+++ b/src/usr/local/www/services_dhcpv6_edit.php
@@ -81,7 +81,7 @@ if (!$g['services_dhcp_server_enable']) {
 	exit;
 }
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $if = $_GET['if'];
 if ($_POST['if']) {

--- a/src/usr/local/www/services_dhcpv6_relay.php
+++ b/src/usr/local/www/services_dhcpv6_relay.php
@@ -62,7 +62,7 @@
 ##|*MATCH=services_dhcpv6_relay.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $pconfig['enable'] = isset($config['dhcrelay6']['enable']);
 

--- a/src/usr/local/www/services_dnsmasq.php
+++ b/src/usr/local/www/services_dnsmasq.php
@@ -64,7 +64,7 @@
 ##|*MATCH=services_dnsmasq.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/services_dnsmasq_domainoverride_edit.php
+++ b/src/usr/local/www/services_dnsmasq_domainoverride_edit.php
@@ -64,7 +64,7 @@
 ##|*MATCH=services_dnsmasq_domainoverride_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['dnsmasq']['domainoverrides'])) {
 	   $config['dnsmasq']['domainoverrides'] = array();

--- a/src/usr/local/www/services_dnsmasq_edit.php
+++ b/src/usr/local/www/services_dnsmasq_edit.php
@@ -78,7 +78,7 @@ function hosts_sort() {
 	usort($config['dnsmasq']['hosts'], "hostcmp");
 }
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['dnsmasq']['hosts'])) {
 	$config['dnsmasq']['hosts'] = array();

--- a/src/usr/local/www/services_dyndns.php
+++ b/src/usr/local/www/services_dyndns.php
@@ -60,7 +60,7 @@
 ##|*MATCH=services_dyndns.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['dyndnses']['dyndns'])) {
 	$config['dyndnses']['dyndns'] = array();

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -73,7 +73,7 @@ function is_dyndns_username($uname) {
 	}
 }
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['dyndnses']['dyndns'])) {
 	$config['dyndnses']['dyndns'] = array();

--- a/src/usr/local/www/services_igmpproxy.php
+++ b/src/usr/local/www/services_igmpproxy.php
@@ -63,7 +63,7 @@
 ##|*MATCH=services_igmpproxy.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['igmpproxy']['igmpentry'])) {
 	$config['igmpproxy']['igmpentry'] = array();

--- a/src/usr/local/www/services_igmpproxy_edit.php
+++ b/src/usr/local/www/services_igmpproxy_edit.php
@@ -65,7 +65,7 @@
 
 $pgtitle = array(gettext("Services"), gettext("IGMP Proxy"), gettext("Edit"));
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['igmpproxy']['igmpentry'])) {
 	$config['igmpproxy']['igmpentry'] = array();

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -62,7 +62,7 @@
 ##|-PRIV
 
 define('NUMTIMESERVERS', 10);		// The maximum number of configurable time servers
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once('rrd.inc');
 require_once("shaper.inc");
 

--- a/src/usr/local/www/services_ntpd_acls.php
+++ b/src/usr/local/www/services_ntpd_acls.php
@@ -62,7 +62,7 @@
 ##|-PRIV
 
 define('NUMACLS', 50); // The maximum number of configurable ACLs
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once('rrd.inc');
 require_once("shaper.inc");
 

--- a/src/usr/local/www/services_pppoe_edit.php
+++ b/src/usr/local/www/services_pppoe_edit.php
@@ -60,7 +60,7 @@
 ##|*MATCH=services_pppoe_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("vpn.inc");
 
 function vpn_pppoe_get_id() {

--- a/src/usr/local/www/services_rfc2136.php
+++ b/src/usr/local/www/services_rfc2136.php
@@ -60,7 +60,7 @@
 ##|*MATCH=services_rfc2136.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['dnsupdates']['dnsupdate'])) {
 	$config['dnsupdates']['dnsupdate'] = array();

--- a/src/usr/local/www/services_rfc2136_edit.php
+++ b/src/usr/local/www/services_rfc2136_edit.php
@@ -60,7 +60,7 @@
 ##|*MATCH=services_rfc2136_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['dnsupdates']['dnsupdate'])) {
 	$config['dnsupdates']['dnsupdate'] = array();

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -64,7 +64,7 @@
 ##|*MATCH=services_router_advertisements.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!$g['services_dhcp_server_enable']) {
 	header("Location: /");

--- a/src/usr/local/www/services_snmp.php
+++ b/src/usr/local/www/services_snmp.php
@@ -63,7 +63,7 @@
 ##|*MATCH=services_snmp.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 
 if (!is_array($config['snmpd'])) {

--- a/src/usr/local/www/services_unbound_acls.php
+++ b/src/usr/local/www/services_unbound_acls.php
@@ -61,8 +61,8 @@
 ##|*MATCH=services_unbound_acls.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("unbound.inc");
+require_once("guiconfig.inc");
+require_once("unbound.inc");
 
 if (!is_array($config['unbound']['acls'])) {
 	$config['unbound']['acls'] = array();

--- a/src/usr/local/www/services_unbound_domainoverride_edit.php
+++ b/src/usr/local/www/services_unbound_domainoverride_edit.php
@@ -65,7 +65,7 @@
 ##|*MATCH=services_unbound_domainoverride_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['unbound']['domainoverrides'])) {
 	$config['unbound']['domainoverrides'] = array();

--- a/src/usr/local/www/services_unbound_host_edit.php
+++ b/src/usr/local/www/services_unbound_host_edit.php
@@ -79,7 +79,7 @@ function hosts_sort() {
 	usort($config['unbound']['hosts'], "hostcmp");
 }
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['unbound']['hosts'])) {
 	$config['unbound']['hosts'] = array();

--- a/src/usr/local/www/services_wol.php
+++ b/src/usr/local/www/services_wol.php
@@ -63,7 +63,7 @@
 ##|*MATCH=services_wol.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 if (!is_array($config['wol']['wolentry'])) {
 	$config['wol']['wolentry'] = array();
 }

--- a/src/usr/local/www/services_wol_edit.php
+++ b/src/usr/local/www/services_wol_edit.php
@@ -73,7 +73,7 @@ function wol_sort() {
 	usort($config['wol']['wolentry'], "wolcmp");
 }
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 if (!is_array($config['wol']['wolentry'])) {
 	$config['wol']['wolentry'] = array();
 }

--- a/src/usr/local/www/status_captiveportal.php
+++ b/src/usr/local/www/status_captiveportal.php
@@ -63,11 +63,11 @@
 ##|*MATCH=status_captiveportal.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 
 $cpzone = $_GET['zone'];
 if (isset($_POST['zone'])) {

--- a/src/usr/local/www/status_captiveportal_expire.php
+++ b/src/usr/local/www/status_captiveportal_expire.php
@@ -61,11 +61,11 @@
 ##|*MATCH=status_captiveportal_expire.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 require_once("voucher.inc");
 
 $cpzone = $_GET['zone'];

--- a/src/usr/local/www/status_captiveportal_test.php
+++ b/src/usr/local/www/status_captiveportal_test.php
@@ -61,11 +61,11 @@
 ##|*MATCH=status_captiveportal_test.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 require_once("voucher.inc");
 
 $cpzone = $_GET['zone'];

--- a/src/usr/local/www/status_captiveportal_voucher_rolls.php
+++ b/src/usr/local/www/status_captiveportal_voucher_rolls.php
@@ -61,11 +61,11 @@
 ##|*MATCH=status_captiveportal_voucher_rolls.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 require_once("voucher.inc");
 
 $cpzone = $_GET['zone'];

--- a/src/usr/local/www/status_captiveportal_vouchers.php
+++ b/src/usr/local/www/status_captiveportal_vouchers.php
@@ -61,11 +61,11 @@
 ##|*MATCH=status_captiveportal_vouchers.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("functions.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
-require("captiveportal.inc");
+require_once("shaper.inc");
+require_once("captiveportal.inc");
 require_once("voucher.inc");
 
 $cpzone = $_GET['zone'];

--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -63,7 +63,7 @@
 ##|*MATCH=status_dhcp_leases.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("config.inc");
 
 $pgtitle = array(gettext("Status"), gettext("DHCP Leases"));

--- a/src/usr/local/www/status_dhcpv6_leases.php
+++ b/src/usr/local/www/status_dhcpv6_leases.php
@@ -64,7 +64,7 @@
 ##|*MATCH=status_dhcpv6_leases.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("config.inc");
 
 $pgtitle = array(gettext("Status"), gettext("DHCPv6 Leases"));

--- a/src/usr/local/www/status_gateway_groups.php
+++ b/src/usr/local/www/status_gateway_groups.php
@@ -66,7 +66,7 @@
 
 define('COLOR', true);
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['gateways']['gateway_group'])) {
 	$config['gateways']['gateway_group'] = array();

--- a/src/usr/local/www/status_gateways.php
+++ b/src/usr/local/www/status_gateways.php
@@ -61,7 +61,7 @@
 ##|*MATCH=status_gateways.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 define('COLOR', true);
 

--- a/src/usr/local/www/status_graph.php
+++ b/src/usr/local/www/status_graph.php
@@ -66,7 +66,7 @@
 ##|*MATCH=ifstats.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("ipsec.inc");
 
 if ($_POST['width']) {

--- a/src/usr/local/www/status_graph_cpu.php
+++ b/src/usr/local/www/status_graph_cpu.php
@@ -64,7 +64,7 @@
 ##|-PRIV
 
 $pgtitle = array(gettext("Status"), gettext("CPU Load Graph"));
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 include("head.inc");
 
 ?>

--- a/src/usr/local/www/status_ipsec.php
+++ b/src/usr/local/www/status_ipsec.php
@@ -64,7 +64,7 @@
 ##|*MATCH=status_ipsec.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("ipsec.inc");
 
 global $g;

--- a/src/usr/local/www/status_ipsec_leases.php
+++ b/src/usr/local/www/status_ipsec_leases.php
@@ -60,8 +60,8 @@
 ##|*MATCH=status_ipsec_leases.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("ipsec.inc");
+require_once("guiconfig.inc");
+require_once("ipsec.inc");
 
 $pgtitle = array(gettext("Status"), gettext("IPsec"), gettext("Leases"));
 $shortcut_section = "ipsec";

--- a/src/usr/local/www/status_ipsec_sad.php
+++ b/src/usr/local/www/status_ipsec_sad.php
@@ -63,8 +63,8 @@
 ##|*MATCH=status_ipsec_sad.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("ipsec.inc");
+require_once("guiconfig.inc");
+require_once("ipsec.inc");
 
 $pgtitle = array(gettext("Status"), gettext("IPsec"), gettext("SADs"));
 $shortcut_section = "ipsec";

--- a/src/usr/local/www/status_ipsec_spd.php
+++ b/src/usr/local/www/status_ipsec_spd.php
@@ -66,8 +66,8 @@
 define('RIGHTARROW', '&#x25ba;');
 define('LEFTARROW',  '&#x25c4;');
 
-require("guiconfig.inc");
-require("ipsec.inc");
+require_once("guiconfig.inc");
+require_once("ipsec.inc");
 
 $pgtitle = array(gettext("Status"), gettext("IPsec"), gettext("SPDs"));
 $shortcut_section = "ipsec";

--- a/src/usr/local/www/status_logs_settings.php
+++ b/src/usr/local/www/status_logs_settings.php
@@ -63,7 +63,7 @@
 ##|*MATCH=status_logs_settings.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/status_openvpn.php
+++ b/src/usr/local/www/status_openvpn.php
@@ -64,7 +64,7 @@
 $pgtitle = array(gettext("Status"), gettext("OpenVPN"));
 $shortcut_section = "openvpn";
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("openvpn.inc");
 require_once("shortcuts.inc");
 require_once("service-utils.inc");

--- a/src/usr/local/www/status_pkglogs.php
+++ b/src/usr/local/www/status_pkglogs.php
@@ -71,8 +71,8 @@
 ##|*MATCH=status_pkglogs.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("pkg-utils.inc");
+require_once("guiconfig.inc");
+require_once("pkg-utils.inc");
 
 if (!($nentries = $config['syslog']['nentries'])) {
 	$nentries = 50;

--- a/src/usr/local/www/status_queues.php
+++ b/src/usr/local/www/status_queues.php
@@ -66,7 +66,7 @@ header("Cache-Control: no-cache, no-store, must-revalidate"); // HTTP/1.1
 header("Pragma: no-cache"); // HTTP/1.0
 */
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 class QueueStats {
 	public $queuename;
 	public $queuelength;

--- a/src/usr/local/www/status_upnp.php
+++ b/src/usr/local/www/status_upnp.php
@@ -61,7 +61,7 @@
 ##|*MATCH=status_upnp.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if ($_POST) {
 	if ($_POST['clear']) {

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -63,7 +63,7 @@
 ##|*MATCH=system.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/system_advanced_admin.php
+++ b/src/usr/local/www/system_advanced_admin.php
@@ -64,7 +64,7 @@
 ##|*MATCH=system_advanced_admin.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/system_advanced_firewall.php
+++ b/src/usr/local/www/system_advanced_firewall.php
@@ -64,7 +64,7 @@
 ##|*MATCH=system_advanced_firewall.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/system_advanced_misc.php
+++ b/src/usr/local/www/system_advanced_misc.php
@@ -64,7 +64,7 @@
 ##|*MATCH=system_advanced_misc.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -64,7 +64,7 @@
 ##|*MATCH=system_advanced_network.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/system_advanced_notifications.php
+++ b/src/usr/local/www/system_advanced_notifications.php
@@ -60,7 +60,7 @@
 ##|*MATCH=system_advanced_notifications.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("notices.inc");
 
 // Growl

--- a/src/usr/local/www/system_advanced_sysctl.php
+++ b/src/usr/local/www/system_advanced_sysctl.php
@@ -64,7 +64,7 @@
 ##|*MATCH=system_advanced_sysctl.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['sysctl'])) {
 	$config['sysctl'] = array();

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -61,7 +61,7 @@
 ##|*MATCH=system_authservers.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("auth.inc");
 
 // Have we been called to populate the "Select a container" modal?

--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -61,7 +61,7 @@
 ##|*MATCH=system_camanager.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("certs.inc");
 
 $ca_methods = array(

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -61,7 +61,7 @@
 ##|*MATCH=system_certmanager.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("certs.inc");
 
 $cert_methods = array(

--- a/src/usr/local/www/system_crlmanager.php
+++ b/src/usr/local/www/system_crlmanager.php
@@ -60,7 +60,7 @@
 ##|*MATCH=system_crlmanager.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("certs.inc");
 require_once("openvpn.inc");
 require_once("vpn.inc");

--- a/src/usr/local/www/system_gateway_groups.php
+++ b/src/usr/local/www/system_gateway_groups.php
@@ -61,7 +61,7 @@
 ##|*MATCH=system_gateway_groups.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/system_gateway_groups_edit.php
+++ b/src/usr/local/www/system_gateway_groups_edit.php
@@ -61,7 +61,7 @@
 ##|*MATCH=system_gateway_groups_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("ipsec.inc");
 require_once("vpn.inc");
 

--- a/src/usr/local/www/system_gateways.php
+++ b/src/usr/local/www/system_gateways.php
@@ -61,7 +61,7 @@
 ##|*MATCH=system_gateways.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -60,8 +60,8 @@
 ##|*MATCH=system_gateways_edit.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("pkg-utils.inc");
+require_once("guiconfig.inc");
+require_once("pkg-utils.inc");
 
 if (isset($_POST['referer'])) {
 	$referer = $_POST['referer'];

--- a/src/usr/local/www/system_groupmanager.php
+++ b/src/usr/local/www/system_groupmanager.php
@@ -65,7 +65,7 @@
 ##|*MATCH=system_groupmanager.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['system']['group'])) {
 	$config['system']['group'] = array();

--- a/src/usr/local/www/system_groupmanager_addprivs.php
+++ b/src/usr/local/www/system_groupmanager_addprivs.php
@@ -64,7 +64,7 @@
 ##|*MATCH=system_groupmanager_addprivs.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Groups"), gettext("Edit"), gettext("Add Privileges"));
 

--- a/src/usr/local/www/system_hasync.php
+++ b/src/usr/local/www/system_hasync.php
@@ -61,7 +61,7 @@
 ##|*MATCH=system_hasync.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 if (!is_array($config['hasync'])) {
 	$config['hasync'] = array();

--- a/src/usr/local/www/system_routes.php
+++ b/src/usr/local/www/system_routes.php
@@ -63,7 +63,7 @@
 ##|*MATCH=system_routes.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/system_update_settings.php
+++ b/src/usr/local/www/system_update_settings.php
@@ -61,8 +61,8 @@
 ##|*MATCH=system_update_settings.php*
 ##|-PRIV
 
-require("guiconfig.inc");
-require("pkg-utils.inc");
+require_once("guiconfig.inc");
+require_once("pkg-utils.inc");
 
 $repos = pkg_list_repos();
 

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -65,8 +65,8 @@
 ##|*MATCH=system_usermanager.php*
 ##|-PRIV
 
-require("certs.inc");
-require("guiconfig.inc");
+require_once("certs.inc");
+require_once("guiconfig.inc");
 
 // start admin user code
 if (isset($_POST['userid']) && is_numericint($_POST['userid'])) {

--- a/src/usr/local/www/system_usermanager_addprivs.php
+++ b/src/usr/local/www/system_usermanager_addprivs.php
@@ -65,7 +65,7 @@ function admusercmp($a, $b) {
 	return strcasecmp($a['name'], $b['name']);
 }
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 $pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Users"), gettext("Edit"), gettext("Add Privileges"));
 

--- a/src/usr/local/www/system_usermanager_settings.php
+++ b/src/usr/local/www/system_usermanager_settings.php
@@ -61,7 +61,7 @@
 ##|*MATCH=system_usermanager_settings.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("auth.inc");
 
 // Test LDAP settings in response to an AJAX request from this page.

--- a/src/usr/local/www/uploadconfig.php
+++ b/src/usr/local/www/uploadconfig.php
@@ -65,7 +65,7 @@
 ##|-PRIV
 
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 
 header("Content-Type: text/plain");
 

--- a/src/usr/local/www/vpn_ipsec.php
+++ b/src/usr/local/www/vpn_ipsec.php
@@ -63,7 +63,7 @@
 ##|*MATCH=vpn_ipsec.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");

--- a/src/usr/local/www/vpn_ipsec_keys.php
+++ b/src/usr/local/www/vpn_ipsec_keys.php
@@ -63,8 +63,8 @@
 ##|*MATCH=vpn_ipsec_keys.php*
 ##|-PRIV
 
-require("functions.inc");
-require("guiconfig.inc");
+require_once("functions.inc");
+require_once("guiconfig.inc");
 require_once("ipsec.inc");
 require_once("vpn.inc");
 require_once("filter.inc");

--- a/src/usr/local/www/vpn_ipsec_keys_edit.php
+++ b/src/usr/local/www/vpn_ipsec_keys_edit.php
@@ -63,8 +63,8 @@
 ##|*MATCH=vpn_ipsec_keys_edit.php*
 ##|-PRIV
 
-require("functions.inc");
-require("guiconfig.inc");
+require_once("functions.inc");
+require_once("guiconfig.inc");
 require_once("ipsec.inc");
 require_once("vpn.inc");
 

--- a/src/usr/local/www/vpn_ipsec_mobile.php
+++ b/src/usr/local/www/vpn_ipsec_mobile.php
@@ -64,8 +64,8 @@
 ##|*MATCH=vpn_ipsec_mobile.php*
 ##|-PRIV
 
-require("functions.inc");
-require("guiconfig.inc");
+require_once("functions.inc");
+require_once("guiconfig.inc");
 require_once("ipsec.inc");
 require_once("vpn.inc");
 require_once("filter.inc");

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -64,8 +64,8 @@
 ##|*MATCH=vpn_ipsec_phase1.php*
 ##|-PRIV
 
-require("functions.inc");
-require("guiconfig.inc");
+require_once("functions.inc");
+require_once("guiconfig.inc");
 require_once("ipsec.inc");
 require_once("vpn.inc");
 require_once("filter.inc");

--- a/src/usr/local/www/vpn_ipsec_phase2.php
+++ b/src/usr/local/www/vpn_ipsec_phase2.php
@@ -64,8 +64,8 @@
 ##|*MATCH=vpn_ipsec_phase2.php*
 ##|-PRIV
 
-require("functions.inc");
-require("guiconfig.inc");
+require_once("functions.inc");
+require_once("guiconfig.inc");
 require_once("ipsec.inc");
 require_once("vpn.inc");
 

--- a/src/usr/local/www/vpn_ipsec_settings.php
+++ b/src/usr/local/www/vpn_ipsec_settings.php
@@ -60,8 +60,8 @@
 ##|*MATCH=vpn_ipsec_settings.php*
 ##|-PRIV
 
-require("functions.inc");
-require("guiconfig.inc");
+require_once("functions.inc");
+require_once("guiconfig.inc");
 require_once("filter.inc");
 require_once("shaper.inc");
 require_once("ipsec.inc");

--- a/src/usr/local/www/vpn_l2tp.php
+++ b/src/usr/local/www/vpn_l2tp.php
@@ -60,7 +60,7 @@
 ##|*MATCH=vpn_l2tp.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("vpn.inc");
 
 if (!is_array($config['l2tp']['radius'])) {

--- a/src/usr/local/www/vpn_l2tp_users.php
+++ b/src/usr/local/www/vpn_l2tp_users.php
@@ -63,7 +63,7 @@
 $pgtitle = array(gettext("VPN"), gettext("L2TP"), gettext("Users"));
 $shortcut_section = "l2tps";
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("vpn.inc");
 
 if (!is_array($config['l2tp']['user'])) {

--- a/src/usr/local/www/vpn_l2tp_users_edit.php
+++ b/src/usr/local/www/vpn_l2tp_users_edit.php
@@ -77,7 +77,7 @@ function l2tp_users_sort() {
 	usort($config['l2tp']['user'], "l2tpusercmp");
 }
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("vpn.inc");
 
 if (!is_array($config['l2tp']['user'])) {

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -61,7 +61,7 @@
 ##|*MATCH=vpn_openvpn_client.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("openvpn.inc");
 require_once("pkg-utils.inc");
 

--- a/src/usr/local/www/vpn_openvpn_csc.php
+++ b/src/usr/local/www/vpn_openvpn_csc.php
@@ -61,7 +61,7 @@
 ##|*MATCH=vpn_openvpn_csc.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("openvpn.inc");
 require_once("pkg-utils.inc");
 

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -61,7 +61,7 @@
 ##|*MATCH=vpn_openvpn_server.php*
 ##|-PRIV
 
-require("guiconfig.inc");
+require_once("guiconfig.inc");
 require_once("openvpn.inc");
 require_once("pkg-utils.inc");
 

--- a/src/usr/local/www/wizard.php
+++ b/src/usr/local/www/wizard.php
@@ -60,11 +60,11 @@
 ##|*MATCH=wizard.php*
 ##|-PRIV
 
-require("globals.inc");
-require("guiconfig.inc");
-require("functions.inc");
+require_once("globals.inc");
+require_once("guiconfig.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("shaper.inc");
+require_once("shaper.inc");
 require_once("rrd.inc");
 require_once("system.inc");
 

--- a/src/usr/local/www/xmlrpc.php
+++ b/src/usr/local/www/xmlrpc.php
@@ -61,14 +61,14 @@
 ##|*MATCH=xmlrpc.php*
 ##|-PRIV
 
-require("config.inc");
-require("functions.inc");
+require_once("config.inc");
+require_once("functions.inc");
 require_once("filter.inc");
-require("ipsec.inc");
-require("vpn.inc");
-require("shaper.inc");
-require("xmlrpc_server.inc");
-require("xmlrpc.inc");
+require_once("ipsec.inc");
+require_once("vpn.inc");
+require_once("shaper.inc");
+require_once("xmlrpc_server.inc");
+require_once("xmlrpc.inc");
 
 function xmlrpc_loop_detect() {
 	global $config;
@@ -532,7 +532,7 @@ function get_notices_xmlrpc($raw_params) {
 		return $xmlrpc_g['return']['authfail'];
 	}
 	if (!function_exists("get_notices")) {
-		require("notices.inc");
+		require_once("notices.inc");
 	}
 	if (!$params) {
 		$toreturn = get_notices();


### PR DESCRIPTION
The usage of require() and require_once() throughout the system is inconsistent, and "bugs" come up now and then when the order of "requires" is a bit different and some require() happens after the include file is already included/required.
It seems to me that there is no harm at all in always using require_once().