### PR TITLE
Breadcrumb links support

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -492,15 +492,28 @@ function gentitle($title) {
 	}
 }
 
-function genhtmltitle($title) {
+function genhtmltitle($title, $links=array()) {
 
 	// If the array contains only one element, there are no breadcrumbs, so don't
 	// add anything else
 	if (count($title) > 1) {
 		$bc = '<ol class="breadcrumb">';
 
-		foreach ($title as $el) {
-			$bc .= '<li>'.$el.'</li>';
+		foreach ($title as $idx => $el) {
+			$href = $links[$idx];
+			if (strlen($href) > 0) {
+				// For convenience, if the caller specifies '@self' then make a link
+				// to the current page, including any query string.
+				if ($href == '@self') {
+					$href = $_SERVER['REQUEST_URI'];
+				}
+				if (substr($href, 0, 1) != '/') {
+					$href = '/' . $href;
+				}
+				$bc .= '<li><a href="' . htmlentities($href) . '">' . $el . '</a></li>';
+			} else {
+				$bc .= '<li>' . $el . '</li>';
+			}
 		}
 
 		$bc .= '</ol>';

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -514,7 +514,7 @@ if (are_notices_pending()) {
 		print('<br />');
 		unset($notitle);
 	} else {
-		print(genhtmltitle($pgtitle));
+		print(genhtmltitle($pgtitle, $pglinks));
 	}
 ?>
 		<ul class="context-links">


### PR DESCRIPTION
Pages can set $pglinks as an array of the links to the relevant pages in the $pgtitle breadcrumb list.
- blank entries in $pglinks array will result in no link for that entry in the chain.
- "@self" entries will generate a reference to the page itself, including any query string. This will usually be used for the last entry in the breadcrumb list, providing an easy place to click and reload/refresh the page.