### PR TITLE
ipsec widget, check for valid array

### DIFF
--- a/src/usr/local/www/widgets/widgets/ipsec.widget.php
+++ b/src/usr/local/www/widgets/widgets/ipsec.widget.php
@@ -181,6 +181,9 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 		break;
 
 		case "mobile" :
+			if (!is_array($mobile['pool'])) {
+				break;
+			}
 			foreach ($mobile['pool'] as $pool) {
 				if (!is_array($pool['lease'])) {
 					continue;


### PR DESCRIPTION
ipsec widget, check for valid array
When switching tabs in the widget it can happen that it will ask for mobile ipsec stats, while the array doesn't exist. This change prevents the php warning below.

PHP Errors:
[03-Jul-2016 18:59:15 CET] PHP Warning:  Invalid argument supplied for foreach() in /usr/local/www/widgets/widgets/ipsec.widget.php on line 184
[03-Jul-2016 18:59:15 CET] PHP Stack trace:
[03-Jul-2016 18:59:15 CET] PHP   1. {main}() /usr/local/www/widgets/widgets/ipsec.widget.php:0
