### PR TITLE
validateipaddr enhance flexibility for translation

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2490,11 +2490,11 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 				if (is_alias($addr)) {
 					return true;
 				} else {
-					$err_msg[] = $label . gettext(" must be a valid IPv4 address or alias.");
+					$err_msg[] = sprintf(gettext("%s must be a valid IPv4 address or alias."), $label);
 					return false;
 				}
 			} else {
-				$err_msg[] = $label . gettext(" must be a valid IPv4 address.");
+				$err_msg[] = sprintf(gettext("%s must be a valid IPv4 address."), $label);
 				return false;
 			}
 		break;
@@ -2506,11 +2506,11 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 				if (is_alias($addr)) {
 					return true;
 				} else {
-					$err_msg[] = $label . gettext(" must be a valid IPv6 address or alias.");
+					$err_msg[] = sprintf(gettext("%s must be a valid IPv6 address or alias."), $label);
 					return false;
 				}
 			} else {
-				$err_msg[] = $label . gettext(" must be a valid IPv6 address.");
+				$err_msg[] = sprintf(gettext("%s must be a valid IPv6 address."), $label);
 				return false;
 			}
 		break;
@@ -2524,11 +2524,11 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 				if (is_alias($addr)) {
 					return true;
 				} else {
-					$err_msg[] = $label . gettext(" must be a valid IPv4 or IPv6 address or alias.");
+					$err_msg[] = sprintf(gettext("%s must be a valid IPv4 or IPv6 address or alias."), $label);
 					return false;
 				}
 			} else {
-				$err_msg[] = $label . gettext(" must be a valid IPv4 or IPv6 address.");
+				$err_msg[] = sprintf(gettext("%s must be a valid IPv4 or IPv6 address."), $label);
 				return false;
 			}
 		break;


### PR DESCRIPTION
By using sprintf() we can allow for some language where the label text does not fit at the start of the sentence.