### PR TITLE
css: Fix jQuery UI widgets' font

### DIFF
--- a/src/usr/local/www/css/pfSense-BETA.css
+++ b/src/usr/local/www/css/pfSense-BETA.css
@@ -82,3 +82,7 @@ a.fa, i.fa {
 .panel-heading {
     padding: 5px 10px;
 }
+
+.ui-widget {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}

--- a/src/usr/local/www/css/pfSense-dark-BETA.css
+++ b/src/usr/local/www/css/pfSense-dark-BETA.css
@@ -86,3 +86,7 @@ a.fa, i.fa {
 .panel-heading {
     padding: 5px 10px;
 }
+
+.ui-widget {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}

--- a/src/usr/local/www/css/pfSense-dark.css
+++ b/src/usr/local/www/css/pfSense-dark.css
@@ -43,9 +43,9 @@ h1 a:link, h1 a:visited {
     color: #fff;
 }
 
-h1 a:hover, h1 a:active { 
-    color: #fff; 
-    text-decoration: none !important; 
+h1 a:hover, h1 a:active {
+    color: #fff;
+    text-decoration: none !important;
 }
 
 /** Content structure */
@@ -348,13 +348,13 @@ caption {
 
 a.list-group-item, .list-group-item {
     background-color: #424242;
-    color: #e0e0e0;  
-    border: 1px solid #212121;  
+    color: #e0e0e0;
+    border: 1px solid #212121;
 }
 
 a.list-group-item:focus, a.list-group-item:hover, .list-group-item:focus, .list-group-item:hover {
     background-color: #303030;
-    color: #e0e0e0; 
+    color: #e0e0e0;
 }
 
 a.list-group-item .list-group-item-heading, .list-group-item .list-group-item-heading {
@@ -406,12 +406,12 @@ ul.tree li A:link, ul.tree li A:hover, ul.tree li A:visited {
 
 table[data-sortable].sortable-theme-bootstrap th[data-sorted="true"] {
     background-color: #000;
-    color: #009688; 
+    color: #009688;
     border-bottom-color: #009688;
 }
 
 table[data-sortable].sortable-theme-bootstrap tbody td {
-    border-top: 1px solid #303030; 
+    border-top: 1px solid #303030;
 }
 
 textarea {
@@ -422,6 +422,10 @@ textarea {
 .ui-autocomplete {
     color: #212121;
     background-color: #e0e0e0;
+}
+
+.ui-widget {
+    font-family: Roboto, sans-serif;
 }
 
 /* Callouts */

--- a/src/usr/local/www/css/pfSense.css
+++ b/src/usr/local/www/css/pfSense.css
@@ -77,6 +77,10 @@ h1 a:hover, h1 a:active {
     cursor: move;
 }
 
+.ui-widget {
+    font-family: Roboto, sans-serif;
+}
+
 tr.disabled td,
 tr.disabled th {
     opacity: .5;


### PR DESCRIPTION
Use the main font with jQuery UI widgets (e.g. autocomplete forms)