### PR TITLE
Do NOT block DHCP traffic with DHCP Relay enabled (Bug #4558, Bug #6996)

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -3397,6 +3397,7 @@ EOD;
 				}
 				/* allow access to DHCP relay on interfaces */
 				if (isset($config['dhcrelay']['enable'])) {
+					$dhcrelaycfg =& $config['dhcrelay'];
 					$dhcifaces = explode(",", $dhcrelaycfg['interface']);
 					foreach ($dhcifaces as $dhcrelayif) {
 						if ($dhcrelayif == $on) {

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -3397,8 +3397,7 @@ EOD;
 				}
 				/* allow access to DHCP relay on interfaces */
 				if (isset($config['dhcrelay']['enable'])) {
-					$dhcrelaycfg =& $config['dhcrelay'];
-					$dhcifaces = explode(",", $dhcrelaycfg['interface']);
+					$dhcifaces = explode(",", $config['dhcrelay']['interface']);
 					foreach ($dhcifaces as $dhcrelayif) {
 						if ($dhcrelayif == $on) {
 							$ipfrules .= <<<EOD


### PR DESCRIPTION
The traffic is getting blocked since $dhcrelaycfg is nowhere defined.