### PR TITLE
Remove unused print_notices and print_notice_box

### DIFF
--- a/src/etc/inc/notices.inc
+++ b/src/etc/inc/notices.inc
@@ -200,61 +200,6 @@ function dump_xml_notices() {
 	return $xml;
 }
 
-/****f* notices/print_notices
- * NAME
- *   print_notices
- * INPUTS
- *	 $notices, $category
- * RESULT
- *   prints notices to the GUI
- ******/
-function print_notices($notices, $category = "all") {
-	foreach ($notices as $notice) {
-		if ($category != "all") {
-			if (in_array($notice['category'], $category)) {
-				$categories[] = $notice['category'];
-			}
-		} else {
-			$categories[] = $notice['category'];
-		}
-	}
-	$categories = array_unique($categories);
-	sort($categories);
-	foreach ($categories as $category) {
-		$toreturn .= "<ul><li>{$category}<ul>";
-		foreach ($notices as $notice) {
-			if (strtolower($notice['category']) == strtolower($category)) {
-				if ($notice['id'] != "") {
-					if ($notice['url'] != "") {
-						$toreturn .= "<li><a href={$notice['url']}>{$notice['id']}</a> - {$notice['notice']}</li>";
-					} else {
-						$toreturn .= "<li>{$notice['id']} - {$notice['notice']}</li>";
-					}
-				}
-			}
-		}
-		$toreturn .= "</ul></li></ul>";
-	}
-	return $toreturn;
-}
-
-/****f* notices/print_notice_box
- * NAME
- *   print_notice_box
- * INPUTS
- *	 $category
- * RESULT
- *   prints an info box to the GUI
- ******/
-function print_notice_box($category = "all") {
-	$notices = get_notices();
-	if (!$notices) {
-		return;
-	}
-	print_info_box(print_notices($notices, $category));
-	return;
-}
-
 /****f* notices/are_notices_pending
  * NAME
  *   are_notices_pending


### PR DESCRIPTION
When looking into how the notices features work these days, I found that these functions are no longer used anywhere.
Maybe they should be deleted?