### PR TITLE
Improve labels + help text for IPv6 tunneling options

### DIFF
--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -158,23 +158,25 @@ $section->addInput(new Form_Checkbox(
 ))->setHelp('NOTE: This does not disable any IPv6 features on the firewall, it only '.
 	'blocks traffic.');
 
+
 $group = new Form_Group('IPv6 over IPv4 Tunneling');
 $group->add(new Form_Checkbox(
 	'ipv6nat_enable',
 	'IPv6 over IPv4 Tunneling',
-	'Enable IPv4 NAT encapsulation of IPv6 packets',
+	'Enable IPv6 over IPv4 tunneling',
 	$pconfig['ipv6nat_enable']
 ));
 
 $group->add(new Form_Input(
 	'ipv6nat_ipaddr',
-	'IP address',
+	'IP address of tunneling peer',
 	'text',
 	$pconfig['ipv6nat_ipaddr']
-))->setHelp('Enable IPv4 NAT encapsulation of IPv6 packets. <br/>This provides an '.
-	'RFC 2893 compatibility mechanism that can be used to tunneling IPv6 packets over '.
-	'IPv4 routing infrastructures. If enabled, don\'t forget to add a firewall rule to '.
-	'permit IPv6 packets.');
+))->setHelp('The IPv4 address of the tunneling peer');
+
+$group->setHelp('These options create an RFC 2893 compatible mechanism for IPv4 NAT encapsulation of IPv6 packets, that can be used ' .
+	'to tunnel IPv6 packets over IPv4 routing infrastructures. A firewall rule to allow passing of IPv6 packets ' .
+	'must also be <a href="firewall_rules.php">created</a>.');
 
 $section->add($group);
 

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -159,7 +159,7 @@ $section->addInput(new Form_Checkbox(
 	'blocks traffic.');
 
 
-$group = new Form_Group('IPv6 over IPv4 Tunneling');
+$group = new Form_Group('IPv6 over IPv4');
 $group->add(new Form_Checkbox(
 	'ipv6nat_enable',
 	'IPv6 over IPv4 Tunneling',

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -169,14 +169,14 @@ $group->add(new Form_Checkbox(
 
 $group->add(new Form_Input(
 	'ipv6nat_ipaddr',
-	'IP address of tunneling peer',
+	'Tunnel Peer\'s IP Address',
 	'text',
 	$pconfig['ipv6nat_ipaddr']
 ))->setHelp('The IPv4 address of the tunneling peer');
 
-$group->setHelp('These options create an RFC 2893 compatible mechanism for IPv4 NAT encapsulation of IPv6 packets, that can be used ' .
-	'to tunnel IPv6 packets over IPv4 routing infrastructures. A firewall rule to allow passing of IPv6 packets ' .
-	'must also be <a href="firewall_rules.php">created</a>.');
+$group->setHelp('These options create an RFC 2893 compatible mechanism for IPv4 NAT encapsulation of IPv6 packets, ' .
+	'that can be used to tunnel IPv6 packets over IPv4 routing infrastructures. A firewall rule to pass IPv6 packets ' .
+	'is <a href="firewall_rules.php">also necessary</a>.');
 
 $section->add($group);
 

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -160,6 +160,7 @@ $section->addInput(new Form_Checkbox(
 
 
 $group = new Form_Group('IPv6 over IPv4');
+
 $group->add(new Form_Checkbox(
 	'ipv6nat_enable',
 	'IPv6 over IPv4 Tunneling',
@@ -169,10 +170,10 @@ $group->add(new Form_Checkbox(
 
 $group->add(new Form_Input(
 	'ipv6nat_ipaddr',
-	'Tunnel Peer\'s IP Address',
+	'IPv4 address of Tunnel Peer',
 	'text',
 	$pconfig['ipv6nat_ipaddr']
-))->setHelp('The IPv4 address of the tunneling peer');
+));
 
 $group->setHelp('These options create an RFC 2893 compatible mechanism for IPv4 NAT encapsulation of IPv6 packets, ' .
 	'that can be used to tunnel IPv6 packets over IPv4 routing infrastructures. A firewall rule to pass IPv6 packets ' .

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -176,8 +176,9 @@ $group->add(new Form_Input(
 ));
 
 $group->setHelp('These options create an RFC 2893 compatible mechanism for IPv4 NAT encapsulation of IPv6 packets, ' .
-	'that can be used to tunnel IPv6 packets over IPv4 routing infrastructures. A firewall rule to pass IPv6 packets ' .
-	'is <a href="firewall_rules.php">also necessary</a>.');
+	'that can be used to tunnel IPv6 packets over IPv4 routing infrastructures. ' .
+	'IPv6 firewall rules are <a href="firewall_rules.php">also required</a>, to control and pass encapsulated traffic.');
+
 
 $section->add($group);
 


### PR DESCRIPTION
* Move the help message to be on the group as a whole not just the IP input field
* Clarify the IP field (label only states "IP address", narrative explains tunelling, but without further field info, the user is left unaided to figure what address should be entered and should it be IPv4, IPv6 or either? This isn't made clear.
* Group title uses the term "tunneling" and this is probably the most commonly understandable term, so keep it consistent and don't switch to "encapsulation" halfway through. (We use the term "encapsulation" in the help text already so it's there for purists)