### PR TITLE
Tidy input errors in services_ntpd_acls

### DIFF
--- a/src/usr/local/www/services_ntpd_acls.php
+++ b/src/usr/local/www/services_ntpd_acls.php
@@ -38,7 +38,7 @@ if (!is_array($config['ntpd'])) {
 
 if (is_array($config['ntpd']['restrictions']) && is_array($config['ntpd']['restrictions']['row'])) {
 	$networkacl = $config['ntpd']['restrictions']['row'];
-}  else {
+} else {
 	$networkacl = array('0' => array('acl_network' => '', 'mask' => ''));
 }
 
@@ -89,19 +89,14 @@ if ($_POST) {
 			if (isset($networkacl[$x]['notrap']) || isset($networkacl[$x]['kod']) || isset($networkacl[$x]['nomodify'])
 			   || isset($networkacl[$x]['noquery']) || isset($networkacl[$x]['nopeer']) || isset($networkacl[$x]['noserve'])) {
 				if (!is_ipaddr($networkacl[$x]['acl_network'])) {
-					$input_errors[] = gettext("A valid IP address must be entered for each row under Networks.");
+					$input_errors[] = sprintf(gettext("A valid IP address must be entered for row %s under Networks."), $networkacl[$x]['acl_network']);
 				} else {
-
-					if (is_ipaddr($networkacl[$x]['acl_network'])) {
-						if (!is_subnet($networkacl[$x]['acl_network']."/".$networkacl[$x]['mask'])) {
-							$input_errors[] = gettext("A valid IPv4 netmask must be entered for each IPv4 row under Networks.");
+					if (is_ipaddrv4($networkacl[$x]['acl_network'])) {
+						if (!is_subnetv4($networkacl[$x]['acl_network']."/".$networkacl[$x]['mask'])) {
+							$input_errors[] = sprintf(gettext("A valid IPv4 netmask must be entered for IPv4 row %s under Networks."), $networkacl[$x]['acl_network']);
 						}
-					} else if (function_exists("is_ipaddrv6")) {
-						if (!is_ipaddrv6($networkacl[$x]['acl_network'])) {
-							$input_errors[] = gettext("A valid IPv6 address must be entered for {$networkacl[$x]['acl_network']}.");
-						} else if (!is_subnetv6($networkacl[$x]['acl_network']."/".$networkacl[$x]['mask'])) {
-							$input_errors[] = gettext("A valid IPv6 netmask must be entered for each IPv6 row under Networks.");
-						}
+					} else if (!is_subnetv6($networkacl[$x]['acl_network']."/".$networkacl[$x]['mask'])) {
+						$input_errors[] = sprintf(gettext("A valid IPv6 netmask must be entered for IPv6 row %s under Networks."), $networkacl[$x]['acl_network']);
 					}
 				}
 			}


### PR DESCRIPTION
1) If there are multiple rows with invalid IP addresses then the same message was displayed multiple times. We might as well let the use know which row(s) have the problem.
2) The section that checks is_subnet stuff was first using is_ipaddr() (redundantly given it is already in the else of !is_ipaddr() ), and then is_subnet() - these would have handled both the IPv4 and IPv6 cases, so the other IPv6 tests would never have happened.
3) I don't think we need to test function_exists("is_ipaddrv6") any more - it had better be there in master!
Note: The front-end JS prevents entry of an invalid mask, so it is a bit hard for the user to actually generate the netmask error messages.