### PR TITLE
Fix #6918 Allow aliases with capital letters in rules

### DIFF
--- a/src/usr/local/www/classes/Form/IpAddress.class.php
+++ b/src/usr/local/www/classes/Form/IpAddress.class.php
@@ -45,6 +45,23 @@ class Form_IpAddress extends Form_Input
 				$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1';
 				$this->_attributes['onChange'] = 'javascript:this.value=this.value.toLowerCase();';
 				break;
+
+			case "ALIASV4V6":
+				$this->_attributes['pattern'] = '[a-zA-Z0-9_.:]+';
+				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or an IPv6 address like 1:2a:3b:ffff::1 or an alias';
+				$this->_attributes['onChange'] = 'javascript:if (this.value.indexOf(":") > -1) {this.value=this.value.toLowerCase();}';
+				break;
+
+			case "ALIASV4":
+				$this->_attributes['pattern'] = '[a-zA-Z0-9_.:]+';
+				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or an alias';
+				break;
+
+			case "ALIASV6":
+				$this->_attributes['pattern'] = '[a-zA-Z0-9_.:]+';
+				$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1 or an alias';
+				$this->_attributes['onChange'] = 'javascript:if (this.value.indexOf(":") > -1) {this.value=this.value.toLowerCase();}';
+				break;
 		}
 	}
 

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1317,8 +1317,9 @@ foreach (['src' => 'Source', 'dst' => 'Destination'] as $type => $name) {
 	$group->add(new Form_IpAddress(
 		$type,
 		$name .' Address',
-		$pconfig[$type]
-	))->addMask($type .'mask', $pconfig[$type.'mask'])->setPattern('[a-zA-Z0-9_.:]+');
+		$pconfig[$type],
+		'ALIASV4V6'
+	))->addMask($type .'mask', $pconfig[$type.'mask']);
 
 	$section->add($group);
 


### PR DESCRIPTION
Expand the types of Form_IpAddress so that the caller can specify
exactly what combination of IPv4, IPv6 address and alias is allowed for
the field.
Set the appropriate input pattern and hover help text.
Only toLowercase() the entered value if it has a ":" in it - i.e. it
looks like it is intended to be an IPv6 address (rather than an IPv4 or
an alias name).