### PR TITLE
Fix #3560 correctly handle disabled static routes

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -1052,7 +1052,8 @@ function filter_get_direct_networks_list($returnsubnetsonly = true) {
 			}
 		}
 	}
-	foreach (get_staticroutes() as $netent) {
+	// Add any enabled static routes
+	foreach (get_staticroutes(false, false, true) as $netent) {
 		if (is_subnet($netent['network'])) {
 			if ($returnsubnetsonly) {
 				$networks_arr[] = $netent['network'];
@@ -1569,7 +1570,8 @@ function filter_nat_rules_automatic_tonathosts($with_descr = false) {
 	$tonathosts = array("127.0.0.0/8");
 	$descriptions = array(gettext("localhost"));
 
-	foreach (get_staticroutes() as $route) {
+	// Add any enabled static routes
+	foreach (get_staticroutes(false, false, true) as $route) {
 		$netip = explode("/", $route['network']);
 		if (isset($GatewaysList[$route['gateway']])) {
 			$gateway =& $GatewaysList[$route['gateway']];
@@ -3708,7 +3710,7 @@ EOD;
 	 */
 	if (isset($config['filter']['bypassstaticroutes']) && is_array($config['staticroutes']['route']) && count($config['staticroutes']['route'])) {
 		$ipfrules .= "# Add rules to bypass firewall rules for static routes\n";
-		foreach (get_staticroutes() as $route) {
+		foreach (get_staticroutes(false, false, true) as $route) { // Parameter 3 returnenabledroutesonly
 			$friendly = $GatewaysList[$route['gateway']]['friendlyiface'];
 			if (is_array($FilterIflist[$friendly])) {
 				$oc = $FilterIflist[$friendly];

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1741,7 +1741,8 @@ function services_dhcrelay_configure() {
 			}
 		}
 		if (!isset($destif)) {
-			foreach (get_staticroutes() as $rtent) {
+			// For each enabled static route
+			foreach (get_staticroutes(false, false, true) as $rtent) {
 				if (ip_in_subnet($srvip, $rtent['network'])) {
 					$a_gateways = return_gateways_array(true);
 					$destif = $a_gateways[$rtent['gateway']]['interface'];
@@ -1874,6 +1875,9 @@ function services_dhcrelay6_configure() {
 		if (!isset($destif)) {
 			if (is_array($config['staticroutes']['route'])) {
 				foreach ($config['staticroutes']['route'] as $rtent) {
+					if (isset($rtent['disabled'])) {
+						continue;
+					}
 					if (ip_in_subnet($srvip, $rtent['network'])) {
 						$a_gateways = return_gateways_array(true);
 						$destif = $a_gateways[$rtent['gateway']]['interface'];

--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -712,7 +712,7 @@ function unbound_acls_config($cfgsubdir = "") {
 				// add for IPv6 static routes to local networks
 				// for safety, we include only routes reachable on an interface with no
 				// gateway specified - read: not an Internet connection.
-				$static_routes = get_staticroutes();
+				$static_routes = get_staticroutes(false, false, true); // Parameter 3 returnenabledroutesonly
 				foreach ($static_routes as $route) {
 					if ((lookup_gateway_interface_by_name($route['gateway']) == $ubif) && !interface_has_gateway($ubif)) {
 						// route is on this interface, interface doesn't have gateway, add it

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2343,7 +2343,7 @@ function route_add_or_change($args) {
 	return ($rc == 0);
 }
 
-function get_staticroutes($returnsubnetsonly = false, $returnhostnames = false) {
+function get_staticroutes($returnsubnetsonly = false, $returnhostnames = false, $returnenabledroutesonly = false) {
 	global $config, $aliastable;
 
 	/* Bail if there are no routes, but return an array always so callers don't have to check. */
@@ -2355,6 +2355,10 @@ function get_staticroutes($returnsubnetsonly = false, $returnhostnames = false) 
 	$allsubnets = array();
 	/* Loop through routes and expand aliases as we find them. */
 	foreach ($config['staticroutes']['route'] as $route) {
+		if ($returnenabledroutesonly && isset($route['disabled'])) {
+			continue;
+		}
+
 		if (is_alias($route['network'])) {
 			if (!isset($aliastable[$route['network']])) {
 				continue;

--- a/src/etc/rc.newroutedns
+++ b/src/etc/rc.newroutedns
@@ -31,7 +31,8 @@ if (file_exists("{$g['varrun_path']}/booting")) {
 	return;
 }
 
-$staticroutes = get_staticroutes();
+// Get enabled static routes
+$staticroutes = get_staticroutes(false, false, true);
 
 if (count($staticroutes)) {
 	log_error("Static Routes: One or more aliases used for routing has changed its IP. Refreshing.");


### PR DESCRIPTION
1) util.inc - add parameter to get_staticroutes() so the caller can
choose to see all static routes or only the ones that are currently
enabled.
2) filter.inc - just process enabled static routes when making direct
networks list, tonathosts etc.
3) services.inc - only include enabled static routes when making confogs
for DHCP(6) Relay.
4) unbound.inc - only include enable static routes in
unbound_acls_config
5) rc.newroutedns - only trigger if there is an enabled static route.

Note: GUI validation has been left as-is. e.g. in system_gateways we don
not allow to delete a gateway if there is a disabled static route using
it... If people want to delete "higher level" stuff, then they need to
first delete the disabled static route(s). Otherwise it will get rather
"risky" having disabled static routes in the config that refer to
gateways that no longer exist, or have a subnet range that now matches a
local interafce or...