### PR TITLE
Fix #3454 Do not show Mark All as Read button when no priv

### DIFF
--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -681,7 +681,9 @@ if (are_notices_pending()):?>
 
 			<div class="modal-footer">
 				<button type="button" class="btn btn-info" data-dismiss="modal"><i class="fa fa-times icon-embed-btn"></i><?=gettext("Close")?></button>
+<?php if (isAllowedPage("/index.php")):?>
 				<button type="button" id="clearallnotices" class="btn btn-primary"><i class="fa fa-trash-o icon-embed-btn"></i><?=gettext("Mark All as Read")?></button>
+<?php endif;?>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
If the user does not have access to index.php then the "Mark All as Read" button for the notices popup does not work for them anyway, so do not show it.
This fixes the obvious UI inconsistency - where the user has a button that they press, but it is not effective.