### PR TITLE
Add new "Ignore client identifiers" DHCP feature

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -885,6 +885,11 @@ EOPP;
 				$dhcpdconf .= "		ignore bootp;\n";
 			}
 
+			// ignore-client-uids
+			if (isset($poolconf['ignoreclientuids'])) {
+				$dhcpdconf .= "		ignore-client-uids true;\n";
+			}
+
 			// netbios-name*
 			if (is_array($poolconf['winsserver']) && $poolconf['winsserver'][0] && ($poolconf['winsserver'][0] != $dhcpifconf['winsserver'][0])) {
 				$dhcpdconf .= "		option netbios-name-servers " . join(",", $poolconf['winsserver']) . ";\n";

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -169,6 +169,7 @@ if (is_array($dhcpdconf)) {
 	list($pconfig['dns1'], $pconfig['dns2'], $pconfig['dns3'], $pconfig['dns4']) = $dhcpdconf['dnsserver'];
 	$pconfig['ignorebootp'] = isset($dhcpdconf['ignorebootp']);
 	$pconfig['denyunknown'] = isset($dhcpdconf['denyunknown']);
+	$pconfig['ignoreclientuids'] = isset($dhcpdconf['ignoreclientuids']);
 	$pconfig['nonak'] = isset($dhcpdconf['nonak']);
 	$pconfig['ddnsdomain'] = $dhcpdconf['ddnsdomain'];
 	$pconfig['ddnsdomainprimary'] = $dhcpdconf['ddnsdomainprimary'];
@@ -542,6 +543,7 @@ if (isset($_POST['save'])) {
 		$dhcpdconf['domainsearchlist'] = $_POST['domainsearchlist'];
 		$dhcpdconf['ignorebootp'] = ($_POST['ignorebootp']) ? true : false;
 		$dhcpdconf['denyunknown'] = ($_POST['denyunknown']) ? true : false;
+		$dhcpdconf['ignoreclientuids'] = ($_POST['ignoreclientuids']) ? true : false;
 		$dhcpdconf['nonak'] = ($_POST['nonak']) ? true : false;
 		$dhcpdconf['ddnsdomain'] = $_POST['ddnsdomain'];
 		$dhcpdconf['ddnsdomainprimary'] = $_POST['ddnsdomainprimary'];
@@ -799,6 +801,13 @@ $section->addInput(new Form_Checkbox(
 	'Denied clients will be ignored rather than rejected.',
 	$pconfig['nonak']
 ))->setHelp("This option is not compatible with failover and cannot be enabled when a Failover Peer IP address is configured.");
+
+$section->addInput(new Form_Checkbox(
+	'ignoreclientuids',
+	'Ignore client identifiers',
+	'If a client includes a unique identifier in its DHCP request, that UID will not be recorded in its lease.',
+	$pconfig['ignoreclientuids']
+))->setHelp("This option may be useful when a client can dual boot using different client identifiers but the same hardware (MAC) address.  Note that the resulting server behavior violates the official DHCP specification.");
 
 
 if (is_numeric($pool) || ($act == "newpool")) {


### PR DESCRIPTION
Exposes the underlying `dhcpd` configuration option `ignore-client-uids` in the pfSense "Services / DHCP Server" GUI by adding an "Ignore client identifiers" checkbox.

As of ISC dhcpd version 4.3.0+, there is a new configuration statement available, `ignore-client-uids`.  According to the ISC's documentation, "If the `ignore-client-uids` statement is present and has a value of `true` or `on`, the UID for clients will not be recorded."

While this behavior does not strictly adhere to the DHCP specification, it can be very useful in environments where devices on the network dual boot or PXE boot.  Normally, if the network stacks in a single device's different operating systems (including PXE firmware) make DHCP requests with differing client identifiers, the server will treat each request with a unique identifier as having come from a unique client, even when they come from the same device.  Thus, different operating systems on the same device and NIC might hold different leases with different IP addresses.

Once activated, the `ignore-client-uids` option tells the DHCP server not to record client identifiers in new DHCP leases, which forces the server to fall back on hardware (MAC) addresses to uniquely identify clients.  Now different operating systems on the same device and NIC will hold the same lease (based on MAC address), which should keep a device's IP address consistent regardless of its currently running operating system.

Same as with most other general and pool-specific DHCP server options in pfSense, note that turning on this option only affects new leases.  Any leases that existed prior to enabling this option will still contain their respective client identifiers.  Manually deleting older leases or flushing the entire lease table can expedite a full migration to the new server behavior, if desired.