### PR TITLE
Fix DDNS domain for static map DHCP entries

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1046,9 +1046,9 @@ EOD;
 
 				if (isset($sm['ddnsupdate'])) {
 					if (($sm['ddnsdomain'] <> "") && ($sm['ddnsdomain'] != $dhcpifconf['ddnsdomain'])) {
-						$pdnscfg .= "		ddns-domainname \"{$sm['ddnsdomain']}\";\n";
+						$smdnscfg .= "		ddns-domainname \"{$sm['ddnsdomain']}\";\n";
 					}
-					$pdnscfg .= "		ddns-update-style interim;\n";
+					$smdnscfg .= "		ddns-update-style interim;\n";
 				}
 
 				if (is_array($sm['dnsserver']) && ($sm['dnsserver'][0]) && ($sm['dnsserver'][0] != $dhcpifconf['dnsserver'][0])) {


### PR DESCRIPTION
If you specify DDNS Domain in a DHCP static map entry, it does not make its way through to dhcpd.conf
This is because the var name $pdnscfg is wrong from an old copy-paste that first made this code.