### PR TITLE
Allow snmpd to bind to multiple interfaces.

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2381,24 +2381,34 @@ begemotSnmpdCommunityDisable    = 1
 
 EOD;
 
-		$bind_to_ip = "0.0.0.0";
+		$bind_to_ips = array();
 		if (isset($config['snmpd']['bindip'])) {
-			if (is_ipaddr($config['snmpd']['bindip'])) {
-				$bind_to_ip = $config['snmpd']['bindip'];
-			} else {
-				$if = get_real_interface($config['snmpd']['bindip']);
-				if (does_interface_exist($if)) {
-					$bind_to_ip = get_interface_ip($config['snmpd']['bindip']);
+			foreach (explode(",", $config['snmpd']['bindip']) as $bind_to_ip) {
+				if (is_ipaddr($bind_to_ip)) {
+					$bind_to_ips[] = $bind_to_ip;
+				} else {
+					$if = get_real_interface($bind_to_ip);
+					if (does_interface_exist($if)) {
+						$bindip = get_interface_ip($bind_to_ip);
+						if (is_ipaddr($bindip)) {
+							$bind_to_ips[] = $bindip;
+						}
+					}
 				}
 			}
 		}
+		if (!count($bind_to_ips)) {
+			$bind_to_ips = array("0.0.0.0");
+		}
 
 		if (is_port($config['snmpd']['pollport'])) {
+			foreach ($bind_to_ips as $bind_to_ip) {
 			$snmpdconf .= <<<EOD
 begemotSnmpdPortStatus.{$bind_to_ip}.{$config['snmpd']['pollport']} = 1
 
 EOD;
 
+			}
 		}
 
 		$snmpdconf .= <<<EOD


### PR DESCRIPTION
This patch makes it possible to bind snmpd to multiple interfaces other than ALL (for example to LAN and LAN CARP VIP). Binding to all interfaces is a security issue if you don't want to expose snmp to WAN.