### PR TITLE
Captive portal: add button to disconnect all users

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -1082,6 +1082,32 @@ function captiveportal_disconnect_client($sessionid, $term_cause = 1, $logoutRea
 	}
 }
 
+/* remove all clients */
+function captiveportal_disconnect_all($term_cause = 6, $logoutReason = "DISCONNECT") {
+	global $g, $config, $cpzone, $cpzoneid;
+
+	$radiussrvs = captiveportal_get_radius_servers();
+	$cpdb = captiveportal_read_db();
+
+	$unsetindexes = array();
+
+	foreach ($cpdb as $cpentry) {
+		if (empty($cpentry[11])) {
+			$cpentry[11] = 'first';
+		}
+		$radiusservers = $radiussrvs[$cpentry[11]];
+
+		captiveportal_disconnect($cpentry, $radiusservers, $term_cause);
+		captiveportal_logportalauth($cpentry[4], $cpentry[3], $cpentry[2], $logoutReason);
+		$unsetindexes[] = $cpentry[5];
+	}
+	unset($cpdb);
+
+	if (!empty($unsetindexes)) {
+		captiveportal_remove_entries($unsetindexes);
+	}
+}
+
 /* send RADIUS acct stop for all current clients */
 function captiveportal_radius_stop_all() {
 	global $config, $cpzone;

--- a/src/usr/local/www/status_captiveportal.php
+++ b/src/usr/local/www/status_captiveportal.php
@@ -62,6 +62,17 @@ if (isset($cpzone) && !empty($cpzone) && isset($a_cp[$cpzone]['zoneid'])) {
 
 if ($_GET['act'] == "del" && !empty($cpzone) && isset($cpzoneid) && isset($_GET['id'])) {
 	captiveportal_disconnect_client($_GET['id'], 6);
+	/* keep displaying last activity times */
+	if ($_GET['showact']) {
+		header("Location: status_captiveportal.php?zone={$cpzone}&showact=1");
+	} else {
+		header("Location: status_captiveportal.php?zone={$cpzone}");
+	}
+	exit;
+}
+
+if ($_GET['deleteall'] && !empty($cpzone) && isset($cpzoneid)) {
+	captiveportal_disconnect_all();
 	header("Location: status_captiveportal.php?zone={$cpzone}");
 	exit;
 }
@@ -197,30 +208,30 @@ else:
 endif;
 ?>
 
-
-<form action="status_captiveportal.php" method="get" style="margin: 14px;">
+<nav class="action-buttons">
 <?php
 if (!empty($cpzone)):
 	if ($_GET['showact']): ?>
-		<input type="hidden" name="showact" value="0" />
-		<button type="submit" class="btn btn-info" value="<?=gettext("Don't show last activity")?>">
-			<i class="fa fa-minus-circle icon-embed-btn"></i>
-			<?=gettext("Hide Last Activity")?>
-		</button>
+	<a href="status_captiveportal.php?zone=<?=htmlspecialchars($cpzone)?>&amp;showact=0" role="button" class="btn btn-info" title="<?=gettext("Don't show last activity")?>">
+		<i class="fa fa-minus-circle icon-embed-btn"></i>
+		<?=gettext("Hide Last Activity")?>
+	</a>
 <?php
 	else:
 ?>
-		<input type="hidden" name="showact" value="1" />
-		<button type="submit" class="btn btn-info" value="<?=gettext("Show last activity")?>">
-			<i class="fa fa-plus-circle icon-embed-btn"></i>
-			<?=gettext("Show Last Activity")?>
-		</button>
+	<a href="status_captiveportal.php?zone=<?=htmlspecialchars($cpzone)?>&amp;showact=1" role="button" class="btn btn-info" title="<?=gettext("Show last activity")?>">
+		<i class="fa fa-plus-circle icon-embed-btn"></i>
+		<?=gettext("Show Last Activity")?>
+	</a>
 <?php
 	endif;
 ?>
-	<input type="hidden" name="zone" value="<?=htmlspecialchars($cpzone)?>" />
+	<a href="status_captiveportal.php?zone=<?=htmlspecialchars($cpzone)?>&amp;deleteall=1" role="button" class="btn btn-danger" title="<?=gettext("Disconnect all active users")?>">
+		<i class="fa fa-trash icon-embed-btn"></i>
+		<?=gettext("Disconnect All Users")?>
+	</a>
 <?php
 endif;
 ?>
-</form>
+</nav>
 <?php include("foot.inc");


### PR DESCRIPTION
I somehow managed to delete my branch so #3285 was auto-closed and I can't re-open it.

I removed the commented code since it definitely looked like it wasn't doing anything useful and stopped setting a common disconnection time for all users letting the function use the actual disconnection time.

I'm still not sure if I should change the function to avoid using globals, it would the only one of a group of related captive portal functions to do that. 