### PR TITLE
Some tweaks to improve alignment in table with checkbox

### DIFF
--- a/src/usr/local/pkg/miniupnpd.xml
+++ b/src/usr/local/pkg/miniupnpd.xml
@@ -26,7 +26,7 @@
 			<fieldname>enable</fieldname>
 			<type>checkbox</type>
 			<enablefields>enable_upnp,enable_natpmp,ext_iface,iface_array,download,upload,overridewanip,upnpqueue,logpackets,sysuptime,permdefault</enablefields>
-			<sethelp>Enable UPnP &amp; NAT-PMP</sethelp>
+			<description>Enable UPnP &amp; NAT-PMP</description>
 		</field>
 		<field>
 			<fielddescr>UPnP Port Mapping</fielddescr>

--- a/src/usr/local/www/classes/Form/Checkbox.class.php
+++ b/src/usr/local/www/classes/Form/Checkbox.class.php
@@ -64,7 +64,7 @@ class Form_Checkbox extends Form_Input
 		$input = parent::_getInput();
 
 		if (empty($this->_description))
-			return $input;
+			return '<label class="chkboxlbl">'. $input .'</label>';
 
 		return '<label class="chkboxlbl">'. $input .' '. htmlspecialchars(gettext($this->_description)) .'</label>';
 	}


### PR DESCRIPTION
1) If a checkbox does not have a description (even if it is empty), layout will be broken as checkbox won't be aligned correctly

2) UPnP checkbox looks better with description instead of help

This commit fixes the two issues