### PR TITLE
 Do not show certificates in drop-down list that are already contained in this CRL.

### DIFF
--- a/src/usr/local/www/system_crlmanager.php
+++ b/src/usr/local/www/system_crlmanager.php
@@ -505,7 +505,7 @@ if ($act == "new" || $act == gettext("Save") || $input_errors) {
 
 	$ca_certs = array();
 	foreach ($a_cert as $cert) {
-		if ($cert['caref'] == $crl['caref']) {
+		if ($cert['caref'] == $crl['caref'] && !is_cert_revoked($cert, $id)) {
 			$ca_certs[] = $cert;
 		}
 	}


### PR DESCRIPTION
On System / Certificate Manager / Certificate Revocation / Edit in section "Choose a Certificate to Revoke" the drop-down list "Certificate" should not list certificates already contained in this CRL.