### PR TITLE
Update include() to include_once()

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -2289,7 +2289,7 @@ function portal_allow($clientip, $clientmac, $username, $password = null, $attri
 			$message = 0;
 		}
 
-		include("{$g['varetc_path']}/captiveportal-{$cpzone}-logout.html");
+		include_once("{$g['varetc_path']}/captiveportal-{$cpzone}-logout.html");
 
 	} else {
 		portal_reply_page($my_redirurl, "redir", "Just redirect the user.");

--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -221,7 +221,7 @@ $sysctls = array("net.inet.ip.portrange.first" => "1024",
 
 /* Include override values for the above if needed. If the file doesn't exist, don't try to load it. */
 if (file_exists("/etc/inc/globals_override.inc")) {
-	@include("globals_override.inc");
+	@include_once("globals_override.inc");
 }
 
 /* Read all XML files in following dir and load menu entries */

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2733,7 +2733,7 @@ function pfSense_handle_custom_code($src_dir) {
 				continue;
 			}
 			// Include the extra handler
-			include("$nf");
+			include_once("$nf");
 		}
 	}
 }

--- a/src/etc/inc/priv.inc
+++ b/src/etc/inc/priv.inc
@@ -88,14 +88,14 @@ function get_priv_files($directory) {
 $dir_array = get_priv_files("/etc/inc/priv");
 foreach ($dir_array as $file) {
 	if (!is_dir("/etc/inc/priv/{$file}") && stristr($file, ".inc")) {
-		include("/etc/inc/priv/{$file}");
+		include_once("/etc/inc/priv/{$file}");
 	}
 }
 if (is_dir("/usr/local/pkg/priv")) {
 	$dir_array = get_priv_files("/usr/local/pkg/priv");
 	foreach ($dir_array as $file) {
 		if (!is_dir("/usr/local/pkg/priv/{$file}") && stristr($file, ".inc")) {
-			include("/usr/local/pkg/priv/{$file}");
+			include_once("/usr/local/pkg/priv/{$file}");
 		}
 	}
 }

--- a/src/usr/local/www/diag_routes.php
+++ b/src/usr/local/www/diag_routes.php
@@ -60,7 +60,7 @@
 ##|*MATCH=diag_routes.php*
 ##|-PRIV
 
-include('guiconfig.inc');
+require_once('guiconfig.inc');
 
 $limit = '100';
 $filter = '';

--- a/src/usr/local/www/diag_sockets.php
+++ b/src/usr/local/www/diag_sockets.php
@@ -60,7 +60,7 @@
 ##|*MATCH=diag_sockets.php*
 ##|-PRIV
 
-include('guiconfig.inc');
+require_once('guiconfig.inc');
 
 $pgtitle = array(gettext("Diagnostics"), gettext("Sockets"));
 

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -817,7 +817,7 @@ function display_widget_tabs(& $tab_array) {
 function outputJavaScriptFileInline($javascript) {
 	if (file_exists($javascript)) {
 		echo "\n<script type=\"text/javascript\">\n";
-		include($javascript);
+		include_once($javascript);
 		echo "\n</script>\n";
 	} else {
 		echo "\n\n<!-- Could not locate file:  {$javascript} -->\n\n";
@@ -829,7 +829,7 @@ function outputJavaScriptFileInline($javascript) {
 function outputCSSPrintFileInline($css) {
 	if (file_exists($css)) {
 		echo "\n<style media=\"print\" type=\"text/css\">\n";
-		include($css);
+		include_once($css);
 		echo "\n</style>\n";
 	} else {
 		echo "\n\n<!-- Could not locate file:  {$css} -->\n\n";
@@ -840,7 +840,7 @@ function outputCSSPrintFileInline($css) {
 function outputCSSFileInline($css) {
 	if (file_exists($css)) {
 		echo "\n<style type=\"text/css\">\n";
-		include($css);
+		include_once($css);
 		echo "\n</style>\n";
 	} else {
 		echo "\n\n<!-- Could not locate file:  {$css} -->\n\n";

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -130,7 +130,7 @@ while (false !== ($filename = readdir($dirhandle))) {
 ## These define vars that specify the widget title and title link.
 foreach ($phpincludefiles as $includename) {
 	if (file_exists($directory . $includename)) {
-		include($directory . $includename);
+		include_once($directory . $includename);
 	}
 }
 
@@ -425,7 +425,7 @@ foreach ($widgets as $widgetname => $widgetconfig) {
 						</h2>
 					</div>
 					<div id="widget-<?=$widgetname?>_panel-body" class="panel-body collapse<?=($widgetconfig['display'] == 'close' ? '' : ' in')?>">
-						<?php include('/usr/local/www/widgets/widgets/'. $widgetname.'.widget.php'); ?>
+						<?php include_once('/usr/local/www/widgets/widgets/'. $widgetname.'.widget.php'); ?>
 					</div>
 				</div>
 				<?php

--- a/src/usr/local/www/restart_httpd.php
+++ b/src/usr/local/www/restart_httpd.php
@@ -68,7 +68,7 @@ include("head.inc");
 ?>
 
 <form>
-<?php include("fbegin.inc"); ?>
+<?php include_once("fbegin.inc"); ?>
 
 <?=gettext("Mounting file systems read/write");?>...
 <?php flush(); sleep(1); conf_mount_rw(); ?>

--- a/src/usr/local/www/shortcuts.inc
+++ b/src/usr/local/www/shortcuts.inc
@@ -168,14 +168,14 @@ function get_shortcut_log_link($shortcut_section, $addspace = true) {
 $dir_array = get_shortcut_files("/usr/local/www/shortcuts");
 foreach ($dir_array as $file) {
 	if (!is_dir("/usr/local/www/shortcuts/{$file}") && stristr($file, ".inc")) {
-		include("/usr/local/www/shortcuts/{$file}");
+		include_once("/usr/local/www/shortcuts/{$file}");
 	}
 }
 if (is_dir("/usr/local/pkg/shortcuts")) {
 	$dir_array = get_shortcut_files("/usr/local/pkg/shortcuts");
 	foreach ($dir_array as $file) {
 		if (!is_dir("/usr/local/pkg/shortcuts/{$file}") && stristr($file, ".inc")) {
-			include("/usr/local/pkg/shortcuts/{$file}");
+			include_once("/usr/local/pkg/shortcuts/{$file}");
 		}
 	}
 }


### PR DESCRIPTION
For safety, use include_once() when including various "side" files.
There are a couple of instances of include("guiconfig,inc") that I
changes to use require_once() to be consistent with everywhere else.
The remaining cases of include() are just (hundreds of) head.inc and
footer.inc - those are only at the start/end of the ordinary top-level
interactive PHP files. There is no nested interaction of those to think
about, so that should be fine.