### PR TITLE
Helper format_duid() for DUID input

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2570,9 +2570,11 @@ function format_duid($dhcp6duid) {
 	if (count($values) == 14) {
 		array_unshift($values, "0e", "00");
 	}
-	foreach ($values as $idx => $value) {
-		$values[$idx] = str_pad($value, 2, "0", STR_PAD_LEFT);
-	}
+
+	array_walk($values, function(&$value) {
+		$value = str_pad($value, 2, '0', STR_PAD_LEFT); 
+	});
+
 	return implode(":", $values);
 }
 

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2566,19 +2566,16 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
  * This function does not validate the input. is_duid() will do validation.
 */
 function format_duid($dhcp6duid) {
-	$formatted_dhcp6duid = strtolower(str_replace("-", ":", $dhcp6duid));
-	$values = explode(":", $formatted_dhcp6duid);
+	$values = explode(":", strtolower(str_replace("-", ":", $dhcp6duid)));
 	if (count($values) == 14) {
-		$formatted_dhcp6duid = '0e:00:' . $formatted_dhcp6duid;
-		$values = explode(":", $formatted_dhcp6duid);
+		array_unshift($values, "0e", "00");
 	}
 	foreach ($values as $idx => $value) {
 		if (strlen($value) == 1) {
 			$values[$idx] = "0" . $value;
 		}
 	}
-	$formatted_dhcp6duid = implode(":", $values);
-	return $formatted_dhcp6duid;
+	return implode(":", $values);
 }
 
 /* returns true if $dhcp6duid is a valid duid entry */

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2553,7 +2553,35 @@ function validateipaddr(&$addr, $type, $label, &$err_msg, $alias=false) {
 	return false;
 }
 
-/* returns true if $dhcp6duid is a valid duid entrry */
+/* format a string to look (more) like the expected DUID format:
+ * 1) Replace any "-" with ":"
+ * 2) If the user inputs 14 components, then add the expected "0e:00:" to the front.
+ *    This is convenience, because the actual DUID (which is reported in logs) is the last 14 components.
+ * 3) If any components are input with just a single char (hex digit hopefully), put a "0" in front.
+ *
+ * The final result should be closer to:
+ *
+ * "0e:00:00:01:00:01:nn:nn:nn:nn:nn:nn:nn:nn:nn:nn"
+ *
+ * This function does not validate the input. is_duid() will do validation.
+*/
+function format_duid($dhcp6duid) {
+	$formatted_dhcp6duid = strtolower(str_replace("-", ":", $dhcp6duid));
+	$values = explode(":", $formatted_dhcp6duid);
+	if (count($values) == 14) {
+		$formatted_dhcp6duid = '0e:00:' . $formatted_dhcp6duid;
+		$values = explode(":", $formatted_dhcp6duid);
+	}
+	foreach ($values as $idx => $value) {
+		if (strlen($value) == 1) {
+			$values[$idx] = "0" . $value;
+		}
+	}
+	$formatted_dhcp6duid = implode(":", $values);
+	return $formatted_dhcp6duid;
+}
+
+/* returns true if $dhcp6duid is a valid duid entry */
 function is_duid($dhcp6duid) {
 	$values = explode(":", $dhcp6duid);
 	if (count($values) != 16 || strlen($dhcp6duid) != 47) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2571,9 +2571,7 @@ function format_duid($dhcp6duid) {
 		array_unshift($values, "0e", "00");
 	}
 	foreach ($values as $idx => $value) {
-		if (strlen($value) == 1) {
-			$values[$idx] = "0" . $value;
-		}
+		$values[$idx] = str_pad($value, 2, "0", STR_PAD_LEFT);
 	}
 	return implode(":", $values);
 }

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -56,6 +56,14 @@ if ($_POST) {
 		$input_errors[] = gettext("An IP address to NAT IPv6 packets must be specified.");
 	}
 
+	if (!empty($_POST['global-v6duid'])) {
+		$_POST['global-v6duid'] = format_duid($_POST['global-v6duid']);
+		$pconfig['global-v6duid'] = $_POST['global-v6duid'];
+		if (!is_duid($_POST['global-v6duid'])) {
+			$input_errors[] = gettext("A valid DUID must be specified");
+		}
+	}
+
 	ob_flush();
 	flush();
 	if (!$input_errors) {
@@ -85,12 +93,7 @@ if ($_POST) {
 		}
 
 		if (!empty($_POST['global-v6duid'])) {
-			$_POST['global-v6duid'] = strtolower(str_replace("-", ":", $_POST['global-v6duid']));
-			if (!is_duid($_POST['global-v6duid'])) {
-				$input_errors[] = gettext("A valid DUID must be specified");
-			} else {
-				$config['system']['global-v6duid'] = $_POST['global-v6duid'];
-			}
+			$config['system']['global-v6duid'] = $_POST['global-v6duid'];
 		} else {
 			unset($config['system']['global-v6duid']);
 		}


### PR DESCRIPTION
format_duid() takes an input string and tries to be nice to the user, massaging the input string as best it can to try and put it into the format that is expected for putting into the config. This should be a convenience for users, specially if they paste a 14-component DUID from a log file into here.

The validation code that set $input_errors[] was in the section that was actually applying the changes. If you input a non-valid string, that would be reported, but also "The changes have been applied successfully."

The validation code has been moved higher up so that non-valid conditions are correctly reported and save is not done.