### PR TITLE
Captive portal: add option to include idle time in total session time

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -814,7 +814,9 @@ function captiveportal_prune_old() {
 			if ($lastact && (($pruning_time - $lastact) >= $uidletimeout)) {
 				$timedout = true;
 				$term_cause = 4; // Idle-Timeout
-				$stop_time = $lastact; // Entry added to comply with WISPr
+				if (!isset($config['captiveportal'][$cpzone]['includeidletime'])) {
+					$stop_time = $lastact;
+				}
 			}
 		}
 

--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -190,6 +190,7 @@ if ($a_cp[$cpzone]) {
 	$pconfig['passthrumacaddusername'] = isset($a_cp[$cpzone]['passthrumacaddusername']);
 	$pconfig['radmac_format'] = $a_cp[$cpzone]['radmac_format'];
 	$pconfig['reverseacct'] = isset($a_cp[$cpzone]['reverseacct']);
+	$pconfig['includeidletime'] = isset($a_cp[$cpzone]['includeidletime']);
 	$pconfig['radiusnasid'] = $a_cp[$cpzone]['radiusnasid'];
 	$pconfig['page'] = array();
 	if ($a_cp[$cpzone]['page']['htmltext']) {
@@ -429,6 +430,7 @@ if ($_POST) {
 		$newcp['passthrumacaddusername'] = $_POST['passthrumacaddusername'] ? true : false;
 		$newcp['radmac_format'] = $_POST['radmac_format'] ? $_POST['radmac_format'] : false;
 		$newcp['reverseacct'] = $_POST['reverseacct'] ? true : false;
+		$newcp['includeidletime'] = $_POST['includeidletime'] ? true : false;
 		$newcp['radiusnasid'] = trim($_POST['radiusnasid']);
 
 		if (!is_array($newcp['page'])) {
@@ -973,6 +975,15 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['reverseacct']
 ))->setHelp('When enabled, data counts for RADIUS accounting packets will be taken from the client perspective, not the NAS. ' .
 			'Acct-Input-Octets will represent download, and Acct-Output-Octets will represent upload.');
+
+$section->addInput(new Form_Checkbox(
+	'includeidletime',
+	'Idle time accounting',
+	'Include idle time in session time',
+	$pconfig['includeidletime']
+))->setHelp('When enabled, if a client is disconnected for exceeding the idle timeout the time spent idle is included in the total session time. ' .
+			'Otherwise the session time reported to the RADIUS server is the time between when the session started and when the last ' .
+			'activity was recorded.');
 
 $section->addInput(new Form_Input(
 	'radiusnasid',


### PR DESCRIPTION
Add an option to choose whether the time spent idle by a user disconnected for exceeding the idle timeout must be included in the total session time sent to the RADIUS server or not.