### PR TITLE
ipsec mobile clients, don't check mobile leases if mobile client isn't enabled to begin with

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -597,8 +597,12 @@ function ipsec_dump_sad() {
  * Return dump of mobile user list
  */
 function ipsec_dump_mobile() {
-	global $g;
+	global $g, $config;
 
+	if(!isset($config['ipsec']['client']['enable'])) {
+		return array();
+	}
+	
 	$_gb = exec("/usr/local/sbin/ipsec leases 2>/dev/null", $output, $rc);
 
 	if ($rc != 0) {


### PR DESCRIPTION
ipsec mobile clients, don't check mobile leases if mobile client isn't enabled to begin with
