### PR TITLE
Fix static blackhole routes

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -655,7 +655,7 @@ function system_staticroutes_configure($interface = "", $update_dns = false) {
 			$interfacegw = $gateway['interface'];
 
 			$blackhole = "";
-			if (!strcasecmp("Null", substr($rtent['gateway'], 0, 3))) {
+			if (!strcasecmp("Null", substr($rtent['gateway'], 0, 4))) {
 				$blackhole = "-blackhole";
 			}
 


### PR DESCRIPTION
This bug was introduced in [February, 2013](https://github.com/pfsense/pfsense/commit/8be135cd114fbc9294ec9dafed2125d0e553956c).