### PR TITLE
Fix #6872 CP bandwidth 0 is no valid

### DIFF
--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -688,7 +688,7 @@ $section->addInput(new Form_Input(
 	'number',
 	$pconfig['bwdefaultup']
 ))->setHelp('If this option is set, the captive portal will restrict each user who logs in to the specified default bandwidth. ' .
-			'RADIUS can override the default settings. Leave empty or set to 0 for no limit.');
+			'RADIUS can override the default settings. Leave empty for no limit.');
 
 $form->add($section);
 


### PR DESCRIPTION
The front-end validation prevents zero from being entered. "Leave empty" is the way to specify no limit.