### PR TITLE
Remove unused arg in get_pkg_info()

### DIFF
--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -340,7 +340,7 @@ function get_package_internal_name($package_data) {
 }
 
 // Get information about packages.
-function get_pkg_info($pkgs = 'all', $info = 'all', $only_local = false) {
+function get_pkg_info($pkgs = 'all', $only_local = false) {
 	global $g, $input_errors;
 
 	$out = '';
@@ -456,7 +456,7 @@ function get_pkg_info($pkgs = 'all', $info = 'all', $only_local = false) {
 function register_all_installed_packages() {
 	global $g, $config, $pkg_interface;
 
-	$pkg_info = get_pkg_info('all', 'all', true);
+	$pkg_info = get_pkg_info('all', true);
 
 	foreach ($pkg_info as $pkg) {
 		if (!isset($pkg['installed'])) {


### PR DESCRIPTION
The 2nd argument ($info) isn't used in that function, and doesn't seem to be used anywhere else in the codebase.