### PR TITLE
Added support for CloudFlare DNS Proxy.

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -95,7 +95,7 @@
 	 *  SelfHost        - Last Tested: 26 December 2011
 	 *  Amazon Route 53 - Last tested: 01 April 2012
 	 *  DNS-O-Matic     - Last Tested: 9 September 2010
-	 *  CloudFlare      - Last Tested: 17 July 2016
+	 *  CloudFlare      - Last Tested: 05 September 2016
 	 *  CloudFlare IPv6 - Last Tested: 17 July 2016
 	 *  Eurodns         - Last Tested: 27 June 2013
 	 *  GratisDNS       - Last Tested: 15 August 2012
@@ -133,6 +133,7 @@
 		var $_FQDN;
 		var $_dnsIP;
 		var $_dnsWildcard;
+		var $_dnsProxied;
 		var $_dnsMX;
 		var $_dnsBackMX;
 		var $_dnsServer;
@@ -164,7 +165,7 @@
 		 *   - $For custom requests, $dnsUpdateURL is parsed for '%IP%', which is replaced with the new IP.
 		 */
 		function updatedns ($dnsService = '', $dnsHost = '', $dnsDomain = '', $dnsUser = '', $dnsPass = '',
-					$dnsWildcard = 'OFF', $dnsMX = '', $dnsIf = '', $dnsBackMX = '',
+					$dnsWildcard = 'OFF', $dnsProxied = false, $dnsMX = '', $dnsIf = '', $dnsBackMX = '',
 					$dnsServer = '', $dnsPort = '', $dnsUpdateURL = '', $forceUpdate = false,
 					$dnsZoneID ='', $dnsTTL='', $dnsResultMatch = '', $dnsRequestIf = '',
 					$dnsID = '', $dnsVerboseLog = false, $curlIpresolveV4 = false, $curlSslVerifypeer = true) {
@@ -233,6 +234,7 @@
 			$this->_dnsServer = $dnsServer;
 			$this->_dnsPort = $dnsPort;
 			$this->_dnsWildcard = $dnsWildcard;
+			$this->_dnsProxied = $dnsProxied;
 			$this->_dnsMX = $dnsMX;
 			$this->_dnsZoneID = $dnsZoneID;
 			$this->_dnsTTL = $dnsTTL;
@@ -727,6 +729,7 @@
 							$hostData = array(
 								"content" => "{$this->_dnsIP}",
 								"type" => "{$recordType}",
+								"proxied" => $this->_dnsProxied,
 								"name" => "{$this->_dnsHost}"
 							);
 							$data_json = json_encode($hostData);

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1951,6 +1951,7 @@ function services_dyndns_configure_client($conf) {
 		$dnsUser = $conf['username'],
 		$dnsPass = $conf['password'],
 		$dnsWildcard = $conf['wildcard'],
+		$dnsProxied = $conf['proxied'],
 		$dnsMX = $conf['mx'],
 		$dnsIf = "{$conf['interface']}",
 		$dnsBackMX = NULL,

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -64,6 +64,7 @@ if (isset($id) && isset($a_dyndns[$id])) {
 	$pconfig['enable'] = !isset($a_dyndns[$id]['enable']);
 	$pconfig['interface'] = $a_dyndns[$id]['interface'];
 	$pconfig['wildcard'] = isset($a_dyndns[$id]['wildcard']);
+	$pconfig['proxied'] = isset($a_dyndns[$id]['proxied']);
 	$pconfig['verboselog'] = isset($a_dyndns[$id]['verboselog']);
 	$pconfig['curl_ipresolve_v4'] = isset($a_dyndns[$id]['curl_ipresolve_v4']);
 	$pconfig['curl_ssl_verifypeer'] = isset($a_dyndns[$id]['curl_ssl_verifypeer']);
@@ -157,6 +158,7 @@ if ($_POST) {
 		$dyndns['domainname'] = $_POST['domainname'];
 		$dyndns['mx'] = $_POST['mx'];
 		$dyndns['wildcard'] = $_POST['wildcard'] ? true : false;
+		$dyndns['proxied'] = $_POST['proxied'] ? true : false;
 		$dyndns['verboselog'] = $_POST['verboselog'] ? true : false;
 		$dyndns['curl_ipresolve_v4'] = $_POST['curl_ipresolve_v4'] ? true : false;
 		$dyndns['curl_ssl_verifypeer'] = $_POST['curl_ssl_verifypeer'] ? true : false;
@@ -322,6 +324,15 @@ $section->addInput(new Form_Checkbox(
 ));
 
 $section->addInput(new Form_Checkbox(
+	'proxied',
+	'CloudFlare Proxy',
+	'Enable Proxy',
+	$pconfig['proxied']
+))->setHelp('Note: This enables CloudFlares Virtual DNS proxy.  When Enabled it will route all traffic '.
+			'through their servers. By Default this is disabled and your Real IP is exposed.'.
+			'More info: <a href="https://blog.cloudflare.com/announcing-virtual-dns-ddos-mitigation-and-global-distribution-for-dns-traffic/" target="_blank">CloudFlare Blog</a>');
+
+$section->addInput(new Form_Checkbox(
 	'verboselog',
 	'Verbose logging',
 	'Enable verbose logging',
@@ -440,6 +451,7 @@ events.push(function() {
 				hideInput('host', true);
 				hideInput('mx', true);
 				hideCheckbox('wildcard', true);
+				hideCheckbox('proxied', true);
 				hideInput('zoneid', true);
 				hideInput('ttl', true);
 				break;
@@ -455,6 +467,7 @@ events.push(function() {
 				hideInput('host', false);
 				hideInput('mx', false);
 				hideCheckbox('wildcard', false);
+				hideCheckbox('proxied', true);
 				hideInput('zoneid', false);
 				hideInput('ttl', false);
 				break;
@@ -468,9 +481,24 @@ events.push(function() {
 				hideInput('host', false);
 				hideInput('mx', false);
 				hideCheckbox('wildcard', false);
+				hideCheckbox('proxied', true);
 				hideInput('zoneid', true);
 				hideInput('ttl', true);
 				break;
+			case "cloudflare-v6":
+			case "cloudflare":
+				hideGroupInput('domainname', true);
+				hideInput('resultmatch', true);
+				hideInput('updateurl', true);
+				hideInput('requestif', true);
+				hideCheckbox('curl_ipresolve_v4', true);
+				hideCheckbox('curl_ssl_verifypeer', true);
+				hideInput('host', false);
+				hideInput('mx', false);
+				hideCheckbox('wildcard', false);
+				hideCheckbox('proxied', false);
+				hideInput('zoneid', true);
+				hideInput('ttl', true);
 			default:
 				hideGroupInput('domainname', true);
 				hideInput('resultmatch', true);
@@ -481,6 +509,7 @@ events.push(function() {
 				hideInput('host', false);
 				hideInput('mx', false);
 				hideCheckbox('wildcard', false);
+				hideCheckbox('proxied', true);
 				hideInput('zoneid', true);
 				hideInput('ttl', true);
 		}


### PR DESCRIPTION
Included a checkbox to enable and disable this feature when CloudeFlare
type is selected.
Included proxied variable in the update script as well.

Defaults to false, as the is the current functionality

Added help text

Updated Last tested date

Hope this helps other people.  I use both dynDNS and the Proxy service.
And by default without this feature, the proxy gets disabled.  This
is a huge problem, as I have all traffic blocked except for CloudFlare.
And because I have certain other security features enabled, when the Proxy
goes disabled, The Site goes down hard to end users.

With this feature, I can ensure the proxy stays enabled.
