### PR TITLE
IPv6 address can contain a dot

### DIFF
--- a/src/usr/local/www/classes/Form/IpAddress.class.php
+++ b/src/usr/local/www/classes/Form/IpAddress.class.php
@@ -39,7 +39,7 @@ class Form_IpAddress extends Form_Input
 				break;
 
 			case "V6":
-				$this->_attributes['pattern'] = '[a-fA-F0-9:]*';
+				$this->_attributes['pattern'] = '[a-fA-F0-9:.]*';
 				$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1';
 				break;
 		}


### PR DESCRIPTION
When requiring the entry of an IPv6 address, the regex pattern should still allow a dot, so that an IPv6 address can be entered in the format that has an IPv4-address-like part at the end:
aa:bb:cc:dd:ee:ff:1.2.3.4
which is a valid way to choose to specify an IPv6 address.