### PR TITLE
Fix #6582 Allow import of ports

### DIFF
--- a/src/usr/local/www/firewall_aliases.php
+++ b/src/usr/local/www/firewall_aliases.php
@@ -306,10 +306,16 @@ display_top_tabs($tab_array);
 		<i class="fa fa-plus icon-embed-btn"></i>
 		<?=gettext("Add");?>
 	</a>
-	<a href="firewall_aliases_import.php" role="button" class="btn btn-primary btn-sm">
+<?php
+if (($tab == "ip") || ($tab == "port") || ($tab == "all")):
+?>
+	<a href="firewall_aliases_import.php?tab=<?=$tab?>" role="button" class="btn btn-primary btn-sm">
 		<i class="fa fa-upload icon-embed-btn"></i>
 		<?=gettext("Import");?>
 	</a>
+<?php
+endif
+?>
 </nav>
 
 <!-- Information section. Icon ID must be "showinfo" and the information <div> ID must be "infoblock".


### PR DESCRIPTION
This change does:
1) Allow bulk import of a port alias. That happens when the Import
button is pressed from the Ports tab of the firewall_aliases screen.
2) Allow bulk import of an IP alias, automatically determine if the
imported data fits a host or network alias type. That happens when the
Import button is pressed from the IP tab of the firewall_aliases screen.
3) When Import is pressed from the "All" tab of the firewall_aliases
screen, make an IP alias.
4) Do not display the Import button when on the URL tab of the
firewall_aliases screen.