### PR TITLE
Report problems applying changes

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -323,6 +323,22 @@ function print_apply_box($msg) {
 	print_info_box($msg, "warning", "apply", gettext("Apply Changes"), 'fa-check', 'success');
 }
 
+// Format and print a box reporting that changes have been applied
+// $retval = status value from the functions called to apply the changes
+// 0 is good
+// non-zero is a problem
+function print_apply_result_box($retval) {
+	$result_msg = get_std_save_message($retval);
+	if ($retval == 0) {
+		// 0 is success
+		$severity = "success";
+	} else {
+		// non-zero means there was some problem
+		$severity = "warning";
+	}
+	print_info_box($result_msg, $severity);
+}
+
 /*
  * Print Bootstrap callout
  *
@@ -350,10 +366,16 @@ function print_callout($msg, $class = 'info', $heading = '') {
 	echo $callout;
 }
 
-function get_std_save_message($ok) {
+function get_std_save_message($retval) {
 	$filter_related = false;
 	$filter_pages = array("nat", "filter");
-	$to_return = gettext("The changes have been applied successfully.");
+	if ($retval == 0) {
+		// 0 is success
+		$to_return = gettext("The changes have been applied successfully.");
+	} else {
+		// non-zero means there was some problem
+		$to_return = gettext("There was a problem applying the changes. See the <a href=\"status_logs.php\">System Logs</a>.");
+	}
 	foreach ($filter_pages as $fp) {
 		if (stristr($_SERVER['SCRIPT_FILENAME'], $fp)) {
 			$filter_related = true;

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -407,11 +407,14 @@ if (isset($wancfg['wireless'])) {
 
 }
 
+$changes_applied = false;
+
 if ($_POST['apply']) {
 	unset($input_errors);
 	if (!is_subsystem_dirty('interfaces')) {
 		$input_errors[] = gettext("The settings have already been applied!");
 	} else {
+		$retval = 0;
 		unlink_if_exists("{$g['tmp_path']}/config.cache");
 		clear_subsystem_dirty('interfaces');
 
@@ -440,24 +443,24 @@ if ($_POST['apply']) {
 			}
 		}
 		/* restart snmp so that it binds to correct address */
-		services_snmpd_configure();
+		$retval |= services_snmpd_configure();
 
 		/* sync filter configuration */
 		setup_gateways_monitor();
 
 		clear_subsystem_dirty('interfaces');
 
-		filter_configure();
+		$retval |= filter_configure();
 
 		enable_rrd_graphing();
+
+		$changes_applied = true;
 
 		if (is_subsystem_dirty('staticroutes') && (system_routing_configure() == 0)) {
 			clear_subsystem_dirty('staticroutes');
 		}
 	}
 	@unlink("{$g['tmp_path']}/.interfaces.apply");
-	header("Location: interfaces.php?if={$if}");
-	exit;
 } else if ($_POST) {
 
 	unset($input_errors);
@@ -1695,10 +1698,9 @@ if (is_subsystem_dirty('interfaces')) {
 					gettext("Don't forget to adjust the DHCP Server range if needed after applying."));
 }
 
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
+if ($changes_applied) {
+	print_apply_result_box($retval);
 }
-
 
 $form = new Form();
 

--- a/src/usr/local/www/system_routes.php
+++ b/src/usr/local/www/system_routes.php
@@ -66,7 +66,6 @@ if ($_POST) {
 		/* reconfigure our gateway monitor */
 		setup_gateways_monitor();
 
-		$savemsg = get_std_save_message($retval);
 		if ($retval == 0) {
 			clear_subsystem_dirty('staticroutes');
 		}
@@ -218,8 +217,8 @@ include("head.inc");
 if ($input_errors) {
 	print_input_errors($input_errors);
 }
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
+if ($_POST['apply']) {
+	print_apply_result_box($retval);
 }
 if (is_subsystem_dirty('staticroutes')) {
 	print_apply_box(gettext("The static route configuration has been changed.") . "<br />" . gettext("The changes must be applied for them to take effect."));


### PR DESCRIPTION
At present various code keeps track of the return value of functions
that are called to apply changes ($retval). Then calls:
```get_std_save_message($retval)```
But get_std_save_message() always returns the same text "The changes
have been applied successfully."

So why is there are parameter to get_std_save_message()?

If we fix this up, returning different text to indicate that there is a
problem, then the subsequent print_info_box() that actually puts up the
message needs to pass the relevant severity also (success, warning,...).
So to minimize code that needs to be changed/duplicated in many places,
I have made print_apply_result_box() which takes $retval and sorts out
both the message text and severity all in 1 go.

system_routes has the typical changes that would be needed in the
top-level code to implement this.

Without changing top-level code, the changes in guiconfig.inc would
result in the problem text being reported when there is a problem, but
in the "success" color.