### PR TITLE
Advanced DHCP config breaks option to ignore DHCP lease from specific IP

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4355,6 +4355,9 @@ function DHCP_Config_File_Advanced($interface, $wancfg, $wanif) {
 	$dhclientconf .= "{$required_options}";
 	$dhclientconf .= "{$option_modifiers}";
 	$dhclientconf .= "\n";
+	if(is_ipaddrv4($wancfg['dhcprejectfrom'])){
+		$dhclientconf .= "reject {$wancfg['dhcprejectfrom']};\n";
+	}
 	$dhclientconf .= "\tscript \"/sbin/dhclient-script\";\n";
 	$dhclientconf .= "}\n";
 

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4355,7 +4355,7 @@ function DHCP_Config_File_Advanced($interface, $wancfg, $wanif) {
 	$dhclientconf .= "{$required_options}";
 	$dhclientconf .= "{$option_modifiers}";
 	$dhclientconf .= "\n";
-	if(is_ipaddrv4($wancfg['dhcprejectfrom'])){
+	if (is_ipaddrv4($wancfg['dhcprejectfrom'])) {
 		$dhclientconf .= "reject {$wancfg['dhcprejectfrom']};\n";
 	}
 	$dhclientconf .= "\tscript \"/sbin/dhclient-script\";\n";


### PR DESCRIPTION
When the advanced DHCP configuration option checkbox is checked for an interface setup as a DHCP client, such as the WAN interface, the config option to ignore leases from a certain DHCP server is no longer included in the actual DHCP server config file and therefore no longer has any effect. This change modifies the DHCP_Config_File_Advanced function to include the "reject x.x.x.x;" line if applicable in the advanced configuration as well.