### PR TITLE
validateipaddr return address family

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2482,9 +2482,9 @@ function get_smart_drive_list() {
 //	$err_msg: pointer to the callers error message array so that error messages can be added to it here
 //	$alias: are aliases permitted for this address?
 // Returns:
-//	4 - if $addr is a valid IPv4 address
-//	6 - if $addr is a valid IPv6 address
-//	1 - if $alias=true and $addr is an alias
+//	IPV4 - if $addr is a valid IPv4 address
+//	IPV6 - if $addr is a valid IPv6 address
+//	ALIAS - if $alias=true and $addr is an alias
 //	false - otherwise
 
 function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2491,10 +2491,10 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 	switch ($type) {
 		case IPV4:
 			if (is_ipaddrv4($addr)) {
-				return 4;
+				return IPV4;
 			} else if ($alias) {
 				if (is_alias($addr)) {
-					return 1;
+					return ALIAS;
 				} else {
 					$err_msg[] = sprintf(gettext("%s must be a valid IPv4 address or alias."), $label);
 					return false;
@@ -2507,10 +2507,10 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 		case IPV6:
 			if (is_ipaddrv6($addr)) {
 				$addr = strtolower($addr);
-				return 6;
+				return IPV6;
 			} else if ($alias) {
 				if (is_alias($addr)) {
-					return 1;
+					return ALIAS;
 				} else {
 					$err_msg[] = sprintf(gettext("%s must be a valid IPv6 address or alias."), $label);
 					return false;
@@ -2523,12 +2523,12 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 		case IPV4V6:
 			if (is_ipaddrv6($addr)) {
 				$addr = strtolower($addr);
-				return 6;
+				return IPV6;
 			} else if (is_ipaddrv4($addr)) {
-				return 4;
+				return IPV4;
 			} else if ($alias) {
 				if (is_alias($addr)) {
-					return 1;
+					return ALIAS;
 				} else {
 					$err_msg[] = sprintf(gettext("%s must be a valid IPv4 or IPv6 address or alias."), $label);
 					return false;

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2481,14 +2481,20 @@ function get_smart_drive_list() {
 //	$label: the label used by the GUI to display this value. Required to compose an error message
 //	$err_msg: pointer to the callers error message array so that error messages can be added to it here
 //	$alias: are aliases permitted for this address?
+// Returns:
+//	4 - if $addr is a valid IPv4 address
+//	6 - if $addr is a valid IPv6 address
+//	1 - if $alias=true and $addr is an alias
+//	false - otherwise
+
 function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 	switch ($type) {
 		case IPV4:
 			if (is_ipaddrv4($addr)) {
-				return true;
+				return 4;
 			} else if ($alias) {
 				if (is_alias($addr)) {
-					return true;
+					return 1;
 				} else {
 					$err_msg[] = sprintf(gettext("%s must be a valid IPv4 address or alias."), $label);
 					return false;
@@ -2501,10 +2507,10 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 		case IPV6:
 			if (is_ipaddrv6($addr)) {
 				$addr = strtolower($addr);
-				return true;
+				return 6;
 			} else if ($alias) {
 				if (is_alias($addr)) {
-					return true;
+					return 1;
 				} else {
 					$err_msg[] = sprintf(gettext("%s must be a valid IPv6 address or alias."), $label);
 					return false;
@@ -2517,12 +2523,12 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 		case IPV4V6:
 			if (is_ipaddrv6($addr)) {
 				$addr = strtolower($addr);
-				return true;
+				return 6;
 			} else if (is_ipaddrv4($addr)) {
-				return true;
+				return 4;
 			} else if ($alias) {
 				if (is_alias($addr)) {
-					return true;
+					return 1;
 				} else {
 					$err_msg[] = sprintf(gettext("%s must be a valid IPv4 or IPv6 address or alias."), $label);
 					return false;


### PR DESCRIPTION
Enhanced the return values from validateipaddr() so the caller can know if the validated address is IPv4 or IPv6 (or an alias if that check was requested). That makes it a better replacement for is_ipaddr().