### PR TITLE
For DHCPv6, ddnsdomainprimary should be V6

### DIFF
--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -289,8 +289,8 @@ if (isset($_POST['apply'])) {
 		if (($_POST['ddnsdomain'] && !is_domain($_POST['ddnsdomain']))) {
 			$input_errors[] = gettext("A valid domain name must be specified for the dynamic DNS registration.");
 		}
-		if (($_POST['ddnsdomain'] && !is_ipaddrv4($_POST['ddnsdomainprimary']))) {
-			$input_errors[] = gettext("A valid primary domain name server IPv4 address must be specified for the dynamic domain name.");
+		if (($_POST['ddnsdomain'] && !is_ipaddrv6($_POST['ddnsdomainprimary']))) {
+			$input_errors[] = gettext("A valid primary domain name server IPv6 address must be specified for the dynamic domain name.");
 		}
 		if (($_POST['ddnsdomainkey'] && !$_POST['ddnsdomainkeyname']) ||
 		    ($_POST['ddnsdomainkeyname'] && !$_POST['ddnsdomainkey'])) {


### PR DESCRIPTION
Actually, I don't know about this, but it looks odd. the DHCPv6 code is insisting that ddnsdomainprimary be an IPv4 address.
Is that really correct?
Or must it be an IPv6 address?
Or can it be either?

Please close if the existing code is actually good!