### PR TITLE
Format file_notice alerts in webgui with newline characters as <br/> for easier reading.

### DIFF
--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -650,7 +650,7 @@ if (are_notices_pending()):?>
 							<a href="<?=htmlspecialchars($notice['url'])?>"><?=htmlspecialchars($notice['id'])?></a> -
 <?php endif;?>
 						</b>
-						<?=htmlspecialchars($notice['notice'])?>
+						<?=str_replace("\n", "<br/>", htmlspecialchars($notice['notice']))?>
 						<i>@ <?=date('Y-m-d H:i:s', $notice['time'])?></i>
 					</li>
 <?php	endforeach;?>


### PR DESCRIPTION
Format file_notice alerts in webgui with newline characters as <br/> for easier reading.