### PR TITLE
Solve problems with IPv6 dpinger, VLAN Interfaces and long socket names

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -128,10 +128,16 @@ function start_dpinger($gateway) {
 
 	$dpinger_defaults = return_dpinger_defaults();
 
-	$pidfile = "{$g['varrun_path']}/dpinger_{$gateway['name']}~" .
-	    "{$gateway['gwifip']}~{$gateway['monitor']}.pid";
-	$socket = "{$g['varrun_path']}/dpinger_{$gateway['name']}~" .
-	    "{$gateway['gwifip']}~{$gateway['monitor']}.sock";
+	$prefix = "{$g['varrun_path']}/dpinger_{$gateway['name']}~" .
+	    "{$gateway['gwifip']}~{$gateway['monitor']}";
+	# dpinger socket path should not be longer then uaddr.sun_path
+	if (strlen($pidfile) > 95) {
+		$prefix = "{$g['varrun_path']}/dpinger_{$gateway['name']}~" .
+		    substr(md5($gateway['gwifip']),0,8) . "~" .
+		    $gateway['monitor'];
+	}
+	$pidfile = $prefix . ".pid";
+	$socket = $prefix . ".sock";
 	$alarm_cmd = "{$g['etc_path']}/rc.gateway_alarm";
 
 	$params  = "-S ";			/* Log warnings via syslog */

--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -79,7 +79,7 @@ function running_dpinger_processes() {
 	}
 
 	foreach ($pidfiles as $pidfile) {
-		if (preg_match('/^dpinger_(.+)_([^_]+)_([^_]+)\.pid$/',
+		if (preg_match('/^dpinger_(.+)~([^~]+)~([^~]+)\.pid$/',
 		    basename($pidfile), $matches)) {
 			$socket_file = preg_replace('/\.pid$/', '.sock',
 			    $pidfile);
@@ -128,10 +128,10 @@ function start_dpinger($gateway) {
 
 	$dpinger_defaults = return_dpinger_defaults();
 
-	$pidfile = "{$g['varrun_path']}/dpinger_{$gateway['name']}_" .
-	    "{$gateway['gwifip']}_{$gateway['monitor']}.pid";
-	$socket = "{$g['varrun_path']}/dpinger_{$gateway['name']}_" .
-	    "{$gateway['gwifip']}_{$gateway['monitor']}.sock";
+	$pidfile = "{$g['varrun_path']}/dpinger_{$gateway['name']}~" .
+	    "{$gateway['gwifip']}~{$gateway['monitor']}.pid";
+	$socket = "{$g['varrun_path']}/dpinger_{$gateway['name']}~" .
+	    "{$gateway['gwifip']}~{$gateway['monitor']}.sock";
 	$alarm_cmd = "{$g['etc_path']}/rc.gateway_alarm";
 
 	$params  = "-S ";			/* Log warnings via syslog */


### PR DESCRIPTION
For more details please see the ticket https://redmine.pfsense.org/issues/6505

1) The use of underscores as delimiter conflicts with vlan interfaces names (which also contain underscors). --> switch to ~
2) shorten long socket names so dpinger won't fail (this is not 100% failsafe due to the fact that the gateway name and monitor ip is actually used and presented in the status_gateway listing.