### PR TITLE
Captive portal: fix race conditions when disconnetting users

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -1089,7 +1089,11 @@ function captiveportal_disconnect_all($term_cause = 6, $logoutReason = "DISCONNE
 	$radiussrvs = captiveportal_get_radius_servers();
 	$cpdb = captiveportal_read_db();
 
-	$unsetindexes = array();
+	/* remove immediately the active users from the database to avoid races */
+	$unsetindexes = array_column($cpdb,5);
+	if (!empty($unsetindexes)) {
+		captiveportal_remove_entries($unsetindexes);
+	}
 
 	foreach ($cpdb as $cpentry) {
 		if (empty($cpentry[11])) {
@@ -1099,13 +1103,8 @@ function captiveportal_disconnect_all($term_cause = 6, $logoutReason = "DISCONNE
 
 		captiveportal_disconnect($cpentry, $radiusservers, $term_cause);
 		captiveportal_logportalauth($cpentry[4], $cpentry[3], $cpentry[2], $logoutReason);
-		$unsetindexes[] = $cpentry[5];
 	}
 	unset($cpdb);
-
-	if (!empty($unsetindexes)) {
-		captiveportal_remove_entries($unsetindexes);
-	}
 }
 
 /* send RADIUS acct stop for all current clients */

--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -1086,6 +1086,16 @@ function captiveportal_disconnect_client($sessionid, $term_cause = 1, $logoutRea
 function captiveportal_disconnect_all($term_cause = 6, $logoutReason = "DISCONNECT") {
 	global $g, $config, $cpzone, $cpzoneid;
 
+	/* check if we're pruning old entries and eventually wait */
+	$rcprunelock = try_lock("rcprunecaptiveportal{$cpzone}", 60);
+
+	/* if we still don't have the lock, unlock forcefully and take it */
+	if (!$rcprunelock) {
+		log_error("CP zone ${cpzone}: could not obtain the lock for more than 60 seconds, lock taken forcefully to disconnect all users");
+		unlock_force("rcprunecaptiveportal{$cpzone}");
+		$rcprunelock = lock("rcprunecaptiveportal{$cpzone}", LOCK_EX);
+	}
+
 	$radiussrvs = captiveportal_get_radius_servers();
 	$cpdb = captiveportal_read_db();
 
@@ -1105,6 +1115,8 @@ function captiveportal_disconnect_all($term_cause = 6, $logoutReason = "DISCONNE
 		captiveportal_logportalauth($cpentry[4], $cpentry[3], $cpentry[2], $logoutReason);
 	}
 	unset($cpdb);
+
+	unlock($rcprunelock);
 }
 
 /* send RADIUS acct stop for all current clients */

--- a/src/etc/rc.prunecaptiveportal
+++ b/src/etc/rc.prunecaptiveportal
@@ -43,18 +43,16 @@ if (!is_array($config['captiveportal'][$cpzone])) {
 }
 $cpzoneid = $config['captiveportal'][$cpzone]['zoneid'];
 
-if (file_exists("{$g['tmp_path']}/.rc.prunecaptiveportal.{$cpzone}.running")) {
-	$stat = stat("{$g['tmp_path']}/.rc.prunecaptiveportal.{$cpzone}.running");
-	if (time() - $stat['mtime'] >= 120) {
-		@unlink("{$g['tmp_path']}/.rc.prunecaptiveportal.{$cpzone}.running");
-	} else {
-		log_error("Skipping CP pruning process because previous/another instance is already running");
-		return;
-	}
+$rcprunelock = try_lock("rcprunecaptiveportal{$cpzone}", 3);
+
+if (!$rcprunelock) {
+	log_error("Skipping CP pruning process for zone {$cpzone} because previous/another instance is already running");
+	unlock_force("rcprunecaptiveportal{$cpzone}");
+	return;
 }
 
-@file_put_contents("{$g['tmp_path']}/.rc.prunecaptiveportal.{$cpzone}.running", "");
 captiveportal_prune_old();
-@unlink("{$g['tmp_path']}/.rc.prunecaptiveportal.{$cpzone}.running");
+
+unlock($rcprunelock);
 
 ?>


### PR DESCRIPTION
While I was doing more tests I found a problem with captiveportal_disconnect_all(). There's a longer explanation in the commit message but basically the problem is that both captiveportal_disconnect_all() and captiveportal_prune_all() read the user database, do a lot of work that with many users can take some time, then update the database, so if they run at the same time one of the two is going to clobber the other.

The first commit papers over the first issue I found by anticipating the update of the database in captiveportal_disconnect_all, so that if captiveportal_prune_all() runs when c_d_a() is working it won't try to disconnect again users that are already being disconnected. That's unfortunately not a solution for c_p_a() because when it starts we have no idea of who's going to be disconnected so we need to wait.

The second commit tries to use locking to avoid the problem once and for all. I found that some functions and modules were using lock()/unlock()/try_lock() from /etc/inc/util.inc, while rc.prunecaptiveportal was using some code that was probably older but did more or less the same things, so I converted it and then used the new lock in c_d_a().

This isn't tested, I didn't even run it, I wanted first to know if something like this is acceptable or if there's another better way to fix the problem that I'm not seeing.