### PR TITLE
Fixed to properly save configs in PPPs interfaces

### DIFF
--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -147,6 +147,9 @@ if (isset($id) && $a_ppps[$id]) {
 			$pconfig['connect-timeout'] = $a_ppps[$id]['connect-timeout'];
 			$pconfig['localip'] = explode(",", $a_ppps[$id]['localip']);
 			$pconfig['gateway'] = explode(",", $a_ppps[$id]['gateway']);
+			$pconfig['country'] = $a_ppps[$id]['country'];
+			$pconfig['provider'] = $a_ppps[$id]['provider'];
+			$pconfig['providerplan'] = $a_ppps[$id]['providerplan'];
 			break;
 		case "l2tp":
 		case "pptp":
@@ -354,6 +357,7 @@ if (isset($_POST) && is_array($_POST) && count($_POST) > 0) {
 		$ppp['if'] = $ppp['type'].$ppp['ptpid'];
 		$ppp['ports'] = implode(',', $_POST['interfaces']);
 		$ppp['username'] = $_POST['username'];
+
 		if ($_POST['passwordfld'] != DMYPWD) {
 			$ppp['password'] = base64_encode($_POST['passwordfld']);
 		} else {
@@ -374,6 +378,9 @@ if (isset($_POST) && is_array($_POST) && count($_POST) > 0) {
 
 		switch ($_POST['type']) {
 			case "ppp":
+				$ppp['country'] = $_POST['country'];
+				$ppp['provider'] = $_POST['provider'];
+				$ppp['providerplan'] = $_POST['providerplan'];
 				if (!empty($_POST['initstr'])) {
 					$ppp['initstr'] = base64_encode($_POST['initstr']);
 				} else {
@@ -401,6 +408,7 @@ if (isset($_POST) && is_array($_POST) && count($_POST) > 0) {
 				} else {
 					unset($ppp['connect-timeout']);
 				}
+
 				break;
 			case "pppoe":
 				if (!empty($_POST['provider'])) {
@@ -728,27 +736,29 @@ $section->addInput(new Form_Checkbox(
 	isset($pconfig['uptime'])
 ))->setHelp(sprintf('Causes cumulative uptime to be recorded and displayed on the %sStatus->Interfaces%s page.', '<a href="status_interfaces.php">', '</a>'));
 
-$group = new Form_Group('Service name');
-$group->addClass('pppoe');
+if ($pconfig['type'] == 'pppoe') {
+	$group = new Form_Group('Service name');
+	$group->addClass('pppoe');
 
-$group->add(new Form_Input(
-	'provider',
-	null,
-	'text',
-	$pconfig['provider']
-));
+	$group->add(new Form_Input(
+		'provider',
+		null,
+		'text',
+		$pconfig['provider']
+	));
 
-$group->add(new Form_Checkbox(
-	'null_service',
-	null,
-	'Configure NULL service name',
-	$pconfig['null_service']
-));
+	$group->add(new Form_Checkbox(
+		'null_service',
+		null,
+		'Configure NULL service name',
+		$pconfig['null_service']
+	));
 
-$group->setHelp('This field can usually be left empty. Service name will not be configured if this field is empty. ' .
-				'Check the "Configure NULL" box to configure a blank Service name.');
+	$group->setHelp('This field can usually be left empty. Service name will not be configured if this field is empty. ' .
+					'Check the "Configure NULL" box to configure a blank Service name.');
 
-$section->add($group);
+	$section->add($group);
+}
 
 $section->addInput(new Form_Select(
 	'pppoe-reset-type',
@@ -1075,6 +1085,7 @@ events.push(function() {
 		hideClass('linkparam', true);
 		hideInput('linkparamhelp', true);
 
+		<?php if ($pconfig['type'] != 'ppp') : ?>
 		var selected = $(".interfaces").val();
 		var length = $(".interfaces :selected").length;
 		for (var i=0; i<length; i++) {
@@ -1085,6 +1096,7 @@ events.push(function() {
 				hideInput('linkparamhelp', false);
 			}
 		}
+		<?php endif; ?>
 	}
 
 	function hideProviders(hide) {
@@ -1110,6 +1122,9 @@ events.push(function() {
 						$('#provider').append(new Option(value, value));
 					}
 				}
+				$("#provider").val("<?=$pconfig['provider'];?>");
+				// select option simulates the provider to populate the Plan
+				$("#provider").trigger("change");
 			}
 		});
 	}
@@ -1132,6 +1147,7 @@ events.push(function() {
 											  providerplan[1]));
 					}
 				}
+				$("#providerplan").val("<?=$pconfig['providerplan'];?>");
 			}
 		});
 	}
@@ -1202,6 +1218,11 @@ events.push(function() {
 	}
 
 	$('#pppoe_resetdate').datepicker();
+
+	if ($("#type").val() == "ppp") {
+		providers_list();
+		hideInput('provider', false);
+	}
 });
 //]]>
 


### PR DESCRIPTION
-Fix country, provider and providerplan configs were not being saved;
-Fix country, provider and providerplan configs were not being show in ppp edit page;
-Fix error in load edit page when try hideInterfaces() function when ppp type was selected;
-Fix conflict in provider input when pppoe type was selected;