### PR TITLE
Fix bandwidth limitation in MAC Pass-through automatic addition feature

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -2121,6 +2121,15 @@ function portal_allow($clientip, $clientmac, $username, $password = null, $attri
 		$tod = gettimeofday();
 		$sessionid = substr(md5(mt_rand() . $tod['sec'] . $tod['usec'] . $clientip . $clientmac), 0, 16);
 
+		if (isset($config['captiveportal'][$cpzone]['peruserbw'])) {
+			$dwfaultbw_up = !empty($config['captiveportal'][$cpzone]['bwdefaultup']) ? $config['captiveportal'][$cpzone]['bwdefaultup'] : 0;
+			$dwfaultbw_down = !empty($config['captiveportal'][$cpzone]['bwdefaultdn']) ? $config['captiveportal'][$cpzone]['bwdefaultdn'] : 0;
+		} else {
+			$dwfaultbw_up = $dwfaultbw_down = 0;
+		}
+		$bw_up = !empty($attributes['bw_up']) ? round(intval($attributes['bw_up'])/1000, 2) : $dwfaultbw_up;
+		$bw_down = !empty($attributes['bw_down']) ? round(intval($attributes['bw_down'])/1000, 2) : $dwfaultbw_down;
+
 		if ($passthrumac) {
 			$mac = array();
 			$mac['action'] = 'pass';
@@ -2165,15 +2174,6 @@ function portal_allow($clientip, $clientmac, $username, $password = null, $attri
 				unlock($cpdblck);
 				return;
 			}
-
-			if (isset($config['captiveportal'][$cpzone]['peruserbw'])) {
-				$dwfaultbw_up = !empty($config['captiveportal'][$cpzone]['bwdefaultup']) ? $config['captiveportal'][$cpzone]['bwdefaultup'] : 0;
-				$dwfaultbw_down = !empty($config['captiveportal'][$cpzone]['bwdefaultdn']) ? $config['captiveportal'][$cpzone]['bwdefaultdn'] : 0;
-			} else {
-				$dwfaultbw_up = $dwfaultbw_down = 0;
-			}
-			$bw_up = !empty($attributes['bw_up']) ? round(intval($attributes['bw_up'])/1000, 2) : $dwfaultbw_up;
-			$bw_down = !empty($attributes['bw_down']) ? round(intval($attributes['bw_down'])/1000, 2) : $dwfaultbw_down;
 
 			$bw_up_pipeno = $pipeno;
 			$bw_down_pipeno = $pipeno + 1;


### PR DESCRIPTION
Hey guys,
I have a system with **pfsense + captive portal + external radius server** and all the stuff works perfectly fine. But now I need to use the Pass-through MAC automatic additions feature and I've found and unexpected behaviour. My radius server add bandwidth limitation in its response (wispr-bandwidth-max-down and wispr-bandwidth-max-up) but the automatic entry added has no bandwidth values set.

I don't know if this issue is a bug or an expected behaviour but this is a proposal to "_fix_" it

Sorry for my poor English. :/
