### PR TITLE
User Defined DUID

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3868,7 +3868,8 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$wanif = get_real_interface($interface, "inet6");
 	$dhcp6cconf = "";
 
-	if (isset($wancfg['dhcp6-duid'])) {
+	if (isset($wancfg['dhcp6-duid'])  &&
+    	    !empty($config['system']['global-v6duid'])) {
 	// Write the DUID file
 		if(!write_dhcp6_duid($config['system']['global-v6duid'])) {
 			log_error(gettext("Failed to write user DUID file!"));

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3868,6 +3868,13 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$wanif = get_real_interface($interface, "inet6");
 	$dhcp6cconf = "";
 
+	if (isset($wancfg['dhcp6-duid'])) {
+	// Write the DUID file
+		if(!write_dhcp6_duid($config['system']['global-v6duid'])) {
+			log_error(gettext("Failed to write user DUID file!"));
+		}
+	}
+	
 	if ($wancfg['adv_dhcp6_config_file_override']) {
 		// DHCP6 Config File Override
 		$dhcp6cconf = DHCP6_Config_File_Override($wancfg, $wanif);

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2559,24 +2559,22 @@ function is_duid($dhcp6duid) {
 }
 
 /* Write the DHCP6 DUID file */
-function write_dhcp6_duid($duidfile) {
+function write_dhcp6_duid($duidstring) {
 	// Create the hex array from the dhcp6duid config entry and write to file
 	global $g;
  	
- 	if(is_duid($duidfile))
- 	{
- 		$temp = str_replace(":","",$duidfile);
- 		$duid_binstring = pack("H*",$temp);
- 		if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "wb")) {
- 			fwrite($fd, $duid_binstring);
-			fclose($fd);
- 			return;
- 		}
- 		else {
- 			log_error(gettext("Error: attempting to write DUID file - File write error"));
- 			return;
- 		}
- 	}
- 	log_error(gettext("Error: attempting to write DUID file - Invalid DUID detected"));
+ 	if(!is_duid($duidstring)) {
+		log_error(gettext("Error: attempting to write DUID file - Invalid DUID detected"));
+		return false;
+	}
+	$temp = str_replace(":","",$duidstring);
+	$duid_binstring = pack("H*",$temp);
+	if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "wb")) {
+		fwrite($fd, $duid_binstring);
+		fclose($fd);
+		return true;
+	}
+	log_error(gettext("Error: attempting to write DUID file - File write error"));
+	return false;
 }
 ?>

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2542,4 +2542,41 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 
 	return false;
 }
+
+/* returns true if $dhcp6duid is a valid duid entrry */
+function is_duid($dhcp6duid) {
+	$values = explode(":", $dhcp6duid);
+	if (count($values) != 16 || strlen($dhcp6duid) != 47) {
+		return false;
+	}
+	for ($i = 0; $i < 16; $i++) {
+		if (ctype_xdigit($values[$i]) == false)
+			return false;
+		if (hexdec($values[$i]) < 0 || hexdec($values[$i]) > 255)
+			return false;
+	}
+	return true;
+}
+
+/* Write the DHCP6 DUID file */
+function write_dhcp6_duid($duidfile) {
+	// Create the hex array from the dhcp6duid config entry and write to file
+	global $g;
+ 	
+ 	if(is_duid($duidfile))
+ 	{
+ 		$temp = str_replace(":","",$duidfile);
+ 		$duid_binstring = pack("H*",$temp);
+ 		if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "wb")) {
+ 			fwrite($fd, $duid_binstring);
+			fclose($fd);
+ 			return;
+ 		}
+ 		else {
+ 			log_error(gettext("Error: attempting to write DUID file - File write error"));
+ 			return;
+ 		}
+ 	}
+ 	log_error(gettext("Error: attempting to write DUID file - Invalid DUID detected"));
+}
 ?>

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -274,7 +274,10 @@ switch ($wancfg['ipaddrv6']) {
 		$pconfig['type6'] = "slaac";
 		break;
 	case "dhcp6":
-		$pconfig['dhcp6-duid'] = $wancfg['dhcp6-duid'];
+		if(empty($config['system']['global-v6duid'])) {
+			unset($wancfg['dhcp6-duid']);
+		}
+		$pconfig['dhcp6-duid'] = isset($wancfg['dhcp6-duid']);
 		if (!isset($wancfg['dhcp6-ia-pd-len'])) {
 			$wancfg['dhcp6-ia-pd-len'] = "none";
 		}
@@ -794,6 +797,9 @@ if ($_POST['apply']) {
 	if (($_POST['spoofmac'] && !is_macaddr($_POST['spoofmac']))) {
 		$input_errors[] = gettext("A valid MAC address must be specified.");
 	}
+	if (($_POST['dhcp6-duid'] && empty($config['system']['global-v6duid']))) {
+		$input_errors[] = gettext("No System DUID has been entered. Please enter a valid DUID in System->Advanced->Networking");
+	}
 	if ($_POST['mtu']) {
 		if (!is_numericint($_POST['mtu'])) {
 			$input_errors[] = "MTU must be an integer.";
@@ -1227,7 +1233,9 @@ if ($_POST['apply']) {
 				break;
 			case "dhcp6":
 				$wancfg['ipaddrv6'] = "dhcp6";
-				$wancfg['dhcp6-duid'] = $_POST['dhcp6-duid'];
+				if ($_POST['dhcp6-duid'] == "yes") {
+					$wancfg['dhcp6-duid'] = true;
+				}
 				$wancfg['dhcp6-ia-pd-len'] = $_POST['dhcp6-ia-pd-len'];
 				if ($_POST['dhcp6-ia-pd-send-hint'] == "yes") {
 					$wancfg['dhcp6-ia-pd-send-hint'] = true;
@@ -2158,6 +2166,12 @@ $section->addInput(new Form_Checkbox(
 	'Do not allow PD/Address release',
 	'dhcp6c will send a release to the ISP on exit, some ISPs then release the allocated address or prefix. This option prevents that signal ever being sent',
 	$pconfig['dhcp6norelease']
+));
+$section->addInput(new Form_Checkbox(
+	'dhcp6-duid',
+	'Use System DUID',
+	'The DUID defined in System->Advanced->Networking will be used on this interface.',
+	$pconfig['dhcp6-duid']
 ));
 $section->addInput(new Form_Input(
 	'adv_dhcp6_config_file_override_path',

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -40,6 +40,7 @@ require_once("shaper.inc");
 $pconfig['ipv6nat_enable'] = isset($config['diag']['ipv6nat']['enable']);
 $pconfig['ipv6nat_ipaddr'] = $config['diag']['ipv6nat']['ipaddr'];
 $pconfig['ipv6allow'] = isset($config['system']['ipv6allow']);
+$pconfig['global-v6duid'] = $config['system']['global-v6duid'];
 $pconfig['prefer_ipv4'] = isset($config['system']['prefer_ipv4']);
 $pconfig['sharednet'] = $config['system']['sharednet'];
 $pconfig['disablechecksumoffloading'] = isset($config['system']['disablechecksumoffloading']);
@@ -81,6 +82,20 @@ if ($_POST) {
 			$config['system']['prefer_ipv4'] = true;
 		} else {
 			unset($config['system']['prefer_ipv4']);
+		}
+
+		if (!empty($_POST['global-v6duid'])) {
+			strtolower(str_replace("-", ":", $_POST['global-v6duid']));
+			if (!is_duid($_POST['global-v6duid'])) {
+				$input_errors[] = gettext("A valid DUID must be specified");
+			} else {
+				$config['system']['global-v6duid'] = $_POST['global-v6duid'];
+			}
+		}
+		else {
+			unset($config['system']['global-v6duid']);
+			// nothing there so clear the WAN setting if its set
+			unset($config['interfaces']['wan']['dhcp6-duid']);
 		}
 
 		if ($_POST['sharednet'] == "yes") {
@@ -185,6 +200,15 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['prefer_ipv4']
 ))->setHelp('By default, if IPv6 is configured and a hostname resolves IPv6 and IPv4 addresses, '. 
 	'IPv6 will be used. If this option is selected, IPv4 will be preferred over IPv6.');
+
+	$section->addInput(new Form_Input(
+	'global-v6duid',
+	'DHCP6 DUID',
+	'text',
+	$pconfig['global-v6duid'],
+	['placeholder' => 'xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx']
+	))->setWidth(9)->sethelp('Enter the DUID to use here. If no DUID is entered, dhcp6c will auto generate a new one if one does not exist.' . '<br />' .
+			'Use this option also if using RAM Disk, as the DUID will be lost on reboot. The existing DUID may be found in var/db/dhcp6_duid.');
 
 $form->add($section);
 $section = new Form_Section('Network Interfaces');


### PR DESCRIPTION
Replaces PR #3297

DUID is configured in System->Advanced->Networking. Checks are made for
validity and length.

User may then opt to use that DUID in WAN->DHCP6. If selected, the
dhcp6c duid file is then written to /var/db/ on call of
interface_dhcpv6_configure.