### PR TITLE
Keep the rule type selection after input errors on firewall rule

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1265,7 +1265,10 @@ foreach (['src' => 'Source', 'dst' => 'Destination'] as $type => $name) {
 
 	// The rule type dropdown on the GUI can be one of the special names like
 	// "any" "LANnet" "LAN address"... or "Single host or alias" or "Network"
-	if (is_specialnet($pconfig[$type])) {
+	if ($pconfig[$type.'type']) {
+		// The rule type came from the $_POST array, after input errors, so keep it.
+		$ruleType = $pconfig[$type.'type'];
+	} elseif (is_specialnet($pconfig[$type])) {
 		// It is one of the special names, let it through as-is.
 		$ruleType = $pconfig[$type];
 	} elseif ((is_ipaddrv6($pconfig[$type]) && $pconfig[$type.'mask'] == 128) ||


### PR DESCRIPTION
If the user does:
a) Edit a firewall rule
b) Select "single host or alias"
c) Enter an invalid IP address that is not an alias
d) Press "Save"
The error is displayed "1.2.3.999 is not a valid source IP address or alias"
But note that the rule type dropdown has changed to "Network".

In the case where there is $_POST data, we do not want to try and deduce the srctype or dsttype from the IP address in the src or dst field, because the value of that field could be the very invalid data that the user entered. We want to maintain the value of srctype or dsttype that the user selected and let them correct the error they made in typing the actual IP address.