### PR TITLE
Fix #6224 NAT edit - preserve user selections when input errors

### DIFF
--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -1236,7 +1236,13 @@ events.push(function() {
 
 	hideSource(!srcenabled);
 	ext_change();
+<?php
+if (!$_POST) {
+?>
 	dst_change($('#interface').val(),'<?=htmlspecialchars($pconfig['interface'])?>','<?=htmlspecialchars($pconfig['dst'])?>');
+<?php
+}
+?>
 	iface_old = $('#interface').val();
 	typesel_change();
 	proto_change();


### PR DESCRIPTION
1) Edit a NAT Port Forward rule, change the destination type to "Network", but do not input any network address/mask.
2) Press Save, an input error is reported telling that the network destination address/mask is required - good.
    However, the destination type is no longer "Network" - it goes to "xxx address" where "xxx" is the selected interface.

The problem is that JS dst_change() is being called on every page load. That is good when starting a new entry (the Destination gets set to WAN address to match the default interface of WAN), or when starting to edit an existing entry (the code runs without messing anything up). But when data has been $_POSTed and there are input errors, we just want to redisplay whatever the user had selected, not go trying to fix up correlations between fields.