### PR TITLE
An alias or IPv4 address cannot contain a colon

### DIFF
--- a/src/usr/local/www/classes/Form/IpAddress.class.php
+++ b/src/usr/local/www/classes/Form/IpAddress.class.php
@@ -53,7 +53,7 @@ class Form_IpAddress extends Form_Input
 				break;
 
 			case "ALIASV4":
-				$this->_attributes['pattern'] = '[a-zA-Z0-9_.:]+';
+				$this->_attributes['pattern'] = '[a-zA-Z0-9_.]+';
 				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or an alias';
 				break;
 


### PR DESCRIPTION
I did a bit too much cut-paste without edit yesterday. At the moment, the ALIASV4 case is not being used, so it is easy to correct it without causing any change to the functional system.