### PR TITLE
Fix #6720 DHCP options by pool

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -911,9 +911,9 @@ EOPP;
 				foreach ($poolconf['numberoptions']['item'] as $itemidx => $item) {
 					$item_value = base64_decode($item['value']);
 					if (empty($item['type']) || $item['type'] == "text") {
-						$dhcpdconf .= "	option custom-{$dhcpif}-{$poolidx}-{$itemidx} \"{$item_value}\";\n";
+						$dhcpdconf .= "		option custom-{$dhcpif}-{$poolidx}-{$itemidx} \"{$item_value}\";\n";
 					} else {
-						$dhcpdconf .= "	option custom-{$dhcpif}-{$poolidx}-{$itemidx} {$item_value};\n";
+						$dhcpdconf .= "		option custom-{$dhcpif}-{$poolidx}-{$itemidx} {$item_value};\n";
 					}
 				}
 			}

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -516,6 +516,20 @@ function services_dhcpdv4_configure() {
 				$custoptions .= "option custom-{$dhcpif}-{$itemidx} code {$item['number']} = {$itemtype};\n";
 			}
 		}
+		if (is_array($dhcpifconf['pool'])) {
+			foreach ($dhcpifconf['pool'] as $poolidx => $poolconf) {
+				if (is_array($poolconf['numberoptions']) && is_array($poolconf['numberoptions']['item'])) {
+					foreach ($poolconf['numberoptions']['item'] as $itemidx => $item) {
+						if (!empty($item['type'])) {
+							$itemtype = $item['type'];
+						} else {
+							$itemtype = "text";
+						}
+						$custoptions .= "option custom-{$dhcpif}-{$poolidx}-{$itemidx} code {$item['number']} = {$itemtype};\n";
+					}
+				}
+			}
+		}
 	}
 
 	$dhcpdconf = <<<EOD
@@ -754,7 +768,7 @@ EOPP;
 		$dhcpdconf .= "subnet {$subnet} netmask {$subnetmask} {\n";
 
 		// Setup pool options
-		foreach ($all_pools as $poolconf) {
+		foreach ($all_pools as $all_pools_idx => $poolconf) {
 			if (!(ip_in_subnet($poolconf['range']['from'], "{$subnet}/{$ifcfgsn}") && ip_in_subnet($poolconf['range']['to'], "{$subnet}/{$ifcfgsn}"))) {
 				// If the user has changed the subnet from the interfaces page and applied,
 				// but has not updated the DHCP range, then the range to/from of the pool can be outside the subnet.
@@ -885,6 +899,23 @@ EOPP;
 			// tftp-server-name
 			if (!empty($poolconf['tftp']) && ($poolconf['tftp'] != $dhcpifconf['tftp'])) {
 				$dhcpdconf .= "		option tftp-server-name \"{$poolconf['tftp']}\";\n";
+			}
+
+			// Handle pool-specific options
+			$dhcpdconf .= "\n";
+			// Ignore the first pool, which is the "overall" pool when $all_pools_idx is 0 - those are put outside the pool block later
+			if ($poolconf['numberoptions']['item'] && ($all_pools_idx > 0)) {
+				// Use the "real" pool index from the config, excluding the "overall" pool, and based from 0.
+				// This matches the way $poolidx was used when generating the $custoptions string earlier.
+				$poolidx = $all_pools_idx - 1;
+				foreach ($poolconf['numberoptions']['item'] as $itemidx => $item) {
+					$item_value = base64_decode($item['value']);
+					if (empty($item['type']) || $item['type'] == "text") {
+						$dhcpdconf .= "	option custom-{$dhcpif}-{$poolidx}-{$itemidx} \"{$item_value}\";\n";
+					} else {
+						$dhcpdconf .= "	option custom-{$dhcpif}-{$poolidx}-{$itemidx} {$item_value};\n";
+					}
+				}
 			}
 
 			// ldap-server


### PR DESCRIPTION
It is a little bit tricky having to generate the unique "option custom-if-n-m code ..." lines at first where n = pool index and m = item index in the items of the pool. Then make sure to reference that later, getting the same pool index into the array of pools. The $all_pools array as the "overall" or "base" pool first (at index 0), followed by the user-specified pools at index 1, 2, 3,... - which are actually at indexes 0, 1, 2,... in the ordinary array of pools in the config. So the -1 at line 910 has to happen.
But it works for me.