### PR TITLE
dhcpv6_pd_str_help add default case

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3019,18 +3019,19 @@ function dhcpv6_pd_str_help($pdlen) {
 		$result = '::x:xxxx:xxxx:xxxx:xxxx';
 		break;
 	/*
-	 * XXX 63, 62 and 61 should use same mask of 60 but it would
-	 * we let user chose this bit it can end up out of PD network
+	 * XXX 63, 62 and 61 should use same mask as 60 but if
+	 * we let the user choose this bit it can end up out of PD network
 	 *
-	 * Leave this with the same of 64 for now until we find a way to
-	 * let user chose it. The side-effect is users with PD with one
-	 * of these lengths will not be able to setup DHCP server range
+	 * Leave this with the same as 64 for now until we find a way to
+	 * let the user choose it. The side-effect is users with PD with one
+	 * of these lengths will not be able to setup DHCP server ranges
 	 * for full PD size, only for last /64 network
 	 */
 	case 61:
 	case 62:
 	case 63:
 	case 64:
+	default:
 		$result = '::xxxx:xxxx:xxxx:xxxx';
 		break;
 	}


### PR DESCRIPTION
When the interface concerned does not yet have its details known (e.g. Track Interface values from upstream have not come yet) then we might as well at least give the caller some reasonable text.
e.g. I was adding V6 Static Mappings on an interface that has "Track Interface" and no IPv6 delegation yet. The error message that tries to tell me the type of input I need to put or the static IP offset had no example at all.