### PR TITLE
Fix bug where CARP vip status is incorrent in interface

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -629,8 +629,11 @@ function get_carp_interface_status($carpid) {
 	$interface = get_real_interface($carpiface);
 	if ($interface == NULL)
 		return "";
+	$vip = get_configured_vip($carpid);
+	if ($vip == NULL || !isset($vip['vhid']))
+		return "";
 
-	$vhid = $carp['vhid'];
+	$vhid = $vip['vhid'];
 	$carp_query = '';
 	$_gb = exec("/sbin/ifconfig $interface | /usr/bin/grep carp: | /usr/bin/grep \"vhid $vhid\"", $carp_query);
 	foreach ($carp_query as $int) {


### PR DESCRIPTION
There is a bug in the web interface showing the status of the CARP VIP. If you configure multiple CARP VIPs for an interface, wich differing skews (we run an active-active setup with failover), it will show the same status for both VIPs on the same interface, as there's a bug in the function logic returning the status of the first VIP, always.
