### PR TITLE
Feature #3151 Disable gateway monitoring actions

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -115,7 +115,9 @@ function start_dpinger($gateway) {
 	$params .= "-B {$gateway['gwifip']} ";	/* Bind src address */
 	$params .= "-p {$pidfile} ";		/* PID filename */
 	$params .= "-u {$socket} ";		/* Status Socket */
-	$params .= "-C \"{$alarm_cmd}\" ";	/* Command to run on alarm */
+	if (!$gateway['action_disable']) {
+		$params .= "-C \"{$alarm_cmd}\" ";	/* Command to run on alarm */
+	}
 
 	$params .= "-d " .
 	    (isset($gateway['data_payload']) && is_numeric($gateway['data_payload'])
@@ -298,7 +300,7 @@ function setup_gateways_monitor() {
 	return;
 }
 
-function get_dpinger_status($gwname) {
+function get_dpinger_status($gwname, $detailed = false) {
 	global $g;
 
 	$running_processes = running_dpinger_processes();
@@ -368,9 +370,18 @@ function get_dpinger_status($gwname) {
 			}
 		}
 
-		if ($r['latency_avg'] > $settings['latencyhigh'] ||
-		    $r['loss'] > $settings['losshigh']) {
-			$r['status'] = "down";
+		if ($r['latency_avg'] > $settings['latencyhigh']) {
+			if ($detailed) {
+				$r['status'] = "highdelay";
+			} else {
+				$r['status'] = "down";
+			}
+		} else if ($r['loss'] > $settings['losshigh']) {
+			if ($detailed) {
+				$r['status'] = "highloss";
+			} else {
+				$r['status'] = "down";
+			}
 		} else if ($r['latency_avg'] > $settings['latencylow']) {
 			$r['status'] = "delay";
 		} else if ($r['loss'] > $settings['losslow']) {
@@ -391,7 +402,11 @@ function return_gateways_status($byname = false) {
 	$gateways_arr = return_gateways_array();
 
 	foreach ($dpinger_gws as $gwname => $gwdata) {
-		$dpinger_status = get_dpinger_status($gwname);
+		// If action is disabled for this gateway, then we want a detailed status.
+		// That reports "highdelay" or "highloss" rather than just "down".
+		// Because reporting the gateway down would be misleading (gateway action is disabled)
+		$detailed = $gateways_arr[$gwname]['action_disable'];
+		$dpinger_status = get_dpinger_status($gwname, $detailed);
 		if ($dpinger_status === false) {
 			continue;
 		}
@@ -525,6 +540,10 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 				$gateway['monitor_disable'] = true;
 			} else if (empty($gateway['monitor'])) {
 				$gateway['monitor'] = $gateway['gateway'];
+			}
+
+			if (isset($gateway['action_disable'])) {
+				$gateway['action_disable'] = true;
 			}
 
 			$gateway['friendlyiface'] = $gateway['interface'];
@@ -808,13 +827,13 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 		if (($gwsttng['ipprotocol'] == $ipprotocol) && isset($gwsttng['defaultgw'])) {
 			$dfltgwfound = true;
 			$dfltgwname = $gwname;
-			if (!isset($gwsttng['monitor_disable']) && $gateways_status[$gwname]['status'] != "none") {
+			if (!isset($gwsttng['monitor_disable']) && !isset($gwsttng['action_disable']) && $gateways_status[$gwname]['status'] != "none") {
 				$dfltgwdown = true;
 			}
 		}
 		/* Keep a record of the last up gateway */
 		/* XXX: Blacklist lan for now since it might cause issues to those who have a gateway set for it */
-		if (empty($upgw) && ($gwsttng['ipprotocol'] == $ipprotocol) && (isset($gwsttng['monitor_disable']) || $gateways_status[$gwname]['status'] == "none") && $gwsttng[$gwname]['friendlyiface'] != "lan") {
+		if (empty($upgw) && ($gwsttng['ipprotocol'] == $ipprotocol) && (isset($gwsttng['monitor_disable']) || isset($gwsttng['action_disable']) || $gateways_status[$gwname]['status'] == "none") && $gwsttng[$gwname]['friendlyiface'] != "lan") {
 			$upgw = $gwname;
 		}
 		if ($dfltgwdown == true && !empty($upgw)) {
@@ -943,7 +962,7 @@ function return_gateway_groups_array() {
 							notify_via_smtp($msg);
 						}
 					}
-				} else if (isset($gateways_arr[$gwname]['monitor_disable'])) {
+				} else if (isset($gateways_arr[$gwname]['monitor_disable']) || isset($gateways_arr[$gwname]['action_disable'])) {
 					$tiers[$tier][] = $gwname;
 				}
 			}

--- a/src/usr/local/www/status_gateways.php
+++ b/src/usr/local/www/status_gateways.php
@@ -127,9 +127,15 @@ display_top_tabs($tab_array);
 					} elseif (stristr($status['status'], "down")) {
 						$online = gettext("Offline");
 						$bgcolor = "bg-danger";
+					} elseif (stristr($status['status'], "highloss")) {
+						$online = gettext("Danger, Packetloss") . ': ' . $status['loss'];
+						$bgcolor = "bg-danger";
 					} elseif (stristr($status['status'], "loss")) {
 						$online = gettext("Warning, Packetloss") . ': ' . $status['loss'];
 						$bgcolor = "bg-warning";
+					} elseif (stristr($status['status'], "highdelay")) {
+						$online = gettext("Danger, Latency") . ': ' . $status['delay'];
+						$bgcolor = "bg-danger";
 					} elseif (stristr($status['status'], "delay")) {
 						$online = gettext("Warning, Latency") . ': ' . $status['delay'];
 						$bgcolor = "bg-warning";

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -83,6 +83,7 @@ if (isset($id) && $a_gateways[$id]) {
 	$pconfig['losshigh'] = $a_gateways[$id]['losshigh'];
 	$pconfig['monitor'] = $a_gateways[$id]['monitor'];
 	$pconfig['monitor_disable'] = isset($a_gateways[$id]['monitor_disable']);
+	$pconfig['action_disable'] = isset($a_gateways[$id]['action_disable']);
 	$pconfig['data_payload'] = $a_gateways[$id]['data_payload'];
 	$pconfig['nonlocalgateway'] = isset($a_gateways[$id]['nonlocalgateway']);
 	$pconfig['descr'] = $a_gateways[$id]['descr'];
@@ -428,6 +429,9 @@ if ($_POST) {
 		if ($_POST['monitor_disable'] == "yes") {
 			$gateway['monitor_disable'] = true;
 		}
+		if ($_POST['action_disable'] == "yes") {
+			$gateway['action_disable'] = true;
+		}
 		if ($_POST['nonlocalgateway'] == "yes") {
 			$gateway['nonlocalgateway'] = true;
 		}
@@ -643,6 +647,13 @@ $section->addInput(new Form_Checkbox(
 	'Disable Gateway Monitoring',
 	$pconfig['monitor_disable']
 ))->toggles('.toggle-monitor-ip')->setHelp('This will consider this gateway as always being up.');
+
+$section->addInput(new Form_Checkbox(
+	'action_disable',
+	'Gateway Action',
+	'Disable Gateway Monitoring Action',
+	$pconfig['action_disable']
+))->setHelp('No action will be taken on gateway events. The gateway is always considered up.');
 
 $group = new Form_Group('Monitor IP');
 $group->addClass('toggle-monitor-ip', 'collapse');

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -220,9 +220,15 @@ function compose_table_body_contents() {
 			} elseif (stristr($gateways_status[$gname]['status'], "down")) {
 				$online = gettext("Offline");
 				$bgcolor = "danger";  // lightcoral
+			} elseif (stristr($gateways_status[$gname]['status'], "highloss")) {
+				$online = gettext("Packetloss");
+				$bgcolor = "danger";  // lightcoral
 			} elseif (stristr($gateways_status[$gname]['status'], "loss")) {
 				$online = gettext("Packetloss");
 				$bgcolor = "warning";  // khaki
+			} elseif (stristr($gateways_status[$gname]['status'], "highdelay")) {
+				$online = gettext("Latency");
+				$bgcolor = "danger";  // lightcoral
 			} elseif (stristr($gateways_status[$gname]['status'], "delay")) {
 				$online = gettext("Latency");
 				$bgcolor = "warning";  // khaki


### PR DESCRIPTION
without disabling gateway monitoring.

This allows the user to continue to monitor the gateway with dpinger, so
they can see how it is performing, but for the system not to take any
real action if the latency/loss exceeds the given limits.

A typical use case for this would be on a single-WAN system. There is no
failover option, so there is no point taking any real action when the
latency/loss is high. Having stuff try to failover (and stop/start
stuff...) is just disruptive.

In this case the user could have disabled monitoring completely, but then
they get no feedback abut gateway performance.