### PR TITLE
dyndns.class, fix json curl body parsing for Cloudflare by not including headers

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -359,8 +359,7 @@
 				curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 			}
 
-			if ($this->_dnsService != 'ods' and $this->_dnsService != 'route53 ') {
-				curl_setopt($ch, CURLOPT_HEADER, 1);
+			if ($this->_dnsService != 'ods') {
 				curl_setopt($ch, CURLOPT_USERAGENT, $this->_UserAgent);
 				curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
 				curl_setopt($ch, CURLOPT_INTERFACE, 'if!' . $realparentif);
@@ -774,7 +773,6 @@
 					$server = 'https://api.dnsimple.com/v1/domains/';
 					$token = $this->_dnsUser . ':' . $this->_dnsPass;
 					$jsondata = '{"record":{"content":"' . $this->_dnsIP . '","ttl":"' . $this->_dnsTTL . '"}}';
-					curl_setopt($ch, CURLOPT_HEADER, 1);
 					curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
 					curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json', 'Content-Type: application/json', 'X-DNSimple-Token: ' . $token));
 					curl_setopt($ch, CURLOPT_URL, $server . $this->_dnsHost . '/records/' . $this->_dnsZoneID);
@@ -821,6 +819,7 @@
 					break;
 			}
 			if ($this->_dnsService != 'ods') {
+				curl_setopt($ch, CURLOPT_HEADER, 1);
 				$response = curl_exec($ch);
 				$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
 				$header = substr($response, 0, $header_size);
@@ -834,7 +833,7 @@
 		 * Private Function (added 12 July 2005) [beta]
 		 *   Retrieve Update Status
 		 */
-		function _checkStatus($ch, $data) {
+		function _checkStatus($ch, $data, $header) {
 			if ($this->_dnsVerboseLog) {
 				log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): _checkStatus() starting.'), $this->_dnsService, $this->_FQDN));
 			}


### PR DESCRIPTION
dyndns.class, fix json curl body parsing for Cloudflare by not including headers.
fix confirmed on forum: https://forum.pfsense.org/index.php?topic=122685.msg681184#msg681184

-Also pass parsed headers into the _checkStatus function
-remove 'route53 ' exclusion from if, as it would never match with the trailing space, and is apparently not needed.. (or so i assume..)