### PR TITLE
Remove a-f from IPv4 address pattern

### DIFF
--- a/src/usr/local/www/classes/Form/IpAddress.class.php
+++ b/src/usr/local/www/classes/Form/IpAddress.class.php
@@ -41,7 +41,7 @@ class Form_IpAddress extends Form_Input
 				break;
 
 			case "V4":
-				$this->_attributes['pattern'] = '[a-f0-9.]*';
+				$this->_attributes['pattern'] = '[0-9.]*';
 				break;
 
 			case "V6":


### PR DESCRIPTION
It seems to me that a through f should not be part of the pattern for the "V4" case.