### PR TITLE
Trigger for external script when gateway status changes

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -923,6 +923,7 @@ function return_gateway_groups_array() {
 						$gwdown = true;
 					}
 					if ($gwdown == true) {
+						if (file_exists('/usr/local/bin/gateway_status.sh')) { mwexec("/usr/local/bin/gateway_status.sh $gwname down"); }
                                         	if (!file_exists("/tmp/.down.$gwname")) {
                                                 	$msg .= "\n".implode("|", $status);
 							touch("/tmp/.down.$gwname");
@@ -932,6 +933,7 @@ function return_gateway_groups_array() {
                                         	}
 					} else {
 						/* Online add member */
+						if (file_exists('/usr/local/bin/gateway_status.sh')) { mwexec("/usr/local/bin/gateway_status.sh $gwname up"); }
 						if (!is_array($tiers[$tier])) {
 							$tiers[$tier] = array();
 						}

--- a/src/usr/local/bin/gateway_status.sh
+++ b/src/usr/local/bin/gateway_status.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+gwname="$1"
+status="$2"
+
+if [ "$status" = "down" ]; then
+	# Insert code here, gets executed when gateway goes down
+	:
+
+elif [ "$status" == "up" ]; then
+	# Insert code here, gets executed multiple times when gateway goes up
+	:
+
+fi

--- a/src/usr/local/bin/gateway_status.sh
+++ b/src/usr/local/bin/gateway_status.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
-gwname="$1"
-status="$2"
+# This script gets executed whenever a gateway status changes
+
+gwname="$1" # Contains the gateway name
+status="$2" # Contains the gateway status ("up"/"down")
 
 if [ "$status" = "down" ]; then
 	# Insert code here, gets executed when gateway goes down

--- a/src/usr/local/bin/gateway_status_template.sh
+++ b/src/usr/local/bin/gateway_status_template.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-# This script gets executed whenever a gateway status changes
+# Copy this script template to /usr/local/bin/gateway_status.sh
+# Script gets executed whenever a gateway status changes
 
 gwname="$1" # Contains the gateway name
 status="$2" # Contains the gateway status ("up"/"down")


### PR DESCRIPTION
Adds a way for users to execute trivial code when a gateway is added or removed from a LB group.
Needed to make squid use failover & loadbalancing toghether, see https://forum.pfsense.org/index.php?topic=109000
I've asked if such a trigger exists before here: https://forum.pfsense.org/index.php?topic=112619.0
