### PR TITLE
User Configurable DUID

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3867,6 +3867,10 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 
 	$wanif = get_real_interface($interface, "inet6");
 	$dhcp6cconf = "";
+	if (!empty($wancfg['dhcp6-duid']) {
+	// Write the DUID file
+		write_dhcp6_duid($wancfg['dhcp6-duid']));
+	}
 
 	if ($wancfg['adv_dhcp6_config_file_override']) {
 		// DHCP6 Config File Override

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2536,4 +2536,38 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 
 	return false;
 }
+/* returns true if $dhcp6duid is a valid duid entrry */
+function is_duid($dhcp6duid) {
+	$values = explode(":", $dhcp6duid);
+	if (count($values) != 16) {
+		return false;
+	}
+	for ($i = 0; $i < 16; $i++) {
+		if (ctype_xdigit($values[$i]) == false)
+			return false;
+		if (hexdec($values[$i]) < 0 || hexdec($values[$i]) > 255)
+			return false;
+	}
+	return true;
+}
+/* Write the DHCP6 DUID file */
+function write_dhcp6_duid($duidfile) {
+	global $g;
+ 	
+ 	if(is_duid($duidfile))
+ 	{
+ 		$temp = str_replace(":","",$duidfile);
+ 		$duid_binstring = pack("H*",$temp);
+ 		if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "wb")) {
+ 			fwrite($fd, $duid_binstring);
+			fclose($fd);
+ 			return;
+ 		}
+ 		else {
+ 			log_error(gettext("Error: attempting to write DUID file - File write error"));
+ 			return;
+ 		}
+ 	}
+ 	log_error(gettext("Error: attempting to write DUID file - Invalid DUID detected"));
+}
 ?>

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -658,6 +658,7 @@ if ($_POST['apply']) {
 	/* normalize MAC addresses - lowercase and convert Windows-ized hyphenated MACs to colon delimited */
 	$staticroutes = get_staticroutes(true);
 	$_POST['spoofmac'] = strtolower(str_replace("-", ":", $_POST['spoofmac']));
+	$_POST['dhcp6-duid'] = strtolower(str_replace("-", ":", $_POST['dhcp6-duid']));
 	if ($_POST['ipaddr']) {
 		if (!is_ipaddrv4($_POST['ipaddr'])) {
 			$input_errors[] = gettext("A valid IPv4 address must be specified.");
@@ -781,6 +782,9 @@ if ($_POST['apply']) {
 	if (($_POST['spoofmac'] && !is_macaddr($_POST['spoofmac']))) {
 		$input_errors[] = gettext("A valid MAC address must be specified.");
 	}
+	if (($_POST['dhcp6-duid'] && !is_duid($_POST['dhcp6-duid']))) {
+		$input_errors[] = gettext("A valid DUID must be specified.");
+	}	
 	if ($_POST['mtu']) {
 		if (!is_numericint($_POST['mtu'])) {
 			$input_errors[] = "MTU must be an integer.";
@@ -2136,6 +2140,14 @@ $section->addInput(new Form_Checkbox(
 	'Required by some ISPs, especially those not using PPPoE',
 	$pconfig['dhcp6withoutra']
 ));
+$section->addInput(new Form_Input(
+	'dhcp6-duid',
+	'DHCP6 DUID',
+	'text',
+	$pconfig['dhcp6-duid'],
+	['placeholder' => 'xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx']
+	))->setWidth(9)->sethelp('Enter the DUID to use here. If no DUID is entered, dhcp6c will auto generate a new one if one does not exist.' . '<br />' .
+			'Use this option also if using RAM Disk, as the DUID will be lost on reboot. The existing DUID may be found in var/db/dhcp6_duid.');
 $section->addInput(new Form_Input(
 	'adv_dhcp6_config_file_override_path',
 	'Configuration File Override',


### PR DESCRIPTION
Replaces PR #3278

User may enter a DUID in WAN DHCP6 section. DUID validity is checked and
on WAN interface configure the  DUID is written to /var/db/dhcp6c_duid.

This also solves the issue of users using RAM disks who lose the DUID on
reboot.

This PR is identical to PR 3278, just tidied up.