### PR TITLE
Add privs to control display of notices

### DIFF
--- a/src/etc/inc/priv/user.priv.inc
+++ b/src/etc/inc/priv/user.priv.inc
@@ -38,6 +38,14 @@ $priv_list['user-config-readonly'] = array();
 $priv_list['user-config-readonly']['name']  = gettext("User - Config: Deny Config Write");
 $priv_list['user-config-readonly']['descr'] = gettext("If present, ignores requests from this user to write config.xml.");
 
+$priv_list['user-view-notices'] = array();
+$priv_list['user-view-notices']['name']  = gettext("User - Notices: View");
+$priv_list['user-view-notices']['descr'] = gettext("This user can view system notices.");
+
+$priv_list['user-view-clear-notices'] = array();
+$priv_list['user-view-clear-notices']['name']  = gettext("User - Notices: View and Clear");
+$priv_list['user-view-clear-notices']['descr'] = gettext("This user can view and clear system notices.");
+
 $priv_list['user-shell-access'] = array();
 $priv_list['user-shell-access']['name']  = gettext("User - System: Shell account access");
 $priv_list['user-shell-access']['descr'] = gettext("Indicates whether the user is able to login for example via SSH.");

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -418,6 +418,20 @@ $numColumns = $user_settings['webgui']['dashboardcolumns'];
 if (($pagename === "index.php") && ($numColumns > 2)) {
 	$columnsContainer = 'style="max-width: ' . 585*$numColumns . 'px;width: 100%"';
 }
+
+$display_notices = false;
+$allow_clear_notices = false;
+
+if (are_notices_pending()) {
+	// Evaluate user privs to determine if notices should be displayed, and if the user can clear them.
+	$user_entry = getUserEntry($_SESSION['Username']);
+	if (userHasPrivilege($user_entry, "user-view-clear-notices") || userHasPrivilege($user_entry, "page-all")) {
+		$display_notices = true;
+		$allow_clear_notices = true;
+	} elseif (userHasPrivilege($user_entry, "user-view-notices")) {
+		$display_notices = true;
+	}
+}
 ?>
 <body id="<?=$numColumns?>">
 <nav id="topmenu" class="navbar navbar-<?=$menuclass?>-top navbar-inverse">
@@ -470,7 +484,7 @@ if (($pagename === "index.php") && ($numColumns > 2)) {
 			 	endforeach?>
 			</ul>
 			<ul class="nav navbar-nav navbar-right">
-				<?php if (are_notices_pending()):?>
+				<?php if ($display_notices):?>
 					<?php $notices = get_notices()?>
 					<li class="dropdown">
 						<a href="#" data-toggle="modal" data-target="#notices" role="button" aria-expanded="false">
@@ -631,7 +645,8 @@ if ($config['remote_managed_pages']['item']) {
 
 // Modal notices window
 // The notices modal needs to be outside of the page display div or things get messy
-if (are_notices_pending()):?>
+if ($display_notices):
+?>
 
 <div id="notices" class="modal fade" role="dialog">
 	<div class="modal-dialog">
@@ -681,7 +696,7 @@ if (are_notices_pending()):?>
 
 			<div class="modal-footer">
 				<button type="button" class="btn btn-info" data-dismiss="modal"><i class="fa fa-times icon-embed-btn"></i><?=gettext("Close")?></button>
-<?php if (isAllowedPage("/index.php")):?>
+<?php if ($allow_clear_notices && isAllowedPage("/index.php")):?>
 				<button type="button" id="clearallnotices" class="btn btn-primary"><i class="fa fa-trash-o icon-embed-btn"></i><?=gettext("Mark All as Read")?></button>
 <?php endif;?>
 			</div>
@@ -709,7 +724,8 @@ if (are_notices_pending()):?>
 //]]>
 </script>
 
-<?php endif;
+<?php
+endif; // ($display_notices)
 
 // Get the flash Messages
 get_flash_message();


### PR DESCRIPTION
This is a suggested way to allow control of the display and clearing of
notices. The use case is:
1) A user with minimal page privs (e.g. can just change their password, or access a few status pages or...) should not be automatically able to see notices or clear them. Because notices might contain critical system information which discloses some problem with the system, and clearing them would prevent a full firewall administrator from seeing them.

For this implementation:
a) Users with all pages (admin, anyone in the admins group or with pages-all priv) will see notices and can clear them.
b) Users with user-view-notices can see the notices but not clear them.
c) Users with user-view-clear-notices can see the notices and also clear them.
d) Other users do not see notices.

In its current implementation, this is not totally backward-compatible.
Users who have only a few page privs will see notices prior to upgrade, then after upgrade they will not be able to see notices. The firewall administrator will have to grant them user-view-notices or user-view-clear-notices if they wish these users to see and/or clear notices.

It would be possible to automatically add these privs to existing users as a config upgrade step, but actually I suspect that in 99% of cases the firewall admin would not really want such users to see/clear notices.

Discussion welcome...