### PR TITLE
Fixup ntpd IPv6 restrict clauses

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1808,7 +1808,7 @@ function system_ntp_configure() {
 		foreach ($networkacl as $acl) {
 			$ntpcfg .= "\nrestrict ";
 			if (is_ipaddrv6($acl['acl_network'])) {
-				$ntpcfg .= "-6 {$acl['acl_network']} mask " . gen_subnet_mask_v6($acl['mask']) . " ";
+				$ntpcfg .= "{$acl['acl_network']} mask " . gen_subnet_mask_v6($acl['mask']) . " ";
 			} elseif (is_ipaddrv4($acl['acl_network'])) {
 				$ntpcfg .= "{$acl['acl_network']} mask " . gen_subnet_mask($acl['mask']) . " ";
 			} else {


### PR DESCRIPTION
This will allow for proper ntp restrictions to be placed upon IPv6 (sub)nets, and eliminate these errors from the ntpd log file:
> Oct 1 02:05:37   ntpd   8336   line 25 column 10 syntax error, unexpected T_Mask, expecting T_EOC
> Oct 1 02:05:37   ntpd   8336   syntax error in /var/etc/ntpd.conf line 25, column 10

This bug is evident when adding **any** IPv6 access restrictions, but here's a few examples created via /services_ntpd_acls.php that would previously bug out:
> ::1/128
> fe80::/10 kod nomodify noquery nopeer notrap
> fc00::/7 kod nomodify nopeer notrap