### PR TITLE
Check for static routes wholly within interface subnet

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -695,7 +695,12 @@ if ($_POST['apply']) {
 
 			foreach ($staticroutes as $route_subnet) {
 				list($network, $subnet) = explode("/", $route_subnet);
-				if ($_POST['subnet'] == $subnet && $network == gen_subnet($_POST['ipaddr'], $_POST['subnet'])) {
+				// If the proposed interface subnet is equal in size, or greater in size (CIDR is smaller) than the static route subnet
+				// and the network address of the static route subnet is in the proposed interface subnet, then there is a problem.
+				// The static routed addresses are contained in the proposed interface subnet, which will be messy!
+				// Note: If the static routed range is bigger than the proposed interface subnet, that is OK.
+				// Addresses in the interface are delivered locally, and outside use the static route.
+				if (($_POST['subnet'] <= $subnet) && ip_in_subnet($network, gen_subnet($_POST['ipaddr'], $_POST['subnet']) . "/" . $_POST['subnet'])) {
 					$input_errors[] = gettext("This IPv4 address conflicts with a Static Route.");
 					break;
 				}
@@ -723,7 +728,8 @@ if ($_POST['apply']) {
 
 			foreach ($staticroutes as $route_subnet) {
 				list($network, $subnet) = explode("/", $route_subnet);
-				if ($_POST['subnetv6'] == $subnet && $network == gen_subnetv6($_POST['ipaddrv6'], $_POST['subnetv6'])) {
+				// See comments above for IPv4 static route checks, the reasoning is the same.
+				if (($_POST['subnetv6'] <= $subnet) && ip_in_subnet($network, gen_subnet($_POST['ipaddrv6'], $_POST['subnetv6']) . "/" . $_POST['subnetv6'])) {
 					$input_errors[] = gettext("This IPv6 address conflicts with a Static Route.");
 					break;
 				}

--- a/src/usr/local/www/system_routes_edit.php
+++ b/src/usr/local/www/system_routes_edit.php
@@ -168,14 +168,14 @@ if ($_POST) {
 			if (is_ipaddrv4($_POST['network']) &&
 			    isset($if['ipaddr']) && isset($if['subnet']) &&
 			    is_ipaddrv4($if['ipaddr']) && is_numeric($if['subnet']) &&
-			    ($_POST['network_subnet'] == $if['subnet']) &&
-			    (gen_subnet($_POST['network'], $_POST['network_subnet']) == gen_subnet($if['ipaddr'], $if['subnet']))) {
+			    ($_POST['network_subnet'] >= $if['subnet']) &&
+			    (ip_in_subnet($_POST['network'], gen_subnet($if['ipaddr'], $if['subnet']) . "/" . $if['subnet']))) {
 				$input_errors[] = sprintf(gettext("This network conflicts with address configured on interface %s."), $if['descr']);
 			} else if (is_ipaddrv6($_POST['network']) &&
 			    isset($if['ipaddrv6']) && isset($if['subnetv6']) &&
 			    is_ipaddrv6($if['ipaddrv6']) && is_numeric($if['subnetv6']) &&
-			    ($_POST['network_subnet'] == $if['subnetv6']) &&
-			    (gen_subnetv6($_POST['network'], $_POST['network_subnet']) == gen_subnetv6($if['ipaddrv6'], $if['subnetv6']))) {
+			    ($_POST['network_subnet'] >= $if['subnetv6']) &&
+			    (ip_in_subnet($_POST['network'], gen_subnet($if['ipaddrv6'], $if['subnetv6']) . "/" . $if['subnetv6']))) {
 				$input_errors[] = sprintf(gettext("This network conflicts with address configured on interface %s."), $if['descr']);
 			}
 		}


### PR DESCRIPTION
The existing code checks for an interface subnet and static route subnet
that are both exactly the same, and puts up an input error for that.
Actually if the static route subnet is contained in the interface
subnet, then we should put up an input error - because that is pretty
dumb to try and static route some part of a local interafce subnet away
out some gateway. Probably it won't break things (the routing will
probably deliver the local packets direct to the local interface anyway,
effectively ignoring the static route). But it seems good to let the
user know that what they are doing is nonsense.
Or is there some use case that I ave not thought about?

Note: If the static route covers a range bigger than an interface
subnet, that is OK. Packets for addresses within the interface are
delivered locally, packets for the rest of the static routed network
will be routed to the specified gateway.