### PR TITLE
Fix #6768 IPv6 static mapping on delegated prefixes

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1346,12 +1346,11 @@ EOD;
 		}
 		$ifcfgsnv6 = get_interface_subnetv6($dhcpv6if);
 		$subnetv6 = gen_subnetv6($ifcfgipv6, $ifcfgsnv6);
-
-		if ($ifcfgv6['ipaddrv6'] == 'track6') {
-			$trackifname = $config['interfaces'][$ifname]['track6-interface'];
-			$trackcfg = $config['interfaces'][$trackifname];
-			$pdlen = 64 - $trackcfg['dhcp6-ia-pd-len'];
-		}
+		// We might have some prefix-delegation on WAN (e.g. /48),
+		// but then it is split and given out to individual interfaces
+		// (LAN, OPT1, OPT2...) as multiple /64 subnets. So the size
+		// of each subnet here is always /64.
+		$pdlen = 64;
 
 		if ($is_olsr_enabled == true) {
 			if ($dhcpv6ifconf['netmask']) {

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -393,10 +393,8 @@ function system_hosts_generate() {
 						$ipaddrv6 = $host['ipaddrv6'];
 						if ($ipaddrv6 && $host['hostname']) {
 							if ($isdelegated) {
-								$trackifname = $config['interfaces'][$dhcpif]['track6-interface'];
-								$trackcfg = $config['interfaces'][$trackifname];
-								$pdlen = 64 - $trackcfg['dhcp6-ia-pd-len'];
-								$ipaddrv6 = merge_ipv6_delegated_prefix(get_interface_ipv6($dhcpif), $ipaddrv6, $pdlen);
+								// We are always in an "end-user" subnet here, which all are /64 for IPv6.
+								$ipaddrv6 = merge_ipv6_delegated_prefix(get_interface_ipv6($dhcpif), $ipaddrv6, 64);
 							}
 							if ($host['domain']) {
 								$dhosts .= "{$ipaddrv6}	{$host['hostname']}.{$host['domain']}\n";


### PR DESCRIPTION
For example, WAN receives a /48 delegated from the upstream (ISP...),
e.g. "2001:470:abcd::" pfSense then uses this as a starting point to
calculate the addresses on LAN, OPT1, OPT2 etc where they have been
specified as "track interface WAN".
Actually each local interface gets just a /64 taken out of the /48,
using the chunk specified by "IPv6 Prefix Id" for that local interface.
e.g. if "IPv6 Prefix Id" is set to "a123" on LAN, then the LAN would be:
2001:470:abcd:a123::/64

Then when we specify a static-mapped address in LAN, or other things
that live in LAN, e.g. "::4242" we mean 4242 on from the base LAN
address, so "2001:470:abcd:a123::4242"

i.e. we always have a CIDR of 64 when calculating this stuff. We do not
want the logic that was in this code that was using the upstream prefix
delegation size (like /48).

Note: The code in services.inc "worked" because var $ifname was not set,
and so $trackifname was blank, $trackcfg was blank, and so the attempted
calculation of $pdlen always came out as 64 anyway. That tricked me for
a while trying to understand why the original code in services.inc worked.
system.inc did not work, because it actually calculated $pdlen and got a
number like 48 - which we do not want here.