### PR TITLE
Remove incorrect code causing GUI issues hidding Translation options (2.4.0-dev)

### DIFF
--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -591,7 +591,7 @@ $section->addInput(new Form_Input(
 	'Source Hash Key',
 	'text',
 	$pconfig['source_hash_key']
-))->setHelp('The key that is fed to the hashing algorithm in hex format, preceeded by "0x", or any string. A non-hex string is hashed using md5 to a hexadecimal key. Defaults to a randomly generated value.')->setWidth(10)->addClass('othersubnet');
+))->setHelp('The key that is fed to the hashing algorithm in hex format, preceeded by "0x", or any string. A non-hex string is hashed using md5 to a hexadecimal key. Defaults to a randomly generated value.')->setWidth(10);
 
 $group = new Form_Group('Port');
 $group->addClass('natportgrp');


### PR DESCRIPTION
Prior to this fix on both Chrome 53 and Firefox 45:
http://i.imgur.com/K3cBHh7.png

Translation header shows but not the option group.
This commit fixes the problem.

Edited to minimize changes. Tested & Working.

Thanks!