### PR TITLE
Crash Reporter report when no data found

### DIFF
--- a/src/usr/local/www/crash_reporter.php
+++ b/src/usr/local/www/crash_reporter.php
@@ -103,8 +103,10 @@ exec("/bin/cat /tmp/PHP_errors.log", $php_errors);
 		if (count($php_errors) > 0) {
 			$crash_reports .= "\nPHP Errors:\n";
 			$crash_reports .= implode("\n", $php_errors) . "\n\n";
+		} else {
+			$crash_reports .= "\nNo PHP errors found.\n";
 		}
-		if (is_array($crash_files))	{
+		if (count($crash_files) > 0) {
 			foreach ($crash_files as $cf) {
 				if (filesize($cf) < FILE_SIZE) {
 					$crash_reports .= "\nFilename: {$cf}\n";
@@ -112,7 +114,7 @@ exec("/bin/cat /tmp/PHP_errors.log", $php_errors);
 				}
 			}
 		} else {
-			echo gettext("Could not locate any crash data.");
+			$crash_reports .= "\nNo FreeBSD crash data found.\n";
 		}
 ?>
 	<div class="panel panel-default">


### PR DESCRIPTION
The glob for $crash_files always returns an array - an empty one in the case when there are no matching crash files. So the echo at old line 115 never happened. In any case, if the echo happens, it is spat out as plain text on the GUI outside of all the nice boxes and menus.

Might be nice for the devs to get explicit feedback about the "missing" parts of a crash report - that there were either "No PHP errors found" or "No FreeBSD crash data found".