### PR TITLE
Add classes for IP V4 and V6 Address Forms

### DIFF
--- a/src/usr/local/www/classes/Form/IpAddress.class.php
+++ b/src/usr/local/www/classes/Form/IpAddress.class.php
@@ -24,25 +24,12 @@ class Form_IpAddress extends Form_Input
 {
 	protected $_mask;
 
-	public function __construct($name, $title, $value, $type = "BOTH")
+	public function __construct($name, $title, $value)
 	{
 		parent::__construct($name, $title, 'text', $value);
 
-		switch ($type) {
-			case "BOTH":
-				$this->_attributes['pattern'] = '[a-fA-F0-9:.]*';
-				$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or an IPv6 address like 1:2a:3b:ffff::1';
-				break;
-
-			case "V4":
-				$this->_attributes['pattern'] = '[0-9.]*';
-				break;
-
-			case "V6":
-				$this->_attributes['pattern'] = '[a-fA-F0-9:.]*';
-				$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1';
-				break;
-		}
+		$this->_attributes['pattern'] = '[a-fA-F0-9:.]*';
+		$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 or an IPv6 address like 1:2a:3b:ffff::1';
 	}
 
 	// $min is provided to allow for VPN masks in which '0' is valid

--- a/src/usr/local/www/classes/Form/IpV4Address.class.php
+++ b/src/usr/local/www/classes/Form/IpV4Address.class.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * IpV4Address.class.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015 Sjon Hortensius
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class Form_IpV4Address extends Form_IpAddress
+{
+	protected $_mask;
+
+	public function __construct($name, $title, $value)
+	{
+		parent::__construct($name, $title, $value);
+
+		$this->_attributes['pattern'] = '[0-9.]*';
+		$this->_attributes['title'] = 'An IPv4 address like 1.2.3.4 zzz';
+	}
+
+	// $min is provided to allow for VPN masks in which '0' is valid
+	public function addMask($name, $value, $max = 32, $min = 1)
+	{
+		return parent::addMask($name, $value, $max, $min);
+	}
+
+}

--- a/src/usr/local/www/classes/Form/IpV6Address.class.php
+++ b/src/usr/local/www/classes/Form/IpV6Address.class.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * IpV6Address.class.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015 Sjon Hortensius
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class Form_IpV6Address extends Form_IpAddress
+{
+	protected $_mask;
+
+	public function __construct($name, $title, $value)
+	{
+		parent::__construct($name, $title, $value);
+
+		$this->_attributes['title'] = 'An IPv6 address like 1:2a:3b:ffff::1';
+	}
+
+}


### PR DESCRIPTION
Instead of having the $type parameter to Form_IpAddress and using a
switch statement, the class hierarchy can be extended to have a Form
class for each IpAddress combination, and put the custom message and
pattern in the specific class.