### PR TITLE
Fix #7059 Set expected icmptypes format

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -423,6 +423,12 @@ if ($_POST) {
 
 	$pconfig = $_POST;
 
+	if (($_POST['proto'] == "icmp") && count($_POST['icmptype'])) {
+		$pconfig['icmptype'] = implode(',', $_POST['icmptype']);
+	} else {
+		unset($pconfig['icmptype']);
+	}
+
 	/* input validation */
 	$reqdfields = explode(" ", "type proto");
 	if (isset($a_filter[$id]['associated-rule-id']) === false) {


### PR DESCRIPTION
icmptype is a comma-separated list in the config. When attempting to save, the array in $_POST['icmptype'] needs to be put into this format in $pconfig in case there are input errors and the user-entered data need to be re-displayed for correction.