### PR TITLE
Fix double domain-name-servers for pool

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -851,9 +851,6 @@ EOPP;
 				$pdnscfg .= "		ddns-update-style interim;\n";
 			}
 
-			if (is_array($poolconf['dnsserver']) && ($poolconf['dnsserver'][0]) && ($poolconf['dnsserver'][0] != $dhcpifconf['dnsserver'][0])) {
-				$pdnscfg .= "		option domain-name-servers " . join(",", $poolconf['dnsserver']) . ";\n";
-			}
 			$dhcpdconf .= "{$pdnscfg}";
 
 			// default-lease-time


### PR DESCRIPTION
Add a pool and specify something in 1 or more of the DNS servers boxes for the pool.
The "option domain-name-servers 1.2.3.4" line appears twice in dhcpd.conf
The first bit of code to do it is at lines 787-799. I have deleted this 2nd time that it is done at lines 854-856.