### PR TITLE
Fix #6050 DHCP - provide Network Booting display/hide advanced button

### DIFF
--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1237,12 +1237,23 @@ $section->addInput(new Form_Button(
 
 $form->add($section);
 
-if ($pconfig['netboot']) {
-	$sectate = COLLAPSIBLE|SEC_OPEN;
-} else {
-	$sectate = COLLAPSIBLE|SEC_CLOSED;
-}
-$section = new Form_Section("Network Booting", nwkbootsec, $sectate);
+$section = new Form_Section("Network Booting");
+$section->addClass('nwkbootopts');
+
+// Advanced Network Booting options
+$btnadv = new Form_Button(
+	'btnadvnwkboot',
+	'Display Advanced',
+	null,
+	'fa-cog'
+);
+
+$btnadv->setAttribute('type','button')->addClass('btn-info btn-sm');
+
+$section->addInput(new Form_StaticText(
+	'Network Booting',
+	$btnadv
+));
 
 $section->addInput(new Form_Checkbox(
 	'netboot',
@@ -1603,6 +1614,45 @@ events.push(function() {
 		show_advopts();
 	});
 
+	// Show advanced LDAP options ======================================================================================
+	var showadvnwkboot = false;
+
+	function show_advnwkboot(ispageload) {
+		var text;
+		// On page load decide the initial state based on the data.
+		if (ispageload) {
+<?php
+			if (empty($pconfig['netboot'])) {
+				$showadv = false;
+			} else {
+				$showadv = true;
+			}
+?>
+			showadvnwkboot = <?php if ($showadv) {echo 'true';} else {echo 'false';} ?>;
+		} else {
+			// It was a click, swap the state.
+			showadvnwkboot = !showadvnwkboot;
+		}
+
+		hideCheckbox('netboot', !showadvnwkboot);
+		hideInput('nextserver', !showadvnwkboot);
+		hideInput('filename', !showadvnwkboot);
+		hideInput('filename32', !showadvnwkboot);
+		hideInput('filename64', !showadvnwkboot);
+		hideInput('rootpath', !showadvnwkboot);
+
+		if (showadvnwkboot) {
+			text = "<?=gettext('Hide Advanced');?>";
+		} else {
+			text = "<?=gettext('Display Advanced');?>";
+		}
+		$('#btnadvnwkboot').html('<i class="fa fa-cog"></i> ' + text);
+	}
+
+	$('#btnadvnwkboot').click(function(event) {
+		show_advnwkboot();
+	});
+
 	// ---------- On initial page load ------------------------------------------------------------
 
 	show_advdns(true);
@@ -1611,6 +1661,7 @@ events.push(function() {
 	show_advtftp(true);
 	show_advldap(true);
 	show_advopts(true);
+	show_advnwkboot(true);
 
 	// Suppress "Delete row" button if there are fewer than two rows
 	checkLastRow();

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1238,7 +1238,6 @@ $section->addInput(new Form_Button(
 $form->add($section);
 
 $section = new Form_Section("Network Booting");
-$section->addClass('nwkbootopts');
 
 // Advanced Network Booting options
 $btnadv = new Form_Button(
@@ -1614,7 +1613,7 @@ events.push(function() {
 		show_advopts();
 	});
 
-	// Show advanced LDAP options ======================================================================================
+	// Show advanced Network Booting options ===========================================================================
 	var showadvnwkboot = false;
 
 	function show_advnwkboot(ispageload) {


### PR DESCRIPTION
This keeps the section header, but instead of a +/- on the right of the section header bar, it puts a Display/Hide Advanced button, like other parts of this GUI page.
The section header looks difficult to remove, because the "Additional BOOTP/DHCP Options" above has its own section, which has to end. So I am leaving the "Network Booting" section header.