### PR TITLE
GitSync Diff Only Option

### DIFF
--- a/src/etc/phpshellsessions/gitsync
+++ b/src/etc/phpshellsessions/gitsync
@@ -38,6 +38,12 @@ $valid_args = array(
 	"--minimal" => "\tPerform a minimal copy of only the updated files.\n" .
 	    "\tNot recommended if the system has files modified by any method other\n" .
 	    "\tthan gitsync.\n",
+	"--diff" => "\tPerform a copy of only the files that are different or missing.\n" .
+	    "\tRecommended for SSD if system has files modified by any method other\n" .
+	    "\tthan gitsync.\n",
+	"--verbose" => "\tDisplay constructed command.  In combination with the --diff\n" .
+	    "\toption, display the array of different and missing files.\n",
+	"--dry-run" => "\tDry-run only.  No files copied.\n",
 	"--help" => "\tDisplay this help list.\n"
 	);
 $args = array();
@@ -66,6 +72,69 @@ while (!empty($temp_args)) {
 	} else {
 		$args[$arg_count++] = $arg;
 	}
+}
+
+if (!function_exists('post_cvssync_commands')) {
+function post_cvssync_commands() {
+	echo "===> Removing FAST-CGI temporary files...\n";
+	exec("find /tmp -name \"php-fastcgi.socket*\" -exec rm -rf {} \;");
+	exec("find /tmp -name \"*.tmp\" -exec rm -rf {} \;");
+
+	exec("rm -rf /tmp/xcache/* 2>/dev/null");
+
+	echo "===> Upgrading configuration (if needed)...\n";
+	convert_config();
+
+	echo "===> Configuring filter...";
+	exec("/etc/rc.filter_configure_sync");
+	exec("pfctl -f /tmp/rules.debug");
+	echo "\n";
+
+	if (file_exists("/etc/rc.php_ini_setup")) {
+		echo "===> Running /etc/rc.php_ini_setup...";
+		exec("/etc/rc.php_ini_setup >/dev/null 2>&1");
+		echo "\n";
+	}
+
+	/* lock down console if necessary */
+	echo "===> Locking down the console if needed...\n";
+	reload_ttys();
+
+	echo "===> Signaling PHP and nginx restart...";
+	$fd = fopen("/tmp/restart_nginx", "w");
+	fwrite($fd, "#!/bin/sh\n");
+	fwrite($fd, "sleep 5\n");
+	fwrite($fd, "/usr/local/sbin/pfSctl -c 'service restart webgui'\n");
+	fclose($fd);
+	mwexec_bg("sh /tmp/restart_nginx");
+	echo "\n";
+}
+}
+
+if (!function_exists('isUrl')) {
+function isUrl($url = "") {
+	if ($url) {
+		if (strstr($url, "rcs.pfsense.org") or
+			strstr($url, "mainline") or
+			strstr($url, ".git") or
+			strstr($url, "git://")) {
+			return true;
+		}
+	}
+	return false;
+}
+}
+
+if (!function_exists('run_cmds')) {
+function run_cmds($cmds) {
+	global $debug;
+	foreach ($cmds as $cmd) {
+		if ($debug) {
+			echo "Running $cmd";
+		}
+		exec($cmd);
+	}
+}
 }
 
 unlink_if_exists("/tmp/config.cache");
@@ -298,8 +367,10 @@ if (isset($args["--minimal"])) {
 		$old_revision = trim(file_get_contents("/etc/version.lastcommit"));
 	}
 	$files_to_copy = strtr(shell_exec("cd $CODIR/pfSenseGITREPO/pfSenseGITREPO && {$GIT_BIN} diff --name-only --relative=src " . escapeshellarg($old_revision)), "\n", " ");
+	$tar_options = '-C ./src';
 } else {
-	$files_to_copy = '-C ./src .';
+	$files_to_copy = '.';
+	$tar_options = '-C ./src';
 }
 
 // Save new commit ID for later minimal file copies
@@ -324,16 +395,74 @@ exec("rm -rf {$CODIR}/pfSenseGITREPO/pfSenseGITREPO/src/conf*");
 exec("rm -rf {$CODIR}/pfSenseGITREPO/pfSenseGITREPO/src/cf 2>/dev/null");
 @chmod("{$CODIR}/pfSenseGITREPO/pfSenseGITREPO/src/tmp", 01777);
 
+if(isset($args["--diff"])) {
+	# Find different and missing files.
+	$different_missing_files = shell_exec("/usr/bin/diff -qr / $CODIR/pfSenseGITREPO/pfSenseGITREPO/src/ | /usr/bin/grep -E '^(Files .*? and $CODIR/pfSenseGITREPO/pfSenseGITREPO/src/.*? differ)|(Only in $CODIR/pfSenseGITREPO/pfSenseGITREPO/src/)'");
+
+	# Get the path of each different or missing file.
+	preg_match_all('@(?:^Files .*? and '.$CODIR.'/pfSenseGITREPO/pfSenseGITREPO/src/(.*?) differ.*?$)@sim', $different_missing_files, $different_files_array, PREG_PATTERN_ORDER);
+	preg_match_all('@(?:^Only in '.$CODIR.'/pfSenseGITREPO/pfSenseGITREPO/src/(.*?)$)@sim', $different_missing_files, $missing_files_array, PREG_PATTERN_ORDER);
+
+	# Deal with diff's output format of missing files (path: missing_file).
+	foreach ($missing_files_array[1] as $key => $file) {
+
+		# Most of the time there will be only the one ': ' injected by diff output.  So global replace with dir delimiter (/) is fine.
+		$tmp = str_replace(": ", "/", $file, $count);
+		if ($count == 1)
+			$file = ltrim($tmp, "/");
+
+		# For the very rare case a path component (dir or file) contains ': ' as well, then need to find and replace only the ': ' injected by diff output.
+		else {
+			$tmp = $file;
+			do {
+				$pos = strrpos($tmp, ": ");
+				if ($pos) {
+					$tmp = substr($tmp, 0, $pos);
+					$res = is_dir("$CODIR/pfSenseGITREPO/pfSenseGITREPO/src/$tmp/");
+				}
+			} while (!$res && $pos);
+
+			if ($res)
+				$file = ltrim($tmp . "/" . substr($file, $pos+2), "/");
+		}
+
+		$missing_files_array[1][$key] = $file;
+	}
+
+	# Convert the list from array to space separated quoted strings.  Quoted for white space file name support.
+	$different_files = $missing_files = '';
+	if (count($different_files_array[1]) > 0)
+		$different_files .= '"' . implode('" "', $different_files_array[1]) . '"';
+	if (count($missing_files_array[1]) > 0)
+		$missing_files .= '"' . implode('" "', $missing_files_array[1]) . '"';
+
+	# Files to be copied.
+	$files_to_copy = trim($different_files . " " . $missing_files);
+	$tar_options = '-C ./src';
+
+	if(isset($args["--verbose"])) {
+		echo "===> Different Files: \n";
+		print_r($different_files_array[1]);
+		echo "===> Missing Files: \n";
+		print_r($missing_files_array[1]);
+	}
+}
+
 echo "===> Installing new files...\n";
 
 if ($g['platform'] == $g['product_name']) {
-	$command = "cd $CODIR/pfSenseGITREPO/pfSenseGITREPO ; tar -cpf - {$files_to_copy} | (cd / ; tar -Uxpf -)";
+	$command = "cd $CODIR/pfSenseGITREPO/pfSenseGITREPO ; tar -cpf - {$tar_options} {$files_to_copy} | (cd / ; tar -Uxpf -)";
 } else {
-	$command = "cd $CODIR/pfSenseGITREPO/pfSenseGITREPO ; tar -cpf - {$files_to_copy} | (cd / ; tar -xpf -) 2>/dev/null";
+	$command = "cd $CODIR/pfSenseGITREPO/pfSenseGITREPO ; tar -cpf - {$tar_options} {$files_to_copy} | (cd / ; tar -xpf -) 2>/dev/null";
 }
 
 if (!empty($files_to_copy)) {
-	exec($command);
+	if(isset($args["--verbose"])) {
+		echo "===> Command: \n$command\n";
+	}
+	if(!isset($args["--dry-run"])) {
+		exec($command);
+	}
 } else {
 	echo "Already up-to-date.\n";
 	$upgrading = true;
@@ -360,64 +489,6 @@ if (!$upgrading) {
 	echo "Your system is now sync'd and PHP and nginx will be restarted in 5 seconds.\n\n";
 } else {
 	echo "Your system is now sync'd.\n\n";
-}
-
-function post_cvssync_commands() {
-	echo "===> Removing FAST-CGI temporary files...\n";
-	exec("find /tmp -name \"php-fastcgi.socket*\" -exec rm -rf {} \;");
-	exec("find /tmp -name \"*.tmp\" -exec rm -rf {} \;");
-
-	exec("rm -rf /tmp/xcache/* 2>/dev/null");
-
-	echo "===> Upgrading configuration (if needed)...\n";
-	convert_config();
-
-	echo "===> Configuring filter...";
-	exec("/etc/rc.filter_configure_sync");
-	exec("pfctl -f /tmp/rules.debug");
-	echo "\n";
-
-	if (file_exists("/etc/rc.php_ini_setup")) {
-		echo "===> Running /etc/rc.php_ini_setup...";
-		exec("/etc/rc.php_ini_setup >/dev/null 2>&1");
-		echo "\n";
-	}
-
-	/* lock down console if necessary */
-	echo "===> Locking down the console if needed...\n";
-	reload_ttys();
-
-	echo "===> Signaling PHP and nginx restart...";
-	$fd = fopen("/tmp/restart_nginx", "w");
-	fwrite($fd, "#!/bin/sh\n");
-	fwrite($fd, "sleep 5\n");
-	fwrite($fd, "/usr/local/sbin/pfSctl -c 'service restart webgui'\n");
-	fclose($fd);
-	mwexec_bg("sh /tmp/restart_nginx");
-	echo "\n";
-
-}
-
-function isUrl($url = "") {
-	if ($url) {
-		if (strstr($url, "rcs.pfsense.org") or
-			strstr($url, "mainline") or
-			strstr($url, ".git") or
-			strstr($url, "git://")) {
-			return true;
-		}
-	}
-	return false;
-}
-
-function run_cmds($cmds) {
-	global $debug;
-	foreach ($cmds as $cmd) {
-		if ($debug) {
-			echo "Running $cmd";
-		}
-		exec($cmd);
-	}
 }
 
 conf_mount_ro();


### PR DESCRIPTION
Diff Option
--diff
SSD Friendlier
Same as default but only copies files that are different, instead of every thing even though identical.

Verbose Option
--verbose
Display constructed command.
In combination with the --diff option, display the array of different and missing files.

Dry Run Option
--dry-run
Run without syncing files.


Fixes

Files to copy variable state is used to determine whether or not to run the command.  Tar options being passed in the files to copy variable causes the command to always run.  Even if there are no files to be copied.  Separate out tar options from files to copy variable so command only runs if there are files to be copied.

Accommodate providing tar options such as '-C ./src' with the --minimal option.

Resolve function redefinition that prevents running gitsync again in same dev shell session (command recall) (function_exists).