### PR TITLE
Improve - System - General - DNS Server Settings descriptions

### DIFF
--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -317,7 +317,9 @@ $section->addInput(new Form_Checkbox(
 	'DNS Query Forwarding',
 	'Enable Forwarding Mode',
 	$pconfig['forwarding']
-));
+))->setHelp(sprintf('If this option is set, DNS queries will be forwarded to the upstream DNS servers defined under'.
+					' %sSystem: General Setup%s or those obtained via DHCP/PPP on WAN'.
+					' (if DNS Server Override is enabled there).','<a href="system.php">','</a>'));
 
 $section->addInput(new Form_Checkbox(
 	'regdhcp',

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -128,7 +128,7 @@ if ($_POST) {
 				}
 			}
 			if ($founddns == false) {
-				$input_errors[] = gettext("At least one DNS server must be specified under System>General Setup to enable Forwarding mode.");
+				$input_errors[] = gettext("At least one DNS server must be specified under System &gt; General Setup to enable Forwarding mode.");
 			}
 		}
 
@@ -318,7 +318,7 @@ $section->addInput(new Form_Checkbox(
 	'Enable Forwarding Mode',
 	$pconfig['forwarding']
 ))->setHelp(sprintf('If this option is set, DNS queries will be forwarded to the upstream DNS servers defined under'.
-					' %sSystem: General Setup%s or those obtained via DHCP/PPP on WAN'.
+					' %sSystem &gt; General Setup%s or those obtained via DHCP/PPP on WAN'.
 					' (if DNS Server Override is enabled there).','<a href="system.php">','</a>'));
 
 $section->addInput(new Form_Checkbox(
@@ -328,7 +328,7 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['regdhcp']
 ))->setHelp(sprintf('If this option is set, then machines that specify their hostname when requesting a DHCP lease will be registered'.
 					' in the DNS Resolver, so that their name can be resolved.'.
-					' The domain in %sSystem: General Setup%s should also be set to the proper value.','<a href="system.php">','</a>'));
+					' The domain in %sSystem &gt; General Setup%s should also be set to the proper value.','<a href="system.php">','</a>'));
 
 $section->addInput(new Form_Checkbox(
 	'regdhcpstatic',
@@ -336,7 +336,7 @@ $section->addInput(new Form_Checkbox(
 	'Register DHCP static mappings in the DNS Resolver',
 	$pconfig['regdhcpstatic']
 ))->setHelp(sprintf('If this option is set, then DHCP static mappings will be registered in the DNS Resolver, so that their name can be resolved. '.
-					'The domain in %sSystem: General Setup%s should also be set to the proper value.','<a href="system.php">','</a>'));
+					'The domain in %sSystem &gt; General Setup%s should also be set to the proper value.','<a href="system.php">','</a>'));
 
 $btnadv = new Form_Button(
 	'btnadvcustom',
@@ -557,7 +557,7 @@ endforeach;
 		" service (if enabled) will automatically serve the LAN IP".
 		" address as a DNS server to DHCP clients so they will use".
 		" the DNS Resolver. If Forwarding is enabled, the DNS Resolver will use the DNS servers".
-		" entered in %sSystem: General Setup%s".
+		" entered in %sSystem &gt; General Setup%s".
 		" or those obtained via DHCP or PPP on WAN if &quot;Allow".
 		" DNS server list to be overridden by DHCP/PPP on WAN&quot;".
 		" is checked."), '<a href="system.php">', '</a>'), 'info', false); ?>

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -392,7 +392,7 @@ for ($i=1; $i<5; $i++) {
 
 	$help = "Enter IP addresses to be used by the system for DNS resolution. " .
 		"These are also used for the DHCP service, DNS Forwarder and DNS Resolver " .
-		"(if it has DNS Query Forwarding enabled).";
+		"when it has DNS Query Forwarding enabled.";
 
 	if ($multiwan)	{
 		$options = array('none' => 'none');

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -391,7 +391,8 @@ for ($i=1; $i<5; $i++) {
 	))->setHelp(($i == 4) ? 'Address':null);
 
 	$help = "Enter IP addresses to be used by the system for DNS resolution. " .
-		"These are also used for the DHCP service, DNS forwarder and for PPTP VPN clients.";
+		"These are also used for the DHCP service, DNS Forwarder and DNS Resolver " .
+		"(if it has DNS Query Forwarding enabled).";
 
 	if ($multiwan)	{
 		$options = array('none' => 'none');
@@ -433,18 +434,18 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['dnsallowoverride']
 ))->setHelp(sprintf(gettext('If this option is set, %s will use DNS servers '.
 	'assigned by a DHCP/PPP server on WAN for its own purposes (including '.
-	'the DNS forwarder). However, they will not be assigned to DHCP and PPTP '.
-	'VPN clients.'), $g['product_name']));
+	'the DNS Forwarder/DNS Resolver). However, they will not be assigned to DHCP '.
+	'clients.'), $g['product_name']));
 
 $section->addInput(new Form_Checkbox(
 	'dnslocalhost',
 	'Disable DNS Forwarder',
-	'Do not use the DNS Forwarder as a DNS server for the firewall',
+	'Do not use the DNS Forwarder/DNS Resolver as a DNS server for the firewall',
 	$pconfig['dnslocalhost']
 ))->setHelp('By default localhost (127.0.0.1) will be used as the first DNS '.
 	'server where the DNS Forwarder or DNS Resolver is enabled and set to '.
-	'listen on Localhost, so system can use the local DNS service to perform '.
-	'lookups. Checking this box omits localhost from the list of DNS servers.');
+	'listen on localhost, so system can use the local DNS service to perform '.
+	'lookups. Checking this box omits localhost from the list of DNS servers in resolv.conf.');
 
 $form->add($section);
 


### PR DESCRIPTION
- Add missing DNS Resolver references 
- Nuke PPTP VPN mentions
- Use letter case consistently.

The "Disable DNS Forwarder" option naming is rather unfortunate as well (would be much better with something like "Use local DNS server"), but changing that would require documentation changes.