### PR TITLE
Added dhcp6c no-release and user configurable DUID

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3865,6 +3865,10 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 		return;
 	}
 
+	if (file_exists("/conf/dhcp6c_duid")) { // Using user defined DUID.
+		exec("cp -f /conf/dhcp6c_duid /var/db/");
+	}
+	
 	$wanif = get_real_interface($interface, "inet6");
 	$dhcp6cconf = "";
 
@@ -3974,10 +3978,11 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 		$rtsoldscript .= "/bin/sleep 1\n";
 	}
 	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
+	$noreleaseOption = isset($wancfg['dhcp6norelease']) ? "-n" : "";
 
 	/* add the start of dhcp6c to the rtsold script if we are going to wait for ra */
 	if (!isset($wancfg['dhcp6withoutra'])) {
-		$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
+		$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} {$noreleaseOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
 		$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
 	}
 	/* Add wide-dhcp6c shell script here. Because we can not pass a argument to it. */
@@ -4003,7 +4008,7 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	if (isset($wancfg['dhcp6withoutra'])) {
 		kill_dhcp6client_process($wanif);
 
-		mwexec("/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
+		mwexec("/usr/local/sbin/dhcp6c {$debugOption} {$noreleaseOption} -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
 		mwexec("/usr/bin/logger -t info 'Starting dhcp6 client for interface wan({$wanif} in DHCP6 without RA mode)'");
 	}
 	mwexec("/usr/sbin/rtsold -1 -p {$g['varrun_path']}/rtsold_{$wanif}.pid -O {$g['varetc_path']}/rtsold_{$wanif}_script.sh {$wanif}");

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1000,7 +1000,21 @@ function is_macaddr($macaddr) {
 
 	return true;
 }
-
+/* returns true if $ddhcp6duid is a valid duid entrry */
+function is_duid($dhcp6duid) {
+	$values = explode(":", $dhcp6duid);
+	if (count($values) != 16) {
+		return false;
+	}
+	for ($i = 0; $i < 16; $i++) {
+		if (ctype_xdigit($values[$i]) == false)
+			return false;
+		if (hexdec($values[$i]) < 0 || hexdec($values[$i]) > 255)
+			return false;
+	}
+	write_dhcp6_duid($dhcp6duid);
+	return true;
+}
 /*
 	If $return_message is true then
 		returns a text message about the reason that the name is invalid.
@@ -2474,5 +2488,21 @@ function get_smart_drive_list() {
 	sort($disk_list);
 	return $disk_list;
 }
+/* Write the DHCP6 DUID file */
 
+function write_dhcp6_duid($dhcp6duid) {
+	// Create the hex array from the dhcp6duid config entry and write to file
+
+	$temp = str_replace(":","",$dhcp6duid);
+	$duid_binstring = pack("H*",$temp);
+	if ($fd = fopen("/conf/dhcp6c_duid", "wB")){
+		fwrite($fd, $duid_binstring);
+		fclose($fd);
+		return 1;
+	}
+	else {
+		log_error(gettext("Error: cannot open duidfile for writing."));
+		return 1;
+	}
+}
 ?>


### PR DESCRIPTION
dhcp6c no-release requires modified WIDE-DHCP6.

Configurable DUID creates dhcp6_duid and stores it in /conf. On dhcp6
configure it copies that file, if it exists, to var/db. This also
corrects a problem with the duid being lost if using a RAM disk.