### PR TITLE
FIX 6857: Configure routing early on during boot process, so remote ldap server s are available when invoking local_sync_accounts()

### DIFF
--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -227,6 +227,9 @@ echo "Setting up gateway monitors...";
 setup_gateways_monitor();
 echo "done.\n";
 
+/* set up static routes */
+system_routing_configure();
+
 echo "Synchronizing user settings...";
 local_sync_accounts();
 echo "done.\n";
@@ -244,9 +247,6 @@ if ($realmem > 0 and $realmem < 65) {
 echo "Configuring CRON...";
 configure_cron();
 echo "done.\n";
-
-/* set up static routes */
-system_routing_configure();
 
 /* enable routing */
 system_routing_enable();


### PR DESCRIPTION
This pull-req fixes redmine issue: https://redmine.pfsense.org/issues/6857
