### PR TITLE
Add Server EKU detection (for IKE v2)

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -571,6 +571,7 @@ function cert_get_purpose($str_crt, $decode = true) {
 	$purpose = array();
 	$purpose['ca'] = (stristr($crt_details['extensions']['basicConstraints'], 'CA:TRUE') === false) ? 'No': 'Yes';
 	$purpose['server'] = (strpos($crt_details['extensions']['nsCertType'], 'SSL Server') !== FALSE) ? 'Yes': 'No';
+	$purpose['serverEKU'] = (strpos($crt_details['extensions']['extendedKeyUsage'], 'TLS Web Server Authentication') !== FALSE) ? 'Yes': 'No';
 	return $purpose;
 }
 

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -997,7 +997,7 @@ foreach ($a_cert as $i => $cert):
 							<i><?=$cert_types[$cert['type']]?></i><br />
 						<?php endif?>
 						<?php if (is_array($purpose)): ?>
-							CA: <b><?=$purpose['ca']?></b>, <?=gettext("Server")?>: <b><?=$purpose['server']?></b>
+							CA: <b><?=$purpose['ca']?></b>, <?=gettext("Server")?>: <b><?=$purpose['server']?></b><br /><?=gettext("Server EKU")?>: <b><?=$purpose['serverEKU']?></b>
 						<?php endif?>
 					</td>
 					<td><?=$caname?></td>


### PR DESCRIPTION
When using IPsec IKEv2, it is imperative that the server certificate server authentication Extended Key Usage be set. The existing certificate manager does not display this property (the "Server" property is really related to the nsCertType extension - see https://redmine.pfsense.org/issues/6877#change-29471) so I thought it would be useful to add this capability. Feel free to rewrite or modify.