### PR TITLE
openvpn, write config and wait for pidfile inside lock_ex

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1245,11 +1245,9 @@ function openvpn_restart($mode, $settings) {
 		$i = 0;
 		$pid = "--";
 		while ($i < 3000) {
-			if (file_exists($pfile) ) {
+			if (isvalidpid($pfile)) {
 				$pid = rtrim(file_get_contents($pfile));
-				if (is_numericint($pid)) {
-					break;
-				}
+				break;
 			}
 			usleep(1000);
 			$i++;

--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1190,6 +1190,7 @@ function openvpn_restart($mode, $settings) {
 	$vpnid = $settings['vpnid'];
 	$mode_id = $mode.$vpnid;
 	$lockhandle = lock("openvpnservice{$mode_id}", LOCK_EX);
+	openvpn_reconfigure($mode, $settings);
 	/* kill the process if running */
 	$pfile = $g['varrun_path']."/openvpn_{$mode_id}.pid";
 	if (file_exists($pfile)) {
@@ -1197,6 +1198,7 @@ function openvpn_restart($mode, $settings) {
 		/* read the pid file */
 		$pid = rtrim(file_get_contents($pfile));
 		unlink($pfile);
+		syslog(LOG_INFO, "OpenVPN terminate old pid: {$pid}");
 
 		/* send a term signal to the process */
 		posix_kill($pid, SIGTERM);
@@ -1238,8 +1240,24 @@ function openvpn_restart($mode, $settings) {
 	/* start the new process */
 	$fpath = $g['varetc_path']."/openvpn/{$mode_id}.conf";
 	openvpn_clear_route($mode, $settings);
-	mwexec("/usr/local/sbin/openvpn --config " . escapeshellarg($fpath));
-
+	$res = mwexec("/usr/local/sbin/openvpn --config " . escapeshellarg($fpath));
+	if ($res == 0) {
+		$i = 0;
+		$pid = "--";
+		while ($i < 3000) {
+			if (file_exists($pfile) ) {
+				$pid = rtrim(file_get_contents($pfile));
+				if (is_numericint($pid)) {
+					break;
+				}
+			}
+			usleep(1000);
+			$i++;
+		}
+		syslog(LOG_INFO, "OpenVPN PID written: {$pid}");
+	} else {
+		syslog(LOG_ERR, "OpenVPN failed to start");
+	}
 	if (!platform_booting()) {
 		send_event("filter reload");
 	}
@@ -1400,7 +1418,6 @@ function openvpn_delete_csc(& $settings) {
 
 // Resync the configuration and restart the VPN
 function openvpn_resync($mode, $settings) {
-	openvpn_reconfigure($mode, $settings);
 	openvpn_restart($mode, $settings);
 }
 


### PR DESCRIPTION
openvpn, make sure config is written and not overwritten while starting openvpn, and wait for pid of child process to be written before exiting function

This prevents openvpn from getting into a 'unmanageable' state where pid file does not match the running process.