### PR TITLE
1:1 NAT validate address family example

### DIFF
--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -38,6 +38,10 @@ require_once("shaper.inc");
 
 $referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_nat_1to1.php');
 
+function get_must_be_both_text() {
+	return(" " . gettext("They must be either both IPv4 or both IPv6 addresses."));
+}
+
 $specialsrcdst = explode(" ", "any pptp pppoe l2tp openvpn");
 $ifdisp = get_configured_interface_with_descr();
 
@@ -163,9 +167,16 @@ if ($_POST) {
 
 	$pconfig = $_POST;
 
+	$extipaddrtype = false;
+	$srcipaddrtype = false;
+	$dstipaddrtype = false;
+
 	/* For external, user can enter only ip's */
-	if (($_POST['external'])) {
-		validateipaddr($_POST['external'], IPV4V6, "External subnet IP", $input_errors, false);
+	if ($_POST['external']) {
+		$extipaddrtype = is_ipaddr($_POST['external']);
+		if (!$extipaddrtype) {
+			validateipaddr($_POST['external'], IPV4V6, "External subnet IP", $input_errors, false);
+		}
 	}
 
 	/* For dst, if user enters an alias and selects "network" then disallow. */
@@ -175,8 +186,19 @@ if ($_POST) {
 
 	/* For src, user can enter only ips or networks */
 	if (!is_specialnet($_POST['srctype'])) {
-		if (($_POST['src'])) {
-			validateipaddr($_POST['src'], IPV4V6, "Internal address", $input_errors, false);
+		if ($_POST['src']) {
+			$srcipaddrtype = is_ipaddr($_POST['src']);
+			if ($srcipaddrtype) {
+				if ($extipaddrtype && ($srcipaddrtype != $extipaddrtype)) {
+					$input_errors[] = sprintf(
+						gettext("The external IP address (%s) and internal IP address (%s) are of different address families.") .
+							get_must_be_both_text(),
+						$_POST['external'],
+						$_POST['src']);
+				}
+			} else {
+				validateipaddr($_POST['src'], IPV4V6, "Internal address", $input_errors, false);
+			}
 		}
 
 		if (($_POST['srcmask'] && !is_numericint($_POST['srcmask']))) {
@@ -186,8 +208,32 @@ if ($_POST) {
 
 	/* For dst, user can enter ips, networks or aliases */
 	if (!is_specialnet($_POST['dsttype'])) {
-		if (($_POST['dst'])) {
-			validateipaddr($_POST['dst'], IPV4V6, "Destination address", $input_errors, true);
+		if ($_POST['dst']) {
+			if (is_ipaddroralias($_POST['dst'])) {
+				$dstipaddrtype = is_ipaddr($_POST['dst']);
+				if ($dstipaddrtype) {
+					if ($extipaddrtype && ($dstipaddrtype != $extipaddrtype)) {
+						$input_errors[] = sprintf(
+							gettext("The external IP address (%s) and destination IP address (%s) are of different address families.") .
+								get_must_be_both_text(),
+							$_POST['external'],
+							$_POST['dst']);
+					}
+					if ($srcipaddrtype && ($dstipaddrtype != $srcipaddrtype)) {
+						$input_errors[] = sprintf(
+							gettext("The internal IP address (%s) and destination IP address (%s) are of different address families.") .
+								get_must_be_both_text(),
+							$_POST['src'],
+							$_POST['dst']);
+					}
+				} else {
+					// Must be an alias.
+					// pf does not report "error loading rules" if the address family of items in the alias does not match the external/internal address family.
+					// So that is up to the user to make sensible, we do not try and verify it here.
+				}
+			} else {
+				validateipaddr($_POST['dst'], IPV4V6, "Destination address", $input_errors, true);
+			}
 		}
 
 		if (($_POST['dstmask'] && !is_numericint($_POST['dstmask']))) {
@@ -299,7 +345,7 @@ function build_dsttype_list() {
 	global $pconfig, $config, $ifdisp;
 
 	$sel = is_specialnet($pconfig['dst']);
-	$list = array('any' => gettext('Any'), 'single' => gettext('Single host or alias'), 'network' => gettext('Network'));
+	$list = array('any' => gettext('Any'), 'single' => gettext('Single host or alias'), 'network' => gettext('Network'), '(self)' => gettext('This Firewall (self)'));
 
 	if (have_ruleint_access("pppoe")) {
 		$list['pppoe'] = gettext('PPPoE clients');


### PR DESCRIPTION
This is what the code would look like with a simple integration of the validateipaddr() changes. Notice how it still needs to use is_ipaddr() to find out the address family, but then also calls validateipaddr() to make the $input_errors stuff happen.
e.g. lines 176 to 179