### PR TITLE
FIX 6856: Avoid removal of lo0's IP aliases during configuration synchronization

### DIFF
--- a/src/usr/local/www/xmlrpc.php
+++ b/src/usr/local/www/xmlrpc.php
@@ -333,8 +333,9 @@ class pfsense_xmlrpc_server {
 						continue;
 					}
 				} elseif ($vip['mode'] == "ipalias" &&
-				    strstr($vip['interface'], "_vip") &&
-				    isset($oldvips[$vip['subnet']])) {
+				    (strstr($vip['interface'], "_vip")
+				    || strstr($vip['interface'], "lo0")) &&
+				        isset($oldvips[$vip['subnet']])) {
 
 					$key = $vip['subnet'];
 					if ($oldvips[$key]['content'] ==


### PR DESCRIPTION
This fixes issue: https://redmine.pfsense.org/issues/6856
