### PR TITLE
Fix redmine #6640 DHCPv6 server time format

### DIFF
--- a/src/usr/local/www/status_dhcpv6_leases.php
+++ b/src/usr/local/www/status_dhcpv6_leases.php
@@ -97,17 +97,14 @@ function adjust_gmt($dt) {
 		}
 	}
 
-	$timezone = $config['system']['timezone'];
-	$ts = strtotime($dt . " GMT");
 	if ($dhcpv6leaseinlocaltime == "yes") {
-		$this_tz = new DateTimeZone($timezone);
-		$dhcp_lt = new DateTime(strftime("%I:%M:%S%p", $ts), $this_tz);
-		$offset = $this_tz->getOffset($dhcp_lt);
-		$ts = $ts + $offset;
-		return strftime("%Y/%m/%d %I:%M:%S%p", $ts);
-	} else {
-		return strftime("%Y/%m/%d %H:%M:%S", $ts);
+		$ts = strtotime($dt . " GMT");
+		if ($ts !== false) {
+			return strftime("%Y/%m/%d %I:%M:%S%p", $ts);
+		}
 	}
+	/* If we did not need to convert to local time or the conversion failed, just return the input. */
+	return $dt;
 }
 
 function remove_duplicate($array, $field) {


### PR DESCRIPTION
The original code here ended up always applying the time zone offset once, and if you had set dhcpv6leaseinlocaltime then it got applied twice, so Sydney at UTC+10:00 would show UTC+20:00 and presumably somewhere at UTC-04:00 would show UTC-08:00

This change makes the code use the same logic as the V4 status_dhcp_leases.php - which works and is simpler.

Note: both the V4 and V6 code format the output, when using local time, as 12-our clock with AM/PM. That seems a bit odd, but I will leave it for now. I will make a separate pull request to change it to 24-hour clock (like is displayed in V4 leases in UTC)