### PR TITLE
Add DHCP Server ddnsforcehostname option

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1079,6 +1079,12 @@ EOD;
 					if (($sm['ddnsdomain'] <> "") && ($sm['ddnsdomain'] != $dhcpifconf['ddnsdomain'])) {
 						$smdnscfg .= "		ddns-domainname \"{$sm['ddnsdomain']}\";\n";
 					}
+# TODO: Implement ddnsforcehostname option for DHCP Server per interface
+					if (isset($dhcpifconf['ddnsforcehostname']) && $sm['hostname']) {
+						$ddnshostname = str_replace(" ", "_", $sm['hostname']);
+						$ddnshostname = str_replace(".", "_", $ddnshostname);
+						$smdnscfg .= "		ddns-hostname \"{$ddnshostname}\";\n";
+					}
 					$smdnscfg .= "		ddns-update-style interim;\n";
 				}
 

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1052,7 +1052,6 @@ EOD;
 					$dhhostname = str_replace(" ", "_", $sm['hostname']);
 					$dhhostname = str_replace(".", "_", $dhhostname);
 					$dhcpdconf .= "	option host-name \"{$dhhostname}\";\n";
-					# TODO: Implement ddnsforcehostname option for DHCP Server per interface
 					if ((isset($dhcpifconf['ddnsupdate']) || isset($sm['ddnsupdate'])) && (isset($dhcpifconf['ddnsforcehostname']) || isset($sm['ddnsforcehostname']))) {
 						$dhcpdconf .= "	ddns-hostname \"{$dhhostname}\";\n";
 					}

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1052,6 +1052,10 @@ EOD;
 					$dhhostname = str_replace(" ", "_", $sm['hostname']);
 					$dhhostname = str_replace(".", "_", $dhhostname);
 					$dhcpdconf .= "	option host-name \"{$dhhostname}\";\n";
+					# TODO: Implement ddnsforcehostname option for DHCP Server per interface
+					if ((isset($dhcpifconf['ddnsupdate']) || isset($sm['ddnsupdate'])) && (isset($dhcpifconf['ddnsforcehostname']) || isset($sm['ddnsforcehostname']))) {
+						$dhcpdconf .= "	ddns-hostname \"{$dhhostname}\";\n";
+					}
 				}
 				if ($sm['filename']) {
 					$dhcpdconf .= "	filename \"{$sm['filename']}\";\n";
@@ -1078,12 +1082,6 @@ EOD;
 				if (isset($sm['ddnsupdate'])) {
 					if (($sm['ddnsdomain'] <> "") && ($sm['ddnsdomain'] != $dhcpifconf['ddnsdomain'])) {
 						$smdnscfg .= "		ddns-domainname \"{$sm['ddnsdomain']}\";\n";
-					}
-# TODO: Implement ddnsforcehostname option for DHCP Server per interface
-					if (isset($dhcpifconf['ddnsforcehostname']) && $sm['hostname']) {
-						$ddnshostname = str_replace(" ", "_", $sm['hostname']);
-						$ddnshostname = str_replace(".", "_", $ddnshostname);
-						$smdnscfg .= "		ddns-hostname \"{$ddnshostname}\";\n";
 					}
 					$smdnscfg .= "		ddns-update-style interim;\n";
 				}

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1017,7 +1017,7 @@ $section->addInput(new Form_Input(
 
 $section->addInput(new Form_Checkbox(
 	'ddnsforcehostname',
-	null,
+	'DDNS Hostnames',
 	'Force dynamic DNS hostname to be the same as configured hostname for Static Mappings',
 	$pconfig['ddnsforcehostname']
 ))->setHelp('Default is to allow DHCP client to supply hostname to be registered.');

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -175,6 +175,7 @@ if (is_array($dhcpdconf)) {
 	$pconfig['ddnsdomainkeyname'] = $dhcpdconf['ddnsdomainkeyname'];
 	$pconfig['ddnsdomainkey'] = $dhcpdconf['ddnsdomainkey'];
 	$pconfig['ddnsupdate'] = isset($dhcpdconf['ddnsupdate']);
+	$pconfig['ddnsforcehostname'] = isset($dhcpdconf['ddnsforcehostname']);
 	$pconfig['mac_allow'] = $dhcpdconf['mac_allow'];
 	$pconfig['mac_deny'] = $dhcpdconf['mac_deny'];
 	list($pconfig['ntp1'], $pconfig['ntp2']) = $dhcpdconf['ntpserver'];
@@ -541,6 +542,7 @@ if (isset($_POST['save'])) {
 		$dhcpdconf['ddnsdomainkeyname'] = $_POST['ddnsdomainkeyname'];
 		$dhcpdconf['ddnsdomainkey'] = $_POST['ddnsdomainkey'];
 		$dhcpdconf['ddnsupdate'] = ($_POST['ddnsupdate']) ? true : false;
+		$dhcpdconf['ddnsforcehostname'] = ($_POST['ddnsforcehostname']) ? true : false;
 		$dhcpdconf['mac_allow'] = $_POST['mac_allow'];
 		$dhcpdconf['mac_deny'] = $_POST['mac_deny'];
 
@@ -1013,6 +1015,13 @@ $section->addInput(new Form_Input(
 ))->setHelp('Leave blank to disable dynamic DNS registration.' . '<br />' .
 			'Enter the dynamic DNS domain which will be used to register client names in the DNS server.');
 
+$section->addInput(new Form_Checkbox(
+	'ddnsforcehostname',
+	null,
+	'Force dynamic DNS hostname to be the same as configured hostname for Static Mappings',
+	$pconfig['ddnsforcehostname']
+))->setHelp('Default is to allow DHCP client to supply hostname to be registered.');
+
 $section->addInput(new Form_IpAddress(
 	'ddnsdomainprimary',
 	'Primary DDNS address',
@@ -1396,7 +1405,7 @@ events.push(function() {
 		// On page load decide the initial state based on the data.
 		if (ispageload) {
 <?php
-			if (!$pconfig['ddnsupdate'] && empty($pconfig['ddnsdomain']) && empty($pconfig['ddnsdomainprimary']) &&
+			if (!$pconfig['ddnsupdate'] && !$pconfig['ddnsforcehostname'] && empty($pconfig['ddnsdomain']) && empty($pconfig['ddnsdomainprimary']) &&
 			    empty($pconfig['ddnsdomainkeyname']) && empty($pconfig['ddnsdomainkey'])) {
 				$showadv = false;
 			} else {
@@ -1411,6 +1420,7 @@ events.push(function() {
 
 		hideCheckbox('ddnsupdate', !showadvdns);
 		hideInput('ddnsdomain', !showadvdns);
+		hideCheckbox('ddnsforcehostname', !showadvdns);
 		hideInput('ddnsdomainprimary', !showadvdns);
 		hideInput('ddnsdomainkeyname', !showadvdns);
 		hideInput('ddnsdomainkey', !showadvdns);

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1020,7 +1020,7 @@ $section->addInput(new Form_Checkbox(
 	'DDNS Hostnames',
 	'Force dynamic DNS hostname to be the same as configured hostname for Static Mappings',
 	$pconfig['ddnsforcehostname']
-))->setHelp('Default is to allow DHCP client to supply hostname to be registered.');
+))->setHelp('Default registers host name option supplied by DHCP client.');
 
 $section->addInput(new Form_IpAddress(
 	'ddnsdomainprimary',

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -110,6 +110,7 @@ if (isset($id) && $a_maps[$id]) {
 	$pconfig['ddnsdomainkeyname'] = $a_maps[$id]['ddnsdomainkeyname'];
 	$pconfig['ddnsdomainkey'] = $a_maps[$id]['ddnsdomainkey'];
 	$pconfig['ddnsupdate'] = isset($a_maps[$id]['ddnsupdate']);
+	$pconfig['ddnsforcehostname'] = isset($a_maps[$id]['ddnsforcehostname']);
 	list($pconfig['ntp1'], $pconfig['ntp2']) = $a_maps[$id]['ntpserver'];
 	$pconfig['tftp'] = $a_maps[$id]['tftp'];
 } else {
@@ -136,6 +137,7 @@ if (isset($id) && $a_maps[$id]) {
 	$pconfig['ddnsdomainkeyname'] = $_GET['ddnsdomainkeyname'];
 	$pconfig['ddnsdomainkey'] = $_GET['ddnsdomainkey'];
 	$pconfig['ddnsupdate'] = isset($_GET['ddnsupdate']);
+	$pconfig['ddnsforcehostname'] = isset($_GET['ddnsforcehostname']);
 	$pconfig['ntp1'] = $_GET['ntp1'];
 	$pconfig['ntp2'] = $_GET['ntp2'];
 	$pconfig['tftp'] = $_GET['tftp'];
@@ -337,6 +339,7 @@ if ($_POST) {
 		$mapent['ddnsdomainkeyname'] = $_POST['ddnsdomainkeyname'];
 		$mapent['ddnsdomainkey'] = $_POST['ddnsdomainkey'];
 		$mapent['ddnsupdate'] = ($_POST['ddnsupdate']) ? true : false;
+		$mapent['ddnsforcehostname'] = ($_POST['ddnsforcehostname']) ? true : false;
 
 		unset($mapent['ntpserver']);
 		if ($_POST['ntp1']) {
@@ -592,6 +595,13 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['ddnsupdate']
 ));
 
+$section->addInput(new Form_Checkbox(
+	'ddnsforcehostname',
+	'DDNS Hostname',
+	'Make dynamic DNS registered hostname the same as Hostname above.',
+	$pconfig['ddnsforcehostname']
+));
+
 $section->addInput(new Form_Input(
 	'ddnsdomain',
 	'DDNS Domain',
@@ -693,7 +703,7 @@ events.push(function() {
 		// On page load decide the initial state based on the data.
 		if (ispageload) {
 <?php
-			if (!$pconfig['ddnsupdate'] && empty($pconfig['ddnsdomain']) && empty($pconfig['ddnsdomainprimary']) &&
+			if (!$pconfig['ddnsupdate'] && !$pconfig['ddnsforcehostname'] && empty($pconfig['ddnsdomain']) && empty($pconfig['ddnsdomainprimary']) &&
 			    empty($pconfig['ddnsdomainkeyname']) && empty($pconfig['ddnsdomainkey'])) {
 				$showadv = false;
 			} else {
@@ -707,6 +717,7 @@ events.push(function() {
 		}
 
 		hideCheckbox('ddnsupdate', !showadvdns);
+		hideCheckbox('ddnsforcehostname', !showadvdns);
 		hideInput('ddnsdomain', !showadvdns);
 		hideInput('ddnsdomainprimary', !showadvdns);
 		hideInput('ddnsdomainkeyname', !showadvdns);

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -134,6 +134,7 @@ if (is_array($config['dhcpdv6'][$if])) {
 	$pconfig['ddnsdomainkeyname'] = $config['dhcpdv6'][$if]['ddnsdomainkeyname'];
 	$pconfig['ddnsdomainkey'] = $config['dhcpdv6'][$if]['ddnsdomainkey'];
 	$pconfig['ddnsupdate'] = isset($config['dhcpdv6'][$if]['ddnsupdate']);
+	$pconfig['ddnsforcehostname'] = isset($config['dhcpdv6'][$if]['ddnsforcehostname']);
 	$pconfig['ddnsreverse'] = isset($config['dhcpdv6'][$if]['ddnsreverse']);
 	$pconfig['ddnsclientupdates'] = $config['dhcpdv6'][$if]['ddnsclientupdates'];
 	list($pconfig['ntp1'], $pconfig['ntp2']) = $config['dhcpdv6'][$if]['ntpserver'];
@@ -425,6 +426,7 @@ if (isset($_POST['apply'])) {
 		$config['dhcpdv6'][$if]['ddnsdomainkeyname'] = $_POST['ddnsdomainkeyname'];
 		$config['dhcpdv6'][$if]['ddnsdomainkey'] = $_POST['ddnsdomainkey'];
 		$config['dhcpdv6'][$if]['ddnsupdate'] = ($_POST['ddnsupdate']) ? true : false;
+		$config['dhcpdv6'][$if]['ddnsforcehostname'] = ($_POST['ddnsforcehostname']) ? true : false;
 		$config['dhcpdv6'][$if]['ddnsreverse'] = ($_POST['ddnsreverse']) ? true : false;
 		$config['dhcpdv6'][$if]['ddnsclientupdates'] = $_POST['ddnsclientupdates'];
 
@@ -751,6 +753,13 @@ $section->addInput(new Form_Input(
 	$pconfig['ddnsdomain']
 ))->setHelp('Leave blank to disable dynamic DNS registration. Enter the dynamic DNS domain which will be used to register client names in the DNS server.');
 
+$section->addInput(new Form_Checkbox(
+	'ddnsforcehostname',
+	null,
+	'Force dynamic DNS hostname to be the same as configured hostname for Static Mappings',
+	$pconfig['ddnsforcehostname']
+))->setHelp('Default is to allow DHCP client to supply hostname to be registered.');
+
 $section->addInput(new Form_IpAddress(
 	'ddnsdomainprimary',
 	'DDNS Server IP',
@@ -1045,6 +1054,7 @@ events.push(function() {
 		if (ispageload) {
 <?php
 			if (!$pconfig['ddnsupdate'] &&
+			    !$pconfig['ddnsforcehostname'] &&
 			    empty($pconfig['ddnsdomain']) &&
 			    empty($pconfig['ddnsdomainprimary']) &&
 			    empty($pconfig['ddnsdomainkeyname']) &&
@@ -1064,6 +1074,7 @@ events.push(function() {
 
 		hideCheckbox('ddnsupdate', !showadvdns);
 		hideInput('ddnsdomain', !showadvdns);
+		hideCheckbox('ddnsforcehostname', !showadvdns);
 		hideInput('ddnsdomainprimary', !showadvdns);
 		hideInput('ddnsdomainkeyname', !showadvdns);
 		hideInput('ddnsdomainkey', !showadvdns);

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -758,7 +758,7 @@ $section->addInput(new Form_Checkbox(
 	'DDNS Hostnames',
 	'Force dynamic DNS hostname to be the same as configured hostname for Static Mappings',
 	$pconfig['ddnsforcehostname']
-))->setHelp('Default is to allow DHCP client to supply hostname to be registered.');
+))->setHelp('Default registers host name option supplied by DHCP client.');
 
 $section->addInput(new Form_IpAddress(
 	'ddnsdomainprimary',

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -755,7 +755,7 @@ $section->addInput(new Form_Input(
 
 $section->addInput(new Form_Checkbox(
 	'ddnsforcehostname',
-	null,
+	'DDNS Hostnames',
 	'Force dynamic DNS hostname to be the same as configured hostname for Static Mappings',
 	$pconfig['ddnsforcehostname']
 ))->setHelp('Default is to allow DHCP client to supply hostname to be registered.');


### PR DESCRIPTION
I was frustrated recently when I discovered that the hostnames used for DDNS updates by the DHCP Server were coming from the clients' supplied host-name option instead of the configured hostnames for static leases. This is consistent with the DHCPD documentation. From the **dhcpd.conf(5)** man page:

> The DHCP server determines the client's hostname by first looking for a ddns-hostname  configuration  option,  and using that if it is present.  If no such option is present, the server looks for a valid hostname  in the  FQDN option sent by the client.  If one is found, it is used; oth- erwise, if the client sent a host-name option, that  is  used.   Other- wise,  if  there  is a host declaration that applies to the client, the name from that declaration will be used.  If none of these applies, the server will not have a hostname for the client, and will not be able to do a DNS update.

pfSense doesn't implement the ddns-hostname option, so I've added it. It can be turned on at the interface level or individually for each Static Mapping.