### PR TITLE
dyndns: add IPv6 support for CloudFlare

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -47,6 +47,7 @@
 	 *    - Custom DDNS (any URL)
 	 *    - Custom DDNS IPv6 (any URL)
 	 *    - CloudFlare (www.cloudflare.com)
+	 *    - CloudFlare IPv6 (www.cloudflare.com)
 	 *    - Eurodns (eurodns.com)
 	 *    - GratisDNS (gratisdns.dk)
 	 *    - City Network (citynetwork.se)
@@ -94,7 +95,8 @@
 	 *  SelfHost        - Last Tested: 26 December 2011
 	 *  Amazon Route 53 - Last tested: 01 April 2012
 	 *  DNS-O-Matic     - Last Tested: 9 September 2010
-	 *  CloudFlare      - Last Tested: 30 May 2013
+	 *  CloudFlare      - Last Tested: 17 July 2016
+	 *  CloudFlare IPv6 - Last Tested: 17 July 2016
 	 *  Eurodns         - Last Tested: 27 June 2013
 	 *  GratisDNS       - Last Tested: 15 August 2012
 	 *  OVH DynHOST     - Last Tested: NEVER
@@ -217,6 +219,7 @@
 				case 'custom-v6':
 				case 'spdyn-v6':
 				case 'freedns-v6':
+				case 'cloudflare-v6':
 					$this->_useIPv6 = true;
 					break;
 				default:
@@ -287,6 +290,7 @@
 					case 'he-net-tunnelbroker':
 					case 'route53':
 					case 'cloudflare':
+					case 'cloudflare-v6':
 					case 'eurodns':
 					case 'gratisdns':
 					case 'ovh-dynhost':
@@ -692,7 +696,10 @@
 					}
 					curl_setopt($ch, CURLOPT_URL, $server);
 					break;
+				case 'cloudflare-v6':
 				case 'cloudflare':
+					$isv6 = ($this->_dnsService === 'cloudflare-v6');
+					$recordType = $isv6 ? "AAAA" : "A";
 					$needsIP = TRUE;
 					$dnsServer ='api.cloudflare.com';
 					$dnsHost = str_replace(' ', '', $this->_dnsHost);
@@ -712,14 +719,14 @@
 					$output = json_decode(curl_exec($ch));
 					$zone = $output->result[0]->id;
 					if ($zone) { // If zone ID was found get host ID
-						$getHostId = "https://{$dnsServer}/client/v4/zones/{$zone}/dns_records?name={$this->_dnsHost}";
+						$getHostId = "https://{$dnsServer}/client/v4/zones/{$zone}/dns_records?name={$this->_dnsHost}&type={$recordType}";
 						curl_setopt($ch, CURLOPT_URL, $getHostId);
 						$output = json_decode(curl_exec($ch));
 						$host = $output->result[0]->id;
 						if ($host) { // If host ID was found update host
 							$hostData = array(
 								"content" => "{$this->_dnsIP}",
-								"type" => "A",
+								"type" => "{$recordType}",
 								"name" => "{$this->_dnsHost}"
 							);
 							$data_json = json_encode($hostData);
@@ -1288,6 +1295,7 @@
 						$status = $status_intro . $error_str . gettext("Result did not match.") . " [" . $data . "]";
 					}
 					break;
+				case 'cloudflare-v6':
 				case 'cloudflare':
 					$output = json_decode($data);
 					if ($output->result->content === $this->_dnsIP) {

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -23,8 +23,8 @@
  * limitations under the License.
  */
 
-define('DYNDNS_PROVIDER_VALUES', 'citynetwork cloudflare custom custom-v6 dnsexit dnsimple dnsmadeeasy dnsomatic dyndns dyndns-custom dyndns-static dyns easydns eurodns freedns freedns-v6 glesys googledomains gratisdns he-net he-net-v6 he-net-tunnelbroker loopia namecheap noip noip-free ods opendns ovh-dynhost route53 selfhost spdyn spdyn-v6 zoneedit');
-define('DYNDNS_PROVIDER_DESCRIPTIONS', 'City Network,CloudFlare,Custom,Custom (v6),DNSexit,DNSimple,DNS Made Easy,DNS-O-Matic,DynDNS (dynamic),DynDNS (custom),DynDNS (static),DyNS,easyDNS,Euro Dns,freeDNS,freeDNS (v6),GleSYS,Google Domains,GratisDNS,HE.net,HE.net (v6),HE.net Tunnelbroker,Loopia,Namecheap,No-IP,No-IP (free),ODS.org,OpenDNS,OVH DynHOST,Route 53,SelfHost,SPDYN,SPDYN (v6),ZoneEdit');
+define('DYNDNS_PROVIDER_VALUES', 'citynetwork cloudflare cloudflare-v6 custom custom-v6 dnsexit dnsimple dnsmadeeasy dnsomatic dyndns dyndns-custom dyndns-static dyns easydns eurodns freedns freedns-v6 glesys googledomains gratisdns he-net he-net-v6 he-net-tunnelbroker loopia namecheap noip noip-free ods opendns ovh-dynhost route53 selfhost spdyn spdyn-v6 zoneedit');
+define('DYNDNS_PROVIDER_DESCRIPTIONS', 'City Network,CloudFlare,CloudFlare (v6),Custom,Custom (v6),DNSexit,DNSimple,DNS Made Easy,DNS-O-Matic,DynDNS (dynamic),DynDNS (custom),DynDNS (static),DyNS,easyDNS,Euro Dns,freeDNS,freeDNS (v6),GleSYS,Google Domains,GratisDNS,HE.net,HE.net (v6),HE.net Tunnelbroker,Loopia,Namecheap,No-IP,No-IP (free),ODS.org,OpenDNS,OVH DynHOST,Route 53,SelfHost,SPDYN,SPDYN (v6),ZoneEdit');
 
 /* implement ipv6 route advertising daemon */
 function services_radvd_configure($blacklist = array()) {


### PR DESCRIPTION
This adds support for managing IPv6/AAAA records to CloudFlare. It uses the extant IPv6 code paths, with only a minor tweak needed to the primary code path to distinguish which record type to update.

I developed and tested this patch against the stable `RELENG_2_3_1` branch (as this is what my router was running), and forward-ported it to the `master` branch. The patch against 2.3.1 which I'm currently using in anger can be found here: https://github.com/thoughtpolice/pfsense/tree/cloudflarev6_2_3_1

Tested on a pfSense 2.3.1_p5 CE virtual machine with a public IPv6 address, as well as pfSense 2.3.1_p5 official Netgate build, on an SG-4860 (my home router with IPv6 provided by my ISP).