### PR TITLE
Enhance security note for privilege assignment pages

### DIFF
--- a/src/usr/local/www/system_groupmanager_addprivs.php
+++ b/src/usr/local/www/system_groupmanager_addprivs.php
@@ -153,7 +153,9 @@ $section->addInput(new Form_Select(
 	build_priv_list(),
 	true
 ))->addClass('multiselect')
-  ->setHelp('Hold down CTRL (PC)/COMMAND (Mac) key to select multiple items.');
+  ->setHelp('Hold down CTRL (PC)/COMMAND (Mac) key to select multiple items.<br /><br />' .
+	   'Security note: Some privileges in this list expose root or other highly privileged access if access is granted.<br />' .
+	    'In particular, <i>WebCfg-All pages</i> exposes root access via the command prompt and edit file pages.');
 
 $section->addInput(new Form_Select(
 	'shadow',
@@ -162,7 +164,9 @@ $section->addInput(new Form_Select(
 	build_priv_list(),
 	true
 ))->addClass('shadowselect')
-  ->setHelp('Hold down CTRL (PC)/COMMAND (Mac) key to select multiple items.');
+  ->setHelp('Hold down CTRL (PC)/COMMAND (Mac) key to select multiple items.<br /><br />' .
+	   'Security note: Some privileges in this list expose root or other highly privileged access if access is granted.<br />' .
+	    'In particular, <i>WebCfg-All pages</i> exposes root access via the command prompt and edit file pages.');
 
 $section->addInput(new Form_Input(
 	'filtertxt',

--- a/src/usr/local/www/system_usermanager_addprivs.php
+++ b/src/usr/local/www/system_usermanager_addprivs.php
@@ -143,7 +143,9 @@ $section->addInput(new Form_Select(
 	build_priv_list(),
 	true
 ))->addClass('multiselect')
-  ->setHelp('Hold down CTRL (PC)/COMMAND (Mac) key to select multiple items.');
+  ->setHelp('Hold down CTRL (PC)/COMMAND (Mac) key to select multiple items.<br /><br />' .
+	   'Security note: Some privileges in this list expose root or other highly privileged access if access is granted.<br />' .
+	    'In particular, <i>WebCfg-All pages</i> exposes root access via the command prompt and edit file pages.');
 
 $section->addInput(new Form_Select(
 	'shadow',
@@ -152,7 +154,9 @@ $section->addInput(new Form_Select(
 	build_priv_list(),
 	true
 ))->addClass('shadowselect')
-  ->setHelp('Hold down CTRL (PC)/COMMAND (Mac) key to select multiple items.');
+  ->setHelp('Hold down CTRL (PC)/COMMAND (Mac) key to select multiple items.<br /><br />' .
+	   'Security note: Some privileges in this list expose root or other highly privileged access if access is granted.<br />' .
+	    'In particular, <i>WebCfg-All pages</i> exposes root access via the command prompt and edit file pages.');
 
 $section->addInput(new Form_Input(
 	'filtertxt',


### PR DESCRIPTION
As commented by Phil Davis on Redmine 2247 (note 3), it might be sensible for some of the privileges to note on the Privilege assignment pages, that they effectively grant root access privileges to any users or groups to whom they are assigned.

Rather than add an extra field to the PRIVS section to state "does it grant root access", I've added a brief note under the privilege selector boxes for users and groups, noting the point and highlighting the most likely permission where it may be overlooked - namely that WebCfg-All pages includes effective root access via command prompt and file editing. 

The note is short, but should be enough for any user setting privileges to get the idea and take it into account when they assign privileges.