### PR TITLE
DHCPv6 server range from-to check

### DIFF
--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -340,10 +340,15 @@ if (isset($_POST['apply'])) {
 		}
 		if (!$input_errors) {
 			/* make sure the range lies within the current subnet */
-			$subnet_start = gen_subnetv6($ifcfgip, $ifcfgsn);
-			$subnet_end = gen_subnetv6_max($ifcfgip, $ifcfgsn);
-
 			if (is_ipaddrv6($ifcfgip)) {
+				if ($ifcfgip == "::") {
+					$subnet_start = "0::";
+				} else {
+					$subnet_start = gen_subnetv6($ifcfgip, $ifcfgsn);
+				}
+
+				$subnet_end = gen_subnetv6_max($ifcfgip, $ifcfgsn);
+
 				if ((!is_inrange_v6($_POST['range_from'], $subnet_start, $subnet_end)) ||
 				    (!is_inrange_v6($_POST['range_to'], $subnet_start, $subnet_end))) {
 					$input_errors[] = gettext("The specified range lies outside of the current subnet.");


### PR DESCRIPTION
When track6 is on, the particular IPv6 address of the interface is not known (and could change from time to time). So $ifcfgip is set to "::", and $ifcfgsn to 64.
Unfortunately gen_subnetv6("::", 64) returns blank "". That no longer passes the checks done by recent changes to is_inrange_v6().
To fix this we can just explicitly set
```
$subnet_start = "0::";
```
for this case.

Alternatively we could add code to gen_subnetv6() to handle the special case of being passed "::" as the IP address.
Actually the underlying issue is that the Net_IPv6 compress() function seems to be compressing "0:0:0:0:0:0:0:0" to "", when I would hope it would compress to "0::" or "::0". But that requires some upstream changes, and sorting out which of "0::" and "::0" is the correct representation.