### PR TITLE
Add cases to Form_IpAddress for host and IP

### DIFF
--- a/src/usr/local/www/classes/Form/IpAddress.class.php
+++ b/src/usr/local/www/classes/Form/IpAddress.class.php
@@ -62,6 +62,23 @@ class Form_IpAddress extends Form_Input
 				$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1 or an alias';
 				$this->_attributes['onChange'] = 'javascript:if (this.value.indexOf(":") > -1) {this.value=this.value.toLowerCase();}';
 				break;
+
+			case "HOSTV4V6":
+				$this->_attributes['pattern'] = '[.:a-zA-Z0-9-]+';
+				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or an IPv6 address like 1:2a:3b:ffff::1 or a host name like myhost.example.com';
+				$this->_attributes['onChange'] = 'javascript:if (this.value.indexOf(":") > -1) {this.value=this.value.toLowerCase();}';
+				break;
+
+			case "HOSTV4":
+				$this->_attributes['pattern'] = '[.a-zA-Z0-9-]+';
+				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or a host name like myhost.example.com';
+				break;
+
+			case "HOSTV6":
+				$this->_attributes['pattern'] = '[.:a-zA-Z0-9-]+';
+				$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1 or a host name like myhost.example.com';
+				$this->_attributes['onChange'] = 'javascript:if (this.value.indexOf(":") > -1) {this.value=this.value.toLowerCase();}';
+				break;
 		}
 	}
 

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1082,15 +1082,15 @@ $section->addInput(new Form_IpAddress(
 	'ntp1',
 	'NTP Server 1',
 	$pconfig['ntp1'],
-	'V4'
-))->setPattern('[.a-zA-Z0-9-]+');
+	'HOSTV4'
+));
 
 $section->addInput(new Form_IpAddress(
 	'ntp2',
 	'NTP Server 2',
 	$pconfig['ntp2'],
-	'V4'
-))->setPattern('[.a-zA-Z0-9-]+');
+	'HOSTV4'
+));
 
 // Advanced TFTP
 $btnadv = new Form_Button(


### PR DESCRIPTION
combinations, so we can specify that entry of a particular IP address family or host name is required, and give the user an appropriate bit of hover text and regex pattern match.
Make first use of it for input of NTP servers.