### PR TITLE
Fix #6927 1:1 NAT validate address family

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2481,14 +2481,20 @@ function get_smart_drive_list() {
 //	$label: the label used by the GUI to display this value. Required to compose an error message
 //	$err_msg: pointer to the callers error message array so that error messages can be added to it here
 //	$alias: are aliases permitted for this address?
+// Returns:
+//	4 - if $addr is a valid IPv4 address
+//	6 - if $addr is a valid IPv6 address
+//	1 - if $alias=true and $addr is an alias
+//	false - otherwise
+
 function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 	switch ($type) {
 		case IPV4:
 			if (is_ipaddrv4($addr)) {
-				return true;
+				return 4;
 			} else if ($alias) {
 				if (is_alias($addr)) {
-					return true;
+					return 1;
 				} else {
 					$err_msg[] = sprintf(gettext("%s must be a valid IPv4 address or alias."), $label);
 					return false;
@@ -2501,10 +2507,10 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 		case IPV6:
 			if (is_ipaddrv6($addr)) {
 				$addr = strtolower($addr);
-				return true;
+				return 6;
 			} else if ($alias) {
 				if (is_alias($addr)) {
-					return true;
+					return 1;
 				} else {
 					$err_msg[] = sprintf(gettext("%s must be a valid IPv6 address or alias."), $label);
 					return false;
@@ -2517,12 +2523,12 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 		case IPV4V6:
 			if (is_ipaddrv6($addr)) {
 				$addr = strtolower($addr);
-				return true;
+				return 6;
 			} else if (is_ipaddrv4($addr)) {
-				return true;
+				return 4;
 			} else if ($alias) {
 				if (is_alias($addr)) {
-					return true;
+					return 1;
 				} else {
 					$err_msg[] = sprintf(gettext("%s must be a valid IPv4 or IPv6 address or alias."), $label);
 					return false;

--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -38,6 +38,10 @@ require_once("shaper.inc");
 
 $referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat_1to1.php');
 
+function get_must_be_both_text() {
+	return(" " . gettext("They must be either both IPv4 or both IPv6 addresses."));
+}
+
 $specialsrcdst = explode(" ", "any pptp pppoe l2tp openvpn");
 $ifdisp = get_configured_interface_with_descr();
 
@@ -163,9 +167,13 @@ if ($_POST) {
 
 	$pconfig = $_POST;
 
+	$extipaddrtype = false;
+	$srcipaddrtype = false;
+	$dstipaddrtype = false;
+
 	/* For external, user can enter only ip's */
-	if (($_POST['external'])) {
-		validateipaddr($_POST['external'], IPV4V6, "External subnet IP", $input_errors, false);
+	if ($_POST['external']) {
+		$extipaddrtype = validateipaddr($_POST['external'], IPV4V6, "External subnet IP", $input_errors, false);
 	}
 
 	/* For dst, if user enters an alias and selects "network" then disallow. */
@@ -175,8 +183,19 @@ if ($_POST) {
 
 	/* For src, user can enter only ips or networks */
 	if (!is_specialnet($_POST['srctype'])) {
-		if (($_POST['src'])) {
-			validateipaddr($_POST['src'], IPV4V6, "Internal address", $input_errors, false);
+		if ($_POST['src']) {
+			$srcipaddrtype = validateipaddr($_POST['src'], IPV4V6, "Internal address", $input_errors, false);
+			if ($srcipaddrtype) {
+				// It is a valid IP address of some address family.
+				// Check that the address family matches the other IP addresses entered.
+				if ($extipaddrtype && ($srcipaddrtype != $extipaddrtype)) {
+					$input_errors[] = sprintf(
+						gettext("The external IP address (%s) and internal IP address (%s) are of different address families.") .
+							get_must_be_both_text(),
+						$_POST['external'],
+						$_POST['src']);
+				}
+			}
 		}
 
 		if (($_POST['srcmask'] && !is_numericint($_POST['srcmask']))) {
@@ -186,8 +205,30 @@ if ($_POST) {
 
 	/* For dst, user can enter ips, networks or aliases */
 	if (!is_specialnet($_POST['dsttype'])) {
-		if (($_POST['dst'])) {
-			validateipaddr($_POST['dst'], IPV4V6, "Destination address", $input_errors, true);
+		if ($_POST['dst']) {
+			$dstipaddrtype = validateipaddr($_POST['dst'], IPV4V6, "Destination address", $input_errors, true);
+			if ($dstipaddrtype == 1) {
+				// It is an alias.
+				// pf does not report "error loading rules" if the address family of items in the alias does not match the external/internal address family.
+				// So that is up to the user to make sensible, we do not try and verify it here.
+			} elseif ($dstipaddrtype) {
+				// It is a valid IP address of some address family.
+				// Check that the address family matches the other IP addresses entered.
+				if ($extipaddrtype && ($dstipaddrtype != $extipaddrtype)) {
+					$input_errors[] = sprintf(
+						gettext("The external IP address (%s) and destination IP address (%s) are of different address families.") .
+							get_must_be_both_text(),
+						$_POST['external'],
+						$_POST['dst']);
+				}
+				if ($srcipaddrtype && ($dstipaddrtype != $srcipaddrtype)) {
+					$input_errors[] = sprintf(
+						gettext("The internal IP address (%s) and destination IP address (%s) are of different address families.") .
+							get_must_be_both_text(),
+						$_POST['src'],
+						$_POST['dst']);
+				}
+			}
 		}
 
 		if (($_POST['dstmask'] && !is_numericint($_POST['dstmask']))) {


### PR DESCRIPTION
Ensure that all the manually-entered addresses come from the same
address family - i.e. they are all either IPv4 or IPv6 addresses.