### PR TITLE
Display local DHCP lease times in 24-hour clock

### DIFF
--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -92,7 +92,7 @@ function adjust_gmt($dt) {
 	if ($dhcpleaseinlocaltime == "yes") {
 		$ts = strtotime($dt . " GMT");
 		if ($ts !== false) {
-			return strftime("%Y/%m/%d %I:%M:%S%p", $ts);
+			return strftime("%Y/%m/%d %H:%M:%S", $ts);
 		}
 	}
 	/* If we did not need to convert to local time or the conversion failed, just return the input. */

--- a/src/usr/local/www/status_dhcpv6_leases.php
+++ b/src/usr/local/www/status_dhcpv6_leases.php
@@ -100,7 +100,7 @@ function adjust_gmt($dt) {
 	if ($dhcpv6leaseinlocaltime == "yes") {
 		$ts = strtotime($dt . " GMT");
 		if ($ts !== false) {
-			return strftime("%Y/%m/%d %I:%M:%S%p", $ts);
+			return strftime("%Y/%m/%d %H:%M:%S", $ts);
 		}
 	}
 	/* If we did not need to convert to local time or the conversion failed, just return the input. */


### PR DESCRIPTION
It seems odd to me that when the times are displayed in UTC they have
24-hour clock, but when displayed in local time they are formatted with
12-hour clock and AM/PM.
24-hour format takes less screen space, and I would have thought that
network admins would prefer working consistently in 24-hour clock
format.