### PR TITLE
Fix for garbled serial console on PC Engines APU2

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1096,7 +1096,8 @@ function setup_serial_port($when = "save", $path = "") {
 	$specific_platform = system_identify_specific_platform();
 	if ($specific_platform['name'] == 'RCC-VE' ||
 	    $specific_platform['name'] == 'RCC' ||
-	    $specific_platform['name'] == 'RCC-DFF') {
+	    $specific_platform['name'] == 'RCC-DFF' ||
+	    $specific_platform['name'] == 'apu2') {
 		$serial_only = true;
 	}
 

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2214,6 +2214,9 @@ function system_identify_specific_platform() {
 		case 'SYS-5018D-FN4T':
 			return (array('name' => 'XG-1540', 'descr' => 'Super Micro XG-1540'));
 			break;
+		case 'apu2':
+			return (array('name' => 'apu2', 'descr' => 'PC Engines APU2'));
+			break;
 		case 'Virtual Machine':
 			if ($maker[0] == "Microsoft Corporation") {
 				return (array('name' => 'Hyper-V', 'descr' => 'Hyper-V Virtual Machine'));


### PR DESCRIPTION
The PC Engines APU2 board is a popular platform for pfSense.  When testing the latest pfSense 2.4 beta on this device, I found that the serial console output was garbled during both the boot block and boot loader phases.  A garbled console during the boot loader makes the boot menu and loader prompt both largely unusable and limits recovery options.  Once the kernel is loaded, however, console output is OK until reboot.

Here is a sample of the garbled output:
```
  /                                    _ _   _ _ _ _                                                      
                          _   _ _     /   _ /   _ _ _ |     _ _ _   _   _ _     _ _ _     _ _ _            
                         |   ' _   \ |   | _ \ _ _ _   \   /   _   \   ' _   \ /   _ _ | /   _   \          
                          |   | _ )   |     _ | _ _ _ )   |     _ _ /   |   |   \ _ _   \     _ _ /          
                           |   . _ _ / | _ |   | _ _ _ _ /   \ _ _ _ | _ |   | _ | _ _ _ / \ _ _ _ |          
                            | _ |                                                                              
                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                             
              WWeellccoommee  ttoo  ppffSSeennssee = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =                                                                                                                   
                                                                                                                                                                                                                  | |                        
| |.. B o o t   M u l t i   U s e r   [ E n t e r ] ]                                                                                                                                                              | |                       
1  .. B o o t   [ S ] i n g l e   U s e r r \                                                                                                                                                                       | |                      
2  .. [ E s c ] a p e   t o   l o a d e r   p r o m p t t                                                                                                                                                            | |                     
3  .. R e b o o t t         \                 /                                 l   p o r t                                                                                                                           | |                    
4     |       /       p       \ _ _ _ _ _ _ /     S e n s e e                                                                                                                                                          | |                   
     | |      \               /             \                                                                                                                                                                           | |                  
O p.. [ K ] e r n e l :   k e r n e l   ( 1   o f   2 ) )                                                                                                                                                                | |                 
5  .. C o n f i g u r e   B o o t   [ O ] p t i o n s . . . .                                                                                                                                                             | |                
6  .. S e l e c t   B o o t   [ E ] n v i r o n m e n t . . . .                                                                                                                                                            | |               
7        | |                                                                                                                                                                                                                | |              
          | |                                                                                                                                                                                                                | |             
           | |                             + +                |                 ,   R e v i s i o n   1 . 1 1                                                                                                                 ++             
= =                                                                               =                                                                                                                                                          
A u t o b o o t   i n   9   s e c o n d s .   [ S p a c e ]   t o   p a u s e e 0 8 : 0 4 : 3 3   C D T   2 0 1 6 ) )
//\                      H                                                      J
LLo a d i n g   / b o o t / d e f a u l t s / l o a d e r . c o n f f
 earching bootorder for: HALT
||-ve 0x000f2e90: PCHS=16383/16/63 translation=lba LCHS=1024/255/63 s=31277232
Space available for UMB: c1000-ef000, f0000-f2e90
Returned 262144 bytes of ZoneHigh
e820 map has 7 items:
  0: 0000000000000000 - 000000000009f800 = 1 RAM
  1: 000000000009f800 - 00000000000a0000 = 2 RESERVED
  2: 00000000000f0000 - 0000000000100000 = 2 RESERVED
  3: 0000000000100000 - 00000000dffae000 = 1 RAM
  4: 00000000dffae000 - 00000000e0000000 = 2 RESERVED
  5: 00000000f8000000 - 00000000fc000000 = 2 RESERVED
  6: 0000000100000000 - 000000011f000000 = 1 RAM
enter handle_19:
  NULL
Booting from Hard Disk...
Booting from 0000:7c00
//bboooott//ccoonnffiigg::  --SS111155220000  --DD



//

```

Given the pattern of either a doubling of the expected characters or double-wide spacing of the expected characters, my hypothesis is that the APU2's BIOS is trying to "helpfully" perform video console redirection to the serial port at the same time that pfSense is trying to "helpfully" send dual console output to both the serial and video consoles.  This results in a doubling of the serial console output up until the point that the kernel takes over and stops relying on BIOS functions for console output.  I checked the BIOS setup and found no options to disable or otherwise control this board's apparent video console redirection behavior.  For what it's worth, I also verified that my terminal program's local echo feature was off.

Changing pfSense from dual serial/video console output to serial-only console output solves the problem.  To this end, I added the APU2 to the existing `system_identify_specific_platform()` function, and then added its platform name to the list of serial-only hardware in `setup_serial_port()`.