### PR TITLE
Allow URLs for TFTP Server (Bug #6634)

### DIFF
--- a/src/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
+++ b/src/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
@@ -19356,7 +19356,7 @@ msgstr ""
 
 #: src/usr/local/www/services_dhcp.php:366
 #: src/usr/local/www/services_dhcp_edit.php:318
-msgid "A valid IP address or hostname must be specified for the TFTP server."
+msgid "A valid IP address, hostname or URL must be specified for the TFTP server."
 msgstr ""
 
 #: src/usr/local/www/services_dhcp.php:369

--- a/src/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
+++ b/src/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
@@ -19760,7 +19760,7 @@ msgstr ""
 
 #: src/usr/local/www/services_dhcp.php:1124
 msgid ""
-"Leave blank to disable.  Enter a full hostname or IP for the TFTP server."
+"Leave blank to disable. Enter a valid IP address, hostname or URL for the TFTP server."
 msgstr ""
 
 #: src/usr/local/www/services_dhcp.php:1137

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -361,8 +361,8 @@ if (isset($_POST['save'])) {
 		if (($_POST['domain'] && !is_domain($_POST['domain']))) {
 			$input_errors[] = gettext("A valid domain name must be specified for the DNS domain.");
 		}
-		if ($_POST['tftp'] && !is_ipaddrv4($_POST['tftp']) && !is_domain($_POST['tftp']) && !is_URL($_POST['tftp'])) {
-			$input_errors[] = gettext("A valid IP address or hostname must be specified for the TFTP server.");
+		if ($_POST['tftp'] && !is_ipaddrv4($_POST['tftp']) && !is_domain($_POST['tftp']) && !filter_var($_POST['tftp'], FILTER_VALIDATE_URL)) {
+			$input_errors[] = gettext("A valid IP address, hostname or URL must be specified for the TFTP server.");
 		}
 		if (($_POST['nextserver'] && !is_ipaddrv4($_POST['nextserver']))) {
 			$input_errors[] = gettext("A valid IP address must be specified for the network boot server.");

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1116,11 +1116,11 @@ $section->addInput(new Form_StaticText(
 	$btnadv
 ));
 
-$section->addInput(new Form_IpAddress(
+$section->addInput(new Form_Input(
 	'tftp',
 	'TFTP Server',
 	$pconfig['tftp']
-))->setHelp('Leave blank to disable.  Enter a full hostname or IP for the TFTP server.')->setPattern('[.a-zA-Z0-9_-]+');
+))->setHelp('Leave blank to disable. Enter a valid IP address, hostname or URL for the TFTP server.');
 
 // Advanced LDAP
 $btnadv = new Form_Button(

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -313,8 +313,8 @@ if ($_POST) {
 	if (($_POST['ntp1'] && !is_ipaddrv4($_POST['ntp1'])) || ($_POST['ntp2'] && !is_ipaddrv4($_POST['ntp2']))) {
 		$input_errors[] = gettext("A valid IP address must be specified for the primary/secondary NTP servers.");
 	}
-	if ($_POST['tftp'] && !is_ipaddrv4($_POST['tftp']) && !is_domain($_POST['tftp']) && !is_URL($_POST['tftp'])) {
-		$input_errors[] = gettext("A valid IP address or hostname must be specified for the TFTP server.");
+	if ($_POST['tftp'] && !is_ipaddrv4($_POST['tftp']) && !is_domain($_POST['tftp']) && !filter_var($_POST['tftp'], FILTER_VALIDATE_URL)) {
+		$input_errors[] = gettext("A valid IP address, hostname or URL must be specified for the TFTP server.");
 	}
 	if (($_POST['nextserver'] && !is_ipaddrv4($_POST['nextserver']))) {
 		$input_errors[] = gettext("A valid IP address must be specified for the network boot server.");


### PR DESCRIPTION
The setPattern() thing ain't usable for this and just causes regressions; also is_URL() from util.inc is way too limited for this purpose.  Backport PR #3083 to RELENG_2_3.