### PR TITLE
Allow NAT 1:1 destination self on edit

### DIFF
--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -38,7 +38,7 @@ require_once("shaper.inc");
 
 $referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat_1to1.php');
 
-$specialsrcdst = explode(" ", "any pptp pppoe l2tp openvpn");
+$specialsrcdst = explode(" ", "any (self) pptp pppoe l2tp openvpn");
 $ifdisp = get_configured_interface_with_descr();
 
 foreach ($ifdisp as $kif => $kdescr) {


### PR DESCRIPTION
1) Add a NAT 1:1 rule with destination "This Firewall (self)" and save (goodness knows why you would want to do this?)
2) Edit the rule
The Destination dropdown displays "any" rather than the special net that was selected for the rule.

This fixes the UI problem.
Maybe "This Firewall (self)" actually should not be in the Destination dropdown list?