### PR TITLE
Uniformize memory limits and remove old code

### DIFF
--- a/src/etc/rc.php_ini_setup
+++ b/src/etc/rc.php_ini_setup
@@ -266,7 +266,7 @@ suhosin.post.max_value_length = 500000
 suhosin.request.max_array_index_length = 256
 suhosin.request.max_vars = 5000
 suhosin.request.max_value_length = 500000
-suhosin.memory_limit = 536870912
+suhosin.memory_limit = 805306368
 
 EOF
 

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -75,11 +75,6 @@ if (!$g['services_dhcp_server_enable']) {
 	exit;
 }
 
-/*	Fix failover DHCP problem
- *	http://article.gmane.org/gmane.comp.security.firewalls.pfsense.support/18749
- */
-ini_set("memory_limit", "64M");
-
 $if = $_GET['if'];
 if ($_POST['if']) {
 	$if = $_POST['if'];

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -38,11 +38,6 @@ if (!$g['services_dhcp_server_enable']) {
 	exit;
 }
 
-/*	Fix failover DHCP problem
- *	http://article.gmane.org/gmane.comp.security.firewalls.pfsense.support/18749
- */
-ini_set("memory_limit", "64M");
-
 $if = $_GET['if'];
 if ($_POST['if']) {
 	$if = $_POST['if'];


### PR DESCRIPTION
1) Increase memory_limit to 192M on i386 (edit: this change has now been reverted)
2) Allow setting a memory_limit up to 768M (Suhosin)
3) Remove old workarounds. Memory limits on config.inc will be new defaults

This will help in working around this issue and improve the code:
https://forum.pfsense.org/index.php?topic=116307.0

Developer of the package can add calls such as ```ini_set('memory_limit', '650M');``` on the affected pages, the limit will be accepted by Suhosin and if system has enough memory everything will play nice (people use this in servers with 8GB+ RAM so no problem).

Thanks!
Backport to RELENG_2_3 if accepted :)