### PR TITLE
Example breadcrumb links

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -500,10 +500,20 @@ function genhtmltitle($title, $links=array()) {
 		$bc = '<ol class="breadcrumb">';
 
 		foreach ($title as $idx => $el) {
-			if (strlen($links[$idx]) > 0) {
-				$bc .= '<li><a href="/' . $links[$idx] . '">' .$el.'</a></li>';
+			$href = $links[$idx];
+			if (strlen($href) > 0) {
+				if ($href == '@self') {
+					$href = $_SERVER['SCRIPT_NAME'];
+					if (strlen($_SERVER['QUERY_STRING']) > 0) {
+						$href .= '?' . $_SERVER['QUERY_STRING'];
+					}
+				}
+				if (substr($href, 0, 1) != '/') {
+					$href = '/' . $href;
+				}
+				$bc .= '<li><a href="' . $href . '">' . $el . '</a></li>';
 			} else {
-				$bc .= '<li>'.$el.'</li>';
+				$bc .= '<li>' . $el . '</li>';
 			}
 		}
 

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -510,7 +510,7 @@ function genhtmltitle($title, $links=array()) {
 				if (substr($href, 0, 1) != '/') {
 					$href = '/' . $href;
 				}
-				$bc .= '<li><a href="' . $href . '">' . $el . '</a></li>';
+				$bc .= '<li><a href="' . htmlentities($href) . '">' . $el . '</a></li>';
 			} else {
 				$bc .= '<li>' . $el . '</li>';
 			}

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -492,15 +492,19 @@ function gentitle($title) {
 	}
 }
 
-function genhtmltitle($title) {
+function genhtmltitle($title, $links=array()) {
 
 	// If the array contains only one element, there are no breadcrumbs, so don't
 	// add anything else
 	if (count($title) > 1) {
 		$bc = '<ol class="breadcrumb">';
 
-		foreach ($title as $el) {
-			$bc .= '<li>'.$el.'</li>';
+		foreach ($title as $idx => $el) {
+			if (strlen($links[$idx]) > 0) {
+				$bc .= '<li><a href="https://' . $_SERVER['SERVER_ADDR'] . '/' . $links[$idx] . '">' .$el.'</a></li>';
+			} else {
+				$bc .= '<li>'.$el.'</li>';
+			}
 		}
 
 		$bc .= '</ol>';

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -502,11 +502,10 @@ function genhtmltitle($title, $links=array()) {
 		foreach ($title as $idx => $el) {
 			$href = $links[$idx];
 			if (strlen($href) > 0) {
+				// For convenience, if the caller specifies '@self' then make a link
+				// to the current page, including any query string.
 				if ($href == '@self') {
-					$href = $_SERVER['SCRIPT_NAME'];
-					if (strlen($_SERVER['QUERY_STRING']) > 0) {
-						$href .= '?' . $_SERVER['QUERY_STRING'];
-					}
+					$href = $_SERVER['REQUEST_URI'];
 				}
 				if (substr($href, 0, 1) != '/') {
 					$href = '/' . $href;

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -501,7 +501,7 @@ function genhtmltitle($title, $links=array()) {
 
 		foreach ($title as $idx => $el) {
 			if (strlen($links[$idx]) > 0) {
-				$bc .= '<li><a href="https://' . $_SERVER['SERVER_ADDR'] . '/' . $links[$idx] . '">' .$el.'</a></li>';
+				$bc .= '<li><a href="/' . $links[$idx] . '">' .$el.'</a></li>';
 			} else {
 				$bc .= '<li>'.$el.'</li>';
 			}

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -514,7 +514,7 @@ if (are_notices_pending()) {
 		print('<br />');
 		unset($notitle);
 	} else {
-		print(genhtmltitle($pgtitle));
+		print(genhtmltitle($pgtitle, $pglinks));
 	}
 ?>
 		<ul class="context-links">

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -721,9 +721,11 @@ function build_pooltable() {
 }
 
 $pgtitle = array(gettext("Services"), gettext("DHCP Server"));
+$pglinks = array("", "services_dhcp.php");
 
 if (!empty($if) && isset($iflist[$if])) {
 	$pgtitle[] = $iflist[$if];
+	$pglinks[] = "";
 }
 $shortcut_section = "dhcp";
 

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -725,7 +725,7 @@ $pglinks = array("", "services_dhcp.php");
 
 if (!empty($if) && isset($iflist[$if])) {
 	$pgtitle[] = $iflist[$if];
-	$pglinks[] = "";
+	$pglinks[] = "@self";
 }
 $shortcut_section = "dhcp";
 

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -395,6 +395,7 @@ if (!empty($if) && isset($iflist[$if])) {
 	$ifname = $iflist[$if];
 }
 $pgtitle = array(gettext("Services"), gettext("DHCP Server"), $ifname, gettext("Edit Static Mapping"));
+$pglinks = array("", "services_dhcp.php", "services_dhcp.php?if={$if}", "");
 $shortcut_section = "dhcp";
 
 include("head.inc");

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -395,7 +395,7 @@ if (!empty($if) && isset($iflist[$if])) {
 	$ifname = $iflist[$if];
 }
 $pgtitle = array(gettext("Services"), gettext("DHCP Server"), $ifname, gettext("Edit Static Mapping"));
-$pglinks = array("", "services_dhcp.php", "services_dhcp.php?if={$if}", "");
+$pglinks = array("", "services_dhcp.php", "services_dhcp.php?if={$if}", "@self");
 $shortcut_section = "dhcp";
 
 include("head.inc");


### PR DESCRIPTION
This is a way that the breadcrumbs could be populated with links, allowing the user to click backwards from where they came from.

a) In most cases the first thing in our breadcrumbs list is not somewhere that can be clicked-to - e.g "Interfaces" or "Services", the name of a top-level menu hat does not have its own page. So no link to put with that breadcrumb.
b) There seems no point putting a link to the place you are at currently (the end of the breadcrumb list).

So there are only links to be put in when there are 3 or more entries in the breadcrumb chain.

Also, I used $_SERVER['SERVER_ADDR'] to make a link that the remote client browser should be able to use to reach the pfSense. SERVER_NAME would sometimes not work here, because the client browser could be running from somewhere that cannot resolve the server name.
But SERVER_ADDR could also be some private IP address that is not reachable from the client browser - e.g. the pfSense itself is behind some NAT that has a port-forward through to the webGUI. How is that supposed to be done? (giving a client browser a proper full link back to something on the current server)

This is just an initial way to demonstrate what could be done for Redmine 7099. Plenty of discussion to come about what breadcrumb elements to put links on, exactly how those links work, and the best underlying architecture/infrastructure to use to code it efficiently.