### PR TITLE
Refactor to use notify_all_remote

### DIFF
--- a/src/etc/inc/notices.inc
+++ b/src/etc/inc/notices.inc
@@ -85,8 +85,7 @@ function file_notice($id, $notice, $category = "General", $url = "", $priority =
 	led_normalize();
 	led_morse(1, 'sos');
 	if (!$local_only) {
-		notify_via_growl($notice);
-		notify_via_smtp($notice);
+		notify_all_remote($notice);
 	}
 	return $queuekey;
 }


### PR DESCRIPTION
While looking at notices.inc I noticed (pardon the pun) that notify_all_remote did exactly the same as these 2 lines of code. notify_all_remote() might as well be used here, to save having the same code repeated.