### PR TITLE
replace attribute 'name' to 'id' in openvpn status

### DIFF
--- a/src/usr/local/www/status_openvpn.php
+++ b/src/usr/local/www/status_openvpn.php
@@ -82,7 +82,7 @@ include("head.inc"); ?>
 			return;
 		}
 
-		$('tr[name="r:' + values[1] + ":" + values[2] + '"]').each(
+		$('tr[id="r:' + values[1] + ":" + values[2] + '"]').each(
 			function(index,row) { $(row).fadeOut(1000); }
 		);
 	}


### PR DESCRIPTION
Replaced the attribute 'name' to 'id' to fade out the row of the openvpn client connected.