### PR TITLE
Update firewall rules separators when NAT associated rule is deleted.

### DIFF
--- a/src/etc/inc/itemid.inc
+++ b/src/etc/inc/itemid.inc
@@ -30,6 +30,8 @@
  *   boolean   - true if item was found and deleted
  ******/
 function delete_id($id, &$array) {
+	global $config;
+
 	// Index to delete
 	$delete_index = NULL;
 
@@ -42,6 +44,7 @@ function delete_id($id, &$array) {
 		// If this item is the one we want to delete
 		if (isset($item['associated-rule-id']) && $item['associated-rule-id'] == $id) {
 			$delete_index = $key;
+			$if = $item['interface'];
 			break;
 		}
 	}
@@ -49,6 +52,13 @@ function delete_id($id, &$array) {
 	// If we found the item, unset it
 	if ($delete_index !== NULL) {
 		unset($array[$delete_index]);
+
+		// Update the separators
+		$a_separators = &$config['filter']['separator'][strtolower($if)];
+		$ridx = ifridx($if, $delete_index);	// get rule index within interface
+		$mvnrows = -1;
+		move_separators($a_separators, $ridx, $mvnrows);
+
 		return true;
 	} else {
 		return false;


### PR DESCRIPTION
Bug: https://redmine.pfsense.org/issues/6676