### PR TITLE
DHCPv6 ddnsdomainprimary must currently be IPv4

### DIFF
--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -754,8 +754,9 @@ $section->addInput(new Form_Input(
 $section->addInput(new Form_IpAddress(
 	'ddnsdomainprimary',
 	'DDNS Server IP',
-	$pconfig['ddnsdomainprimary']
-))->setHelp('Enter the primary domain name server IP address for the dynamic domain name.');
+	$pconfig['ddnsdomainprimary'],
+	'V4'
+))->setHelp('Enter the primary domain name server IPv4 address for the dynamic domain name.');
 
 $section->addInput(new Form_Input(
 	'ddnsdomainkeyname',


### PR DESCRIPTION
This field is currently validated to allow only an IPv4 address to be entered, so it may as well be consistent client-side so the user knows that only an IPv4 address is allowed.