### PR TITLE
Fix display of the number of states in the firewall rules status page

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -89,7 +89,7 @@ function print_states($tracker) {
 	printf("data-content=\"evaluations: %s<br>packets: %s<br>bytes: %s<br>states: %s<br>state creations: %s\" data-html=\"true\">",
 	    format_number($evaluations), format_number($packets), format_bytes($bytes),
 	    format_number($states), format_number($stcreations));
-	printf("%d/%s</a><br>", format_number($states), format_bytes($bytes));
+	printf("%s/%s</a><br>", format_number($states), format_bytes($bytes));
 }
 
 function delete_nat_association($id) {


### PR DESCRIPTION
For numbers greater than 1000 format_number() returns strings formatted like N.NNN K/M/G/T, that get cut to only the integer part if '%d' is used.