### PR TITLE
Fix DNS Server Gateway Check

### DIFF
--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -193,12 +193,10 @@ if ($_POST) {
 	for ($dnscounter=1; $dnscounter<5; $dnscounter++) {
 		$dnsitem = "dns{$dnscounter}";
 		$dnsgwitem = "dns{$dnscounter}gw";
-		if ($_POST[$dnsgwitem]) {
-			if (interface_has_gateway($_POST[$dnsgwitem])) {
-				foreach ($direct_networks_list as $direct_network) {
-					if (ip_in_subnet($_POST[$dnsitem], $direct_network)) {
-						$input_errors[] = sprintf(gettext("A gateway can not be assigned to DNS '%s' server which is on a directly connected network."), $_POST[$dnsitem]);
-					}
+		if ($_POST[$dnsgwitem] && ($_POST[$dnsgwitem] <> "none")) {
+			foreach ($direct_networks_list as $direct_network) {
+				if (ip_in_subnet($_POST[$dnsitem], $direct_network)) {
+					$input_errors[] = sprintf(gettext("A gateway can not be assigned to DNS '%s' server which is on a directly connected network."), $_POST[$dnsitem]);
 				}
 			}
 		}


### PR DESCRIPTION
If I enter a DNS server IP address that is on a locally connected network, and choose a gateway for it, this code was supposed to give an error message. But no error was given because $_POST[$dnsgwitem] is actually the name of the gateway, but old line 197 called interface_has_gateway() which was expecting an interface to be passed.
Just get rid of the interface_has_gateway() test, and come into this foreach() whenever the users chooses a gateway that is not "none".