### PR TITLE
Correction to dhcp6 before RA

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4016,7 +4016,7 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	if (isset($wancfg['dhcp6withoutra'])) {
 		kill_dhcp6client_process($wanif);	
 		
-		mwexec("/usr/local/sbin/dhcp6c {$debugOption} -x -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
+		mwexec("/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
  		mwexec("/usr/bin/logger -t mwtag 'Starting dhcp6 client for interface wan({$wanif} in IPoE mode)'"); 
     } 	
 	mwexec("/usr/sbin/rtsold -1 -p {$g['varrun_path']}/rtsold_{$wanif}.pid -O {$g['varetc_path']}/rtsold_{$wanif}_script.sh {$wanif}");


### PR DESCRIPTION
Remove '-x' flag from dhcpwithoutra launch of dhcp6c.
In a previous commit ( accepted ) that was made to fix an issue with certain ISP's requiring that a dhcp6 init be sent before RA there is an extra '-x' flag on the command line for dhcp6c. This flag is going to be used for an updated dhcp6c client to enable a 'no release' option. In the current release of dhcp6c it causes the client to error and exit and must therefore be removed.