### PR TITLE
Enable a direction on any firewall rule

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2705,14 +2705,14 @@ function filter_generate_user_rule($rule) {
 	} else {
 		$aline['type'] = $type . " ";
 	}
-	if (isset($rule['floating']) && $rule['floating'] == "yes") {
-		if ($rule['direction'] != "any") {
-			$aline['direction'] = " " . $rule['direction'] . " ";
-		}
-	} else {
-		/* ensure the direction is in */
+	if (isset($rule['direction']) && in_array($rule['direction'], ['in', 'out'])) {
+		// if explicitly in/out, use that value
+		$aline['direction'] = " " . $rule['direction'] . " ";
+	} elseif (!(isset($rule['floating']) && $rule['floating'] == "yes") && $rule['direction'] != 'any') {
+		// not floating rule and not "any", "in" or "out", so set to "in" - default for non floating rules
 		$aline['direction'] = " in ";
 	}
+		// else "any" direction, either by default or because set explicitly - nothing to add to rule
 	if (isset($rule['log'])) {
 		$aline['log'] = "log ";
 	}

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -363,7 +363,7 @@ if (isset($config['interfaces'][$if]['blockbogons'])) {
 $rulescnt = pfSense_get_pf_rules();
 
 // Update this if you add or remove columns!
-$columns_in_table = 13;
+$columns_in_table = 14;
 
 ?>
 <form method="post">
@@ -376,6 +376,7 @@ $columns_in_table = 13;
 						<th><!-- checkbox --></th>
 						<th><!-- status icons --></th>
 						<th><?=gettext("States")?></th>
+						<th style="text-align:center"><?=($if == "FloatingRules" ? gettext("Interfaces+<br/>direction") : gettext("Direction")) ?></th>
 						<th><?=gettext("Protocol")?></th>
 						<th><?=gettext("Source")?></th>
 						<th><?=gettext("Port")?></th>
@@ -404,6 +405,7 @@ $columns_in_table = 13;
 						<td>*</td>
 						<td>*</td>
 						<td>*</td>
+						<td>*</td>
 						<td><?=$iflist[$if];?> Address</td>
 						<td><?=$alports?></td>
 						<td>*</td>
@@ -420,6 +422,7 @@ $columns_in_table = 13;
 						<td></td>
 						<td title="<?=gettext("traffic is blocked")?>"><i class="fa fa-times text-danger"></i></td>
 						<td><?php print_states(intval(RFC1918_TRACKER)); ?></td>
+						<td>*</td>
 						<td>*</td>
 						<td><?=gettext("RFC 1918 networks");?></td>
 						<td>*</td>
@@ -439,6 +442,7 @@ $columns_in_table = 13;
 						<td></td>
 						<td title="<?=gettext("traffic is blocked")?>"><i class="fa fa-times text-danger"></i></td>
 						<td><?php print_states(intval(BOGONS_TRACKER)); ?></td>
+						<td>*</td>
 						<td>*</td>
 						<td><?=sprintf(gettext("Reserved%sNot assigned by IANA"), "<br />");?></td>
 						<td>*</td>
@@ -661,6 +665,17 @@ foreach ($a_filter as $filteri => $filterent):
 		}
 	?>
 				<td><?php print_states(intval($filterent['tracker'])); ?></td>
+ 				<td>
+ 	<?php
+		$s = (($filterent['direction'] == 'in' || $filterent['direction'] == 'out') ? gettext($filterent['direction']) : '*');
+		if ($filterent['interface'] != $if || $if == "FloatingRules") {
+			echo sprintf(str_replace(',', ',<wbr>&#8203;', $filterent['interface']) . ' ' . $s);
+			// add <wbr>&#8203; (2 x zero width space methods for linebreaking). Doesn't work in all browsers but not fatal if non-working.
+		} else {
+			echo $s;
+		}
+	?>
+				</td>
 				<td>
 	<?php
 		if (isset($filterent['ipprotocol'])) {

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1189,9 +1189,9 @@ $group->add(new Form_Select(
 ));
 
 if ($is_floating)  {
-	$group->setHelp('Choose the interface(s) and direction of packets, to match this rule.');
+	$group->setHelp('Choose the interface(s) and direction of packets, to match this rule. Floating rules are usually set on packets travelling in any direction through the stated interfaces.');
 } else {
-	$group->setHelp('Choose the interface and direction of packets, to match this rule.');
+	$group->setHelp('Choose the interface and direction of packets, to match this rule. Rules are usually set on incoming packets (received by the router at the interface).');
 }
 
 // FIXME: Found this code elsewhere used to fix widths of input elements in a group. Seems to work fine here. Is there a better fix?

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1194,6 +1194,7 @@ if ($is_floating)  {
 	$group->setHelp('Choose the interface and direction of packets, to match this rule.');
 }
 
+// FIXME: Found this code elsewhere used to fix widths of input elements in a group. Seems to work fine here. Is there a better fix?
 $group->add(new Form_StaticText(
 	'',
 	"</td></tr></table>"

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1189,9 +1189,9 @@ $group->add(new Form_Select(
 ));
 
 if ($is_floating)  {
-	$group->setHelp('Choose the interface(s) and direction of packets, to match this rule. Floating rules are usually set on packets travelling in any direction through the stated interfaces.');
+	$group->setHelp('Choose the interface(s) and direction of packets, to match this rule. Floating rules are usually set on packets travelling in any direction through the stated interface(s).');
 } else {
-	$group->setHelp('Choose the interface and direction of packets, to match this rule. Rules are usually set on incoming packets (received by the router at the interface).');
+	$group->setHelp('Choose the interface and direction of packets, to match this rule. Rules for an individual interface are usually - but not always - set on incoming packets to the router at the interface).');
 }
 
 // FIXME: Found this code elsewhere used to fix widths of input elements in a group. Seems to work fine here. Is there a better fix?

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -733,8 +733,10 @@ if ($_POST) {
 		if (isset($_POST['tagged'])) {
 			$filterent['tagged'] = $_POST['tagged'];
 		}
-		if ($if == "FloatingRules" || isset($_POST['floating'])) {
+		if (isset($_POST['direction'])) {
 			$filterent['direction'] = $_POST['direction'];
+		}
+		if ($if == "FloatingRules" || isset($_POST['floating'])) {
 			if (isset($_POST['quick']) && $_POST['quick'] <> "") {
 				$filterent['quick'] = $_POST['quick'];
 			}
@@ -1163,35 +1165,43 @@ if ($edit_disabled) {
 	}
 }
 
-if ($if == "FloatingRules" || isset($pconfig['floating'])) {
-	$section->addInput($input = new Form_Select(
-		'interface',
-		'Interface',
-		$pconfig['interface'],
-		build_if_list(),
-		true
-	))->setHelp('Choose the interface(s) for this rule.');
+$group = new Form_Group('Interface and direction');
+
+$is_floating = ($if == "FloatingRules" || isset($pconfig['floating'])); // for ease
+
+$group->add($input = new Form_Select(
+	'interface',
+	($is_floating ? 'Interface(s)' : 'Interface'),
+	$pconfig['interface'],
+	build_if_list(),
+	($is_floating ? true : null)
+));
+
+$group->add(new Form_Select(
+	'direction',
+	'Direction',
+	isset($pconfig['direction']) ? $pconfig['direction'] : ($is_floating ? "any" : "in"),
+	array(
+		'any' => gettext('any'),
+		'in' => gettext('in'),
+		'out' => gettext('out'),
+	)
+));
+
+if ($is_floating)  {
+	$group->setHelp('Choose the interface(s) and direction of packets, to match this rule.');
 } else {
-	$section->addInput($input = new Form_Select(
-		'interface',
-		'Interface',
-		$pconfig['interface'],
-		build_if_list()
-	))->setHelp('Choose the interface from which packets must come to match this rule.');
+	$group->setHelp('Choose the interface and direction of packets, to match this rule.');
 }
 
-if ($if == "FloatingRules" || isset($pconfig['floating'])) {
-	$section->addInput(new Form_Select(
-		'direction',
-		'Direction',
-		$pconfig['direction'],
-		array(
-			'any' => gettext('any'),
-			'in' => gettext('in'),
-			'out' => gettext('out'),
-		)
-	));
+$group->add(new Form_StaticText(
+	'',
+	"</td></tr></table>"
+));
 
+$section->add($group);
+
+if ($is_floating) {
 	$section->addInput(new Form_Input(
 		'floating',
 		'Floating',


### PR DESCRIPTION
It can be very useful to set rules on outgoing (not just incoming) packets on an IF. This is already available for floating rules, but not for rules on other IF's (even though it would work). No obvious drawback or issues resulted in testing or apparent from the codebase or PF documentation. So this PR makes the "in/out/any" option visible and working on all rules, not just floating rules. Totally transparent + no config update needed. 

firewall_rules.php now shows interfaces+direction (for floating rules, which it probably should anyway as this is quite important info) or just direction (others interfaces). Care taken to ensure word wrapping is assisted on the IF's for floating rules, for narrower displays.

If direction is not explicitly set on a rule, then it's assumed to be "any" for floating rules and "in" for rules on all other interfaces (both when editing the rule and also when building the pf config in filter.inc).