### PR TITLE
Status DHCP Leases show CID and other enhancements

### DIFF
--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -275,25 +275,33 @@ if (count($pools) > 0) {
 	asort($pools);
 }
 
+$got_cid = false;
+
 foreach ($config['interfaces'] as $ifname => $ifarr) {
 	if (is_array($config['dhcpd'][$ifname]) &&
 	    is_array($config['dhcpd'][$ifname]['staticmap'])) {
 		$staticmap_array_index = 0;
 		foreach ($config['dhcpd'][$ifname]['staticmap'] as $static) {
-			$slease = array();
-			$slease['ip'] = $static['ipaddr'];
-			$slease['type'] = $static_string;
-			$slease['mac'] = $static['mac'];
-			$slease['if'] = $ifname;
-			$slease['start'] = "";
-			$slease['end'] = "";
-			$slease['hostname'] = htmlentities($static['hostname']);
-			$slease['descr'] = htmlentities($static['descr']);
-			$slease['act'] = $static_string;
-			$slease['online'] = in_array(strtolower($slease['mac']), $arpdata_mac) ? $online_string : $offline_string;
-			$slease['staticmap_array_index'] = $staticmap_array_index;
-			$leases[] = $slease;
-			$staticmap_array_index++;
+			if (!empty($static['mac']) || !empty($static['cid'])) {
+				$slease = array();
+				$slease['ip'] = $static['ipaddr'];
+				$slease['type'] = $static_string;
+				if (!empty($static['cid'])) {
+					$slease['cid'] = $static['cid'];
+					$got_cid = true;
+				}
+				$slease['mac'] = $static['mac'];
+				$slease['if'] = $ifname;
+				$slease['start'] = "";
+				$slease['end'] = "";
+				$slease['hostname'] = htmlentities($static['hostname']);
+				$slease['descr'] = htmlentities($static['descr']);
+				$slease['act'] = $static_string;
+				$slease['online'] = in_array(strtolower($slease['mac']), $arpdata_mac) ? $online_string : $offline_string;
+				$slease['staticmap_array_index'] = $staticmap_array_index;
+				$leases[] = $slease;
+				$staticmap_array_index++;
+			}
 		}
 	}
 }
@@ -345,6 +353,14 @@ if (count($pools) > 0) {
 					<th><!-- icon --></th>
 					<th><?=gettext("IP address")?></th>
 					<th><?=gettext("MAC address")?></th>
+<?php
+/* only make CID column when we have one */
+if ($got_cid) {
+?>
+					<th><?=gettext("Client Id")?></th>
+<?php
+}
+?>
 					<th><?=gettext("Hostname")?></th>
 					<th><?=gettext("Description")?></th>
 					<th><?=gettext("Start")?></th>
@@ -358,11 +374,14 @@ if (count($pools) > 0) {
 <?php
 $dhcp_leases_subnet_counter = array(); //array to sum up # of leases / subnet
 $iflist = get_configured_interface_with_descr(); //get interface descr for # of leases
+$no_leases_displayed = true;
 
 foreach ($leases as $data):
 	if ($data['act'] != $active_string && $data['act'] != $static_string && $_GET['all'] != 1) {
 		continue;
 	}
+
+	$no_leases_displayed = false;
 
 	if ($data['act'] == $active_string) {
 		/* Active DHCP Lease */
@@ -422,6 +441,14 @@ foreach ($leases as $data):
 							(<?=$mac_man[$mac_hi]?>)
 						<?php endif; ?>
 					</td>
+<?php
+/* only make CID column when we have one */
+if ($got_cid) {
+?>
+					<td><?=$data['cid']?></td>
+<?php
+}
+?>
 					<td><?=$data['hostname']?></td>
 					<td><?=$data['descr']?></td>
 					<? if ($data['type'] != "static"): ?>
@@ -450,6 +477,12 @@ foreach ($leases as $data):
 					</td>
 				</tr>
 <?php endforeach; ?>
+<?php if ($no_leases_displayed): ?>
+				<tr>
+					<td></td>
+					<td><?=gettext("No leases to display")?></td>
+				</tr>
+<?php endif; ?>
 			</tbody>
 		</table>
 	</div>
@@ -469,6 +502,7 @@ foreach ($leases as $data):
 			</thead>
 			<tbody>
 <?php
+if (count($dhcp_leases_subnet_counter)) {
 	ksort($dhcp_leases_subnet_counter);
 	foreach ($dhcp_leases_subnet_counter as $listcounters):
 ?>
@@ -478,7 +512,16 @@ foreach ($leases as $data):
 					<td><?=$listcounters['to']?></td>
 					<td><?=$listcounters['count']?></td>
 				</tr>
-<?php endforeach; ?>
+<?php
+	endforeach;
+} else {
+?>
+				<tr>
+					<td><?=gettext("No leases are in use")?></td>
+				</tr>
+<?php
+	}
+?>
 			</tbody>
 		</table>
 	</div>

--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -502,7 +502,7 @@ if ($got_cid) {
 			</thead>
 			<tbody>
 <?php
-if (count($dhcp_leases_subnet_counter)) {
+if (count($dhcp_leases_subnet_counter)):
 	ksort($dhcp_leases_subnet_counter);
 	foreach ($dhcp_leases_subnet_counter as $listcounters):
 ?>
@@ -514,14 +514,12 @@ if (count($dhcp_leases_subnet_counter)) {
 				</tr>
 <?php
 	endforeach;
-} else {
+else:
 ?>
 				<tr>
 					<td><?=gettext("No leases are in use")?></td>
 				</tr>
-<?php
-	}
-?>
+<?php endif; ?>
 			</tbody>
 		</table>
 	</div>


### PR DESCRIPTION
1) If there is a Client Id specified then show it (otherwise it is possible to define a Static Mapping that has only Client Id and all other fields empty, which would look like an empty row in the displayed table).
2) Ignore empty static lease entries - when an interface has no static mappings the "static" section of the DHCP server settings can be "" which was resulting in a single-element that was empty being displayed as an empty row.
3) If there are no leases to display, then make a row with the message "No leases to display" so the user knows the system at least tried.
4) If there are no leases in use, then make a row with the message "No leases are in use" so the user knows the system at least tried.