### PR TITLE
Make is_inrange_v6 more robust

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1155,8 +1155,12 @@ function is_inrange_v4($test, $start, $end) {
 
 /* returns true if $test is in the range between $start and $end */
 function is_inrange_v6($test, $start, $end) {
-	if ((inet_pton($test) <= inet_pton($end)) && (inet_pton($test) >= inet_pton($start))) {
-		return true;
+	if (is_ipaddrv6($test) && is_ipaddrv6($start) && is_ipaddrv6($end)) {
+		if ((inet_pton($test) <= inet_pton($end)) && (inet_pton($test) >= inet_pton($start))) {
+			return true;
+		} else {
+			return false;
+		}
 	} else {
 		return false;
 	}


### PR DESCRIPTION
If passed invalid IPv6 strings in the parameters, inet_pton() was
emitting warnings. Avoid this by first checking for valid IPv6
addresses.

This helps https://forum.pfsense.org/index.php?topic=119565.0 by stopping annoying "inet_pton(): Unrecognized address" warnings.