### PR TITLE
Backport openvpn_add_dhcpopts already sets redirect-gateway

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1233,10 +1233,6 @@ function openvpn_resync_csc(& $settings) {
 
 	openvpn_add_dhcpopts($settings, $conf);
 
-	if ($settings['gwredir']) {
-		$conf .= "push \"redirect-gateway def1\"\n";
-	}
-
 	openvpn_add_custom($settings, $conf);
 	/* Loop through servers, find which ones can use this CSC */
 	if (is_array($config['openvpn']['openvpn-server'])) {


### PR DESCRIPTION
Ticket 6633
Original commit to master was
https://github.com/pfsense/pfsense/commit/f8038899f250c656b1ef03fe351fb9cfdadeaf0c
Adding this PR for completeness so that this is visible as something
that can be back-ported to RELENG_2_3 at some time in the future after 2.3.2 is done and dusted.