### PR TITLE
Protect package_reinstall_all()

### DIFF
--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -998,6 +998,9 @@ function package_reinstall_all() {
 		    FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 		unlink_if_exists("{$g['cf_conf_path']}/packages_to_reinstall_after_upgrade.txt");
 	} else {
+		if (!isset($config['installedpackages']['package']) || !is_array($config['installedpackages']['package'])) {
+			return true;
+		}
 		$package_list = array();
 		foreach ($config['installedpackages']['package'] as $package) {
 			$package_list[] = get_package_internal_name($package);


### PR DESCRIPTION
If one restores a config.xml without packages, there will be a warning about invalid argument supplied for foreach(). This commit fixes the problem.

If accepted, please backport to RELENG_2_3 as well.
Thanks!