### PR TITLE
new blank rules - move "any" to top of list

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -275,6 +275,7 @@ if (isset($id) && $a_filter[$id]) {
 		$pconfig['interface'] = $_GET['if'];
 	}
 	$pconfig['type'] = "pass";
+	$pconfig['proto'] = "tcp"; // for new blank rules, default=tcp, also ensures ports fields are visible
 	$pconfig['src'] = "any";
 	$pconfig['dst'] = "any";
 }
@@ -1216,6 +1217,7 @@ $section->addInput(new Form_Select(
 	'Protocol',
 	$pconfig['proto'],
 	array(
+		'any' => gettext('any'),
 		'tcp' => 'TCP',
 		'udp' => 'UDP',
 		'tcp/udp' => 'TCP/UDP',
@@ -1228,7 +1230,6 @@ $section->addInput(new Form_Select(
 		'pim' => 'PIM',
 		'ospf' => 'OSPF',
 		'sctp' => 'SCTP',
-		'any' => gettext('any'),
 		'carp' => 'CARP',
 		'pfsync' => 'PFSYNC',
 	)

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1217,7 +1217,7 @@ $section->addInput(new Form_Select(
 	'Protocol',
 	$pconfig['proto'],
 	array(
-		'any' => gettext('any'),
+		'any' => gettext('Any'),
 		'tcp' => 'TCP',
 		'udp' => 'UDP',
 		'tcp/udp' => 'TCP/UDP',


### PR DESCRIPTION
@jim-p wanted this split out from PR #3139 as it wasn't related to that PR.

Users should not have to search for the "any option in the list of protocols. This moves "any" at the logical place people look for it (top of list not 2/3 down it at random. keeps default = tcp and ensures  extra ports etc fields visible.

Will probably need rebasing after previous PR merged, but will deal with that at the time.