### PR TITLE
Redundant logic

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -311,20 +311,20 @@ if ($_POST) {
 						continue;
 					}
 					if (($_POST['ipprotocol'] == "inet46") && ($_POST['ipprotocol'] != $family)) {
-						$input_errors[] = gettext("A gateway can not be assigned to a rule that applies to IPv4 and IPv6");
+						$input_errors[] = gettext("A gateway can not be assigned to a rule that applies to both IPv4 and IPv6");
 					}
 					if (($_POST['ipprotocol'] == "inet6") && ($_POST['ipprotocol'] != $family)) {
-						$input_errors[] = gettext("An IPv4 gateway group can not be assigned on an IPv6 Address Family rule");
+						$input_errors[] = gettext("An IPv4 gateway group can not be assigned to an IPv6 Filter rule");
 					}
 					if (($_POST['ipprotocol'] == "inet") && ($_POST['ipprotocol'] != $family)) {
-						$input_errors[] = gettext("An IPv6 gateway group can not be assigned on an IPv4 Address Family rule");
+						$input_errors[] = gettext("An IPv6 gateway group can not be assigned to an IPv4 Filter rule");
 					}
 				}
 			}
 		}
 		if (is_ipaddr(lookup_gateway_ip_by_name($_POST['gateway']))) {
 			if (($_POST['ipprotocol'] == "inet46") && ($_POST['gateway'] <> "")) {
-				$input_errors[] = gettext("A gateway can not be assigned to a rule that applies to IPv4 and IPv6");
+				$input_errors[] = gettext("A gateway can not be assigned to a rule that applies to both IPv4 and IPv6");
 			}
 			if (($_POST['ipprotocol'] == "inet6") && (!is_ipaddrv6(lookup_gateway_ip_by_name($_POST['gateway'])))) {
 				$input_errors[] = gettext("An IPv4 Gateway can not be assigned to an IPv6 Filter rule");

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -322,16 +322,16 @@ if ($_POST) {
 				}
 			}
 		}
-	}
-	if (($_POST['ipprotocol'] <> "") && ($_POST['gateway'] <> "") && (is_ipaddr(lookup_gateway_ip_by_name($_POST['gateway'])))) {
-		if (($_POST['ipprotocol'] == "inet46") && ($_POST['gateway'] <> "")) {
-			$input_errors[] = gettext("A gateway can not be assigned to a rule that applies to IPv4 and IPv6");
-		}
-		if (($_POST['ipprotocol'] == "inet6") && (!is_ipaddrv6(lookup_gateway_ip_by_name($_POST['gateway'])))) {
-			$input_errors[] = gettext("An IPv4 Gateway can not be assigned to an IPv6 Filter rule");
-		}
-		if (($_POST['ipprotocol'] == "inet") && (!is_ipaddrv4(lookup_gateway_ip_by_name($_POST['gateway'])))) {
-			$input_errors[] = gettext("An IPv6 Gateway can not be assigned to an IPv4 Filter rule");
+		if (is_ipaddr(lookup_gateway_ip_by_name($_POST['gateway']))) {
+			if (($_POST['ipprotocol'] == "inet46") && ($_POST['gateway'] <> "")) {
+				$input_errors[] = gettext("A gateway can not be assigned to a rule that applies to IPv4 and IPv6");
+			}
+			if (($_POST['ipprotocol'] == "inet6") && (!is_ipaddrv6(lookup_gateway_ip_by_name($_POST['gateway'])))) {
+				$input_errors[] = gettext("An IPv4 Gateway can not be assigned to an IPv6 Filter rule");
+			}
+			if (($_POST['ipprotocol'] == "inet") && (!is_ipaddrv4(lookup_gateway_ip_by_name($_POST['gateway'])))) {
+				$input_errors[] = gettext("An IPv6 Gateway can not be assigned to an IPv4 Filter rule");
+			}
 		}
 	}
 	if (($_POST['proto'] == "icmp") && ($_POST['icmptype'] <> "")) {

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -305,18 +305,12 @@ if ($_POST) {
 	if (($_POST['ipprotocol'] <> "") && ($_POST['gateway'] <> "")) {
 		if (is_array($config['gateways']['gateway_group'])) {
 			foreach ($config['gateways']['gateway_group'] as $gw_group) {
-				if ($gw_group['name'] == $_POST['gateway']) {
-					$family = $a_gatewaygroups[$_POST['gateway']]['ipprotocol'];
-					if ($_POST['ipprotocol'] == $family) {
-						continue;
-					}
-					if (($_POST['ipprotocol'] == "inet46") && ($_POST['ipprotocol'] != $family)) {
+				if ($gw_group['name'] == $_POST['gateway'] && $_POST['ipprotocol'] != $a_gatewaygroups[$_POST['gateway']]['ipprotocol']) {
+					if ($_POST['ipprotocol'] == "inet46") {
 						$input_errors[] = gettext("Gateways can not be assigned in a rule that applies to both IPv4 and IPv6.");
-					}
-					if (($_POST['ipprotocol'] == "inet6") && ($_POST['ipprotocol'] != $family)) {
+					} elseif ($_POST['ipprotocol'] == "inet6") {
 						$input_errors[] = gettext("An IPv4 gateway group can not be assigned in IPv6 rules.");
-					}
-					if (($_POST['ipprotocol'] == "inet") && ($_POST['ipprotocol'] != $family)) {
+					} elseif ($_POST['ipprotocol'] == "inet") {
 						$input_errors[] = gettext("An IPv6 gateway group can not be assigned in IPv4 rules.");
 					}
 				}

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -311,26 +311,26 @@ if ($_POST) {
 						continue;
 					}
 					if (($_POST['ipprotocol'] == "inet46") && ($_POST['ipprotocol'] != $family)) {
-						$input_errors[] = gettext("A gateway can not be assigned to a rule that applies to both IPv4 and IPv6");
+						$input_errors[] = gettext("Gateways can not be assigned in a rule that applies to both IPv4 and IPv6.");
 					}
 					if (($_POST['ipprotocol'] == "inet6") && ($_POST['ipprotocol'] != $family)) {
-						$input_errors[] = gettext("An IPv4 gateway group can not be assigned to an IPv6 Filter rule");
+						$input_errors[] = gettext("An IPv4 gateway group can not be assigned in IPv6 rules.");
 					}
 					if (($_POST['ipprotocol'] == "inet") && ($_POST['ipprotocol'] != $family)) {
-						$input_errors[] = gettext("An IPv6 gateway group can not be assigned to an IPv4 Filter rule");
+						$input_errors[] = gettext("An IPv6 gateway group can not be assigned in IPv4 rules.");
 					}
 				}
 			}
 		}
 		if (is_ipaddr(lookup_gateway_ip_by_name($_POST['gateway']))) {
 			if (($_POST['ipprotocol'] == "inet46") && ($_POST['gateway'] <> "")) {
-				$input_errors[] = gettext("A gateway can not be assigned to a rule that applies to both IPv4 and IPv6");
+				$input_errors[] = gettext("Gateways can not be assigned in a rule that applies to both IPv4 and IPv6.");
 			}
 			if (($_POST['ipprotocol'] == "inet6") && (!is_ipaddrv6(lookup_gateway_ip_by_name($_POST['gateway'])))) {
-				$input_errors[] = gettext("An IPv4 Gateway can not be assigned to an IPv6 Filter rule");
+				$input_errors[] = gettext("An IPv4 gateway can not be assigned in IPv6 rules.");
 			}
 			if (($_POST['ipprotocol'] == "inet") && (!is_ipaddrv4(lookup_gateway_ip_by_name($_POST['gateway'])))) {
-				$input_errors[] = gettext("An IPv6 Gateway can not be assigned to an IPv4 Filter rule");
+				$input_errors[] = gettext("An IPv6 gateway can not be assigned in IPv4 rules.");
 			}
 		}
 	}
@@ -528,7 +528,7 @@ if ($_POST) {
 	}
 	if ((is_ipaddr($_POST['src']) && is_ipaddr($_POST['dst']))) {
 		if (!validate_address_family($_POST['src'], $_POST['dst'])) {
-			$input_errors[] = sprintf(gettext("The Source IP address %s Address Family differs from the destination %s."), $_POST['src'], $_POST['dst']);
+			$input_errors[] = gettext("The source and destination IP addresses must have the same family (IPv4 / IPv6).");
 		}
 	}
 	if ((is_ipaddrv6($_POST['src']) || is_ipaddrv6($_POST['dst'])) && ($_POST['ipprotocol'] == "inet")) {
@@ -539,7 +539,7 @@ if ($_POST) {
 	}
 
 	if ((is_ipaddr($_POST['src']) || is_ipaddr($_POST['dst'])) && ($_POST['ipprotocol'] == "inet46")) {
-		$input_errors[] = gettext("An IPv4 or IPv6 address can not be used in combined IPv4 + IPv6 rules.");
+		$input_errors[] = gettext("IPv4 and IPv6 addresses can not be used in rules that apply to both IPv4 and IPv6.");
 	}
 
 	if ($_POST['srcbeginport'] > $_POST['srcendport']) {

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -322,14 +322,15 @@ if ($_POST) {
 				}
 			}
 		}
-		if (is_ipaddr(lookup_gateway_ip_by_name($_POST['gateway']))) {
-			if (($_POST['ipprotocol'] == "inet46") && ($_POST['gateway'] <> "")) {
+		if ($iptype = is_ipaddr(lookup_gateway_ip_by_name($_POST['gateway']))) {
+			// this also implies that  $_POST['gateway'] was set and not empty
+			if ($_POST['ipprotocol'] == "inet46") {
 				$input_errors[] = gettext("Gateways can not be assigned in a rule that applies to both IPv4 and IPv6.");
 			}
-			if (($_POST['ipprotocol'] == "inet6") && (!is_ipaddrv6(lookup_gateway_ip_by_name($_POST['gateway'])))) {
+			if (($_POST['ipprotocol'] == "inet6") && ($iptype != 6)) {
 				$input_errors[] = gettext("An IPv4 gateway can not be assigned in IPv6 rules.");
 			}
-			if (($_POST['ipprotocol'] == "inet") && (!is_ipaddrv4(lookup_gateway_ip_by_name($_POST['gateway'])))) {
+			if (($_POST['ipprotocol'] == "inet") && ($iptype != 4)) {
 				$input_errors[] = gettext("An IPv6 gateway can not be assigned in IPv4 rules.");
 			}
 		}

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -42,8 +42,8 @@ if (isset($_POST['referer'])) {
 }
 
 function is_posnumericint($arg) {
-	// Note that to be safe we do not allow any leading zero - "01", "007"
-	return (is_numericint($arg) && $arg[0] != '0' && $arg > 0);
+	// Integer > 0? (Note that to be safe we do not allow any leading zero - "01", "007")
+	return (is_numericint($arg) && $arg[0] != '0');
 }
 
 function is_aoadv_used($rule_config) {


### PR DESCRIPTION
1) if it's a numeric integer (hence non-empty [0-9]+ ) and the first char isn't "0" then the value will always be >0, so test is redundant

2) logic for gateway type is part tested in previous error check, no need to duplicate, clearer this way

3) minor standardising of error message texts (some referred to an "IPv4/6 Address Family rule" and others to an "IPv4/6 Filter rule", some refer to "a rule that applies to IPv4 and IPv6" while others refer to "combined IPv4 and IPv6 rules")