### PR TITLE
Allow snmpd to bind to multiple interfaces.

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2379,24 +2379,34 @@ begemotSnmpdCommunityDisable    = 1
 
 EOD;
 
-		$bind_to_ip = "0.0.0.0";
+		$bind_to_ips = array();
 		if (isset($config['snmpd']['bindip'])) {
-			if (is_ipaddr($config['snmpd']['bindip'])) {
-				$bind_to_ip = $config['snmpd']['bindip'];
-			} else {
-				$if = get_real_interface($config['snmpd']['bindip']);
-				if (does_interface_exist($if)) {
-					$bind_to_ip = get_interface_ip($config['snmpd']['bindip']);
+			foreach (explode(",", $config['snmpd']['bindip']) as $bind_to_ip) {
+				if (is_ipaddr($bind_to_ip)) {
+					$bind_to_ips[] = $bind_to_ip;
+				} else {
+					$if = get_real_interface($bind_to_ip);
+					if (does_interface_exist($if)) {
+						$bindip = get_interface_ip($bind_to_ip);
+						if (is_ipaddr($bindip)) {
+							$bind_to_ips[] = $bindip;
+						}
+					}
 				}
 			}
 		}
+		if (!count($bind_to_ips)) {
+			$bind_to_ips = array("0.0.0.0");
+		}
 
 		if (is_port($config['snmpd']['pollport'])) {
+			foreach ($bind_to_ips as $bind_to_ip) {
 			$snmpdconf .= <<<EOD
 begemotSnmpdPortStatus.{$bind_to_ip}.{$config['snmpd']['pollport']} = 1
 
 EOD;
 
+			}
 		}
 
 		$snmpdconf .= <<<EOD

--- a/src/usr/local/www/services_snmp.php
+++ b/src/usr/local/www/services_snmp.php
@@ -71,7 +71,11 @@ $pconfig['hostres'] = isset($config['snmpd']['modules']['hostres']);
 $pconfig['bridge'] = isset($config['snmpd']['modules']['bridge']);
 $pconfig['ucd'] = isset($config['snmpd']['modules']['ucd']);
 $pconfig['regex'] = isset($config['snmpd']['modules']['regex']);
-$pconfig['bindip'] = $config['snmpd']['bindip'];
+if (empty($config['snmpd']['bindip'])) {
+	$pconfig['bindip'] = array();
+} else {
+	$pconfig['bindip'] = explode(",", $config['snmpd']['bindip']);
+}
 
 if ($_POST) {
 
@@ -151,7 +155,9 @@ if ($_POST) {
 		$config['snmpd']['modules']['bridge'] = $_POST['bridge'] ? true : false;
 		$config['snmpd']['modules']['ucd'] = $_POST['ucd'] ? true : false;
 		$config['snmpd']['modules']['regex'] = $_POST['regex'] ? true : false;
-		$config['snmpd']['bindip'] = $_POST['bindip'];
+		if (is_array($_POST['bindip']) && !empty($_POST['bindip'])) {
+			$config['snmpd']['bindip'] = implode(",", $_POST['bindip']);
+		}
 
 		write_config();
 
@@ -161,17 +167,28 @@ if ($_POST) {
 	}
 }
 
-function build_iplist() {
-	$listenips = get_possible_listen_ips();
-	$iplist = array();
-	$iplist[''] = 'All';
+function build_if_list($selectedifs) {
+	$interface_addresses = get_possible_listen_ips(true);
+	$iflist = array('options' => array(), 'selected' => array());
 
-	foreach ($listenips as $lip => $ldescr) {
-		$iplist[$lip] = $ldescr;
+	$iflist['options']['all']	= gettext("All");
+	if (empty($selectedifs) || empty($selectedifs[0]) || in_array("all", $selectedifs)) {
+		array_push($iflist['selected'], "all");
 	}
-	unset($listenips);
 
-	return($iplist);
+	foreach ($interface_addresses as $laddr => $ldescr) {
+		if (is_ipaddr(get_interface_ip($laddr))) {
+			$iflist['options'][$laddr] = htmlspecialchars($ldescr);
+		}
+
+		if ($selectedifs && in_array($laddr, $selectedifs)) {
+			array_push($iflist['selected'], $laddr);
+		}
+	}
+
+	unset($interface_addresses);
+
+	return($iflist);
 }
 
 $pgtitle = array(gettext("Services"), gettext("SNMP"));
@@ -325,11 +342,14 @@ $form->add($section);
 
 $section = new Form_Section('Interface Binding');
 
+$iflist = build_if_list($pconfig['bindip']);
+
 $section->addInput(new Form_Select(
 	'bindip',
-	'Bind Interface',
-	$pconfig['bindip'],
-	build_iplist()
+	'Bind Interfaces',
+	$iflist['selected'],
+	$iflist['options'],
+	true
 ));
 
 $form->add($section);


### PR DESCRIPTION
This patch makes it possible to bind snmpd to multiple interfaces other than ALL (for example to LAN and LAN CARP VIP). Binding to all interfaces is a security issue if you don't want to expose snmp to WAN.
