### PR TITLE
xmlrpc, use authentication through the basic auth header

### DIFF
--- a/src/etc/inc/xmlrpc_client.inc
+++ b/src/etc/inc/xmlrpc_client.inc
@@ -21,11 +21,9 @@
 
 require_once("XML/RPC2/Client.php");
 
-define('PEAR_IGNORE_BACKTRACE', 1);
-
 class pfsense_xmlrpc_client {
 	
-	private $username, $password, $url, $filenotice, $error;
+	private $username, $password, $url, $logurl, $filenotice, $error;
 	
 	public function __construct() {
 		global $config;
@@ -67,7 +65,11 @@ class pfsense_xmlrpc_client {
 		if (is_ipaddrv6($syncip)) {
 			$syncip = "[{$syncip}]";
 		}
-		$this->url = "{$scheme}://{$syncip}:{$port}/xmlrpc.php";
+		$user = urlencode($this->username);
+		$pass = urlencode($this->password);
+		
+		$this->logurl = "{$scheme}://{$syncip}:{$port}/xmlrpc.php";
+		$this->url = "{$scheme}://{$user}:{$pass}@{$syncip}:{$port}/xmlrpc.php";
 	}
 
 	public function set_noticefile($noticefile) {
@@ -86,10 +88,10 @@ class pfsense_xmlrpc_client {
 		while ($numberofruns < 2) {
 			$numberofruns++;
 
-			log_error(sprintf(gettext("Beginning XMLRPC sync data to %s."), $this->url));
+			log_error(sprintf(gettext("Beginning XMLRPC sync data to %s."), $this->logurl));
 			$cli = XML_RPC2_Client::create($this->url, $options);
 			if (!is_object($cli)) {
-				$this->error = sprintf(gettext("A communications error occurred while attempting XMLRPC sync with %s (pfsense.%s)."), $this->url, $method);
+				$this->error = sprintf(gettext("A communications error occurred while attempting XMLRPC sync with %s (pfsense.%s)."), $this->log, $method);
 				log_error($this->error);
 				file_notice($this->filenotice, $this->error, "Settings Sync", "");
 				continue;
@@ -97,7 +99,7 @@ class pfsense_xmlrpc_client {
 			try {//restore_config_section
 				$REQUEST_URI = $_SERVER['REQUEST_URI'];
 				unset($_SERVER['REQUEST_URI']); // force use of 'toText()' when setting XML_RPC2_CurlException message
-				$resp = $cli->$method($this->username, $this->password, $parameter);
+				$resp = $cli->$method($parameter);
 			} catch (XML_RPC2_FaultException $e) {
 				// The XMLRPC server returns a XMLRPC error
 				$this->error = "Exception calling XMLRPC method {$method} #" . $e->getFaultCode() . ' : ' . $e->getFaultString();
@@ -109,7 +111,7 @@ class pfsense_xmlrpc_client {
 				if ($previouserror == null) {
 					// CurlException doesnt get filled with PreviousError,
 					// however we dont want to show the stacktrace included in the 'message' to non sysadmin users
-					$this->error = "CurlException calling XMLRPC method {$method} #" . strtok($e->getMessage(), "\n");
+					$this->error = "CurlException calling XMLRPC method {$method} #" . $e->getMessage();
 				} else {
 					$this->error = "CurlException calling XMLRPC method {$method} #" . $previouserror->getMessage();
 				}
@@ -130,12 +132,12 @@ class pfsense_xmlrpc_client {
 			}
 
 			if (!is_array($resp) && trim($resp) == "Authentication failed") {
-				$this->error = "An authentication failure occurred while trying to access {$this->url} ({$method}).";
+				$this->error = "An authentication failure occurred while trying to access {$this->logurl} ({$method}).";
 				log_error($this->error);
 				file_notice($this->filenotice, $this->error, "Settings Sync", "");
 				continue;
 			}
-			log_error(sprintf(gettext("XMLRPC reload data success with %s (pfsense.{$method})."), $this->url));
+			log_error(sprintf(gettext("XMLRPC reload data success with %s (pfsense.{$method})."), $this->logurl));
 			return $resp;
 		}
 		return null;
@@ -156,6 +158,6 @@ class pfsense_xmlrpc_client {
 	}
 	
 	public function getUrl() {
-		return $this->url;
+		return $this->logurl;
 	}
 }

--- a/src/usr/local/www/xmlrpc.php
+++ b/src/usr/local/www/xmlrpc.php
@@ -41,8 +41,10 @@ class pfsense_xmlrpc_server {
 	private $loop_detected = false;
 	private $remote_addr;
 
-	private function auth($username, $password) {
+	private function auth() {
 		global $config;
+		$username = $_SERVER['PHP_AUTH_USER'];
+		$password = $_SERVER['PHP_AUTH_PW'];
 
 		$login_ok = false;
 		if (!empty($username) && !empty($password)) {
@@ -117,28 +119,22 @@ class pfsense_xmlrpc_server {
 	/**
 	 * Get host version information
 	 *
-	 * @param string $username
-	 * @param string $password
-	 *
 	 * @return array
 	 */
-	public function host_firmware_version($username, $password) {
-		$this->auth($username, $password);
-
+	public function host_firmware_version($dummy = 1) {
+		$this->auth();
 		return host_firmware_version();
 	}
 
 	/**
 	 * Executes a PHP block of code
 	 *
-	 * @param string $username
-	 * @param string $password
 	 * @param string $code
 	 *
 	 * @return bool
 	 */
-	public function exec_php($username, $password, $code) {
-		$this->auth($username, $password);
+	public function exec_php($code) {
+		$this->auth();
 
 		eval($code);
 		if ($toreturn) {
@@ -151,14 +147,12 @@ class pfsense_xmlrpc_server {
 	/**
 	 * Executes shell commands
 	 *
-	 * @param string $username
-	 * @param string $password
 	 * @param string $code
 	 *
 	 * @return bool
 	 */
-	public function exec_shell($username, $password, $code) {
-		$this->auth($username, $password);
+	public function exec_shell($code) {
+		$this->auth();
 
 		mwexec($code);
 		return true;
@@ -167,14 +161,12 @@ class pfsense_xmlrpc_server {
 	/**
 	 * Backup chosen config sections
 	 *
-	 * @param string $username
-	 * @param string $password
 	 * @param array $section
 	 *
 	 * @return array
 	 */
-	public function backup_config_section($username, $password, $section) {
-		$this->auth($username, $password);
+	public function backup_config_section($section) {
+		$this->auth();
 
 		global $config;
 
@@ -184,14 +176,12 @@ class pfsense_xmlrpc_server {
 	/**
 	 * Restore defined config section into local config
 	 *
-	 * @param string $username
-	 * @param string $password
 	 * @param array $sections
 	 *
 	 * @return bool
 	 */
-	public function restore_config_section($username, $password, $sections) {
-		$this->auth($username, $password);
+	public function restore_config_section($sections) {
+		$this->auth();
 
 		global $config;
 
@@ -406,14 +396,12 @@ class pfsense_xmlrpc_server {
 	/**
 	 * Merge items into installedpackages config section
 	 *
-	 * @param string $username
-	 * @param string $password
 	 * @param array $section
 	 *
 	 * @return bool
 	 */
-	public function merge_installedpackages_section($username, $password, $section) {
-		$this->auth($username, $password);
+	public function merge_installedpackages_section($section) {
+		$this->auth();
 
 		global $config;
 
@@ -435,14 +423,12 @@ class pfsense_xmlrpc_server {
 	/**
 	 * Merge items into config
 	 *
-	 * @param string $username
-	 * @param string $password
 	 * @param array $section
 	 *
 	 * @return bool
 	 */
-	public function merge_config_section($username, $password, $section) {
-		$this->auth($username, $password);
+	public function merge_config_section($section) {
+		$this->auth();
 
 		global $config;
 
@@ -464,13 +450,10 @@ class pfsense_xmlrpc_server {
 	/**
 	 * Wrapper for filter_configure()
 	 *
-	 * @param string $username
-	 * @param string $password
-	 *
 	 * @return bool
 	 */
-	public function filter_configure($username, $password) {
-		$this->auth($username, $password);
+	public function filter_configure() {
+		$this->auth();
 
 		global $g, $config;
 
@@ -523,13 +506,10 @@ class pfsense_xmlrpc_server {
 	/**
 	 * Wrapper for configuring CARP interfaces
 	 *
-	 * @param string $username
-	 * @param string $password
-	 *
 	 * @return bool
 	 */
-	public function interfaces_carp_configure($username, $password) {
-		$this->auth($username, $password);
+	public function interfaces_carp_configure() {
+		$this->auth();
 
 		if ($this->loop_detected) {
 			log_error("Disallowing CARP sync loop");
@@ -544,13 +524,10 @@ class pfsense_xmlrpc_server {
 	/**
 	 * Wrapper for rc.reboot
 	 *
-	 * @param string $username
-	 * @param string $password
-	 *
 	 * @return bool
 	 */
-	public function reboot($username, $password) {
-		$this->auth($username, $password);
+	public function reboot() {
+		$this->auth();
 
 		mwexec_bg("/etc/rc.reboot");
 
@@ -560,14 +537,12 @@ class pfsense_xmlrpc_server {
 	/**
 	 * Wrapper for get_notices()
 	 *
-	 * @param string $username
-	 * @param string $password
 	 * @param string $category
 	 *
 	 * @return bool
 	 */
-	public function get_notices($username, $password, $category = 'all') {
-		$this->auth($username, $password);
+	public function get_notices($category = 'all') {
+		$this->auth();
 
 		global $g;
 


### PR DESCRIPTION
This avoids credentials showing up in stacktraces. And seems to be the common way of using authentication with XMLRPC2.

Or was there a specific reason to implement it previously with the extra parameters in each function?