### PR TITLE
Fix some PHP notice issues

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -2603,7 +2603,7 @@ $section->addInput(new Form_Input(
 	'Idle timeout',
 	'number',
 	$pconfig['pppoe_idletimeout'],
-	[min => 0]
+	['min' => 0]
 ))->setHelp('If no qualifying outgoing packets are transmitted for the specified number of seconds, the connection is brought down. ' .
 			'An idle timeout of zero disables this feature.');
 
@@ -2622,7 +2622,7 @@ $group->add(new Form_Input(
 	null,
 	'number',
 	$pconfig['pppoe_resethour'],
-	[min => 0, max => 23]
+	['min' => 0, 'max' => 23]
 ))->setHelp('Hour (0-23)');
 
 $group->add(new Form_Input(
@@ -2630,7 +2630,7 @@ $group->add(new Form_Input(
 	null,
 	'number',
 	$pconfig['pppoe_resetminute'],
-	[min => 0, max => 59]
+	['min' => 0, 'max' => 59]
 ))->setHelp('Minutes (0-59)');
 
 $group->add(new Form_Input(
@@ -2734,7 +2734,7 @@ $section->addInput(new Form_Input(
 	'Idle timeout (seconds)',
 	'number',
 	$pconfig['pptp_idletimeout'],
-	[min => 0]
+	['min' => 0]
 ))->setHelp('If no qualifying outgoing packets are transmitted for the specified number of seconds, the connection is brought down. ' .
 			'An idle timeout of zero disables this feature.');
 

--- a/src/usr/local/www/system_crlmanager.php
+++ b/src/usr/local/www/system_crlmanager.php
@@ -434,7 +434,7 @@ if ($act == "new" || $act == gettext("Save") || $input_errors) {
 		'Serial',
 		'number',
 		$pconfig['serial'],
-		[min => '0', max => '9999']
+		['min' => '0', 'max' => '9999']
 	));
 
 	$form->add($section);

--- a/src/usr/local/www/system_usermanager_settings.php
+++ b/src/usr/local/www/system_usermanager_settings.php
@@ -216,7 +216,7 @@ $section->addInput(new Form_Input(
 	'Session timeout',
 	'number',
 	$pconfig['session_timeout'],
-	[min => 0]
+	['min' => 0]
 ))->setHelp('Time in minutes to expire idle management sessions. The default is 4 '.
 	'hours (240 minutes). Enter 0 to never expire sessions. NOTE: This is a security '.
 	'risk!');


### PR DESCRIPTION
Use of undefined constant min - assumed 'min'
Use of undefined constant max - assumed 'max'