### PR TITLE
Remove unused print_info_box($savemsg)

### DIFF
--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -512,10 +512,6 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
-}
-
 $tab_array = array();
 $tab_array[] = array(gettext("Configuration"), true, "services_captiveportal.php?zone={$cpzone}");
 $tab_array[] = array(gettext("MACs"), false, "services_captiveportal_mac.php?zone={$cpzone}");

--- a/src/usr/local/www/services_captiveportal_hostname.php
+++ b/src/usr/local/www/services_captiveportal_hostname.php
@@ -98,10 +98,6 @@ if ($_GET['act'] == "del" && !empty($cpzone) && isset($cpzoneid)) {
 
 include("head.inc");
 
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
-}
-
 $tab_array = array();
 $tab_array[] = array(gettext("Configuration"), false, "services_captiveportal.php?zone={$cpzone}");
 $tab_array[] = array(gettext("MACs"), false, "services_captiveportal_mac.php?zone={$cpzone}");

--- a/src/usr/local/www/services_captiveportal_ip.php
+++ b/src/usr/local/www/services_captiveportal_ip.php
@@ -92,10 +92,6 @@ if ($_GET['act'] == "del" && !empty($cpzone) && isset($cpzoneid)) {
 
 include("head.inc");
 
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
-}
-
 $tab_array = array();
 $tab_array[] = array(gettext("Configuration"), false, "services_captiveportal.php?zone={$cpzone}");
 $tab_array[] = array(gettext("MACs"), false, "services_captiveportal_mac.php?zone={$cpzone}");

--- a/src/usr/local/www/services_captiveportal_vouchers_edit.php
+++ b/src/usr/local/www/services_captiveportal_vouchers_edit.php
@@ -175,10 +175,6 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
-}
-
 $form = new Form();
 
 $section = new Form_Section('Voucher Rolls');

--- a/src/usr/local/www/services_captiveportal_zones.php
+++ b/src/usr/local/www/services_captiveportal_zones.php
@@ -60,10 +60,6 @@ $pgtitle = array(gettext("Services"), gettext("Captive Portal"));
 $shortcut_section = "captiveportal";
 include("head.inc");
 
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
-}
-
 if (is_subsystem_dirty('captiveportal')) {
 	print_apply_box(gettext("The Captive Portal entry list has been changed.") . "<br />" . gettext("The changes must be applied for them to take effect."));
 }

--- a/src/usr/local/www/services_checkip_edit.php
+++ b/src/usr/local/www/services_checkip_edit.php
@@ -110,10 +110,6 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
-}
-
 $form = new Form;
 
 $section = new Form_Section('Check IP Service');

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -244,10 +244,6 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
-}
-
 $form = new Form;
 
 $section = new Form_Section('Dynamic DNS Client');

--- a/src/usr/local/www/services_pppoe_edit.php
+++ b/src/usr/local/www/services_pppoe_edit.php
@@ -285,10 +285,6 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
-}
-
 $form = new Form();
 
 $section = new Form_Section('PPPoE Server Configuration');

--- a/src/usr/local/www/services_rfc2136_edit.php
+++ b/src/usr/local/www/services_rfc2136_edit.php
@@ -152,10 +152,6 @@ if ($input_errors) {
 	print_input_errors($input_errors);
 }
 
-if ($savemsg) {
-	print_info_box($savemsg, 'success');
-}
-
 $form = new Form;
 
 $section = new Form_Section('RFC 2136 Client');


### PR DESCRIPTION
These are files that make no use of $savemsg.
May as well remove the print_info_box($savemsg) to avoid future
confusion for maintainers wondering why it is there.