### PR TITLE
System Update Settings - GitSync Options

### DIFF
--- a/src/usr/local/share/pfSense/post_upgrade_command.php
+++ b/src/usr/local/share/pfSense/post_upgrade_command.php
@@ -62,7 +62,14 @@
 			exec("cd /root/pfsense/pfSenseGITREPO/pfSenseGITREPO && git config remote.origin.url " . escapeshellarg($config['system']['gitsync']['repositoryurl']));
 		}
 		if (!empty($config['system']['gitsync']['branch'])) {
-			system("pfSsh.php playback gitsync " . escapeshellarg($config['system']['gitsync']['branch']) . " --upgrading");
+
+			$options  = isset($config['system']['gitsync']['minimal']) ? ' --minimal' : '';
+			$options .= isset($config['system']['gitsync']['diff']) ? ' --diff' : '';
+			$options .= isset($config['system']['gitsync']['show_files']) ? ' --show-files' : '';
+			$options .= isset($config['system']['gitsync']['show_command']) ? ' --show-command' : '';
+			$options .= isset($config['system']['gitsync']['dryrun']) ? ' --dry-run' : '';
+
+			system("pfSsh.php playback gitsync " . escapeshellarg($config['system']['gitsync']['branch']) . $options . " --upgrading");
 		}
 	}
 

--- a/src/usr/local/www/system_update_settings.php
+++ b/src/usr/local/www/system_update_settings.php
@@ -98,6 +98,36 @@ if ($_POST) {
 		}
 	}
 
+	if ($_POST['minimal'] == "yes") {
+		$config['system']['gitsync']['minimal'] = true;
+	} else {
+		unset($config['system']['gitsync']['minimal']);
+	}
+
+	if ($_POST['diff'] == "yes") {
+		$config['system']['gitsync']['diff'] = true;
+	} else {
+		unset($config['system']['gitsync']['diff']);
+	}
+
+	if ($_POST['show_files'] == "yes") {
+		$config['system']['gitsync']['show_files'] = true;
+	} else {
+		unset($config['system']['gitsync']['show_files']);
+	}
+
+	if ($_POST['show_command'] == "yes") {
+		$config['system']['gitsync']['show_command'] = true;
+	} else {
+		unset($config['system']['gitsync']['show_command']);
+	}
+
+	if ($_POST['dryrun'] == "yes") {
+		$config['system']['gitsync']['dryrun'] = true;
+	} else {
+		unset($config['system']['gitsync']['dryrun']);
+	}
+
 	write_config();
 
 	$savemsg = gettext("Changes have been saved successfully");
@@ -225,6 +255,46 @@ if (file_exists("/usr/local/bin/git") && $g['platform'] == $g['product_name']) {
 		($gitcfg['branch'] ? $gitcfg['branch'] : '')
 		))->setHelp('The most recently used branch was "%s". (Usually the branch name is RELENG_2_3)' .
 					'<br />Note: Sync will not be performed if a branch is not specified.', [$lastbranch]);
+
+	$group = new Form_Group('Sync options');
+
+	$group->add(new Form_Checkbox(
+		'minimal',
+		null,
+		'Minimal',
+		isset($gitcfg['minimal'])
+		))->setHelp('Copy of only the updated files.');
+
+	$group->add(new Form_Checkbox(
+		'diff',
+		null,
+		'Diff',
+		isset($gitcfg['diff'])
+		))->setHelp('Copy of only the different or missing files.');
+
+	$group->add(new Form_Checkbox(
+		'show_files',
+		null,
+		'Show Files',
+		isset($gitcfg['show_files'])
+		))->setHelp('Show different and missing files.<br />With \'Diff/Minimal\' option..');
+
+	$group->add(new Form_Checkbox(
+		'show_command',
+		null,
+		'Show Command',
+		isset($gitcfg['show_command'])
+		))->setHelp('Show constructed command.<br />With \'Diff/Minimal\' option.');
+
+	$group->add(new Form_Checkbox(
+		'dryrun',
+		null,
+		'Dry Run',
+		isset($gitcfg['dryrun'])
+		))->setHelp('Dry-run only.<br />No files copied.');
+
+	$group->setHelp('See "playback gitsync --help" in console "PHP Shell + pfSense tools" for additional information.');
+	$section->add($group);
 
 	$form->add($section);
 } // e-o-if (file_exists())


### PR DESCRIPTION
Add GitSync options selectors to post update GitSync.
Minimal, Diff, Verbose, Dry Run

The GitSync options have utility for post update sync also.

Also applicable to RELENG_2_3_2.

Dependency Note:
The verbose option will need to be split out into "show_files" and "show_command" when the following commit is applied.
https://github.com/pfsense/pfsense/pull/3168/commits/a6fd4c0ff4141a1836ed74add1df55477d87ddd0
