### PR TITLE
Ensure extensions.ini is readable by non root users

### DIFF
--- a/src/etc/rc.php_ini_setup
+++ b/src/etc/rc.php_ini_setup
@@ -101,6 +101,7 @@ else
 	fi
 fi
 
+/bin/chmod 0644 /usr/local/etc/php/extensions.ini
 /usr/bin/sort -u -o /usr/local/etc/php/extensions.ini /usr/local/etc/php/extensions.ini
 
 # Set upload directory


### PR DESCRIPTION
This commit adds a chmod call ensuring permissions are set to 0644 (-rw-r--r--) for extensions.ini
It should do the trick.

Thanks!