### PR TITLE
Reset .tcshrc prompt foreground color to terminal default instead of hardcoding white

### DIFF
--- a/src/etc/skel/dot.tcshrc
+++ b/src/etc/skel/dot.tcshrc
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set prompt="%{\033[0;1;33m%}[%{\033[0;1;37m%}`cat /etc/version`%{\033[0;1;33m%}]%{\033[0;1;33m%}%B[%{\033[0;1;37m%}%n%{\033[0;1;31m%}@%{\033[0;1;37m%}%M%{\033[0;1;33m%}]%{\033[0;1;32m%}%b%/%{\033[0;1;33m%}%{\033[0;1;36m%}%{\033[0;1;31m%}:%{\033[0;0;0m%} "
+set prompt="%{\033[0;1;33m%}[%{\033[0;0;0m%}`cat /etc/version`%{\033[0;1;33m%}]%{\033[0;1;33m%}%B[%{\033[0;0;0m%}%n%{\033[0;1;31m%}@%{\033[0;0;0m%}%M%{\033[0;1;33m%}]%{\033[0;1;32m%}%b%/%{\033[0;1;33m%}%{\033[0;1;36m%}%{\033[0;1;31m%}:%{\033[0;0;0m%} "
 set autologout="0"
 set autolist set color set colorcat
 setenv CLICOLOR "true"


### PR DESCRIPTION
Some parts of the tcsh prompt (e.g. release vesrion, username, hostname) are hardcoded to white text instead of using the terminal default foreground color. This results in the prompt being hard to read on terminals where the background is not black or a dark color, as there is poor contrast between the light background and white text. This change fixes the problem by resetting the foreground color to the terminal default foreground color instead of the hardcoded white.