### PR TITLE
Add support for chrooted SCP to User Manager

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -474,6 +474,8 @@ function local_user_set(& $user) {
 		$user_shell = "/bin/tcsh";
 	} elseif (userHasPrivilege($user, "user-copy-files")) {
 		$user_shell = "/usr/local/bin/scponly";
+	} elseif (userHasPrivilege($user, "user-copy-files-chroot")) {
+		$user_shell = "/usr/local/sbin/scponlyc";
 	} elseif (userHasPrivilege($user, "user-ssh-tunnel")) {
 		$user_shell = "/usr/local/sbin/ssh_tunnel_shell";
 	} elseif (userHasPrivilege($user, "user-ipsec-xauth-dialin")) {

--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -472,10 +472,10 @@ function local_user_set(& $user) {
 	/* Cases here should be ordered by most privileged to least privileged. */
 	if (userHasPrivilege($user, "user-shell-access") || userHasPrivilege($user, "page-all")) {
 		$user_shell = "/bin/tcsh";
-	} elseif (userHasPrivilege($user, "user-copy-files")) {
-		$user_shell = "/usr/local/bin/scponly";
 	} elseif (userHasPrivilege($user, "user-copy-files-chroot")) {
 		$user_shell = "/usr/local/sbin/scponlyc";
+	} elseif (userHasPrivilege($user, "user-copy-files")) {
+		$user_shell = "/usr/local/bin/scponly";
 	} elseif (userHasPrivilege($user, "user-ssh-tunnel")) {
 		$user_shell = "/usr/local/sbin/ssh_tunnel_shell";
 	} elseif (userHasPrivilege($user, "user-ipsec-xauth-dialin")) {

--- a/src/etc/inc/priv/user.priv.inc
+++ b/src/etc/inc/priv/user.priv.inc
@@ -46,12 +46,19 @@ $priv_list['user-copy-files'] = array();
 $priv_list['user-copy-files']['name']  = gettext("User - System: Copy files (scp)");
 $priv_list['user-copy-files']['descr'] = gettext("Indicates whether this user is allowed to copy files onto the {$g['product_name']} appliance via SCP/SFTP.");
 
+$priv_list['user-copy-files-chroot'] = array();
+$priv_list['user-copy-files-chroot']['name']  = gettext("User - System: Copy files to home directory (chrooted scp)");
+$priv_list['user-copy-files-chroot']['descr'] = gettext("Indicates whether this user is allowed to copy files to the home directory via SCP/SFTP.".
+										"Note: User - System - Copy files (scp) conflicts with this privilege.".
+						       				"Warning: Manual chroot setup required, see /usr/local/etc/rc.d/scponlyc.");
+
 $priv_list['user-ssh-tunnel'] = array();
 $priv_list['user-ssh-tunnel']['name']  = gettext("User - System: SSH tunneling");
 $priv_list['user-ssh-tunnel']['descr'] = gettext("Indicates whether the user is able to login for ".
 										"tunneling via SSH when they have no shell access. ".
-										"Note: User - System - Copy files conflicts with ".
-										"this privilege.");
+										"Note: User - System - Copy files (scp) and ".
+						 				"System: Copy files to home directory (chrooted scp) ".
+										"conflict with this privilege.");
 
 $priv_list['user-ipsec-xauth-dialin'] = array();
 $priv_list['user-ipsec-xauth-dialin']['name'] = gettext("User - VPN: IPsec xauth Dialin");

--- a/src/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
+++ b/src/usr/local/share/locale/en/LC_MESSAGES/pfSense.pot
@@ -3520,8 +3520,20 @@ msgid "User - System: Copy files (scp)"
 msgstr ""
 
 #: src/etc/inc/priv/user.priv.inc:47
-msgid "Indicates whether this user is allowed to copy files onto the %s appliance "
+msgid ""
+"Indicates whether this user is allowed to copy files onto the %s appliance "
 "via SCP/SFTP."
+msgstr ""
+
+#: src/etc/inc/priv/user.priv.inc:50
+msgid "User - System: Copy files to home directory (chrooted scp)"
+msgstr ""
+
+#: src/etc/inc/priv/user.priv.inc:51
+msgid ""
+"Indicates whether this user is allowed to copy files to the home directory via SCP/SFTP."
+"Note: User - System - Copy files (scp) conflicts with this privilege."
+"Warning: Manual chroot setup required, see /usr/local/etc/rc.d/scponlyc."
 msgstr ""
 
 #: src/etc/inc/priv/user.priv.inc:53
@@ -3531,8 +3543,8 @@ msgstr ""
 #: src/etc/inc/priv/user.priv.inc:54
 msgid ""
 "Indicates whether the user is able to login for tunneling via SSH when they "
-"have no shell access. Note: User - System - Copy files conflicts with this "
-"privilege."
+"have no shell access. Note: User - System - Copy files and "
+"System: Copy files to home directory (chrooted scp) conflict with this privilege."
 msgstr ""
 
 #: src/etc/inc/priv/user.priv.inc:60


### PR DESCRIPTION
This makes it possible to assign a chrooted SCP privilege to users, as discussed in Bug #7012. 

NOTE: I'd rather not overcomplicate this given the fact that this is quite a fringe use case, so the chroot setup is left as a manual exercise to admins for now; however there's ```/usr/local/etc/rc.d/scponlyc``` script shipped with the package which should pretty much automate this in case someone needs such setup.