### PR TITLE
Improve dhcpd and dhcpleases reload

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1158,16 +1158,16 @@ function interfaces_configure() {
 		/* reload IPsec tunnels */
 		vpn_ipsec_configure();
 
+		/* restart dns servers (defering dhcpd reload) */
+		if (isset($config['dnsmasq']['enable'])) {
+			services_dnsmasq_configure(false);
+		}
+		if (isset($config['unbound']['enable'])) {
+			services_unbound_configure(false);
+		}
+
 		/* reload dhcpd (interface enabled/disabled status may have changed) */
 		services_dhcpd_configure();
-
-		if (isset($config['dnsmasq']['enable'])) {
-			services_dnsmasq_configure();
-		}
-
-		if (isset($config['unbound']['enable'])) {
-			services_unbound_configure();
-		}
 	}
 
 	return 0;
@@ -3536,14 +3536,15 @@ function interface_track6_configure($interface = "lan", $wancfg, $linkupevent = 
 			require_once("services.inc");
 		}
 
+		/* restart dns servers (defering dhcpd reload) */
 		if (isset($config['unbound']['enable'])) {
-			services_unbound_configure();
+			services_unbound_configure(false);
 		}
-
 		if (isset($config['dnsmasq']['enable'])) {
-			services_dnsmasq_configure();
+			services_dnsmasq_configure(false);
 		}
 
+		/* reconfigure dhcpdv6 (leaving dhcpdv4 alone) */
 		services_dhcpd_configure("inet6");
 	}
 

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -426,6 +426,7 @@ function system_hosts_generate() {
 		sigkillbypid("{$g['varrun_path']}/dhcpleases.pid", "TERM");
 		@unlink("{$g['varrun_path']}/dhcpleases.pid");
 	}
+
 	$fd = fopen("{$g['varetc_path']}/hosts", "w");
 	if (!$fd) {
 		log_error(gettext("Error: cannot open hosts file in system_hosts_generate()."));
@@ -437,6 +438,11 @@ function system_hosts_generate() {
 	if (isset($config['unbound']['enable'])) {
 		require_once("unbound.inc");
 		unbound_hosts_generate();
+	}
+
+	/* restart dhcpleases */
+	if (!platform_booting()) {
+		system_dhcpleases_configure();
 	}
 
 	return 0;


### PR DESCRIPTION
1) Avoid running services_dhcpd_configure() more times than needed.
2) Always restart dhcpleases after it's killed during interface recycle.
3) It's not necessary to restart dhcpdv4 when doing changes in ipv6 config.