### PR TITLE
Fix #6864 Improve help for IP address format

### DIFF
--- a/src/usr/local/www/classes/Form/IpAddress.class.php
+++ b/src/usr/local/www/classes/Form/IpAddress.class.php
@@ -31,14 +31,17 @@ class Form_IpAddress extends Form_Input
 		switch ($type) {
 			case "BOTH":
 				$this->_attributes['pattern'] = '[a-f0-9:.]*';
+				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or an IPv6 address like 1:2a:3b:ffff::1 (use lowercase)';
 				break;
 
 			case "V4":
 				$this->_attributes['pattern'] = '[0-9.]*';
+				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4';
 				break;
 
 			case "V6":
 				$this->_attributes['pattern'] = '[a-f0-9:]*';
+				$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1 (use lowercase)';
 				break;
 		}
 	}


### PR DESCRIPTION
This is the first thing that is easily done. The 'title' text is appended after "Please match the requested format: ", so this will give the user some idea what the input format problem is. The 'title' text also appears when hovering over the field.

The next nice step would be to automatically convert to lowercase as characters are typed or pasted into the field.