### PR TITLE
Fix capitalization of confirmation messages for btn-danger buttons an…

### DIFF
--- a/src/usr/local/www/js/pfSense.js
+++ b/src/usr/local/www/js/pfSense.js
@@ -144,7 +144,7 @@ $(function() {
 	// the element value
 	$('.btn-danger, .fa-trash').on('click', function(e){
 		if (!($(this).hasClass('no-confirm'))) {
-			var msg = $.trim(this.textContent);
+			var msg = $.trim(this.textContent).toLowerCase();
 
 			if (!msg)
 				var msg = $.trim(this.value).toLowerCase();


### PR DESCRIPTION
…d fa-trash icons

Value and title were converted to lower case but not textContent. Consequently some pop-up messages included capitalized words, for example in the Log Settings page ("Are you sure you wish to Reset Log Files?").