### PR TITLE
Fix a redundant HTTP "User-Agent" string.

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -123,7 +123,7 @@
 		var $_cacheFile;
 		var $_cacheFile_v6;
 		var $_debugFile;
-		var $_UserAgent = 'User-Agent: phpDynDNS/0.7';
+		var $_UserAgent = 'phpDynDNS/0.7';
 		var $_errorVerbosity = 0;
 		var $_dnsService;
 		var $_dnsUser;


### PR DESCRIPTION
CURLOPT_USERAGENT expect the value to the user-agent string, not the entire key-value pair.
Before this fix, HTTP header "User-Agent: User-Agent: phpDynDNS/0.7" was sent for DDNS updates.
NGINX configuration at GratisDNS will not accept a user-agent formatted in the above way.
This commit fixes GratisDNS Dynamic DNS service.