### PR TITLE
Correctly report unmonitored gateway status

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -466,6 +466,8 @@ function return_gateways_status($byname = false) {
 			$status[$target]['loss'] = "";
 			$status[$target]['status'] = "none";
 		}
+
+		$status[$target]['monitor_disable'] = true;
 	}
 	return($status);
 }

--- a/src/usr/local/www/status_gateways.php
+++ b/src/usr/local/www/status_gateways.php
@@ -140,11 +140,17 @@ display_top_tabs($tab_array);
 						$online = gettext("Warning, Latency") . ': ' . $status['delay'];
 						$bgcolor = "bg-warning";
 					} elseif ($status['status'] == "none") {
-						$online = gettext("Online");
+						if ($status['monitor_disable'] || ($status['monitorip'] == "none")) {
+							$online = gettext("Online (unmonitored)");
+						} else {
+							$online = gettext("Online");
+						}
 						$bgcolor = "bg-success";
 					}
 				} else if (isset($gateway['monitor_disable'])) {
-						$online = gettext("Online");
+					// Note: return_gateways_status() always returns an array entry for all gateways,
+					//       so this "else if" never happens.
+						$online = gettext("Online (unmonitored)");
 						$bgcolor = "bg-success";
 				} else {
 					$online = gettext("Pending");

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -233,7 +233,7 @@ function compose_table_body_contents() {
 				$online = gettext("Latency");
 				$bgcolor = "warning";  // khaki
 			} elseif ($gateways_status[$gname]['status'] == "none") {
-				if ($gateways_status[$gname]['monitorip'] == "none") {
+				if ($gateways_status[$gname]['monitor_disable'] || ($gateways_status[$gname]['monitorip'] == "none")) {
 					$online = gettext("Online <br/>(unmonitored)");
 				} else {
 					$online = gettext("Online");


### PR DESCRIPTION
If an alternate monitor IP has been entered and saved, then the user
checks "Disable Gateway Monitoring" and saves, the alternate monitor IP
is retained in the config - that is handy for when unchecking "Disable
Gateway Monitoring" later on.
But the Gateways widget and Status Gateways do not correctly understand
this combination. The gateway status shows as "Online" when it is
intended to show "Online (unmonitored)".

This PR corrects this.