### PR TITLE
DHCP6 init before RA option

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4017,24 +4017,22 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
 	$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
 	/* non ipoe Process */
- 	if (!isset($wancfg['dhcp6withoutra'])){	
+ 	if (!isset($wancfg['dhcp6withoutra'])) {	
 		$rtsoldscript .= "if [ -f {$g['varrun_path']}/dhcp6c_{$wanif}.pid ]; then\n";
 		$rtsoldscript .= "\t/bin/pkill -F {$g['varrun_path']}/dhcp6c_{$wanif}.pid\n";
 		$rtsoldscript .= "\t/bin/sleep 1\n";
 		$rtsoldscript .= "fi\n";
-	}
-	else
-	{
+	} else {
 		$rtsoldscript .= "\t/bin/sleep 1\n";
 	}
 	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
-	if (!isset($wancfg['dhcp6withoutra'])){
+	if (!isset($wancfg['dhcp6withoutra'])) {
 		$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
 		$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
         }
 	/* Add wide-dhcp6c shell script here. Because we can not pass a argument to it. */
 	if (!@file_put_contents("{$g['varetc_path']}/rtsold_{$wanif}_script.sh", $rtsoldscript)) {
-		printf("Error: cannot open rtsold_{$interface}_script.sh in interface_dhcpv6_configure() for writing.\n");
+		printf("Error: cannot open rtsold_{$wanif}_script.sh in interface_dhcpv6_configure() for writing.\n");
 		unset($rtsoldscript);
 		return 1;
 	}
@@ -4050,13 +4048,12 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 		killbypid("{$g['varrun_path']}/rtsold_{$wanif}.pid");
 		sleep(2);
 	}
-	if (isset($wancfg['dhcp6withoutra'])){
+	if (isset($wancfg['dhcp6withoutra'])) {
 		kill_dhcp6client_process($wanif);	
-		sleep(3);
 		
 		mwexec("/usr/local/sbin/dhcp6c {$debugOption} -x -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
  		mwexec("/usr/bin/logger -t mwtag 'Starting dhcp6 client for interface wan({$wanif} in IPoE mode)'"); 
-    } 	
+        } 	
 	mwexec("/usr/sbin/rtsold -1 -p {$g['varrun_path']}/rtsold_{$wanif}.pid -O {$g['varetc_path']}/rtsold_{$wanif}_script.sh {$wanif}");
 
 	/* NOTE: will be called from rtsold invoked script

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3067,6 +3067,21 @@ function find_dhcp6c_process($interface) {
 
 	return intval($pid);
 }
+function kill_dhcp6client_process($interface) {
+ 	if (empty($interface) || !does_interface_exist($interface)) {
+ 		return;
+ 	}
+ 
+ 	$i = 0;
+ 	while ((($pid = find_dhcp6c_process($interface)) != 0) && ($i < 3)) {
+ 		/* 3rd time make it die for sure */
+ 		$sig = ($i == 2 ? SIGKILL : SIGTERM);
+ 		posix_kill($pid, $sig);
+ 		sleep(1);
+ 		$i++;
+ 	}
+ 	unset($i);
+}
 
 function interface_virtual_create($interface) {
 	global $config;
@@ -3546,10 +3561,7 @@ function interface_track6_configure($interface = "lan", $wancfg, $linkupevent = 
 				 * XXX: Probably DHCPv6 client should handle this automagically itself?
 				 */
 				$parentrealif = get_real_interface($wancfg['track6-interface']);
-				$pidv6 = find_dhcp6c_process($parentrealif);
-				if ($pidv6) {
-					posix_kill($pidv6, SIGHUP);
-				}
+				kill_dhcp6client_process($parentrealif);
 			}
 			break;
 	}
@@ -4004,9 +4016,25 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
 	$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
 	$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
+	/* non ipoe Process */
+ 	if (!isset($wancfg['dhcp6withoutra'])){	
+		$rtsoldscript .= "if [ -f {$g['varrun_path']}/dhcp6c_{$wanif}.pid ]; then\n";
+		$rtsoldscript .= "\t/bin/pkill -F {$g['varrun_path']}/dhcp6c_{$wanif}.pid\n";
+		$rtsoldscript .= "\t/bin/sleep 1\n";
+		$rtsoldscript .= "fi\n";
+	}
+	else
+	{
+		$rtsoldscript .= "\t/bin/sleep 1\n";
+	}
+	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
+	if (!isset($wancfg['dhcp6withoutra'])){
+		$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
+		$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
+        }
 	/* Add wide-dhcp6c shell script here. Because we can not pass a argument to it. */
 	if (!@file_put_contents("{$g['varetc_path']}/rtsold_{$wanif}_script.sh", $rtsoldscript)) {
-		printf("Error: cannot open rtsold_{$wanif}_script.sh in interface_dhcpv6_configure() for writing.\n");
+		printf("Error: cannot open rtsold_{$interface}_script.sh in interface_dhcpv6_configure() for writing.\n");
 		unset($rtsoldscript);
 		return 1;
 	}
@@ -4022,12 +4050,20 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 		killbypid("{$g['varrun_path']}/rtsold_{$wanif}.pid");
 		sleep(2);
 	}
+	if (isset($wancfg['dhcp6withoutra'])){
+		kill_dhcp6client_process($wanif);	
+		sleep(3);
+		
+		mwexec("/usr/local/sbin/dhcp6c {$debugOption} -x -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
+ 		mwexec("/usr/bin/logger -t mwtag 'Starting dhcp6 client for interface wan({$wanif} in IPoE mode)'"); 
+    } 	
 	mwexec("/usr/sbin/rtsold -1 -p {$g['varrun_path']}/rtsold_{$wanif}.pid -O {$g['varetc_path']}/rtsold_{$wanif}_script.sh {$wanif}");
 
 	/* NOTE: will be called from rtsold invoked script
 	 * link_interface_to_track6($interface, "update");
 	 */
 
+	
 	return 0;
 }
 

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -317,6 +317,7 @@ switch ($wancfg['ipaddrv6']) {
 		$pconfig['dhcp6prefixonly'] = isset($wancfg['dhcp6prefixonly']);
 		$pconfig['dhcp6usev4iface'] = isset($wancfg['dhcp6usev4iface']);
 		$pconfig['dhcp6debug'] = isset($wancfg['dhcp6debug']);
+		$pconfig['dhcp6withoutra'] = isset($wancfg['dhcp6withoutra']);
 		break;
 	case "6to4":
 		$pconfig['type6'] = "6to4";
@@ -1011,6 +1012,7 @@ if ($_POST['apply']) {
 		unset($wancfg['dhcp6debug']);
 		unset($wancfg['track6-interface']);
 		unset($wancfg['track6-prefix-id']);
+		unset($wancfg['dhcp6withoutra']);
 		unset($wancfg['prefix-6rd']);
 		unset($wancfg['prefix-6rd-v4plen']);
 		unset($wancfg['gateway-6rd']);
@@ -1258,6 +1260,9 @@ if ($_POST['apply']) {
 					$wancfg['dhcp6debug'] = true;
 				}
 
+				if ($_POST['dhcp6withoutra'] == "yes") {
+					$wancfg['dhcp6withoutra'] = true;
+				}
 				if (!empty($_POST['adv_dhcp6_interface_statement_send_options'])) {
 					$wancfg['adv_dhcp6_interface_statement_send_options'] = $_POST['adv_dhcp6_interface_statement_send_options'];
 				}
@@ -2154,7 +2159,12 @@ $section->addInput(new Form_Checkbox(
 	'Start DHCP6 client in debug mode',
 	$pconfig['dhcp6debug']
 ));
-
+$section->addInput(new Form_Checkbox(
+	'dhcp6withoutra',
+	'Do not wait for a RA',
+	'Required by some ISPs, especially those not using PPPoE',
+	$pconfig['dhcp6withoutra']
+));
 $section->addInput(new Form_Input(
 	'adv_dhcp6_config_file_override_path',
 	'Configuration File Override',


### PR DESCRIPTION
Some ISP BNG's require tha a dhcp6 init is sent befire RA. The additions in these two files handle that option. The interfaces.php has changes that create an extra option in the DHCP6 WAN config - adding an the option 'Do not wait for a RA'; this will set or unset the flag 'dhcp6withoutra'.

interfaces.inc uses the flag set in the configuration to decide whether to launch dhcp6c using the rtsoldscript or to launch it without waiting for an RA that would trigger the script.

Other additions to the interfaces.inc attempt to consolidate the multiple calls and methods of killing the dhcp6c client into a single call, much the same as is used with the dhcp4 client. The only place this cannot be done is where rtsold launches dhcp6c and the script itself must kill the client, if it is running.