### PR TITLE
Fix diag_dns regressions

### DIFF
--- a/src/usr/local/www/diag_dns.php
+++ b/src/usr/local/www/diag_dns.php
@@ -62,7 +62,7 @@ function resolve_host_addresses($host) {
 		}
 	}
 	error_reporting($errreporting);// restore original php warning/error settings.
-	
+
 	foreach ($dnsresult as $item) {
 		$newitem = array();
 		$newitem['type'] = $item['type'];
@@ -79,7 +79,6 @@ function resolve_host_addresses($host) {
 				$newitem['data'] = $item['ipv6'];
 				$resolved[] = $newitem;
 				break;
-				
 		}
 	}
 	return $resolved;
@@ -152,7 +151,7 @@ if ($_POST) {
 	}
 
 	$type = "unknown";
-	$resolved = "";
+	$resolved = array();
 	$ipaddr = "";
 	if (!$input_errors) {
 		if (is_ipaddr($host)) {
@@ -167,26 +166,15 @@ if ($_POST) {
 			}
 		} elseif (is_hostname($host)) {
 			$type = "hostname";
-			$resolved = gethostbyname($host);
-			if ($host != $resolved) {
-				$resolved = resolve_host_addresses($host);
-				foreach ($resolved as $item) {
-					if ($item['type'] == 'A') {
-						$ipaddr = $item['data'];
-						break;
-					}
-				}
-			}
-		}
-
-		if ($host == $resolved) {
-			$resolved = gettext("No record found");
+			$ipaddr = gethostbyname($host);
+			$resolved = resolve_host_addresses($host);
 		}
 	}
 }
 
-if (($_POST['host']) && ($_POST['dialog_output'])) {
-	display_host_results ($host, $resolved, $dns_speeds);
+if ($_POST['host'] && $_POST['dialog_output']) {
+	$host = (isset($resolvedptr) ? $resolvedptr : $host);
+	display_host_results ($ipaddr, $host, $dns_speeds);
 	exit;
 }
 
@@ -268,7 +256,7 @@ if (!$input_errors && $type) {
 <div class="panel panel-default">
 	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Results')?></h2></div>
 	<div class="panel-body">
-		
+
 		<table class="table">
 		<thead>
 			<tr>


### PR DESCRIPTION
After testing diag_dns behaviour some regressions have been noticed.

1) Looking up ipv6.google.com (it only has AAAA records) doesn't work
   - gethostbyname() only supports v4, ipv6.google.com only has v6
   - this bug was recently and inadvertently introduced

2) Results table will always show even when domain is not resolved
   - since refactoring ages ago, $resolved is an array, bad idea to replace with a string, this will cause issues
   - this piece of code was 'dead' until the recent commit has 'enabled' it again, removing it as not needed

3) Parameters for display_host_results (see: fe74228f2a8a9abc45a580a01559518043ca8d0b for its introduction) weren't correctly updated
   - mostly a dead function, doubt this is used for anything, keeping it just in case.

This commit fixes all aforementioned issues.

PS: Also reduced a good deal of code, gethostbyname() does a good job getting the IPv4 (if any), so no need to loop through the results in order to grab it.