### PR TITLE
services_dhcp: Ignore BOOTP queries

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -866,6 +866,11 @@ EOPP;
 				$dhcpdconf .= "		max-lease-time {$poolconf['maxleasetime']};\n";
 			}
 
+			// ignore bootp
+			if (isset($poolconf['ignorebootp'])) {
+				$dhcpdconf .= "		ignore bootp;\n";
+			}
+
 			// netbios-name*
 			if (is_array($poolconf['winsserver']) && $poolconf['winsserver'][0] && ($poolconf['winsserver'][0] != $dhcpifconf['winsserver'][0])) {
 				$dhcpdconf .= "		option netbios-name-servers " . join(",", $poolconf['winsserver']) . ";\n";

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -167,6 +167,7 @@ if (is_array($dhcpdconf)) {
 	$pconfig['domainsearchlist'] = $dhcpdconf['domainsearchlist'];
 	list($pconfig['wins1'], $pconfig['wins2']) = $dhcpdconf['winsserver'];
 	list($pconfig['dns1'], $pconfig['dns2'], $pconfig['dns3'], $pconfig['dns4']) = $dhcpdconf['dnsserver'];
+	$pconfig['ignorebootp'] = isset($dhcpdconf['ignorebootp']);
 	$pconfig['denyunknown'] = isset($dhcpdconf['denyunknown']);
 	$pconfig['nonak'] = isset($dhcpdconf['nonak']);
 	$pconfig['ddnsdomain'] = $dhcpdconf['ddnsdomain'];
@@ -532,6 +533,7 @@ if (isset($_POST['save'])) {
 		$dhcpdconf['gateway'] = $_POST['gateway'];
 		$dhcpdconf['domain'] = $_POST['domain'];
 		$dhcpdconf['domainsearchlist'] = $_POST['domainsearchlist'];
+		$dhcpdconf['ignorebootp'] = ($_POST['ignorebootp']) ? true : false;
 		$dhcpdconf['denyunknown'] = ($_POST['denyunknown']) ? true : false;
 		$dhcpdconf['nonak'] = ($_POST['nonak']) ? true : false;
 		$dhcpdconf['ddnsdomain'] = $_POST['ddnsdomain'];
@@ -761,6 +763,13 @@ if (!is_numeric($pool) && !($act == "newpool")) {
 } else {
 	print_info_box(gettext('Editing pool-specific options. To return to the Interface, click its tab above.'), 'info', false);
 }
+
+$section->addInput(new Form_Checkbox(
+	'ignorebootp',
+	'BOOTP',
+	'Ignore BOOTP queries',
+	$pconfig['ignorebootp']
+));
 
 $section->addInput(new Form_Checkbox(
 	'denyunknown',


### PR DESCRIPTION
BOOTP leases do not have a maximum lease time by default, this could potentially lead to a DHCP address pool exhaustion.

This commit adds an option to ignore BOOTP queries.

Redmine [#4351](https://redmine.pfsense.org/issues/4351)