### PR TITLE
Fix "http://pf.sense/UNKNOWN" links in Pkg Manager

### DIFF
--- a/src/usr/local/www/pkg_mgr.php
+++ b/src/usr/local/www/pkg_mgr.php
@@ -78,12 +78,12 @@ function get_pkg_table() {
 		$pkgtbl .= 	'<tr>' . "\n";
 		$pkgtbl .= 	'<td>' . "\n";
 
-		if ($index['www']) {
+		if (($index['www']) && ($index['www'] != "UNKNOWN")) {
 			$pkgtbl .= 	'<a title="' . gettext("Visit official website") . '" target="_blank" href="' . htmlspecialchars($index['www']) . '">' . "\n";
+			$pkgtbl .= htmlspecialchars($index['shortname']) . '</a>' . "\n";
+		} else {
+			$pkgtbl .= htmlspecialchars($index['shortname']);
 		}
-
-		$pkgtbl .= htmlspecialchars($index['shortname']);
-		$pkgtbl .= 		'</a>' . "\n";
 		$pkgtbl .= 	'</td>' . "\n";
 		$pkgtbl .= 	'<td>' . "\n";
 


### PR DESCRIPTION
I noticed that some packages do not have the 'www' field in the database filled, or have it set to UNKNOWN.  The way the table is built on the 'Available Packages' page causes bad links to be generated pointing to e.g. http://pf.sense/UNKNOWN.  This patch fixes it, causing only packages with actual links to get the `<a>` tag.