### PR TITLE
firewall_rules_edit stop Floating field displaying

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1239,7 +1239,7 @@ if ($if == "FloatingRules" || isset($pconfig['floating'])) {
 		)
 	));
 
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'floating',
 		'Floating',
 		'hidden',


### PR DESCRIPTION
Seems to fix https://redmine.pfsense.org/issues/7057
But I have not looked underneath the hood - just copied the way other hidden fields are done in that code.