### PR TITLE
Check IP Services

### DIFF
--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -238,4 +238,15 @@ if (file_exists("{$g['cf_conf_path']}/enableserial_force")) {
 
 $config_parsed = false;
 
+/* Factory default check IP service. */
+$factory_default_checkipservice = array(
+	"enable" => true,
+	"name" => 'Default',
+	"url" => 'http://checkip.dyndns.org',
+//	"username" => '',
+//	"password" => '',
+//	"verifysslpeer" => true,
+	"descr" => 'Default Check IP Service'
+);
+
 ?>

--- a/src/etc/inc/priv.defs.inc
+++ b/src/etc/inc/priv.defs.inc
@@ -646,6 +646,18 @@ $priv_list['page-services-captiveportal-editzones']['descr'] = gettext("Allow ac
 $priv_list['page-services-captiveportal-editzones']['match'] = array();
 $priv_list['page-services-captiveportal-editzones']['match'][] = "services_captiveportal_zones_edit.php*";
 
+$priv_list['page-services-checkipservices'] = array();
+$priv_list['page-services-checkipservices']['name'] = gettext("WebCfg - Services: Check IP Service");
+$priv_list['page-services-checkipservices']['descr'] = gettext("Allow access to the 'Services: Check IP Service' page.");
+$priv_list['page-services-checkipservices']['match'] = array();
+$priv_list['page-services-checkipservices']['match'][] = "services_checkip.php*";
+
+$priv_list['page-services-checkipedit'] = array();
+$priv_list['page-services-checkipedit']['name'] = gettext("WebCfg - Services: Check IP Service: Edit");
+$priv_list['page-services-checkipedit']['descr'] = gettext("Allow access to the 'Services: Check IP Service: Edit' page.");
+$priv_list['page-services-checkipedit']['match'] = array();
+$priv_list['page-services-checkipedit']['match'][] = "services_checkip_edit.php*";
+
 $priv_list['page-services-dhcpserver'] = array();
 $priv_list['page-services-dhcpserver']['name'] = gettext("WebCfg - Services: DHCP Server");
 $priv_list['page-services-dhcpserver']['descr'] = gettext("Allow access to the 'Services: DHCP Server' page.");

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1963,7 +1963,7 @@ function services_dyndns_configure($int = "") {
 }
 
 function dyndnsCheckIP($int) {
-	global $config;
+	global $config, $factory_default_checkipservice;
 	$ip_address = get_interface_ip($int);
 	if (is_private_ip($ip_address)) {
 		$gateways_status = return_gateways_status(true);
@@ -1972,14 +1972,35 @@ function dyndnsCheckIP($int) {
 		if (stristr($gateways_status[$config['interfaces'][$int]['gateway']]['status'], "down")) {
 			return "down";
 		}
-		$hosttocheck = "http://checkip.dyndns.org";
+
+		// Append the factory default check IP service to the list (if not disabled).
+		if (!isset($config['checkipservices']['disable_factory_default'])) {
+			$config['checkipservices']['checkipservice'][] = $factory_default_checkipservice;
+		}
+
+		// Use the first enabled check IP service as the default.
+		if (is_array($config['checkipservices']['checkipservice'])) {
+			foreach ($config['checkipservices']['checkipservice'] as $i => $checkipservice) {
+				if (isset($checkipservice['enable'])) {
+					$url = $checkipservice['url'];
+					$username = $checkipservice['username'];
+					$password = $checkipservice['password'];
+					$verifysslpeer = isset($checkipservice['verifysslpeer']);
+					break;
+				}
+			}
+		}
+
+		$hosttocheck = $url;
 		$ip_ch = curl_init($hosttocheck);
 		curl_setopt($ip_ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($ip_ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+		curl_setopt($ip_ch, CURLOPT_SSL_VERIFYPEER, $verifysslpeer);
 		curl_setopt($ip_ch, CURLOPT_INTERFACE, 'host!' . $ip_address);
 		curl_setopt($ip_ch, CURLOPT_CONNECTTIMEOUT, '30');
 		curl_setopt($ip_ch, CURLOPT_TIMEOUT, 120);
 		curl_setopt($ip_ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+		curl_setopt($ip_ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+		curl_setopt($ip_ch, CURLOPT_USERPWD, "{$username}:{$password}");
 		$ip_result_page = curl_exec($ip_ch);
 		curl_close($ip_ch);
 		$ip_result_decoded = urldecode($ip_result_page);

--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -66,6 +66,7 @@ function listtags() {
 		'acls', 'alias', 'aliasurl', 'allowedip', 'allowedhostname', 'authserver',
 		'bridged', 'build_port_path',
 		'ca', 'cacert', 'cert', 'crl', 'clone', 'config', 'container', 'columnitem',
+		'checkipservice',
 		'depends_on_package', 'disk', 'dnsserver', 'dnsupdate', 'domainoverrides', 'dyndns',
 		'earlyshellcmd', 'element', 'encryption-algorithm-option',
 		'field', 'fieldname',

--- a/src/etc/inc/xmlreader.inc
+++ b/src/etc/inc/xmlreader.inc
@@ -66,6 +66,7 @@ function listtags() {
 		'acls', 'alias', 'aliasurl', 'allowedip', 'allowedhostname', 'authserver',
 		'bridged', 'build_port_path',
 		'ca', 'cacert', 'cert', 'crl', 'clone', 'config', 'container', 'columnitem',
+		'checkipservice',
 		'depends_on_package', 'disk', 'dnsserver', 'dnsupdate', 'domainoverrides', 'dyndns',
 		'earlyshellcmd', 'element', 'encryption-algorithm-option',
 		'field', 'fieldname',

--- a/src/usr/local/www/services_checkip.php
+++ b/src/usr/local/www/services_checkip.php
@@ -1,0 +1,198 @@
+<?php
+/*
+	services_checkip.php
+*/
+/* ====================================================================
+ *	Copyright (c)  2004-2015  Electric Sheep Fencing, LLC. All rights reserved.
+ *
+ *	Redistribution and use in source and binary forms, with or without modification,
+ *	are permitted provided that the following conditions are met:
+ *
+ *	1. Redistributions of source code must retain the above copyright notice,
+ *		this list of conditions and the following disclaimer.
+ *
+ *	2. Redistributions in binary form must reproduce the above copyright
+ *		notice, this list of conditions and the following disclaimer in
+ *		the documentation and/or other materials provided with the
+ *		distribution.
+ *
+ *	3. All advertising materials mentioning features or use of this software
+ *		must display the following acknowledgment:
+ *		"This product includes software developed by the pfSense Project
+ *		 for use in the pfSense software distribution. (http://www.pfsense.org/).
+ *
+ *	4. The names "pfSense" and "pfSense Project" must not be used to
+ *		 endorse or promote products derived from this software without
+ *		 prior written permission. For written permission, please contact
+ *		 coreteam@pfsense.org.
+ *
+ *	5. Products derived from this software may not be called "pfSense"
+ *		nor may "pfSense" appear in their names without prior written
+ *		permission of the Electric Sheep Fencing, LLC.
+ *
+ *	6. Redistributions of any form whatsoever must retain the following
+ *		acknowledgment:
+ *
+ *	"This product includes software developed by the pfSense Project
+ *	for use in the pfSense software distribution (http://www.pfsense.org/).
+ *
+ *	THIS SOFTWARE IS PROVIDED BY THE pfSense PROJECT ``AS IS'' AND ANY
+ *	EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *	IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *	PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE pfSense PROJECT OR
+ *	ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ *	STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ *	OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *	====================================================================
+ *
+ */
+
+##|+PRIV
+##|*IDENT=page-services-checkipservices
+##|*NAME=Services: Check IP Service
+##|*DESCR=Allow access to the 'Services: Check IP Service' page.
+##|*MATCH=services_checkip.php*
+##|-PRIV
+
+require_once("guiconfig.inc");
+
+if (!is_array($config['checkipservices']['checkipservice'])) {
+	$config['checkipservices']['checkipservice'] = array();
+}
+
+$a_checkipservice = &$config['checkipservices']['checkipservice'];
+
+$dirty = false;
+if ($_GET['act'] == "del") {
+	unset($a_checkipservice[$_GET['id']]);
+	$dirty = true;
+} else if ($_GET['act'] == "toggle") {
+	if ($a_checkipservice[$_GET['id']]) {
+		if (isset($a_checkipservice[$_GET['id']]['enable'])) {
+			unset($a_checkipservice[$_GET['id']]['enable']);
+		} else {
+			$a_checkipservice[$_GET['id']]['enable'] = true;
+		}
+		$dirty = true;
+	} else if ($_GET['id'] == count($a_checkipservice)) {
+		if (isset($config['checkipservices']['disable_factory_default'])) {
+			unset($config['checkipservices']['disable_factory_default']);
+		} else {
+			$config['checkipservices']['disable_factory_default'] = true;
+		}
+		$dirty = true;
+	}
+}
+if ($dirty) {
+	write_config();
+
+	header("Location: services_checkip.php");
+	exit;
+}
+
+$pgtitle = array(gettext("Services"), gettext("Dynamic DNS"), gettext("Check IP Services"));
+include("head.inc");
+
+$tab_array = array();
+$tab_array[] = array(gettext("Dynamic DNS Clients"), false, "services_dyndns.php");
+$tab_array[] = array(gettext("RFC 2136 Clients"), false, "services_rfc2136.php");
+$tab_array[] = array(gettext("Check IP Services"), true, "services_checkip.php");
+display_top_tabs($tab_array);
+
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+?>
+
+<form action="services_checkip.php" method="post" name="iform" id="iform">
+	<div class="panel panel-default">
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Check IP Services')?></h2></div>
+		<div class="panel-body">
+			<div class="table-responsive">
+				<table class="table table-striped table-hover table-condensed">
+					<thead>
+						<tr>
+							<th><?=gettext("Name")?></th>
+							<th><?=gettext("URL")?></th>
+							<th><?=gettext("Verify SSL Peer")?></th>
+							<th><?=gettext("Description")?></th>
+							<th><?=gettext("Actions")?></th>
+						</tr>
+					</thead>
+					<tbody>
+<?php
+// Is the factory default check IP service disabled?
+if (isset($config['checkipservices']['disable_factory_default'])) {
+	unset($factory_default_checkipservice['enable']);
+}
+
+// Append the factory default check IP service to the list.
+$a_checkipservice[] = $factory_default_checkipservice;
+$factory_default = count($a_checkipservice) - 1;
+
+$i = 0;
+foreach ($a_checkipservice as $checkipservice):
+
+	// Hide edit and delete controls on the factory default check IP service entry (last one; id = count-1), and retain layout positioning.
+	if ($i == $factory_default) {
+		$visibility = 'invisible';
+	} else {
+		$visibility = 'visible';
+	}
+?>
+						<tr<?=(isset($checkipservice['enable']) ? '' : ' class="disabled"')?>>
+						<td>
+							<?=htmlspecialchars($checkipservice['name'])?>
+						</td>
+						<td>
+							<?=htmlspecialchars($checkipservice['url'])?>
+						</td>
+						<td class="text-center">
+							<i<?=(isset($checkipservice['verifysslpeer'])) ? ' class="fa fa-check"' : '';?>></i>
+						</td>
+						<td>
+							<?=htmlspecialchars($checkipservice['descr'])?>
+						</td>
+						<td>
+							<a class="fa fa-pencil <?=$visibility?>" title="<?=gettext('Edit service')?>" href="services_checkip_edit.php?id=<?=$i?>"></a>
+						<?php if (isset($checkipservice['enable'])) {
+						?>
+							<a	class="fa fa-ban" title="<?=gettext('Disable service')?>" href="?act=toggle&amp;id=<?=$i?>"></a>
+						<?php } else {
+						?>
+							<a class="fa fa-check-square-o" title="<?=gettext('Enable service')?>" href="?act=toggle&amp;id=<?=$i?>"></a>
+						<?php }
+						?>
+							<a class="fa fa-trash <?=$visibility?>" title="<?=gettext('Delete service')?>" href="services_checkip.php?act=del&amp;id=<?=$i?>"></a>
+						</td>
+					</tr>
+<?php
+	$i++;
+endforeach; ?>
+
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</form>
+
+<nav class="action-buttons">
+	<a href="services_checkip_edit.php" class="btn btn-sm btn-success btn-sm">
+		<i class="fa fa-plus icon-embed-btn"></i>
+		<?=gettext('Add')?>
+	</a>
+</nav>
+
+<?php
+print_info_box(gettext('The first (highest in list) enabled check ip service will be used to ' . 
+						'check IP addresses for Dynamic DNS services, and ' .
+						'RFC 2136 entries that have the "Use public IP" option enabled.'));
+
+include("foot.inc");

--- a/src/usr/local/www/services_checkip_edit.php
+++ b/src/usr/local/www/services_checkip_edit.php
@@ -1,0 +1,216 @@
+<?php
+/*
+	services_checkip_edit.php
+*/
+/* ====================================================================
+ *	Copyright (c)  2004-2015  Electric Sheep Fencing, LLC. All rights reserved.
+ *
+ *	Redistribution and use in source and binary forms, with or without modification,
+ *	are permitted provided that the following conditions are met:
+ *
+ *	1. Redistributions of source code must retain the above copyright notice,
+ *		this list of conditions and the following disclaimer.
+ *
+ *	2. Redistributions in binary form must reproduce the above copyright
+ *		notice, this list of conditions and the following disclaimer in
+ *		the documentation and/or other materials provided with the
+ *		distribution.
+ *
+ *	3. All advertising materials mentioning features or use of this software
+ *		must display the following acknowledgment:
+ *		"This product includes software developed by the pfSense Project
+ *		 for use in the pfSense software distribution. (http://www.pfsense.org/).
+ *
+ *	4. The names "pfSense" and "pfSense Project" must not be used to
+ *		 endorse or promote products derived from this software without
+ *		 prior written permission. For written permission, please contact
+ *		 coreteam@pfsense.org.
+ *
+ *	5. Products derived from this software may not be called "pfSense"
+ *		nor may "pfSense" appear in their names without prior written
+ *		permission of the Electric Sheep Fencing, LLC.
+ *
+ *	6. Redistributions of any form whatsoever must retain the following
+ *		acknowledgment:
+ *
+ *	"This product includes software developed by the pfSense Project
+ *	for use in the pfSense software distribution (http://www.pfsense.org/).
+ *
+ *	THIS SOFTWARE IS PROVIDED BY THE pfSense PROJECT ``AS IS'' AND ANY
+ *	EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *	IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *	PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE pfSense PROJECT OR
+ *	ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ *	STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ *	OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *	====================================================================
+ *
+ */
+
+##|+PRIV
+##|*IDENT=page-services-checkipedit
+##|*NAME=Services: Check IP Service: Edit
+##|*DESCR=Allow access to the 'Services: Check IP Service: Edit' page.
+##|*MATCH=services_checkip_edit.php*
+##|-PRIV
+
+require_once("guiconfig.inc");
+
+if (!is_array($config['checkipservices']['checkipservice'])) {
+	$config['checkipservices']['checkipservice'] = array();
+}
+
+$a_checkip = &$config['checkipservices']['checkipservice'];
+
+if (is_numericint($_GET['id'])) {
+	$id = $_GET['id'];
+}
+
+if (isset($_POST['id']) && is_numericint($_POST['id'])) {
+	$id = $_POST['id'];
+}
+
+if (isset($id) && isset($a_checkip[$id])) {
+	$pconfig['enable'] = isset($a_checkip[$id]['enable']);
+	$pconfig['name'] = $a_checkip[$id]['name'];
+	$pconfig['url'] = $a_checkip[$id]['url'];
+	$pconfig['username'] = $a_checkip[$id]['username'];
+	$pconfig['password'] = $a_checkip[$id]['password'];
+	$pconfig['verifysslpeer'] = isset($a_checkip[$id]['verifysslpeer']);
+	$pconfig['descr'] = $a_checkip[$id]['descr'];
+}
+
+if ($_POST) {
+	unset($input_errors);
+	$pconfig = $_POST;
+
+	/* input validation */
+	$reqdfields = array();
+	$reqdfieldsn = array();
+	$reqdfields = array_merge($reqdfields, explode(" ", "name url"));
+	$reqdfieldsn = array_merge($reqdfieldsn, array(gettext("Name"), gettext("URL")));
+
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
+
+	if (($_POST['name'] && !is_validaliasname($_POST['name']))) {
+		$input_errors[] = gettext("The Check IP Service name contains invalid characters.");
+	}
+	if (($_POST['url'] && !is_URL($_POST['url']))) {
+		$input_errors[] = gettext("The Check IP Service URL is not valid.");
+	}
+	if ($_POST['passwordfld'] != $_POST['passwordfld_confirm']) {
+		$input_errors[] = gettext("Password and confirmed password must match.");
+	}
+
+	if (!$input_errors) {
+		$checkip = array();
+		$checkip['enable'] = $_POST['enable'] ? true : false;
+		$checkip['name'] = $_POST['name'];
+		$checkip['url'] = $_POST['url'];
+		$checkip['username'] = $_POST['username'];
+
+		if ($_POST['passwordfld'] != DMYPWD) {
+			$checkip['password'] = $_POST['passwordfld'];
+		} else {
+			$checkip['password'] = $a_checkip[$id]['password'];;
+		}
+
+		$checkip['verifysslpeer'] = $_POST['verifysslpeer'] ? true : false;
+		$checkip['descr'] = $_POST['descr'];
+
+		if (isset($id) && $a_checkip[$id]) {
+			$a_checkip[$id] = $checkip;
+		} else {
+			$a_checkip[] = $checkip;
+		}
+
+		write_config(gettext("New/Edited Check IP Services entry was posted."));
+
+		header("Location: services_checkip.php");
+		exit;
+	}
+}
+
+$pgtitle = array(gettext("Services"), gettext("Dynamic DNS"), gettext("Check IP Services"), gettext("Edit"));
+include("head.inc");
+
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+
+if ($savemsg) {
+	print_info_box($savemsg, 'success');
+}
+
+$form = new Form;
+
+$section = new Form_Section('Check IP Service');
+
+$section->addInput(new Form_Checkbox(
+	'enable',
+	'Enable',
+	null,
+	$pconfig['enable']
+));
+
+$section->addInput(new Form_Input(
+	'name',
+	'Name',
+	'text',
+	$pconfig['name']
+))->setHelp('The name of the service may only consist of the characters "a-z, A-Z, 0-9 and _".');
+
+$section->addInput(new Form_Input(
+	'url',
+	'URL',
+	'text',
+	$pconfig['url']
+));
+
+$section->addInput(new Form_Input(
+	'username',
+	'User name',
+	'text',
+	$pconfig['username']
+));
+
+$section->addPassword(new Form_Input(
+	'passwordfld',
+	'Password',
+	'password',
+	$pconfig['password']
+));
+
+$section->addInput(new Form_Checkbox(
+	'verifysslpeer',
+	'Verify SSL Peer',
+	'Verify SSL Peer',
+	$pconfig['verifysslpeer']
+));
+
+$section->addInput(new Form_Input(
+	'descr',
+	'Description',
+	'text',
+	$pconfig['descr']
+))->setHelp('A description may be entered here for administrative reference (not parsed).');
+
+if (isset($id) && $a_checkip[$id]) {
+	$section->addInput(new Form_Input(
+		'id',
+		null,
+		'hidden',
+		$id
+	));
+}
+
+$form->add($section);
+print($form);
+
+include("foot.inc");

--- a/src/usr/local/www/services_dyndns.php
+++ b/src/usr/local/www/services_dyndns.php
@@ -107,6 +107,7 @@ if ($input_errors) {
 $tab_array = array();
 $tab_array[] = array(gettext("Dynamic DNS Clients"), true, "services_dyndns.php");
 $tab_array[] = array(gettext("RFC 2136 Clients"), false, "services_rfc2136.php");
+$tab_array[] = array(gettext("Check IP Services"), false, "services_checkip.php");
 display_top_tabs($tab_array);
 ?>
 <form action="services_dyndns.php" method="post" name="iform" id="iform">

--- a/src/usr/local/www/services_rfc2136.php
+++ b/src/usr/local/www/services_rfc2136.php
@@ -95,6 +95,7 @@ include("head.inc");
 $tab_array = array();
 $tab_array[] = array(gettext("Dynamic DNS Clients"), false, "services_dyndns.php");
 $tab_array[] = array(gettext("RFC 2136 Clients"), true, "services_rfc2136.php");
+$tab_array[] = array(gettext("Check IP Services"), false, "services_checkip.php");
 display_top_tabs($tab_array);
 
 if ($input_errors) {


### PR DESCRIPTION
Configurable check IP services.
Used by Dynamic DNS services to check IP addresses.
Configure as many check IP services as desired.  The first (highest in the list) that is enabled will be used as the default.
A future possibility could be to add an option to the Dynamic DNS entires to use a specific check IP service.
Addresses bug #6493 by allowing additional check IP service to be added and selected as the default.