### PR TITLE
Ensure only one instance of services_dhcpd_configure runs concurrently

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -395,6 +395,8 @@ function services_radvd_configure($blacklist = array()) {
 function services_dhcpd_configure($family = "all", $blacklist = array()) {
 	global $config, $g;
 
+	$dhcpdconfigurelck = lock("dhcpdconfigure", LOCK_EX);
+
 	/* configure DHCPD chroot once */
 	$fd = fopen("{$g['tmp_path']}/dhcpd.sh", "w");
 	fwrite($fd, "/bin/mkdir -p {$g['dhcpd_chroot_path']}\n");
@@ -425,6 +427,8 @@ function services_dhcpd_configure($family = "all", $blacklist = array()) {
 		services_dhcpdv6_configure($blacklist);
 		services_radvd_configure($blacklist);
 	}
+
+	unlock($dhcpdconfigurelck);
 }
 
 function services_dhcpdv4_configure() {


### PR DESCRIPTION
Sometimes when interfaces are disconnected and reconnected too fast, you may get multiple ```dhcpd -6``` and/or ```dhcpleases6``` running because the whole kill/respawn reaches concurrency conditions.

By securing ```services_dhcpd_configure()``` it ensures only one instance runs concurrently, thereby controlling the flow of the scripts calling it.

Thanks!
Please backport to RELENG_2_3 if accepted.