### PR TITLE
User Defined DUID

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3868,6 +3868,13 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	$wanif = get_real_interface($interface, "inet6");
 	$dhcp6cconf = "";
 
+	if (!empty($config['system']['global-v6duid'])) {
+		// Write the DUID file
+		if(!write_dhcp6_duid($config['system']['global-v6duid'])) {
+		    log_error(gettext("Failed to write user DUID file!"));
+		}
+	}
+	
 	if ($wancfg['adv_dhcp6_config_file_override']) {
 		// DHCP6 Config File Override
 		$dhcp6cconf = DHCP6_Config_File_Override($wancfg, $wanif);

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2542,4 +2542,40 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 
 	return false;
 }
+
+
+/* returns true if $dhcp6duid is a valid duid entrry */
+function is_duid($dhcp6duid) {
+	$values = explode(":", $dhcp6duid);
+	if (count($values) != 16 || strlen($dhcp6duid) != 47) {
+		return false;
+	}
+	for ($i = 0; $i < 16; $i++) {
+		if (ctype_xdigit($values[$i]) == false)
+			return false;
+		if (hexdec($values[$i]) < 0 || hexdec($values[$i]) > 255)
+			return false;
+	}
+	return true;
+}
+
+/* Write the DHCP6 DUID file */
+function write_dhcp6_duid($duidstring) {
+	// Create the hex array from the dhcp6duid config entry and write to file
+	global $g;
+ 	
+ 	if(!is_duid($duidstring)) {
+		log_error(gettext("Error: attempting to write DUID file - Invalid DUID detected"));
+		return false;
+	}
+	$temp = str_replace(":","",$duidstring);
+	$duid_binstring = pack("H*",$temp);
+	if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "wb")) {
+		fwrite($fd, $duid_binstring);
+		fclose($fd);
+		return true;
+	}
+	log_error(gettext("Error: attempting to write DUID file - File write error"));
+	return false;
+}
 ?>

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2543,7 +2543,6 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 	return false;
 }
 
-
 /* returns true if $dhcp6duid is a valid duid entrry */
 function is_duid($dhcp6duid) {
 	$values = explode(":", $dhcp6duid);
@@ -2578,19 +2577,20 @@ function write_dhcp6_duid($duidstring) {
 	log_error(gettext("Error: attempting to write DUID file - File write error"));
 	return false;
 }
+
 /* returns duid string from 'vardb_path']}/dhcp6c_duid' */
 function get_duid_from_file()
 {
 	global $g;
 	
+	$duid_ASCII = "";
 	$count = 0;
 	
 	if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "r")) {
 		if(filesize("{$g['vardb_path']}/dhcp6c_duid")==16) {
-			$buffer = fread($fd,filesize("{$g['vardb_path']}/dhcp6c_duid"));					
-			while($count < 16) {				
-				$a = $buffer[$count];
-				$duid_ASCII .= bin2hex($a);
+			$buffer = fread($fd,16);					
+			while($count < 16) {
+				$duid_ASCII .= bin2hex($buffer[$count]);
 				$count++;
 				if($count < 16) {
 					$duid_ASCII .= ":";
@@ -2600,7 +2600,7 @@ function get_duid_from_file()
 		fclose($fd);
 	}
 	//if no file or error with read then the string returns blanked DUID string
-	if($count != 16) {
+	if(!is_duid($duid_ASCII)) {
 		return "--:--:--:--:--:--:--:--:--:--:--:--:--:--:--:--";
 	}
 	return($duid_ASCII);	

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2586,14 +2586,10 @@ function get_duid_from_file()
 	$count = 0;
 	
 	if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "r")) {
-		
 		if(filesize("{$g['vardb_path']}/dhcp6c_duid")==16) {
-			
-			$string = fread($fd,filesize("{$g['vardb_path']}/dhcp6c_duid"));
-					
-			while($count < 16) {
-				
-				$a = $string[$count];
+			$buffer = fread($fd,filesize("{$g['vardb_path']}/dhcp6c_duid"));					
+			while($count < 16) {				
+				$a = $buffer[$count];
 				$duid_ASCII .= bin2hex($a);
 				$count++;
 				if($count < 16) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2578,4 +2578,35 @@ function write_dhcp6_duid($duidstring) {
 	log_error(gettext("Error: attempting to write DUID file - File write error"));
 	return false;
 }
+/* returns duid string from 'vardb_path']}/dhcp6c_duid' */
+function get_duid_from_file()
+{
+	global $g;
+	
+	$count = 0;
+	
+	if ($fd = fopen("{$g['vardb_path']}/dhcp6c_duid", "r")) {
+		
+		if(filesize("{$g['vardb_path']}/dhcp6c_duid")==16) {
+			
+			$string = fread($fd,filesize("{$g['vardb_path']}/dhcp6c_duid"));
+					
+			while($count < 16) {
+				
+				$a = $string[$count];
+				$duid_ASCII .= bin2hex($a);
+				$count++;
+				if($count < 16) {
+					$duid_ASCII .= ":";
+				}
+			}
+		}
+		fclose($fd);
+	}
+	//if no file or error with read then the string returns blanked DUID string
+	if($count != 16) {
+		return "--:--:--:--:--:--:--:--:--:--:--:--:--:--:--:--";
+	}
+	return($duid_ASCII);	
+}
 ?>

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -119,7 +119,7 @@ if ($_POST) {
 		if ($_POST['disablelargereceiveoffloading'] == "yes") {
 			$config['system']['disablelargereceiveoffloading'] = true;
 		} else {
-			unset($config['system']['disablelargereceiveoffloading']); 
+			unset($config['system']['disablelargereceiveoffloading']);
 		}
 
 		setup_microcode();

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -91,8 +91,7 @@ if ($_POST) {
 			} else {
 				$config['system']['global-v6duid'] = $_POST['global-v6duid'];
 			}
-		}
-		else {
+		} else {
 			unset($config['system']['global-v6duid']);
 		}
 

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -40,6 +40,7 @@ require_once("shaper.inc");
 $pconfig['ipv6nat_enable'] = isset($config['diag']['ipv6nat']['enable']);
 $pconfig['ipv6nat_ipaddr'] = $config['diag']['ipv6nat']['ipaddr'];
 $pconfig['ipv6allow'] = isset($config['system']['ipv6allow']);
+$pconfig['global-v6duid'] = $config['system']['global-v6duid'];
 $pconfig['prefer_ipv4'] = isset($config['system']['prefer_ipv4']);
 $pconfig['sharednet'] = $config['system']['sharednet'];
 $pconfig['disablechecksumoffloading'] = isset($config['system']['disablechecksumoffloading']);
@@ -81,6 +82,18 @@ if ($_POST) {
 			$config['system']['prefer_ipv4'] = true;
 		} else {
 			unset($config['system']['prefer_ipv4']);
+		}
+
+		if (!empty($_POST['global-v6duid'])) {
+			$_POST['global-v6duid'] = strtolower(str_replace("-", ":", $_POST['global-v6duid']));
+			if (!is_duid($_POST['global-v6duid'])) {
+				$input_errors[] = gettext("A valid DUID must be specified");
+			} else {
+				$config['system']['global-v6duid'] = $_POST['global-v6duid'];
+			}
+		}
+		else {
+			unset($config['system']['global-v6duid']);
 		}
 
 		if ($_POST['sharednet'] == "yes") {
@@ -185,6 +198,15 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['prefer_ipv4']
 ))->setHelp('By default, if IPv6 is configured and a hostname resolves IPv6 and IPv4 addresses, '. 
 	'IPv6 will be used. If this option is selected, IPv4 will be preferred over IPv6.');
+
+$section->addInput(new Form_Input(
+	'global-v6duid',
+	'DHCP6 DUID',
+	'text',
+	$pconfig['global-v6duid'],
+	['placeholder' => 'xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx']
+	))->setWidth(9)->sethelp('Enter the DUID to use here. Use this option if using RAM Disk, as the DUID will be lost on reboot. The existing DUID may be found in var/db/dhcp6_duid.' .'<br />' .
+			'NOTE: Do not use this option with multiple DHCP6 interfaces.');
 
 $form->add($section);
 $section = new Form_Section('Network Interfaces');

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -205,7 +205,7 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['global-v6duid'],
 	['placeholder' => $duid]
-	))->setWidth(9)->sethelp('The current DUID is displayed above. You may enter a new DUID whuch will be used on the next WAN interface UP event.' .'<br />' .
+	))->setWidth(9)->sethelp('The current DUID is displayed above. You may enter a new DUID which will be used on the next WAN interface UP event.' .'<br />' .
 			'Unless you enter a DUID the system will default to using the DUID created by the client on start, this DUID is NOT saved to config.' .
 			'It is strongly recommended if you use RAM disk to enter a DUID here and then save. The saved DUID will take effect after a machine'.
 			' reboot or re-configure of the WAN interface(s).');

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -119,8 +119,8 @@ if ($_POST) {
 		if ($_POST['disablelargereceiveoffloading'] == "yes") {
 			$config['system']['disablelargereceiveoffloading'] = true;
 		} else {
-			unset($config['system']['disablelargereceiveoffloading']); hi		
-}
+			unset($config['system']['disablelargereceiveoffloading']); 
+		}
 
 		setup_microcode();
 

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -119,8 +119,8 @@ if ($_POST) {
 		if ($_POST['disablelargereceiveoffloading'] == "yes") {
 			$config['system']['disablelargereceiveoffloading'] = true;
 		} else {
-			unset($config['system']['disablelargereceiveoffloading']);
-		}
+			unset($config['system']['disablelargereceiveoffloading']); hi		
+}
 
 		setup_microcode();
 
@@ -206,7 +206,7 @@ $section->addInput(new Form_Input(
 	$pconfig['global-v6duid'],
 	['placeholder' => 'xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx']
 	))->setWidth(9)->sethelp('Enter the DUID to use here. Use this option if using RAM Disk, as the DUID will be lost on reboot. The existing DUID may be found in var/db/dhcp6_duid.' .'<br />' .
-			'NOTE: Do not use this option with multiple DHCP6 interfaces.');
+			'NOTE: Do not use this option with multiple DHCP6 WAN interfaces.');
 
 $form->add($section);
 $section = new Form_Section('Network Interfaces');

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -208,8 +208,8 @@ $section->addInput(new Form_Input(
 	['placeholder' => $duid]
 	))->setWidth(9)->sethelp('The current DUID is displayed above. You may enter a new DUID whuch will be used on the next WAN interface UP event.' .'<br />' .
 			'Unless you enter a DUID the system will default to using the DUID created by the client on start, this DUID is NOT saved to config.' .
-			'It is strongly recommended if you use RAM disk to enter a DUID here and then SAVE, the DUID will then be saved to config also and' .
-			' will be active on the next WAN interface UP event.');
+			'It is strongly recommended if you use RAM disk to enter a DUID here and then save. The saved DUID will take effect after a machine'.
+			' reboot or re-configure of the WAN interface(s).');
 
 $form->add($section);
 $section = new Form_Section('Network Interfaces');

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -158,6 +158,7 @@ $tab_array[] = array(gettext("Networking"), true, "system_advanced_network.php")
 $tab_array[] = array(gettext("Miscellaneous"), false, "system_advanced_misc.php");
 $tab_array[] = array(gettext("System Tunables"), false, "system_advanced_sysctl.php");
 $tab_array[] = array(gettext("Notifications"), false, "system_advanced_notifications.php");
+$duid = get_duid_from_file();
 display_top_tabs($tab_array);
 
 $form = new Form;
@@ -204,9 +205,11 @@ $section->addInput(new Form_Input(
 	'DHCP6 DUID',
 	'text',
 	$pconfig['global-v6duid'],
-	['placeholder' => 'xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx']
-	))->setWidth(9)->sethelp('Enter the DUID to use here. Use this option if using RAM Disk, as the DUID will be lost on reboot. The existing DUID may be found in var/db/dhcp6_duid.' .'<br />' .
-			'NOTE: Do not use this option with multiple DHCP6 WAN interfaces.');
+	['placeholder' => $duid]
+	))->setWidth(9)->sethelp('The current DUID is displayed above. You may enter a new DUID whuch will be used on the next WAN interface UP event.' .'<br />' .
+			'Unless you enter a DUID the system will default to using the DUID created by the client on start, this DUID is NOT saved to config.' .
+			'It is strongly recommended if you use RAM disk to enter a DUID here and then SAVE, the DUID will then be saved to config also and' .
+			' will be active on the next WAN interface UP event.');
 
 $form->add($section);
 $section = new Form_Section('Network Interfaces');


### PR DESCRIPTION
User may define a DUID to use in System->Advanced->Networking. The
entered DUID is validated for composition and length, if valid it is
stored in the config.xml. On call of wan_dhcp6_configure() the DUID is
written to file to be read by dhcp6c on launch.