### PR TITLE
Restart unbound after clearing logs (Bug #6915)

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -823,6 +823,7 @@ function clear_all_log_files($restart = false) {
 		system_syslogd_start();
 		killbyname("dhcpd");
 		services_dhcpd_configure();
+		services_unbound_configure(false);
 	}
 	return;
 }

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -822,6 +822,9 @@ function clear_all_log_files($restart = false) {
 	if ($restart) {
 		system_syslogd_start();
 		killbyname("dhcpd");
+		if (!function_exists('services_dhcpd_configure')) {
+			require_once('services.inc');
+		}
 		services_dhcpd_configure();
 		services_unbound_configure(false);
 	}


### PR DESCRIPTION
Restart unbound after clearing logs. No need to restart dhcpd again with unbound since we've done that just above.

Also added a missing include while here.