### PR TITLE
User Define DUID - Moved to System->Advanced->Networking

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3868,8 +3868,9 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$wanif = get_real_interface($interface, "inet6");
 	$dhcp6cconf = "";
 
-	if (isset($wancfg['dhcp6-duid'])) {
-	// Write the DUID file
+	if (isset($wancfg['dhcp6-duid']) &&
+		!empty($config['system']['global-v6duid'])) { 
+		// Write the DUID file
 		if(!write_dhcp6_duid($config['system']['global-v6duid'])) {
 			log_error(gettext("Failed to write user DUID file!"));
 		}

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3868,6 +3868,13 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$wanif = get_real_interface($interface, "inet6");
 	$dhcp6cconf = "";
 
+	if (isset($wancfg['dhcp6-duid'])) {
+	// Write the DUID file
+		if(!write_dhcp6_duid($config['system']['global-v6duid'])) {
+			log_error(gettext("Failed to write user DUID file!"));
+		}
+	}
+
 	if ($wancfg['adv_dhcp6_config_file_override']) {
 		// DHCP6 Config File Override
 		$dhcp6cconf = DHCP6_Config_File_Override($wancfg, $wanif);

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2536,4 +2536,39 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 
 	return false;
 }
+* returns true if $dhcp6duid is a valid duid entrry */
+function is_duid($dhcp6duid) {
+	$values = explode(":", $dhcp6duid);
+	if (count($values) != 16) {
+		return false;
+	}
+	for ($i = 0; $i < 16; $i++) {
+		if (ctype_xdigit($values[$i]) == false)
+			return false;
+		if (hexdec($values[$i]) < 0 || hexdec($values[$i]) > 255)
+			return false;
+	}
+	return true;
+}
+/* Write the DHCP6 DUID file */
+function write_dhcp6_duid($duidfile) {
+	// Create the hex array from the dhcp6duid config entry and write to file
+	global $g;
+ 	
+ 	if(is_duid($duidfile))
+ 	{
+ 		$temp = str_replace(":","",$duidfile);
+ 		$duid_binstring = pack("H*",$temp);
+ 		if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "wb")) {
+ 			fwrite($fd, $duid_binstring);
+			fclose($fd);
+ 			return;
+ 		}
+ 		else {
+ 			log_error(gettext("Error: attempting to write DUID file - File write error"));
+ 			return;
+ 		}
+ 	}
+ 	log_error(gettext("Error: attempting to write DUID file - Invalid DUID detected"));
+}
 ?>

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2536,7 +2536,8 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 
 	return false;
 }
-* returns true if $dhcp6duid is a valid duid entrry */
+
+/* returns true if $dhcp6duid is a valid duid entrry */
 function is_duid($dhcp6duid) {
 	$values = explode(":", $dhcp6duid);
 	if (count($values) != 16) {
@@ -2550,25 +2551,25 @@ function is_duid($dhcp6duid) {
 	}
 	return true;
 }
+
 /* Write the DHCP6 DUID file */
-function write_dhcp6_duid($duidfile) {
+function write_dhcp6_duid($duid) {
 	// Create the hex array from the dhcp6duid config entry and write to file
 	global $g;
  	
- 	if(is_duid($duidfile))
+ 	if(!is_duid($duid))
  	{
- 		$temp = str_replace(":","",$duidfile);
- 		$duid_binstring = pack("H*",$temp);
- 		if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "wb")) {
- 			fwrite($fd, $duid_binstring);
-			fclose($fd);
- 			return;
- 		}
- 		else {
- 			log_error(gettext("Error: attempting to write DUID file - File write error"));
- 			return;
- 		}
+		log_error(gettext("Error: attempting to write DUID file - Invalid DUID detected"));
+ 		return false;
  	}
- 	log_error(gettext("Error: attempting to write DUID file - Invalid DUID detected"));
+	$temp = str_replace(":","",$duid);
+ 	$duid_binstring = pack("H*",$temp);
+ 	if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "wb")) {
+ 		fwrite($fd, $duid_binstring);
+		fclose($fd);
+ 		return true;
+ 	}
+ 	log_error(gettext("Error: attempting to write DUID file - File write error"));
+	return false;
 }
 ?>

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -1233,7 +1233,7 @@ if ($_POST['apply']) {
 					$wancfg['dhcp6withoutra'] = true;
 				}
 				if ($_POST['dhcp6-duid'] == "yes") {
-					$wancfg['ddhcp6-duid'] = true;
+					$wancfg['dhcp6-duid'] = true;
 				}
 				if (!empty($_POST['adv_dhcp6_interface_statement_send_options'])) {
 					$wancfg['adv_dhcp6_interface_statement_send_options'] = $_POST['adv_dhcp6_interface_statement_send_options'];

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -274,7 +274,6 @@ switch ($wancfg['ipaddrv6']) {
 		$pconfig['type6'] = "slaac";
 		break;
 	case "dhcp6":
-		$pconfig['dhcp6-duid'] = $wancfg['dhcp6-duid'];
 		if (!isset($wancfg['dhcp6-ia-pd-len'])) {
 			$wancfg['dhcp6-ia-pd-len'] = "none";
 		}
@@ -285,6 +284,7 @@ switch ($wancfg['ipaddrv6']) {
 		$pconfig['dhcp6usev4iface'] = isset($wancfg['dhcp6usev4iface']);
 		$pconfig['dhcp6debug'] = isset($wancfg['dhcp6debug']);
 		$pconfig['dhcp6withoutra'] = isset($wancfg['dhcp6withoutra']);
+		$pconfig['dhcp6-duid'] = isset($wancfg['dhcp6-duid']);
 		break;
 	case "6to4":
 		$pconfig['type6'] = "6to4";
@@ -1216,7 +1216,6 @@ if ($_POST['apply']) {
 				break;
 			case "dhcp6":
 				$wancfg['ipaddrv6'] = "dhcp6";
-				$wancfg['dhcp6-duid'] = $_POST['dhcp6-duid'];
 				$wancfg['dhcp6-ia-pd-len'] = $_POST['dhcp6-ia-pd-len'];
 				if ($_POST['dhcp6-ia-pd-send-hint'] == "yes") {
 					$wancfg['dhcp6-ia-pd-send-hint'] = true;
@@ -1230,9 +1229,11 @@ if ($_POST['apply']) {
 				if ($_POST['dhcp6debug'] == "yes") {
 					$wancfg['dhcp6debug'] = true;
 				}
-
 				if ($_POST['dhcp6withoutra'] == "yes") {
 					$wancfg['dhcp6withoutra'] = true;
+				}
+				if ($_POST['dhcp6-duid'] == "yes") {
+					$wancfg['ddhcp6-duid'] = true;
 				}
 				if (!empty($_POST['adv_dhcp6_interface_statement_send_options'])) {
 					$wancfg['adv_dhcp6_interface_statement_send_options'] = $_POST['adv_dhcp6_interface_statement_send_options'];

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -781,6 +781,9 @@ if ($_POST['apply']) {
 	if (($_POST['spoofmac'] && !is_macaddr($_POST['spoofmac']))) {
 		$input_errors[] = gettext("A valid MAC address must be specified.");
 	}
+	if (($_POST['dhcp6-duid'] && ($config['system']['global-v6duid'] == ""))) {
+		$input_errors[] = gettext("No System DUID has been entered.");
+	}
 	if ($_POST['mtu']) {
 		if (!is_numericint($_POST['mtu'])) {
 			$input_errors[] = "MTU must be an integer.";
@@ -2129,6 +2132,12 @@ $section->addInput(new Form_Checkbox(
 	'Debug',
 	'Start DHCP6 client in debug mode',
 	$pconfig['dhcp6debug']
+));
+$section->addInput(new Form_Checkbox(
+	'dhcp6-duid',
+	'Use System DUID',
+	'The DUID defined in System->Advanced->Networking will be used on this interface.',
+	$pconfig['dhcp6-duid']
 ));
 $section->addInput(new Form_Checkbox(
 	'dhcp6withoutra',

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -85,12 +85,15 @@ if ($_POST) {
 			unset($config['system']['prefer_ipv4']);
 		}
 
-		if (($_POST['global-v6duid']) != "") {
-			$_POST['global-v6duid'] = strtolower(str_replace("-", ":", $_POST['global-v6duid']));
-			if (!is_duid($_POST['global-v6duid'])) {
+		if (!empty($_POST['global-v6duid'])) {
+			strtolower(str_replace("-", ":", $_POST['global-v6duid']));
+			if (!is_duid($_POST['global-v6duid']) || strlen($_POST['global-v6duid']) != 47) {
 				$input_errors[] = gettext("A valid DUID must be specified.");
 			} else {
-			$config['system']['global-v6duid'] = $_POST['global-v6duid'];
+			    $config['system']['global-v6duid'] = $_POST['global-v6duid'];
+			}
+		} else {
+			$config['system']['global-v6duid'] = "";
 		}
 
 		if ($_POST['sharednet'] == "yes") {

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -90,9 +90,10 @@ if ($_POST) {
 			if (!is_duid($_POST['global-v6duid']) || strlen($_POST['global-v6duid']) != 47) {
 				$input_errors[] = gettext("A valid DUID must be specified.");
 			} else {
-			    $config['system']['global-v6duid'] = $_POST['global-v6duid'];
+				$config['system']['global-v6duid'] = $_POST['global-v6duid'];
 			}
-		} else {
+		}
+		else {
 			$config['system']['global-v6duid'] = "";
 		}
 

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -40,6 +40,7 @@ require_once("shaper.inc");
 $pconfig['ipv6nat_enable'] = isset($config['diag']['ipv6nat']['enable']);
 $pconfig['ipv6nat_ipaddr'] = $config['diag']['ipv6nat']['ipaddr'];
 $pconfig['ipv6allow'] = isset($config['system']['ipv6allow']);
+$pconfig['global-v6duid'] = $config['system']['global-v6duid'];
 $pconfig['prefer_ipv4'] = isset($config['system']['prefer_ipv4']);
 $pconfig['polling_enable'] = isset($config['system']['polling']);
 $pconfig['sharednet'] = $config['system']['sharednet'];
@@ -82,6 +83,13 @@ if ($_POST) {
 			$config['system']['prefer_ipv4'] = true;
 		} else {
 			unset($config['system']['prefer_ipv4']);
+		}
+
+		$_POST['global-v6duid'] = strtolower(str_replace("-", ":", $_POST['global-v6duid']));
+		if (($_POST['global-v6duid'] && !is_duid($_POST['global-v6duid']))) {
+		$input_errors[] = gettext("A valid DUID must be specified.");
+		} else {
+			$config['system']['global-v6duid'] = $_POST['global-v6duid'];
 		}
 
 		if ($_POST['sharednet'] == "yes") {
@@ -194,6 +202,15 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['prefer_ipv4']
 ))->setHelp('By default, if IPv6 is configured and a hostname resolves IPv6 and IPv4 addresses, '. 
 	'IPv6 will be used. If this option is selected, IPv4 will be preferred over IPv6.');
+
+$section->addInput(new Form_Input(
+	'global-v6duid',
+	'DHCP6 DUID',
+	'text',
+	$pconfig['global-v6duid'],
+	['placeholder' => 'xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx']
+	))->setWidth(9)->sethelp('Enter the DUID to use here. If no DUID is entered, dhcp6c will auto generate a new one if one does not exist.' . '<br />' .
+			'Use this option also if using RAM Disk, as the DUID will be lost on reboot. The existing DUID may be found in var/db/dhcp6_duid.');
 
 $form->add($section);
 $section = new Form_Section('Network Interfaces');

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -85,10 +85,11 @@ if ($_POST) {
 			unset($config['system']['prefer_ipv4']);
 		}
 
-		$_POST['global-v6duid'] = strtolower(str_replace("-", ":", $_POST['global-v6duid']));
-		if (($_POST['global-v6duid'] && !is_duid($_POST['global-v6duid']))) {
-		$input_errors[] = gettext("A valid DUID must be specified.");
-		} else {
+		if (($_POST['global-v6duid']) != "") {
+			$_POST['global-v6duid'] = strtolower(str_replace("-", ":", $_POST['global-v6duid']));
+			if (!is_duid($_POST['global-v6duid'])) {
+				$input_errors[] = gettext("A valid DUID must be specified.");
+			} else {
 			$config['system']['global-v6duid'] = $_POST['global-v6duid'];
 		}
 


### PR DESCRIPTION
Moved the Configuration of the DUID to System->Advanced->Networking.

DUID validity is checked for content and length. then creates a system
config variable called global-v6duid.
Can replace PR #3294

In Interfaces WAN an option exists to use the global DUID ( which has
been defined or it flags an error ). On WAN interface configure the
write of the DUID file takes place by calling the function in util.inc