### PR TITLE
Fix #6613 Do not show Aply Changes button when Save needed

### DIFF
--- a/src/usr/local/www/interfaces_assign.php
+++ b/src/usr/local/www/interfaces_assign.php
@@ -504,7 +504,7 @@ if (file_exists("/var/run/interface_mismatch_reboot_needed")) {
 			$class = "warning";
 		}
 	} else {
-		$applymsg = gettext("Interface mismatch detected. Please resolve the mismatch and click 'Apply Changes'. The firewall will reboot afterwards.");
+		$savemsg = gettext("Interface mismatch detected. Please resolve the mismatch, save and then click 'Apply Changes'. The firewall will reboot afterwards.");
 		$class = "warning";
 	}
 }


### PR DESCRIPTION
I got a bit carried away in the fix for #6460 https://github.com/pfsense/pfsense/commit/21c18c3df11547aba172c10f95872dbd8682f7d9
The message here at line 507 should not actually show the Apply Changes button. At this point the user needs to adjust the assigned interfaces and save. Then after saving an Apply Changes button can be used to implement the saved changes.