### PR TITLE
Fix get_notices parameter in xmlrpc.php

### DIFF
--- a/src/usr/local/www/xmlrpc.php
+++ b/src/usr/local/www/xmlrpc.php
@@ -550,10 +550,10 @@ class pfsense_xmlrpc_server {
 		if (!function_exists("get_notices")) {
 			require_once("notices.inc");
 		}
-		if (!$params) {
+		if (!$category) {
 			$toreturn = get_notices();
 		} else {
-			$toreturn = get_notices($params);
+			$toreturn = get_notices($category);
 		}
 
 		return $toreturn;

--- a/src/usr/local/www/xmlrpc.php
+++ b/src/usr/local/www/xmlrpc.php
@@ -534,30 +534,6 @@ class pfsense_xmlrpc_server {
 
 		return true;
 	}
-
-	/**
-	 * Wrapper for get_notices()
-	 *
-	 * @param string $category
-	 *
-	 * @return bool
-	 */
-	public function get_notices($category = 'all') {
-		$this->auth();
-
-		global $g;
-
-		if (!function_exists("get_notices")) {
-			require_once("notices.inc");
-		}
-		if (!$category) {
-			$toreturn = get_notices();
-		} else {
-			$toreturn = get_notices($category);
-		}
-
-		return $toreturn;
-	}
 }
 
 $xmlrpclockkey = lock('xmlrpc', LOCK_EX);


### PR DESCRIPTION
This looks to me like the var name here should be $category
Note: I don't see where this get_notices() inside class pfsense_xmlrpc_server is ever unused anyway - so maybe get_notices() can just be deleted from here?