### PR TITLE
NAT 1:1 edit - preserve user selections on edit-save with input errors

### DIFF
--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -100,7 +100,6 @@ if (isset($_GET['dup'])) {
 if ($_POST) {
 
 	unset($input_errors);
-	$pconfig = $_POST;
 	/*	run through $_POST items encoding HTML entities so that the user
 	 *	cannot think he is slick and perform a XSS attack on the unwilling
 	 */
@@ -161,6 +160,8 @@ if ($_POST) {
 		$_POST['dstmask'] = 32;
 		$_POST['dsttype'] = "single";
 	}
+
+	$pconfig = $_POST;
 
 	/* For external, user can enter only ip's */
 	if (($_POST['external'] && !is_ipaddr($_POST['external']))) {
@@ -276,6 +277,11 @@ function build_srctype_list() {
 function srctype_selected() {
 	global $pconfig;
 
+	if ($pconfig['srctype']) {
+		// The rule type came from the $_POST array, after input errors, so keep it.
+		return $pconfig['srctype'];
+	}
+
 	$sel = is_specialnet($pconfig['src']);
 
 	if (!$sel) {
@@ -336,6 +342,11 @@ function build_dsttype_list() {
 
 function dsttype_selected() {
 	global $pconfig;
+
+	if ($pconfig['dsttype']) {
+		// The rule type came from the $_POST array, after input errors, so keep it.
+		return $pconfig['dsttype'];
+	}
 
 	$sel = is_specialnet($pconfig['dst']);
 


### PR DESCRIPTION
1) Edit a NAT 1:1 rule, change the source and/or destination type to "Network", but do not input any network address/mask.
2) Press Save, input errors are reported telling that the network source and/or destination address/mask is required - good.
However, the source and/or destination type is no longer "Network" - it defaults back to single or any.

To fix, firstly move "$pconfig = $_POST" to after where all the various special things have been done to $_POST - this makes $pconfig have the correctly-massaged stuff that the user $_POSTed.

Then add the special code to srctype_selected() and dsttype_selected() to handle the case when these have been specifically $_POSTed by the user (rather than inferring them from the src/dst vales and the logic in is_specialnet() ).

This is equivalent to the fix for firewall_rules_edit.php at commit https://github.com/pfsense/pfsense/commit/81e2aa253a946b36a92e88f19b8761efe771b7a1