### PR TITLE
Fix #6552 Handle more invalid IPv6 formats

### DIFF
--- a/src/etc/inc/IPv6.inc
+++ b/src/etc/inc/IPv6.inc
@@ -557,7 +557,7 @@ class Net_IPv6
 
         if (false !== strpos($uip, '::') ) {
 
-            list($ip1, $ip2) = explode('::', $uip);
+            list($ip1, $ip2, $ip3) = explode('::', $uip);
 
             if ("" == $ip1) {
 
@@ -606,21 +606,27 @@ class Net_IPv6
 
                 $uip = "0:0:0:0:0:0:0:0";
 
+                if (isset($ip3)) { // ::::xxx - not good
+                    if ("" == $ip3) { // ::::
+                        $ip3 = 0; // Give back a 9th "0"
+                    }
+                    $uip .= ":" . $ip3;
+                }
+
             } else if (-1 == $c1) {              // ::xxx
 
-                $fill = str_repeat('0:', 7-$c2);
+                $fill = str_repeat('0:', max(1, 7-$c2));
                 $uip  = str_replace('::', $fill, $uip);
 
             } else if (-1 == $c2) {              // xxx::
 
-                $fill = str_repeat(':0', 7-$c1);
+                $fill = str_repeat(':0', max(1, 7-$c1));
                 $uip  = str_replace('::', $fill, $uip);
 
             } else {                          // xxx::xxx
 
-                $fill = str_repeat(':0:', max(1, 6-$c2-$c1));
+                $fill = ':' . str_repeat('0:', max(1, 6-$c2-$c1));
                 $uip  = str_replace('::', $fill, $uip);
-                $uip  = str_replace('::', ':', $uip);
 
             }
         }
@@ -921,7 +927,7 @@ class Net_IPv6
 
             }
 
-            if (8 == $count) {
+            if (8 == $count and empty($ipPart[1])) {
 
                 return true;
 


### PR DESCRIPTION
Redmine https://redmine.pfsense.org/issues/6552

All the following formats can currently be entered and accepted as "valid" IPv6 addresses, when actually they should be rejected.

1:2:3:4:5:6:7:8:1.2.3.4 - a full 8 pieces of IPv6 followed by an IPv4 on the end. (a valid address in this form has 6 colon-separated IPv6 parts followed by the IPv4 format on the end).
- fixed by line 930

::1:2:3:4:5:6:7:8 - the front "::" was getting uncompressed into "", resulting in "1:2:3:4:5:6:7:8" which looked good, but actually the input is bad.
- fixed by line 618

1:2:3:4:5:6:7:8:: - the end "::" was getting uncompressed into "", resulting in "1:2:3:4:5:6:7:8" which looked good, but actually the input is bad.
- fixed by line 623

1:2:3:4:5:6:::8 - the triple-colon ":::" happened to uncompress into "1:2:3:4:5:6:0:8" which looked good, but actually the input is bad.
- fixed by line 628

::::a - start with 4 colons
- fixed by lines 560 and 609-625

:::: - just input 4 colons
- fixed with a bit of enhancement at lines 610-612. We don't want to give back "0:0:0:0:0:0:0:0:" from uncompress(), so add a 9th 0 on the end to make it look nicer but invalid.

That's all I can find for now.