### PR TITLE
Provide compress_ip6 wrapper

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3809,7 +3809,7 @@ function interface_6to4_configure($interface = "wan", $wancfg) {
 	foreach ($stfbrbinarr as $bin) {
 		$stfbrarr[] = dechex(bindec($bin));
 	}
-	$stfbrgw = Net_IPv6::compress(implode(":", $stfbrarr));
+	$stfbrgw = compress_ip6(implode(":", $stfbrarr));
 
 	/* convert the 128 bits for the broker address back into a valid IPv6 address */
 	$stflanarr = array();
@@ -3818,9 +3818,9 @@ function interface_6to4_configure($interface = "wan", $wancfg) {
 	foreach ($stflanbinarr as $bin) {
 		$stflanarr[] = dechex(bindec($bin));
 	}
-	$stflanpr = Net_IPv6::compress(implode(":", $stflanarr));
+	$stflanpr = compress_ip6(implode(":", $stflanarr));
 	$stflanarr[7] = 1;
-	$stflan = Net_IPv6::compress(implode(":", $stflanarr));
+	$stflan = compress_ip6(implode(":", $stflanarr));
 
 	/* setup the stf interface */
 	if (!is_module_loaded("if_stf")) {

--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -710,7 +710,7 @@ function ipsec_get_phase1($ikeid) {
 
 function ipsec_fixup_ip($ipaddr) {
 	if (is_ipaddrv6($ipaddr) || is_subnetv6($ipaddr)) {
-		return Net_IPv6::compress(Net_IPv6::uncompress($ipaddr));
+		return compress_ip6(Net_IPv6::uncompress($ipaddr));
 	} else {
 		return $ipaddr;
 	}

--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1711,8 +1711,8 @@ function openvpn_get_interface_ipv6($ipv6, $prefix) {
 	// Is there a better way to do this math?
 	$ipv6_arr = explode(':', $basev6);
 	$last = hexdec(array_pop($ipv6_arr));
-	$ipv6_1 = Net_IPv6::compress(Net_IPv6::uncompress(implode(':', $ipv6_arr) . ':' . dechex($last + 1)));
-	$ipv6_2 = Net_IPv6::compress(Net_IPv6::uncompress(implode(':', $ipv6_arr) . ':' . dechex($last + 2)));
+	$ipv6_1 = compress_ip6(Net_IPv6::uncompress(implode(':', $ipv6_arr) . ':' . dechex($last + 1)));
+	$ipv6_2 = compress_ip6(Net_IPv6::uncompress(implode(':', $ipv6_arr) . ':' . dechex($last + 2)));
 	return array($ipv6_1, $ipv6_2);
 }
 

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2902,7 +2902,7 @@ function convert_128bit_to_ipv6($ip6bin) {
 	foreach ($ip6binarr as $binpart) {
 		$ip6arr[] = dechex(bindec($binpart));
 	}
-	$ip6addr = Net_IPv6::compress(implode(":", $ip6arr));
+	$ip6addr = compress_ip6(implode(":", $ip6arr));
 
 	return($ip6addr);
 }
@@ -2983,7 +2983,7 @@ function merge_ipv6_delegated_prefix($prefix, $suffix, $len = 64) {
 		break;
 	}
 
-	return Net_IPv6::compress(substr($prefix, 0, $prefix_len) .
+	return compress_ip6(substr($prefix, 0, $prefix_len) .
 	    substr($suffix, $prefix_len));
 }
 

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -267,7 +267,7 @@ function gen_subnetv4($ipaddr, $bits) {
 /* same as gen_subnet() but accepts IPv6 only */
 function gen_subnetv6($ipaddr, $bits) {
 	if (is_ipaddrv6($ipaddr) && is_numericint($bits) && $bits <= 128) {
-		return Net_IPv6::compress(Net_IPv6::getNetmask($ipaddr, $bits));
+		return compress_ip6(Net_IPv6::getNetmask($ipaddr, $bits));
 	}
 	return "";
 }
@@ -392,10 +392,22 @@ function bin_to_ip6($bin) {
 }
 
 /*
+ * Compress an IPv6 address
+*/
+function compress_ip6($ipaddr) {
+	if ($ipaddr == "0:0:0:0:0:0:0:0") {
+		// Special case until Net_IPv6::compress() handles the zero address correctly
+		return "::";
+	} else {
+		return Net_IPv6::compress($ipaddr);
+	}
+}
+
+/*
  * Convert IPv6 binary to compressed address
  */
 function bin_to_compressed_ip6($bin) {
-	return Net_IPv6::compress(bin_to_ip6($bin));
+	return compress_ip6(bin_to_ip6($bin));
 }
 
 /* Find out how many IPs are contained within a given IP range

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -223,9 +223,9 @@ if (isset($_POST['apply'])) {
 		    $_POST['prefixrange_length']) {
 			$netmask = Net_IPv6::getNetmask($_POST['prefixrange_from'],
 			    $_POST['prefixrange_length']);
-			$netmask = Net_IPv6::compress($netmask);
+			$netmask = compress_ip6($netmask);
 
-			if ($netmask != Net_IPv6::compress(strtolower(
+			if ($netmask != compress_ip6(strtolower(
 			    $_POST['prefixrange_from']))) {
 				$input_errors[] = sprintf(gettext(
 				    "Prefix Delegation From address is not a valid IPv6 Netmask for %s"),
@@ -234,9 +234,9 @@ if (isset($_POST['apply'])) {
 
 			$netmask = Net_IPv6::getNetmask($_POST['prefixrange_to'],
 			    $_POST['prefixrange_length']);
-			$netmask = Net_IPv6::compress($netmask);
+			$netmask = compress_ip6($netmask);
 
-			if ($netmask != Net_IPv6::compress(strtolower(
+			if ($netmask != compress_ip6(strtolower(
 			    $_POST['prefixrange_to']))) {
 				$input_errors[] = sprintf(gettext(
 				    "Prefix Delegation To address is not a valid IPv6 Netmask for %s"),


### PR DESCRIPTION
To handle special case where
```
Net_IPv6::compress("0:0:0:0:0:0:0:0");
```
returns blank "", when it should return "::".

Change all Net_IPv6::compress() calls to use compress_ip6()