### PR TITLE
Fix CPU update period in System Information widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -225,7 +225,8 @@ $filesystems = get_mounted_filesystems();
 					<div id="cpuPB" class="progress-bar progress-bar-striped" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
 					</div>
 				</div>
-				<span id="cpumeter"><?=gettext('(Updating in 10 seconds)')?></span>
+				<?php $update_period = (isset($config['widgets']['period']) && !empty($config['widgets']['period'])) ? $config['widgets']['period'] : "10"; ?>
+				<span id="cpumeter"><?=sprintf(gettext("Updating in %s seconds"), $update_period)?></span>
 			</td>
 		</tr>
 		<tr>

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -225,7 +225,7 @@ $filesystems = get_mounted_filesystems();
 					<div id="cpuPB" class="progress-bar progress-bar-striped" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
 					</div>
 				</div>
-				<?php $update_period = (isset($config['widgets']['period']) && !empty($config['widgets']['period'])) ? $config['widgets']['period'] : "10"; ?>
+				<?php $update_period = (!empty($config['widgets']['period'])) ? $config['widgets']['period'] : "10"; ?>
 				<span id="cpumeter"><?=sprintf(gettext("Updating in %s seconds"), $update_period)?></span>
 			</td>
 		</tr>


### PR DESCRIPTION
This only updates after the refresh period set in System - General Setup - Dashboard update period; should not be hardcoded.

@rbgarga - This probably needs the update_pot.sh magic. 