### PR TITLE
Fix #7031 Allow interfaces that use DHCP for OpenVPN

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -5972,6 +5972,52 @@ function get_failover_interface($interface, $family = "all") {
 	return get_real_interface($interface, $family);
 }
 
+/****f* interfaces/interface_has_dhcp
+ * NAME
+ *   interface_has_dhcp - determine if the interface or gateway group uses DHCP
+ * INPUTS
+ *   interface or gateway group name
+ *   family - 4 (check for IPv4 DHCP) or 6 (check for IPv6 DHCP)
+ * RESULT
+ *   true - if the interface uses DHCP/DHCP6, or the name is a gateway group which has any member that uses DHCP/DHCP6
+ *   false - otherwise (DHCP/DHCP6 not in use, or the name is not an interface or gateway group)
+ ******/
+function interface_has_dhcp($interface, $family = 4) {
+	global $config;
+
+	if ($config['interfaces'][$interface]) {
+		if (($family == 4) && ($config['interfaces'][$interface]['ipaddr'] == "dhcp")) {
+			return true;
+		}
+		if (($family == 6) && ($config['interfaces'][$interface]['ipaddrv6'] == "dhcp6")) {
+			return true;
+		}
+	} else {
+		if (is_array($config['gateways']['gateway_group'])) {
+			if ($family == 6) {
+				$dhcp_string = "_DHCP6";
+			} else {
+				$dhcp_string = "_DHCP";
+			}
+
+			foreach ($config['gateways']['gateway_group'] as $group) {
+				if ($group['name'] == $interface) {
+					if (is_array($group['item'])) {
+						foreach ($group['item'] as $item) {
+							$item_data = explode("|", $item);
+							if (substr($item_data[0], -strlen($dhcp_string)) == $dhcp_string) {
+								return true;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
 function remove_ifindex($ifname) {
 	return preg_replace("/[0-9]+$/", "", $ifname);
 }

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -5988,29 +5988,31 @@ function interface_has_dhcp($interface, $family = 4) {
 	if ($config['interfaces'][$interface]) {
 		if (($family == 4) && ($config['interfaces'][$interface]['ipaddr'] == "dhcp")) {
 			return true;
-		}
-		if (($family == 6) && ($config['interfaces'][$interface]['ipaddrv6'] == "dhcp6")) {
+		} elseif (($family == 6) && ($config['interfaces'][$interface]['ipaddrv6'] == "dhcp6")) {
 			return true;
+		} else {
+			return false;
 		}
-	} else {
-		if (is_array($config['gateways']['gateway_group'])) {
-			if ($family == 6) {
-				$dhcp_string = "_DHCP6";
-			} else {
-				$dhcp_string = "_DHCP";
-			}
+	}
 
-			foreach ($config['gateways']['gateway_group'] as $group) {
-				if ($group['name'] == $interface) {
-					if (is_array($group['item'])) {
-						foreach ($group['item'] as $item) {
-							$item_data = explode("|", $item);
-							if (substr($item_data[0], -strlen($dhcp_string)) == $dhcp_string) {
-								return true;
-							}
-						}
-					}
-				}
+	if (!is_array($config['gateways']['gateway_group'])) {
+		return false;
+	}
+
+	if ($family == 6) {
+		$dhcp_string = "_DHCP6";
+	} else {
+		$dhcp_string = "_DHCP";
+	}
+
+	foreach ($config['gateways']['gateway_group'] as $group) {
+		if (($group['name'] != $interface) || !is_array($group['item'])) {
+			continue;
+		}
+		foreach ($group['item'] as $item) {
+			$item_data = explode("|", $item);
+			if (substr($item_data[0], -strlen($dhcp_string)) == $dhcp_string) {
+				return true;
 			}
 		}
 	}

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -187,9 +187,17 @@ if ($_POST) {
 	} elseif (is_ipaddrv6($iv_ip) && (stristr($pconfig['protocol'], "6") === false)) {
 		$input_errors[] = gettext("Protocol and IP address families do not match. An IPv4 protocol and an IPv6 IP address cannot be selected.");
 	} elseif ((stristr($pconfig['protocol'], "6") === false) && !get_interface_ip($iv_iface) && ($pconfig['interface'] != "any")) {
-		$input_errors[] = gettext("An IPv4 protocol was selected, but the selected interface has no IPv4 address.");
+		// If an underlying interface to be used by this client uses DHCP, then it may not have received an IP address yet.
+		// So in that case we do not report a problem.
+		if (!interface_has_dhcp($iv_iface, 4)) {
+			$input_errors[] = gettext("An IPv4 protocol was selected, but the selected interface has no IPv4 address.");
+		}
 	} elseif ((stristr($pconfig['protocol'], "6") !== false) && !get_interface_ipv6($iv_iface) && ($pconfig['interface'] != "any")) {
-		$input_errors[] = gettext("An IPv6 protocol was selected, but the selected interface has no IPv6 address.");
+		// If an underlying interface to be used by this client uses DHCP6, then it may not have received an IP address yet.
+		// So in that case we do not report a problem.
+		if (!interface_has_dhcp($iv_iface, 6)) {
+			$input_errors[] = gettext("An IPv6 protocol was selected, but the selected interface has no IPv6 address.");
+		}
 	}
 
 	if ($pconfig['mode'] != "p2p_shared_key") {

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -257,9 +257,17 @@ if ($_POST) {
 	} elseif (is_ipaddrv6($iv_ip) && (stristr($pconfig['protocol'], "6") === false)) {
 		$input_errors[] = gettext("Protocol and IP address families do not match. An IPv4 protocol and an IPv6 IP address cannot be selected.");
 	} elseif ((stristr($pconfig['protocol'], "6") === false) && !get_interface_ip($iv_iface) && ($pconfig['interface'] != "any")) {
-		$input_errors[] = gettext("An IPv4 protocol was selected, but the selected interface has no IPv4 address.");
+		// If an underlying interface to be used by this server uses DHCP, then it may not have received an IP address yet.
+		// So in that case we do not report a problem.
+		if (!interface_has_dhcp($iv_iface, 4)) {
+			$input_errors[] = gettext("An IPv4 protocol was selected, but the selected interface has no IPv4 address.");
+		}
 	} elseif ((stristr($pconfig['protocol'], "6") !== false) && !get_interface_ipv6($iv_iface) && ($pconfig['interface'] != "any")) {
-		$input_errors[] = gettext("An IPv6 protocol was selected, but the selected interface has no IPv6 address.");
+		// If an underlying interface to be used by this server uses DHCP6, then it may not have received an IP address yet.
+		// So in that case we do not report a problem.
+		if (!interface_has_dhcp($iv_iface, 6)) {
+			$input_errors[] = gettext("An IPv6 protocol was selected, but the selected interface has no IPv6 address.");
+		}
 	}
 
 	if ($pconfig['mode'] != "p2p_shared_key") {


### PR DESCRIPTION
even though the interface (or gateway group) has not yet actually
received an IP address.
This is useful when setting up a new system that is currently offline.