### PR TITLE
Fix DHCP Release and some Status > Interfaces changes

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1273,6 +1273,7 @@ function interface_bring_down($interface = "wan", $destroy = false, $ifacecfg = 
 			}
 			break;
 		case "dhcp":
+			mwexec("/usr/local/sbin/dhclient -v -r -lf /var/db/dhclient.leases.{$realif} -i {$realif}");
 			kill_dhclient_process($realif);
 			unlink_if_exists("{$g['varetc_path']}/dhclient_{$interface}.conf");
 			if (does_interface_exist("$realif")) {

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1382,6 +1382,22 @@ function get_ppp_uptime($port) {
 	}
 }
 
+//converts subnet mask to cidr notation
+function netmask2cidr($netmask) {  
+     $long = ip2long($netmask);  
+     $base = ip2long('255.255.255.255');  
+     return 32-log(($long ^ $base)+1,2);       
+}  
+
+//fetches the physical name of the NIC, stolen from util.inc :S sorry...
+function getinterfacename($intname) {
+	$dmesg_arr = array();
+	exec("/sbin/dmesg |grep $intname | head -n1", $dmesg_arr);
+	preg_match_all("/<(.*?)>/i", $dmesg_arr[0], $dmesg);
+	$toput = $dmesg[1][0];
+	return $toput;
+}
+
 //returns interface information
 function get_interface_info($ifdescr) {
 	global $config, $g;
@@ -1402,7 +1418,9 @@ function get_interface_info($ifdescr) {
 	$ifinfo['macaddr'] = $ifinfotmp['macaddr'];
 	$ifinfo['mtu'] = $ifinfotmp['mtu'];
 	$ifinfo['ipaddr'] = $ifinfotmp['ipaddr'];
-	$ifinfo['subnet'] = $ifinfotmp['subnet'];
+	$cidr = netmask2cidr($ifinfotmp['subnet']);
+	$ifinfo['subnet'] = "${ifinfotmp['subnet']} (/${cidr})";
+	$ifinfo['NIC'] = getinterfacename($ifinfo['hwif']);
 	$ifinfo['linklocal'] = get_interface_linklocal($ifdescr);
 	$ifinfo['ipaddrv6'] = get_interface_ipv6($ifdescr);
 	$ifinfo['subnetv6'] = get_interface_subnetv6($ifdescr);
@@ -1467,6 +1485,7 @@ function get_interface_info($ifdescr) {
 			/* see if dhclient is up */
 			if (find_dhclient_process($ifinfo['if']) != 0) {
 				$ifinfo['dhcplink'] = "up";
+				$ifinfo['linktype'] = "DHCP";
 			} else {
 				$ifinfo['dhcplink'] = "down";
 			}
@@ -1474,11 +1493,14 @@ function get_interface_info($ifdescr) {
 			break;
 		/* PPPoE/PPTP/L2TP interface? -> get status from virtual interface */
 		case "pppoe":
+			$ifinfo['linktype'] = "PPPoE";
 		case "pptp":
+			$ifinfo['linktype'] = "PPTP";
 		case "l2tp":
 			if ($ifinfo['status'] == "up" && !isset($link0)) {
 				/* get PPPoE link status for dial on demand */
 				$ifinfo["{$link_type}link"] = "up";
+				$ifinfo['linktype'] = "L2TP";
 			} else {
 				$ifinfo["{$link_type}link"] = "down";
 			}
@@ -1488,6 +1510,7 @@ function get_interface_info($ifdescr) {
 		case "ppp":
 			if ($ifinfo['status'] == "up") {
 				$ifinfo['ppplink'] = "up";
+				$ifinfo['linktype'] = "PPP";
 			} else {
 				$ifinfo['ppplink'] = "down" ;
 			}
@@ -1544,6 +1567,7 @@ function get_interface_info($ifdescr) {
 			}
 			break;
 		default:
+			$ifinfo['linktype'] = "Static";
 			break;
 	}
 

--- a/src/usr/local/www/status_interfaces.php
+++ b/src/usr/local/www/status_interfaces.php
@@ -91,7 +91,7 @@ foreach ($ifdescrs as $ifdescr => $ifname):
 	<div class="panel-body">
 		<dl class="dl-horizontal">
 <?php
-		showDef(true, gettext("Status"), $ifinfo['status']);
+		showDef(true, gettext("Interface Status"), $ifinfo['status']);
 		showDefBtn($ifinfo['dhcplink'], 'DHCP', $ifinfo['dhcplink'], $ifdescr, $ifinfo['dhcplink'] == "up" ? gettext("Release") : gettext("Renew"));
 		showDefBtn($ifinfo['dhcp6link'], 'DHCP6', $ifinfo['dhcp6link'], $ifdescr, $ifinfo['dhcp6link'] == "up" ? gettext("Release") : gettext("Renew"));
 		showDefBtn($ifinfo['pppoelink'], 'PPPoE', $ifinfo['pppoelink'], $ifdescr, $ifinfo['pppoelink'] == "up" ? gettext("Disconnect") : gettext("Connect"));
@@ -116,7 +116,7 @@ foreach ($ifdescrs as $ifdescr => $ifname):
 
 		if ($ifinfo['status'] != "down") {
 			if ($ifinfo['dhcplink'] != "down" && $ifinfo['pppoelink'] != "down" && $ifinfo['pptplink'] != "down") {
-				showDef($ifinfo['ipaddr'], gettext('IPv4 Address'), $ifinfo['ipaddr']);
+				showDef($ifinfo['ipaddr'], gettext('IPv4 Address'), "${ifinfo['ipaddr']} (${ifinfo['linktype']})");
 				showDef($ifinfo['subnet'], gettext('Subnet mask IPv4'), $ifinfo['subnet']);
 				showDef($ifinfo['gateway'], gettext('Gateway IPv4'), $ifinfo['gateway']);
 				showDef($ifinfo['linklocal'], gettext('IPv6 Link Local'), $ifinfo['linklocal']);
@@ -128,13 +128,14 @@ foreach ($ifdescrs as $ifdescr => $ifname):
 					$dns_servers = get_dns_servers();
 					$dnscnt = 0;
 					foreach ($dns_servers as $dns) {
-						showDef(true, $dnscnt == 0 ? gettext('DNS servers'):'', $dns);
+						showDef(true, $dnscnt == 0 ? gettext('DNS server(s)'):'', $dns);
 						$dnscnt++;
 					}
 				}
 			}
 
 			showDef($ifinfo['mtu'], gettext("MTU"), $ifinfo['mtu']);
+			showDef($ifinfo['NIC'], gettext("NIC"), $ifinfo['NIC']);
 			showDef($ifinfo['media'], gettext("Media"), $ifinfo['media']);
 			showDef($ifinfo['laggproto'], gettext("LAGG Protocol"), $ifinfo['laggproto']);
 			showDef($ifinfo['laggport'], gettext("LAGG Ports"), $laggport);


### PR DESCRIPTION
Ticket #4209: Send DHCP Release packet
When you hit 'Release' on the status_interfaces.php the dhclient did not
send the proper release packet to the DHCP server. This is sometimes
required by some ISP's and the freebsd dhclient doesn't do it, however I
found a quick fix. A copy of ISC's dhclient is sitting on pfSense 2.3 so
we will utilize it for this function.

A few minor touchups on the wording along with showing the configuration
type after the IP address so you know where the IP was obtained from,
similar to DD-WRT/Tomato, etc. It also shows the CIDR notation after the
subnet masks since pfSense refers to the CIDR notation everywhere else.
It also shows the name of the NIC cuz I thought it was interesting to
show there.
https://forum.pfsense.org/index.php?topic=113088.msg629905#msg629905