### PR TITLE
Fix #6864 automatically convert IPv6 input to lowercase

### DIFF
--- a/src/usr/local/www/classes/Form/IpAddress.class.php
+++ b/src/usr/local/www/classes/Form/IpAddress.class.php
@@ -31,14 +31,19 @@ class Form_IpAddress extends Form_Input
 		switch ($type) {
 			case "BOTH":
 				$this->_attributes['pattern'] = '[a-f0-9:.]*';
+				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or an IPv6 address like 1:2a:3b:ffff::1 (use lowercase)';
+				$this->_attributes['onChange'] = 'javascript:this.value=this.value.toLowerCase();';
 				break;
 
 			case "V4":
 				$this->_attributes['pattern'] = '[0-9.]*';
+				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4';
 				break;
 
 			case "V6":
 				$this->_attributes['pattern'] = '[a-f0-9:]*';
+				$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1 (use lowercase)';
+				$this->_attributes['onChange'] = 'javascript:this.value=this.value.toLowerCase();';
 				break;
 		}
 	}

--- a/src/usr/local/www/classes/Form/IpAddress.class.php
+++ b/src/usr/local/www/classes/Form/IpAddress.class.php
@@ -31,7 +31,7 @@ class Form_IpAddress extends Form_Input
 		switch ($type) {
 			case "BOTH":
 				$this->_attributes['pattern'] = '[a-f0-9:.]*';
-				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or an IPv6 address like 1:2a:3b:ffff::1 (use lowercase)';
+				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or an IPv6 address like 1:2a:3b:ffff::1';
 				$this->_attributes['onChange'] = 'javascript:this.value=this.value.toLowerCase();';
 				break;
 
@@ -42,7 +42,7 @@ class Form_IpAddress extends Form_Input
 
 			case "V6":
 				$this->_attributes['pattern'] = '[a-f0-9:]*';
-				$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1 (use lowercase)';
+				$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1';
 				$this->_attributes['onChange'] = 'javascript:this.value=this.value.toLowerCase();';
 				break;
 		}


### PR DESCRIPTION
1) As the user leaves the field, or presses Save, onChange will fire and
convert the input string to lowercase. This saves the user havng to even
think about it.
2) Provide some extra text that describes the expected format, to avoid
them getting just "Please match the requested format"
