### PR TITLE
dpinger: fixed check for pidfile length #6505

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -100,7 +100,7 @@ function start_dpinger($gateway) {
 	$prefix = "{$g['varrun_path']}/dpinger_{$gateway['name']}~" .
 	    "{$gateway['gwifip']}~{$gateway['monitor']}";
 	# dpinger socket path should not be longer then uaddr.sun_path
-	if (strlen($pidfile) > 95) {
+	if (strlen($prefix) > 95) {
 		$prefix = "{$g['varrun_path']}/dpinger_{$gateway['name']}~" .
 		    substr(md5($gateway['gwifip']),0,8) . "~" .
 		    $gateway['monitor'];


### PR DESCRIPTION
This is a followup fix. Somehow through testing the check for the pidfile length was done $pidfile instead of $prefix which was used 2 lines later ...