### PR TITLE
Nuke outdated hint about scponly install

### DIFF
--- a/src/etc/inc/priv/user.priv.inc
+++ b/src/etc/inc/priv/user.priv.inc
@@ -44,10 +44,7 @@ $priv_list['user-shell-access']['descr'] = gettext("Indicates whether the user i
 
 $priv_list['user-copy-files'] = array();
 $priv_list['user-copy-files']['name']  = gettext("User - System: Copy files (scp)");
-$priv_list['user-copy-files']['descr'] = gettext("Indicates whether the user is allowed to copy files ".
-										 "onto the {$g['product_name']} appliance via SCP/SFTP. ".
-										 "To use this privilege, scponly must be installed ".
-										 "on the appliance (Hint: pkg_add -r scponly).");
+$priv_list['user-copy-files']['descr'] = gettext("Indicates whether the user is allowed to copy files onto the {$g['product_name']} appliance via SCP/SFTP");
 
 $priv_list['user-ssh-tunnel'] = array();
 $priv_list['user-ssh-tunnel']['name']  = gettext("User - System: SSH tunneling");


### PR DESCRIPTION
Apparently installed by default on 2.3+, additionally the command is wrong.