### PR TITLE
Prevent accessing undefined offset in IPv6.inc

### DIFF
--- a/src/etc/inc/IPv6.inc
+++ b/src/etc/inc/IPv6.inc
@@ -557,7 +557,7 @@ class Net_IPv6
 
         if (false !== strpos($uip, '::') ) {
 
-            list($ip1, $ip2, $ip3) = explode('::', $uip);
+            list($ip1, $ip2) = explode('::', $uip, 2);
 
             if ("" == $ip1) {
 
@@ -605,13 +605,6 @@ class Net_IPv6
             if (-1 == $c1 && -1 == $c2) { // ::
 
                 $uip = "0:0:0:0:0:0:0:0";
-
-                if (isset($ip3)) { // ::::xxx - not good
-                    if ("" == $ip3) { // ::::
-                        $ip3 = 0; // Give back a 9th "0"
-                    }
-                    $uip .= ":" . $ip3;
-                }
 
             } else if (-1 == $c1) {              // ::xxx
 
@@ -898,6 +891,10 @@ class Net_IPv6
 
         if (!empty($ipPart[0])) {
             $ipv6 = explode(':', $ipPart[0]);
+
+			if(8 < count($ipv6)) {
+				return false;
+			}
 
             foreach($ipv6 as $element) { // made a validate precheck
                 if(!preg_match('/^[0-9a-fA-F]*$/', $element)) {


### PR DESCRIPTION
On perfectly good IPs (eg. 1:2::3:4) this code could cause the following notice:
Notice: Undefined offset: 2 in IPv6.inc on line 560

On bad IPs like 1::2::3 it would not result in any notice.
This commit fixes the above problem, while making sure that only valid sequences pass validation.

Related work targeting 2.4: https://github.com/phil-davis/Net_IPv6_svn/pull/1

Thanks!