### PR TITLE
Improve input validation for services_dhcp_relay

### DIFF
--- a/src/usr/local/www/services_dhcp_relay.php
+++ b/src/usr/local/www/services_dhcp_relay.php
@@ -38,6 +38,7 @@ if (empty($config['dhcrelay']['interface'])) {
 }
 
 $pconfig['agentoption'] = isset($config['dhcrelay']['agentoption']);
+$pconfig['server'] = $config['dhcrelay']['server'];
 
 $iflist = array_intersect_key(
 	get_configured_interface_with_descr(),
@@ -82,17 +83,22 @@ if ($_POST) {
 
 		if ($_POST['server']) {
 			foreach ($_POST['server'] as $checksrv => $srv) {
-				if (!is_ipaddr($srv[0])) {
-					$input_errors[] = gettext("A valid Destination Server IP address must be specified.");
-				}
-
 				if (!empty($srv[0])) { // Filter out any empties
+					if (!is_ipaddr($srv[0])) {
+						$input_errors[] = sprintf(gettext("Destination Server IP address %s is not a valid IP address."), $srv[0]);
+					}
+
 					if (!empty($svrlist)) {
 						$svrlist .= ',';
 					}
 
 					$svrlist .= $srv[0];
 				}
+			}
+
+			// Check that the user input something in one of the Destination Server fields
+			if (empty($svrlist)) {
+				$input_errors[] = gettext("At least one Destination Server IP address must be specified.");
 			}
 		}
 	}
@@ -114,8 +120,6 @@ if ($_POST) {
 		filter_configure();
 	}
 }
-
-$pconfig['server'] = $config['dhcrelay']['server'];
 
 $pgtitle = array(gettext("Services"), gettext("DHCP Relay"));
 $shortcut_section = "dhcp";


### PR DESCRIPTION
While looking at interactions between DHCP Relay and DHCP Server, I noticed a few annoying/inconsistent things in driving the UI:
1) If there were validation errors on the Destination Server IP Addresses that the user input, messages would be given about invalid addresses but the data in the Destination Server row(s) would be reset to what it was before the user started editing, losing whatever they changes they had been trying to make so far.
2) Empty rows would be reported as errors. The code already did some ignoring of empty rows, but not entirely successfully.
This change:
a) Reports which IP addresses were invalid
b) Preserves the data that the user tried to enter, so they can correct it and try again.
c) Ignores any empty rows, only reporting an error if all the rows are empty.