### PR TITLE
Backport DHCP6 init before RA

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4048,7 +4048,7 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	if (isset($wancfg['dhcp6withoutra'])) {
 		kill_dhcp6client_process($wanif);
 
-		mwexec("/usr/local/sbin/dhcp6c {$debugOption} -x -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
+		mwexec("/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
  		mwexec("/usr/bin/logger -t mwtag 'Starting dhcp6 client for interface wan({$wanif} in IPoE mode)'");
 	}
 	mwexec("/usr/sbin/rtsold -1 -p {$g['varrun_path']}/rtsold_{$wanif}.pid -O {$g['varetc_path']}/rtsold_{$wanif}_script.sh {$wanif}");

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3061,6 +3061,22 @@ function find_dhcp6c_process($interface) {
 	return intval($pid);
 }
 
+function kill_dhcp6client_process($interface) {
+ 	if (empty($interface) || !does_interface_exist($interface)) {
+ 		return;
+ 	}
+
+ 	$i = 0;
+ 	while ((($pid = find_dhcp6c_process($interface)) != 0) && ($i < 3)) {
+ 		/* 3rd time make it die for sure */
+ 		$sig = ($i == 2 ? SIGKILL : SIGTERM);
+ 		posix_kill($pid, $sig);
+ 		sleep(1);
+ 		$i++;
+ 	}
+ 	unset($i);
+}
+
 function interface_virtual_create($interface) {
 	global $config;
 
@@ -3997,6 +4013,20 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
 	$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
 	$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
+	/* non ipoe Process */
+ 	if (!isset($wancfg['dhcp6withoutra'])) {
+		$rtsoldscript .= "if [ -f {$g['varrun_path']}/dhcp6c_{$wanif}.pid ]; then\n";
+		$rtsoldscript .= "\t/bin/pkill -F {$g['varrun_path']}/dhcp6c_{$wanif}.pid\n";
+		$rtsoldscript .= "\t/bin/sleep 1\n";
+		$rtsoldscript .= "fi\n";
+	} else {
+		$rtsoldscript .= "\t/bin/sleep 1\n";
+	}
+	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
+	if (!isset($wancfg['dhcp6withoutra'])) {
+		$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
+		$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
+	}
 	/* Add wide-dhcp6c shell script here. Because we can not pass a argument to it. */
 	if (!@file_put_contents("{$g['varetc_path']}/rtsold_{$wanif}_script.sh", $rtsoldscript)) {
 		printf("Error: cannot open rtsold_{$wanif}_script.sh in interface_dhcpv6_configure() for writing.\n");
@@ -4014,6 +4044,12 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	if (isvalidpid("{$g['varrun_path']}/rtsold_{$wanif}.pid")) {
 		killbypid("{$g['varrun_path']}/rtsold_{$wanif}.pid");
 		sleep(2);
+	}
+	if (isset($wancfg['dhcp6withoutra'])) {
+		kill_dhcp6client_process($wanif);
+
+		mwexec("/usr/local/sbin/dhcp6c {$debugOption} -x -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
+ 		mwexec("/usr/bin/logger -t mwtag 'Starting dhcp6 client for interface wan({$wanif} in IPoE mode)'");
 	}
 	mwexec("/usr/sbin/rtsold -1 -p {$g['varrun_path']}/rtsold_{$wanif}.pid -O {$g['varetc_path']}/rtsold_{$wanif}_script.sh {$wanif}");
 

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -316,6 +316,7 @@ switch ($wancfg['ipaddrv6']) {
 		$pconfig['dhcp6prefixonly'] = isset($wancfg['dhcp6prefixonly']);
 		$pconfig['dhcp6usev4iface'] = isset($wancfg['dhcp6usev4iface']);
 		$pconfig['dhcp6debug'] = isset($wancfg['dhcp6debug']);
+		$pconfig['dhcp6withoutra'] = isset($wancfg['dhcp6withoutra']);
 		break;
 	case "6to4":
 		$pconfig['type6'] = "6to4";
@@ -1010,6 +1011,7 @@ if ($_POST['apply']) {
 		unset($wancfg['dhcp6debug']);
 		unset($wancfg['track6-interface']);
 		unset($wancfg['track6-prefix-id']);
+		unset($wancfg['dhcp6withoutra']);
 		unset($wancfg['prefix-6rd']);
 		unset($wancfg['prefix-6rd-v4plen']);
 		unset($wancfg['gateway-6rd']);
@@ -1255,6 +1257,10 @@ if ($_POST['apply']) {
 				}
 				if ($_POST['dhcp6debug'] == "yes") {
 					$wancfg['dhcp6debug'] = true;
+				}
+
+				if ($_POST['dhcp6withoutra'] == "yes") {
+					$wancfg['dhcp6withoutra'] = true;
 				}
 
 				if (!empty($_POST['adv_dhcp6_interface_statement_send_options'])) {
@@ -2152,6 +2158,13 @@ $section->addInput(new Form_Checkbox(
 	'Debug',
 	'Start DHCP6 client in debug mode',
 	$pconfig['dhcp6debug']
+));
+
+$section->addInput(new Form_Checkbox(
+	'dhcp6withoutra',
+	'Do not wait for a RA',
+	'Required by some ISPs, especially those not using PPPoE',
+	$pconfig['dhcp6withoutra']
 ));
 
 $section->addInput(new Form_Input(


### PR DESCRIPTION
Original PR to master was #3055
Now that 2.3.2 has been branched, this is an example of stuff that could be back-ported to RELENG_2_3 to make it available to 32-bit systems that will never be able to upgrade to 2.4