### PR TITLE
Captive portal: use "Admin Reset" as termination cause when disconnec…

### DIFF
--- a/src/usr/local/www/status_captiveportal.php
+++ b/src/usr/local/www/status_captiveportal.php
@@ -61,7 +61,7 @@ if (isset($cpzone) && !empty($cpzone) && isset($a_cp[$cpzone]['zoneid'])) {
 }
 
 if ($_GET['act'] == "del" && !empty($cpzone) && isset($cpzoneid) && isset($_GET['id'])) {
-	captiveportal_disconnect_client($_GET['id']);
+	captiveportal_disconnect_client($_GET['id'], 6);
 	header("Location: status_captiveportal.php?zone={$cpzone}");
 	exit;
 }

--- a/src/usr/local/www/widgets/widgets/captive_portal_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/captive_portal_status.widget.php
@@ -48,7 +48,7 @@ if (isset($cpzone) && !empty($cpzone) && isset($a_cp[$cpzone]['zoneid'])) {
 }
 
 if (($_GET['act'] == "del") && !empty($cpzone) && isset($cpzoneid)) {
-	captiveportal_disconnect_client($_GET['id']);
+	captiveportal_disconnect_client($_GET['id'], 6);
 }
 unset($cpzone);
 


### PR DESCRIPTION
…ting a user from admin UI

When a user is disconnected by the administrator using the pfSense captive portal status page or widget set the value of the Acct-Terminate-Cause in the RADIUS accounting stop packet to "Admin Reset" (6) as per RFC 2866.