### PR TITLE
update LAN regex 

### DIFF
--- a/src/usr/local/www/wizards/setup_wizard.xml
+++ b/src/usr/local/www/wizards/setup_wizard.xml
@@ -573,7 +573,7 @@
 			<type>input</type>
 			<bindstofield>interfaces->lan->ipaddr</bindstofield>
 			<description>Type dhcp if this interface uses DHCP to obtain its IP address.</description>
-			<validate>^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$</validate>
+			<validate>^((dhcp)|(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))$/i</validate>
 			<message>LAN IP Address field is invalid</message>
 		</field>
 				<field>

--- a/src/usr/local/www/wizards/setup_wizard.xml
+++ b/src/usr/local/www/wizards/setup_wizard.xml
@@ -588,7 +588,7 @@
 	</fields>
 	<stepsubmitphpaction>
 		<![CDATA[
-		if (empty($_POST['lanipaddress']) || !is_ipaddr($_POST['lanipaddress']) || strcasecmp($_POST['lanipaddress'],"dhcp")!=0) {
+		if if (empty($_POST['lanipaddress'])) || (!is_ipaddr($_POST['lanipaddress']) && (strtolower($_POST['lanipaddress']) != "dhcp"))) {
 			print_info_box("Invalid LAN IP address. Please press back in the browser window and correct.");
 			die;
 		}

--- a/src/usr/local/www/wizards/setup_wizard.xml
+++ b/src/usr/local/www/wizards/setup_wizard.xml
@@ -573,7 +573,7 @@
 			<type>input</type>
 			<bindstofield>interfaces->lan->ipaddr</bindstofield>
 			<description>Type dhcp if this interface uses DHCP to obtain its IP address.</description>
-			<validate>^((dhcp)|(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))$/i</validate>
+			<validate>^(dhcp|(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))$/i</validate>
 			<message>LAN IP Address field is invalid</message>
 		</field>
 				<field>

--- a/src/usr/local/www/wizards/setup_wizard.xml
+++ b/src/usr/local/www/wizards/setup_wizard.xml
@@ -588,7 +588,7 @@
 	</fields>
 	<stepsubmitphpaction>
 		<![CDATA[
-		if (empty($_POST['lanipaddress']) || !is_ipaddr($_POST['lanipaddress'])) {
+		if (empty($_POST['lanipaddress']) || !is_ipaddr($_POST['lanipaddress']) || strcasecmp($_POST['lanipaddress'],"dhcp")!=0) {
 			print_info_box("Invalid LAN IP address. Please press back in the browser window and correct.");
 			die;
 		}

--- a/src/usr/local/www/wizards/setup_wizard.xml
+++ b/src/usr/local/www/wizards/setup_wizard.xml
@@ -588,7 +588,7 @@
 	</fields>
 	<stepsubmitphpaction>
 		<![CDATA[
-		if if (empty($_POST['lanipaddress'])) || (!is_ipaddr($_POST['lanipaddress']) && (strtolower($_POST['lanipaddress']) != "dhcp"))) {
+		if (empty($_POST['lanipaddress'])) || (!is_ipaddr($_POST['lanipaddress']) && (strtolower($_POST['lanipaddress']) != "dhcp"))) {
 			print_info_box("Invalid LAN IP address. Please press back in the browser window and correct.");
 			die;
 		}


### PR DESCRIPTION
During initial setup wizard, LAN configuration does not allow the option of DHCP due to invalid regex. Updated regex allows for case-insensitive string "dhcp" or ip address ( as original regex)