### PR TITLE
Protect get_dir from causing PHP errors

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -739,6 +739,9 @@ function get_filename_from_url($url) {
 function get_dir($dir) {
 	$dir_array = array();
 	$d = dir($dir);
+	if(!is_object($d)) {
+		return array();
+	}
 	while (false !== ($entry = $d->read())) {
 		array_push($dir_array, $entry);
 	}


### PR DESCRIPTION
See: https://forum.pfsense.org/index.php?topic=114570.0

Thanks!