### PR TITLE
Allow Hyphens in DHCP NTP Server form validation

### DIFF
--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1070,13 +1070,13 @@ $section->addInput(new Form_IpAddress(
 	'ntp1',
 	'NTP Server 1',
 	$pconfig['ntp1']
-))->setPattern('[.a-zA-Z0-9_]+');
+))->setPattern('[.a-zA-Z0-9-]+');
 
 $section->addInput(new Form_IpAddress(
 	'ntp2',
 	'NTP Server 2',
 	$pconfig['ntp2']
-))->setPattern('[.a-zA-Z0-9_]+');
+))->setPattern('[.a-zA-Z0-9-]+');
 
 // Advanced TFTP
 $btnadv = new Form_Button(


### PR DESCRIPTION
Also removes the ability to have underscores `_` in ntp server
FQDNs.

Closes #6806