### PR TITLE
Allow aliases where valid for Form_IpAddress

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -697,7 +697,8 @@ while ($counter < count($addresses)) {
 	$group->add(new Form_IpAddress(
 		'address' . $counter,
 		$tab == 'port' ? 'Port':'Address',
-		$address
+		$address,
+		'ALIASV4V6'
 	))->addMask('address_subnet' . $counter, $address_subnet)->setWidth(4)->setPattern($pattern_str[$tab]);
 
 	$group->add(new Form_Input(

--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -439,7 +439,7 @@ $group->add(new Form_IpAddress(
 	'src',
 	null,
 	is_specialnet($pconfig['src']) ? '': $pconfig['src']
-))->addMask('srcmask', $pconfig['srcmask'], 31)->setHelp('Address/mask')->setPattern('[a-zA-Z0-9.:_]+');
+))->addMask('srcmask', $pconfig['srcmask'], 31)->setHelp('Address/mask');
 
 $group->setHelp('Enter the internal (LAN) subnet for the 1:1 mapping. ' .
 				'The subnet size specified for the internal subnet will be applied to the external subnet.');
@@ -465,8 +465,9 @@ $group->add(new Form_Select(
 $group->add(new Form_IpAddress(
 	'dst',
 	null,
-	is_specialnet($pconfig['dst']) ? '': $pconfig['dst']
-))->addMask('dstmask', $pconfig['dstmask'], 31)->setHelp('Address/mask')->setPattern('[a-zA-Z0-9.:_]+');
+	is_specialnet($pconfig['dst']) ? '': $pconfig['dst'],
+	'ALIASV4V6'
+))->addMask('dstmask', $pconfig['dstmask'], 31)->setHelp('Address/mask');
 
 $group->setHelp('The 1:1 mapping will only be used for connections to or from the specified destination. Hint: this is usually "Any".');
 

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -721,8 +721,9 @@ $group->add(new Form_Select(
 $group->add(new Form_IpAddress(
 	'src',
 	null,
-	is_specialnet($pconfig['src']) ? '': $pconfig['src']
-))->setPattern('[.a-zA-Z0-9_:]+')->addMask('srcmask', $pconfig['srcmask'])->setHelp('Address/mask');
+	is_specialnet($pconfig['src']) ? '': $pconfig['src'],
+	'ALIASV4V6'
+))->addMask('srcmask', $pconfig['srcmask'])->setHelp('Address/mask');
 
 $section->add($group);
 
@@ -788,8 +789,9 @@ $group->add(new Form_Select(
 $group->add(new Form_IpAddress(
 	'dst',
 	null,
-	is_specialnet($pconfig['dst']) ? '': $pconfig['dst']
-))->setPattern('[.a-zA-Z0-9_:]+')->addMask('dstmask', $pconfig['dstmask'], 31)->setHelp('Address/mask');
+	is_specialnet($pconfig['dst']) ? '': $pconfig['dst'],
+	'ALIASV4V6'
+))->addMask('dstmask', $pconfig['dstmask'], 31)->setHelp('Address/mask');
 
 $section->add($group);
 
@@ -832,8 +834,9 @@ $section->add($group);
 $section->addInput(new Form_IpAddress(
 	'localip',
 	'Redirect target IP',
-	$pconfig['localip']
-))->setPattern('[.a-zA-Z0-9_:]+')->setHelp('Enter the internal IP address of the server on which to map the ports.' . '<br />' .
+	$pconfig['localip'],
+	'ALIASV4V6'
+))->setHelp('Enter the internal IP address of the server on which to map the ports.' . '<br />' .
 			'e.g.: 192.168.1.12');
 
 $group = new Form_Group('Redirect target port');

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -498,8 +498,9 @@ $group->add(new Form_Select(
 $group->add(new Form_IpAddress(
 	'source',
 	null,
-	$pconfig['source']
-))->addMask('source_subnet', $pconfig['source_subnet'])->setHelp('Source network for the outbound NAT mapping.')->setPattern('[a-zA-Z0-9_.:]+');
+	$pconfig['source'],
+	'ALIASV4V6'
+))->addMask('source_subnet', $pconfig['source_subnet'])->setHelp('Source network for the outbound NAT mapping.');
 
 $group->add(new Form_Input(
 	'sourceport',
@@ -522,8 +523,9 @@ $group->add(new Form_Select(
 $group->add(new Form_IpAddress(
 	'destination',
 	null,
-	$pconfig['destination'] == "any" ? "":$pconfig['destination']
-))->addMask('destination_subnet', $pconfig['destination_subnet'])->setHelp('Destination network for the outbound NAT mapping.')->setPattern('[a-zA-Z0-9_.:]+');
+	$pconfig['destination'] == "any" ? "":$pconfig['destination'],
+	'ALIASV4V6'
+))->addMask('destination_subnet', $pconfig['destination_subnet'])->setHelp('Destination network for the outbound NAT mapping.');
 
 $group->add(new Form_Input(
 	'dstport',

--- a/src/usr/local/www/services_dhcpv6_relay.php
+++ b/src/usr/local/www/services_dhcpv6_relay.php
@@ -169,7 +169,8 @@ function createDestinationServerInputGroup($value = null) {
 	$group->add(new Form_IpAddress(
 		'server',
 		'Destination server',
-		$value
+		$value,
+		'V6'
 	))->setWidth(4)
 	  ->setHelp('This is the IPv6 address of the server to which DHCPv6 requests are relayed.')
 	  ->setIsRepeated();

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -398,7 +398,8 @@ foreach ($pconfig['subnets'] as $subnet) {
 	$group->add(new Form_IpAddress(
 		$address_name,
 		null,
-		$address
+		$address,
+		'V6'
 	))->addMask($bits_name, $subnet);
 
 	$group->add(new Form_Button(
@@ -430,8 +431,9 @@ for ($idx=1; $idx<=3; $idx++) {
 	$section->addInput(new Form_IpAddress(
 		'radns' . $idx,
 		'Server ' . $idx,
-		$pconfig['radns' . $idx]
-	))->setPattern('[a-zA-Z0-9_.:]+')->setHelp(($idx < 3) ? '':'Leave blank to use the system default DNS servers - this interface\'s IP if DNS Forwarder or Resolver is enabled, otherwise the servers configured on the General page');
+		$pconfig['radns' . $idx],
+		'ALIASV6'
+	))->setHelp(($idx < 3) ? '':'Leave blank to use the system default DNS servers - this interface\'s IP if DNS Forwarder or Resolver is enabled, otherwise the servers configured on the General page');
 }
 
 $section->addInput(new Form_Input(

--- a/src/usr/local/www/system_routes_edit.php
+++ b/src/usr/local/www/system_routes_edit.php
@@ -245,8 +245,9 @@ $section = new Form_Section('Edit Route Entry');
 $section->addInput(new Form_IpAddress(
 	'network',
 	'Destination network',
-	$pconfig['network']
-))->addMask('network_subnet', $pconfig['network_subnet'])->setPattern('[.a-zA-Z0-9_:]+')->setHelp('Destination network for this static route');
+	$pconfig['network'],
+	'ALIASV4V6'
+))->addMask('network_subnet', $pconfig['network_subnet'])->setHelp('Destination network for this static route');
 
 $allGateways = array_combine(
 	array_map(function($g){ return $g['name']; }, $a_gateways),


### PR DESCRIPTION
For any Form_IpAddress calls where we want to accept an alias, we need
to specify the parameter 'ALIASV4V6' 'ALIASV4' or 'ALIASV6' so that the
correct regex pattern and hover text will be used, and that mixed-case
alias names will not be automagically converted to lowercase.