### PR TITLE
The ability for the Radius auth server to detect openVPN and distinguished different server configurations

### DIFF
--- a/src/etc/inc/openvpn.auth-user.php
+++ b/src/etc/inc/openvpn.auth-user.php
@@ -67,17 +67,11 @@ require_once("interfaces.inc");
 /**
  * Get the NAS-Identifier
  *
- * We will use our local hostname to make up the nas_id
+ * We will return "openVPN" so that connections can be distinguished by the Radius
  */
 if (!function_exists("getNasID")) {
 function getNasID() {
-	global $g;
-
-	$nasId = gethostname();
-	if (empty($nasId)) {
-		$nasId = $g['product_name'];
-	}
-	return $nasId;
+	return "openVPN";
 }
 }
 
@@ -96,6 +90,40 @@ function getNasIP() {
 	return $nasIp;
 }
 }
+
+/**
+ * Set the NAS-Port-Type
+ *
+ * Should be "Virtual" since that denotes VPN connections
+ */
+if (!function_exists("getNasPortType")) {
+function getNasPortType() {
+	return RADIUS_VIRTUAL;
+}
+}
+
+/**
+ * Set the NAS-Port
+ *
+ * We will return the port the client connected to
+ */
+if (!function_exists("getNasPort")) {
+function getNasPort() {
+	return $_GET['nas_port'];
+}
+}
+
+/**
+ * Set the Called-Station-ID
+ *
+ * We will return the IP and port the client connected to
+ */
+if (!function_exists("getCalledStationId")) {
+function getCalledStationId() {
+	return get_interface_ip() . ":" . getNasPort();
+}
+}
+
 /* setup syslog logging */
 openlog("openvpn", LOG_ODELAY, LOG_AUTH);
 

--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -851,7 +851,7 @@ function openvpn_reconfigure($mode, $settings) {
 					if ($settings['strictusercn']) {
 						$strictusercn = "true";
 					}
-					$conf .= "auth-user-pass-verify \"/usr/local/sbin/ovpn_auth_verify user '{$settings['authmode']}' {$strictusercn} {$mode_id}\" via-env\n";
+					$conf .= "auth-user-pass-verify \"/usr/local/sbin/ovpn_auth_verify user '{$settings['authmode']}' {$strictusercn} {$mode_id} {$settings['local_port']}\" via-env\n";
 				}
 				break;
 		}

--- a/src/etc/inc/radius.inc
+++ b/src/etc/inc/radius.inc
@@ -303,12 +303,26 @@ class Auth_RADIUS extends PEAR {
         $this->putAttribute(RADIUS_NAS_IP_ADDRESS, $ipaddr, "addr");
 
         // Add support for sending NAS-Identifier
-        if (empty($config["captiveportal"][$cpzone]["radiusnasid"])) {
+        if (function_exists("getNasID")) {
+            $nasId = getNasID();
+        } else if (empty($config["captiveportal"][$cpzone]["radiusnasid"])) {
             $nasId = php_uname("n");
         } else {
             $nasId = $config["captiveportal"][$cpzone]["radiusnasid"];
         }
         $this->putAttribute(RADIUS_NAS_IDENTIFIER, $nasId);
+        
+        if (function_exists("getNasPortType")) {
+            $this->putAttribute(RADIUS_NAS_PORT_TYPE, getNasPortType());
+        }
+        
+        if (function_exists("getNasPort")) {
+            $this->putAttribute(RADIUS_NAS_PORT, getNasPort(), 'integer');
+        }
+        
+        if (function_exists("getCalledStationId")) {
+            $this->putAttribute(RADIUS_CALLED_STATION_ID, getCalledStationId());
+        }
     }
 
     /**

--- a/src/usr/local/sbin/ovpn_auth_verify
+++ b/src/usr/local/sbin/ovpn_auth_verify
@@ -7,7 +7,7 @@ else
 	# Base64 and urlEncode usernames and passwords
 	password=$(echo -n "${password}" | openssl enc -base64 | sed -e 's_=_%3D_g;s_+_%2B_g;s_/_%2F_g')
 	username=$(echo -n "${username}" | openssl enc -base64 | sed -e 's_=_%3D_g;s_+_%2B_g;s_/_%2F_g')
-	RESULT=$(/usr/local/sbin/fcgicli -f /etc/inc/openvpn.auth-user.php -d "username=$username&password=$password&cn=$common_name&strictcn=$3&authcfg=$2&modeid=$4")
+	RESULT=$(/usr/local/sbin/fcgicli -f /etc/inc/openvpn.auth-user.php -d "username=$username&password=$password&cn=$common_name&strictcn=$3&authcfg=$2&modeid=$4&nas_port=$5")
 fi
 
 if [ "${RESULT}" = "OK" ]; then


### PR DESCRIPTION
I've added the ability for the Radius auth server to detect openVPN and distinguished different server configurations (by port). I've also corrected some of the Radius attributes to be more in line with what strongSwan uses. 