### PR TITLE
Fix display advanced after input error for system_gateways_edit

### DIFF
--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -850,12 +850,12 @@ events.push(function() {
 <?php
 			if (!(!empty($pconfig['latencylow']) || !empty($pconfig['latencyhigh']) ||
 			    !empty($pconfig['losslow']) || !empty($pconfig['losshigh']) || !empty($pconfig['data_payload']) ||
-			    (isset($pconfig['weight']) && $pconfig['weight'] > 1) ||
-			    (isset($pconfig['interval']) && !($pconfig['interval'] == $dpinger_default['interval'])) ||
-			    (isset($pconfig['loss_interval']) && !($pconfig['loss_interval'] == $dpinger_default['loss_interval'])) ||
-			    (isset($pconfig['time_period']) && !($pconfig['time_period'] == $dpinger_default['time_period'])) ||
-			    (isset($pconfig['alert_interval']) && !($pconfig['alert_interval'] == $dpinger_default['alert_interval'])) ||
-			    (isset($pconfig['nonlocalgateway']) && $pconfig['nonlocalgateway']))) {
+			    (!empty($pconfig['weight']) && $pconfig['weight'] > 1) ||
+			    (!empty($pconfig['interval']) && !($pconfig['interval'] == $dpinger_default['interval'])) ||
+			    (!empty($pconfig['loss_interval']) && !($pconfig['loss_interval'] == $dpinger_default['loss_interval'])) ||
+			    (!empty($pconfig['time_period']) && !($pconfig['time_period'] == $dpinger_default['time_period'])) ||
+			    (!empty($pconfig['alert_interval']) && !($pconfig['alert_interval'] == $dpinger_default['alert_interval'])) ||
+			    (!empty($pconfig['nonlocalgateway']) && $pconfig['nonlocalgateway']))) {
 				$showadv = false;
 			} else {
 				$showadv = true;


### PR DESCRIPTION
Use case:
1) Edit a gateway that has no advanced settings (i.e. the Advanced section does not need to open on page load) - that works fine.
2) Modify the Gateway IP Address to something invalid like 1:2::z
3) Press Save
The error is shown - "A valid gateway IP address must be specified" - good.
The Advanced section is shown - not good.

The problem is that after POSTing the page, and the resulting validation, finding an input error, and re-displaying the page, each of the $pconfig keys is set, even though set to the empty string "". So the isset() tests are true, and it gets the wrong idea.

We only care about these parameters if they are not "". In this case !empty() gives the correct result, because although a value of 0 will be considered empty, 0 is not allowed by the front-end of the UI anyway (as it happens, these parameters are not allowed to be 0), so we never get that case. And by the way, I generally hate empty() because of having to think of all its quirks.