### PR TITLE
Specify IP to set for zoneedit

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -485,7 +485,7 @@
 					if ($this->_dnsPort) {
 						$port = ":" . $this->_dnsPort;
 					}
-					curl_setopt($ch, CURLOPT_URL, "{$server}{$port}?host=" .$this->_dnsHost);
+					curl_setopt($ch, CURLOPT_URL, "{$server}{$port}?host=" . $this->_dnsHost . '&dnsto=' . $this->_dnsIP);
 					break;
 				case 'dyns':
 					$needsIP = FALSE;


### PR DESCRIPTION
Documentation of the zoneedit dynamic DNS change API:
https://support.zoneedit.com/Knowledgebase/Article/View/4/1/changes-to-dynamic-dns

Format is:
https://dynamic.zoneedit.com/auth/dynamic.html?host=<your_hostname>&dnsto=<your_ip>

The dyndns.class code for "zoneedit" does not specify "dnsto" at all. So I guess Zoneedit will be assuming the IP address that the request came from, which will be whatever is the current default gateway of pfSense - which probably works OK for ordinary failover of a primary to secondary, but not when the user wants the dynamic DNS name to point to something else.

This is a possible fix for Redmine 6992. It needs testing by someone with the relevant configuration and Zoneedit account, e.g. the OP of the issue.
https://redmine.pfsense.org/issues/6992
