### PR TITLE
Captive portal: convert tables to sortable tables

### DIFF
--- a/src/usr/local/www/services_captiveportal_hostname.php
+++ b/src/usr/local/www/services_captiveportal_hostname.php
@@ -112,12 +112,12 @@ $tab_array[] = array(gettext("File Manager"), false, "services_captiveportal_fil
 display_top_tabs($tab_array, true);
 ?>
 <div class="table-responsive">
-	<table class="table table-hover table-striped table-condensed table-rowdblclickedit">
+	<table class="table table-hover table-striped table-condensed table-rowdblclickedit sortable-theme-bootstrap" data-sortable>
 		<thead>
 			<tr>
 				<th><?=gettext("Hostname"); ?></th>
 				<th><?=gettext("Description"); ?></th>
-				<th><?=gettext("Actions"); ?></th>
+				<th data-sortable="false"><?=gettext("Actions"); ?></th>
 			</tr>
 		</thead>
 

--- a/src/usr/local/www/services_captiveportal_ip.php
+++ b/src/usr/local/www/services_captiveportal_ip.php
@@ -107,12 +107,12 @@ display_top_tabs($tab_array, true);
 
 ?>
 <div class="table-responsive">
-	<table class="table table-hover table-striped table-condensed table-rowdblclickedit">
+	<table class="table table-hover table-striped table-condensed table-rowdblclickedit sortable-theme-bootstrap" data-sortable>
 		<thead>
 			<tr>
 				<th><?=gettext("IP Addresses"); ?></th>
 				<th><?=gettext("Description"); ?></th>
-				<th><?=gettext("Actions"); ?></th>
+				<th data-sortable="false"><?=gettext("Actions"); ?></th>
 			</tr>
 		</thead>
 

--- a/src/usr/local/www/services_captiveportal_vouchers.php
+++ b/src/usr/local/www/services_captiveportal_vouchers.php
@@ -385,7 +385,7 @@ display_top_tabs($tab_array, true);
 	<div class="panel-heading"><h2 class="panel-title"><?=gettext("Voucher Rolls");?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
-			<table class="table table-striped table-hover table-condensed table-rowdblclickedit">
+			<table class="table table-striped table-hover table-condensed table-rowdblclickedit sortable-theme-bootstrap" data-sortable>
 				<thead>
 					<tr>
 						<th><?=gettext("Roll #")?></th>
@@ -401,18 +401,10 @@ $i = 0;
 foreach ($a_roll as $rollent):
 ?>
 					<tr>
-						<td>
-							<?=htmlspecialchars($rollent['number']); ?>&nbsp;
-						</td>
-						<td>
-							<?=htmlspecialchars($rollent['minutes'])?>&nbsp;
-						</td>
-						<td>
-							<?=htmlspecialchars($rollent['count'])?>&nbsp;
-						</td>
-						<td>
-							<?=htmlspecialchars($rollent['descr']); ?>&nbsp;
-						</td>
+						<td><?=htmlspecialchars($rollent['number']); ?></td>
+						<td><?=htmlspecialchars($rollent['minutes'])?></td>
+						<td><?=htmlspecialchars($rollent['count'])?></td>
+						<td><?=htmlspecialchars($rollent['descr']); ?></td>
 						<td>
 							<!-- These buttons are hidden/shown on checking the 'enable' checkbox -->
 							<a class="fa fa-pencil"		title="<?=gettext("Edit voucher roll"); ?>" href="services_captiveportal_vouchers_edit.php?zone=<?=$cpzone?>&amp;id=<?=$i; ?>"></a>

--- a/src/usr/local/www/services_captiveportal_zones.php
+++ b/src/usr/local/www/services_captiveportal_zones.php
@@ -72,14 +72,14 @@ if (is_subsystem_dirty('captiveportal')) {
 	<div class="panel panel-default">
 	<div class="panel-heading"><h2 class="panel-title"><?=gettext('Captive Portal Zones')?></h2></div>
 		<div class="panel-body table-responsive">
-			<table class="table table-striped table-hover table-rowdblclickedit">
+			<table class="table table-striped table-hover table-rowdblclickedit sortable-theme-bootstrap" data-sortable>
 				<thead>
 					<tr>
 						<th><?=gettext('Zone')?></th>
 						<th><?=gettext('Interfaces')?></th>
 						<th><?=gettext('Number of users'); ?></th>
 						<th><?=gettext('Description'); ?></th>
-						<th><?=gettext('Actions'); ?></th>
+						<th data-sortable="false"><?=gettext('Actions'); ?></th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/usr/local/www/status_captiveportal_voucher_rolls.php
+++ b/src/usr/local/www/status_captiveportal_voucher_rolls.php
@@ -75,17 +75,17 @@ display_top_tabs($tab_array);
 ?>
 
 <div class="table-responsive">
-	<table class="table table-striped table-hover table-condensed">
-	    <thead>
-    		<tr>
-    			<th><?=gettext("Roll#"); ?></th>
-    			<th><?=gettext("Minutes/Ticket"); ?></th>
-    			<th><?=gettext("# of Tickets"); ?></th>
-    			<th><?=gettext("Comment"); ?></th>
-    			<th><?=gettext("used"); ?></th>
-    			<th><?=gettext("active"); ?></th>
-    			<th><?=gettext("ready"); ?></th>
-    		</tr>
+	<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
+		<thead>
+    			<tr>
+    				<th><?=gettext("Roll#"); ?></th>
+    				<th><?=gettext("Minutes/Ticket"); ?></th>
+    				<th><?=gettext("# of Tickets"); ?></th>
+    				<th><?=gettext("Comment"); ?></th>
+    				<th><?=gettext("used"); ?></th>
+    				<th><?=gettext("active"); ?></th>
+    				<th><?=gettext("ready"); ?></th>
+    			</tr>
 		</thead>
 		<tbody>
 <?php
@@ -98,35 +98,21 @@ display_top_tabs($tab_array);
 				/* used also count active vouchers, remove them */
 				$used = $used - $active;
 ?>
-    		<tr>
-    			<td>
-    				<?=htmlspecialchars($rollent['number'])?>
-    			</td>
-    			<td>
-    				<?=htmlspecialchars($rollent['minutes'])?>
-    			</td>
-    			<td>
-    				<?=htmlspecialchars($rollent['count'])?>
-    			</td>
-    			<td>
-    				<?=htmlspecialchars($rollent['comment'])?>
-    			</td>
-    			<td>
-    				<?=htmlspecialchars($used)?>
-    			</td>
-    			<td>
-    				<?=htmlspecialchars($active)?>
-    			</td>
-    			<td>
-    				<?=htmlspecialchars($ready)?>
-    			</td>
-    		</tr>
+    			<tr>
+    				<td><?=htmlspecialchars($rollent['number'])?></td>
+    				<td><?=htmlspecialchars($rollent['minutes'])?></td>
+    				<td><?=htmlspecialchars($rollent['count'])?></td>
+    				<td><?=htmlspecialchars($rollent['comment'])?></td>
+    				<td><?=htmlspecialchars($used)?></td>
+    				<td><?=htmlspecialchars($active)?></td>
+    				<td><?=htmlspecialchars($ready)?></td>
+    			</tr>
 <?php
 				$i++;
 			endforeach;
 
 			unlock($voucherlck)?>
-	    </tbody>
+		</tbody>
 	</table>
 </div>
 <?php include("foot.inc");

--- a/src/usr/local/www/status_captiveportal_vouchers.php
+++ b/src/usr/local/www/status_captiveportal_vouchers.php
@@ -57,11 +57,6 @@ if (empty($cpzone)) {
 $pgtitle = array(gettext("Status"), gettext("Captive Portal"), htmlspecialchars($a_cp[$cpzone]['zone']), gettext("Active Vouchers"));
 $shortcut_section = "captiveportal-vouchers";
 
-function clientcmp($a, $b) {
-	global $order;
-	return strcmp($a[$order], $b[$order]);
-}
-
 if (!is_array($config['voucher'][$cpzone]['roll'])) {
 	$config['voucher'][$cpzone]['roll'] = array();
 }
@@ -94,11 +89,6 @@ foreach ($a_roll as $rollent) {
 	}
 }
 
-if ($_GET['order']) {
-	$order = $_GET['order'];
-	usort($db, "clientcmp");
-}
-
 include("head.inc");
 
 $tab_array = array();
@@ -113,14 +103,14 @@ display_top_tabs($tab_array);
 <div class="panel panel-default">
 	<div class="panel-heading"><h2 class="panel-title"><?=sprintf(gettext("Vouchers in Use (%d)"), count($db))?></h2></div>
 	<div class="panel-body table-responsive">
-		<table class="table table-striped table-hover table-condensed">
+		<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 			<thead>
 				<tr>
-					<th><a href="?zone=<?=htmlspecialchars($cpzone)?>&amp;order=0&amp;showact=<?=htmlspecialchars($_GET['showact'])?>"><?=gettext("Voucher"); ?></a></th>
-					<th><a href="?zone=<?=htmlspecialchars($cpzone)?>&amp;order=1&amp;showact=<?=htmlspecialchars($_GET['showact'])?>"><?=gettext("Roll"); ?></a></th>
-					<th><a href="?zone=<?=htmlspecialchars($cpzone)?>&amp;order=2&amp;showact=<?=htmlspecialchars($_GET['showact'])?>"><?=gettext("Activated at"); ?></a></th>
-					<th><a href="?zone=<?=htmlspecialchars($cpzone)?>&amp;order=3&amp;showact=<?=htmlspecialchars($_GET['showact'])?>"><?=gettext("Expires in"); ?></a></th>
-					<th><a href="?zone=<?=htmlspecialchars($cpzone)?>&amp;order=4&amp;showact=<?=htmlspecialchars($_GET['showact'])?>"><?=gettext("Expires at"); ?></a></th>
+					<th><?=gettext("Voucher"); ?></th>
+					<th><?=gettext("Roll"); ?></th>
+					<th><?=gettext("Activated at"); ?></th>
+					<th><?=gettext("Expires in"); ?></th>
+					<th><?=gettext("Expires at"); ?></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -128,10 +118,10 @@ display_top_tabs($tab_array);
 foreach ($db as $dbent):
 ?>
 				<tr>
-					<td><?=$dbent[0]?></td>
-					<td><?=$dbent[1]?></td>
+					<td><?=htmlspecialchars($dbent[0])?></td>
+					<td><?=htmlspecialchars($dbent[1])?></td>
 					<td><?=htmlspecialchars(date("m/d/Y H:i:s", $dbent[2]))?></td>
-					<td><?=$dbent[3]?><?=gettext("min"); ?></td>
+					<td><?=htmlspecialchars($dbent[3])?><?=gettext("min"); ?></td>
 					<td><?=htmlspecialchars(date("m/d/Y H:i:s", $dbent[4]))?></td>
 				</tr>
 <?php


### PR DESCRIPTION
Convert the used vouchers table from the old GET order method to a sortable table, and make the other tables (allowed IPs, hostnames, zones) sortable too.