### PR TITLE
Remove unusued $heading in genhtmltitle()

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -508,7 +508,7 @@ function genhtmltitle($title) {
 		$bc = "";
 	}
 
-	return $heading . $bc;
+	return $bc;
 }
 
 /* update the changedesc and changecount(er) variables */


### PR DESCRIPTION
It came into use in  https://github.com/pfsense/pfsense/commit/45eebe10a93fa1e2399c6cdf133ad88dc21ee6e7 but genhtmltitle() has changed since then and no longer uses $heading