### PR TITLE
Breadcrumbs detail

### DIFF
--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -516,6 +516,7 @@ function build_area_list($showall) {
 }
 
 $pgtitle = array(gettext("Diagnostics"), htmlspecialchars(gettext("Backup & Restore")), htmlspecialchars(gettext("Backup & Restore")));
+$pglinks = array("", "@self", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/diag_confbak.php
+++ b/src/usr/local/www/diag_confbak.php
@@ -97,6 +97,7 @@ $confvers = get_backups();
 unset($confvers['versions']);
 
 $pgtitle = array(gettext("Diagnostics"), htmlspecialchars(gettext("Backup & Restore")), gettext("Config History"));
+$pglinks = array("", "diag_backup.php", "@self");
 include("head.inc");
 
 if ($savemsg) {

--- a/src/usr/local/www/diag_dump_states.php
+++ b/src/usr/local/www/diag_dump_states.php
@@ -73,6 +73,7 @@ if (isset($_POST['filter']) && isset($_POST['killfilter'])) {
 }
 
 $pgtitle = array(gettext("Diagnostics"), gettext("States"), gettext("States"));
+$pglinks = array("", "@self", "@self");
 include("head.inc");
 ?>
 

--- a/src/usr/local/www/diag_dump_states_sources.php
+++ b/src/usr/local/www/diag_dump_states_sources.php
@@ -51,6 +51,7 @@ if ($_POST['filter']) {
 
 
 $pgtitle = array(gettext("Diagnostics"), gettext("States"), gettext("Source Tracking"));
+$pglinks = array("", "diag_dump_states.php", "@self");
 include("head.inc");
 
 $tab_array = array();

--- a/src/usr/local/www/diag_resetstate.php
+++ b/src/usr/local/www/diag_resetstate.php
@@ -54,6 +54,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Diagnostics"), gettext("States"), gettext("Reset States"));
+$pglinks = array("", "diag_dump_states.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/diag_smart.php
+++ b/src/usr/local/www/diag_smart.php
@@ -34,6 +34,7 @@ require_once("guiconfig.inc");
 $action = (isset($_POST['action']) ? $_POST['action'] : $_GET['action']);
 
 $pgtitle = array(gettext("Diagnostics"), gettext("S.M.A.R.T. Status"));
+$pglinks = array("", "@self", "@self");
 
 if ($action != 'config') {
 	$pgtitle[] = htmlspecialchars(gettext('Information & Tests'));

--- a/src/usr/local/www/firewall_aliases.php
+++ b/src/usr/local/www/firewall_aliases.php
@@ -169,6 +169,7 @@ foreach ($tab_array as $dtab) {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("Aliases"), $bctab);
+$pglinks = array("", "firewall_aliases.php", "@self");
 $shortcut_section = "aliases";
 
 include("head.inc");

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -35,8 +35,6 @@ require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");
 
-$pgtitle = array(gettext("Firewall"), gettext("Aliases"), gettext("Edit"));
-
 if (isset($_POST['referer'])) {
 	$referer = $_POST['referer'];
 } else {
@@ -61,8 +59,6 @@ if (!is_array($config['aliases']['alias'])) {
 	$config['aliases']['alias'] = array();
 }
 $a_aliases = &$config['aliases']['alias'];
-
-$tab = $_REQUEST['tab'];
 
 if ($_POST) {
 	$origname = $_POST['origname'];
@@ -130,6 +126,21 @@ if (isset($id) && $a_aliases[$id]) {
 		}
 	}
 }
+
+$tab = $_REQUEST['tab'];
+
+if (empty($tab)) {
+	if (preg_match("/url/i", $pconfig['type'])) {
+		$tab = 'url';
+	} else if ($pconfig['type'] == 'host') {
+		$tab = 'ip';
+	} else {
+		$tab = $pconfig['type'];
+	}
+}
+
+$pgtitle = array(gettext("Firewall"), gettext("Aliases"), gettext("Edit"));
+$pglinks = array("", "firewall_aliases.php?tab=" . $tab, "@self");
 
 if ($_POST) {
 
@@ -603,16 +614,6 @@ $types = array(
 	'urltable' => gettext("URL Table (IPs)"),
 	'urltable_ports' => gettext("URL Table (Ports)"),
 );
-
-if (empty($tab)) {
-	if (preg_match("/url/i", $pconfig['type'])) {
-		$tab = 'url';
-	} else if ($pconfig['type'] == 'host') {
-		$tab = 'ip';
-	} else {
-		$tab = $pconfig['type'];
-	}
-}
 
 if ($input_errors) {
 	print_input_errors($input_errors);

--- a/src/usr/local/www/firewall_aliases_import.php
+++ b/src/usr/local/www/firewall_aliases_import.php
@@ -35,8 +35,6 @@ require_once("util.inc");
 require_once("filter.inc");
 require_once("shaper.inc");
 
-$pgtitle = array(gettext("Firewall"), gettext("Aliases"), gettext("Bulk import"));
-
 $referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_aliases.php');
 
 // Add all Load balance names to reserved_keywords
@@ -53,6 +51,9 @@ $tab = $_REQUEST['tab'];
 if (empty($tab)) {
 	$tab = 'ip';
 }
+
+$pgtitle = array(gettext("Firewall"), gettext("Aliases"), gettext("Bulk import"));
+$pglinks = array("", "firewall_aliases.php?tab=" . $tab, "@self");
 
 if (!is_array($config['aliases']['alias'])) {
 	$config['aliases']['alias'] = array();

--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -184,6 +184,7 @@ if (isset($_POST['del_x'])) {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("NAT"), gettext("Port Forward"));
+$pglinks = array("", "@self", "@self");
 include("head.inc");
 
 if ($savemsg) {

--- a/src/usr/local/www/firewall_nat_1to1.php
+++ b/src/usr/local/www/firewall_nat_1to1.php
@@ -120,6 +120,7 @@ if (isset($_POST['del_x'])) {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("NAT"), gettext("1:1"));
+$pglinks = array("", "firewall_nat.php", "@self");
 include("head.inc");
 
 if ($savemsg) {

--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -288,6 +288,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("NAT"), gettext("1:1"), gettext("Edit"));
+$pglinks = array("", "firewall_nat.php", "firewall_nat_1to1.php", "@self");
 include("head.inc");
 
 function build_srctype_list() {

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -636,6 +636,7 @@ function dsttype_selected() {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("NAT"), gettext("Port Forward"), gettext("Edit"));
+$pglinks = array("", "firewall_nat.php", "firewall_nat.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/firewall_nat_npt.php
+++ b/src/usr/local/www/firewall_nat_npt.php
@@ -120,6 +120,7 @@ if (isset($_POST['del_x'])) {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("NAT"), gettext("NPt"));
+$pglinks = array("", "firewall_nat.php", "@self");
 include("head.inc");
 
 if ($savemsg) {

--- a/src/usr/local/www/firewall_nat_npt_edit.php
+++ b/src/usr/local/www/firewall_nat_npt_edit.php
@@ -176,6 +176,7 @@ function build_if_list() {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("NAT"), gettext("NPt"), gettext("Edit"));
+$pglinks = array("", "firewall_nat.php", "firewall_nat_npt.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/firewall_nat_out.php
+++ b/src/usr/local/www/firewall_nat_out.php
@@ -204,6 +204,7 @@ if (isset($_POST['del_x'])) {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("NAT"), gettext("Outbound"));
+$pglinks = array("", "firewall_nat.php", "@self");
 include("head.inc");
 
 if ($savemsg) {

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -376,6 +376,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("NAT"), gettext("Outbound"), gettext("Edit"));
+$pglinks = array("", "firewall_nat.php", "firewall_nat_out.php", "@self");
 include("head.inc");
 
 function build_target_list() {

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -39,7 +39,6 @@ require_once("shaper.inc");
 $XmoveTitle = gettext("Move checked rules above this one. Shift+Click to move checked rules below.");
 $ShXmoveTitle = gettext("Move checked rules below this one. Release shift to move checked rules above.");
 
-$pgtitle = array(gettext("Firewall"), gettext("Rules"));
 $shortcut_section = "firewall";
 
 function get_pf_rules($rules, $tracker) {
@@ -322,6 +321,7 @@ foreach ($tab_array as $dtab) {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("Rules"), $bctab);
+$pglinks = array("", "firewall_rules.php", "@self");
 $shortcut_section = "firewall";
 
 include("head.inc");

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1089,11 +1089,20 @@ function build_if_list() {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("Rules"));
+$pglinks = array("");
 
 if ($if == "FloatingRules" || isset($pconfig['floating'])) {
+	$pglinks[] = "firewall_rules.php?if=FloatingRules";
 	$pgtitle[] = gettext('Floating');
+	$pglinks[] = "firewall_rules.php?if=FloatingRules";
+} elseif (!empty($if)) {
+	$pglinks = array("", "firewall_rules.php?if=" . $if);
+} else {
+	$pglinks = array("", "firewall_rules.php");
 }
+
 $pgtitle[] = gettext("Edit");
+$pglinks[] = "@self";
 $shortcut_section = "firewall";
 
 $page_filename = "firewall_rules_edit.php";

--- a/src/usr/local/www/firewall_schedule_edit.php
+++ b/src/usr/local/www/firewall_schedule_edit.php
@@ -50,6 +50,7 @@ require_once("filter.inc");
 require_once("shaper.inc");
 
 $pgtitle = array(gettext("Firewall"), gettext("Schedules"), gettext("Edit"));
+$pglinks = array("", "firewall_schedule.php", "@self");
 
 $referer = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '/firewall_schedule.php');
 

--- a/src/usr/local/www/firewall_shaper.php
+++ b/src/usr/local/www/firewall_shaper.php
@@ -39,6 +39,7 @@ if ($_GET['reset'] != "") {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("Traffic Shaper"), gettext("By Interface"));
+$pglinks = array("", "@self", "@self");
 $shortcut_section = "trafficshaper";
 
 $shaperIFlist = get_configured_interface_with_descr();

--- a/src/usr/local/www/firewall_shaper_queues.php
+++ b/src/usr/local/www/firewall_shaper_queues.php
@@ -186,6 +186,7 @@ if ($_POST['apply']) {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("Traffic Shaper"), gettext("By Queue"));
+$pglinks = array("", "firewall_shaper.php", "@self");
 $shortcut_section = "trafficshaper";
 
 include("head.inc");

--- a/src/usr/local/www/firewall_shaper_vinterface.php
+++ b/src/usr/local/www/firewall_shaper_vinterface.php
@@ -37,6 +37,7 @@ if ($_GET['reset'] != "") {
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("Traffic Shaper"), gettext("Limiters"));
+$pglinks = array("", "firewall_shaper.php", "@self");
 $shortcut_section = "trafficshaper-limiters";
 $dfltmsg = false;
 

--- a/src/usr/local/www/firewall_shaper_wizards.php
+++ b/src/usr/local/www/firewall_shaper_wizards.php
@@ -62,6 +62,7 @@ if ($_POST['apply']) {
 $shaperIFlist = get_configured_interface_with_descr();
 
 $pgtitle = array(gettext("Firewall"), gettext("Traffic Shaper"), gettext("Wizards"));
+$pglinks = array("", "firewall_shaper.php", "@self");
 $shortcut_section = "trafficshaper";
 
 $wizards = array(

--- a/src/usr/local/www/firewall_virtual_ip_edit.php
+++ b/src/usr/local/www/firewall_virtual_ip_edit.php
@@ -287,6 +287,7 @@ $ipaliashelp = gettext('The mask must be the network\'s subnet mask. It does not
 $proxyarphelp = gettext('Enter a CIDR block of proxy ARP addresses.');
 
 $pgtitle = array(gettext("Firewall"), gettext("Virtual IPs"), gettext("Edit"));
+$pglinks = array("", "firewall_virtual_ip.php", "@self");
 include("head.inc");
 
 function build_if_list() {

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -492,15 +492,28 @@ function gentitle($title) {
 	}
 }
 
-function genhtmltitle($title) {
+function genhtmltitle($title, $links=array()) {
 
 	// If the array contains only one element, there are no breadcrumbs, so don't
 	// add anything else
 	if (count($title) > 1) {
 		$bc = '<ol class="breadcrumb">';
 
-		foreach ($title as $el) {
-			$bc .= '<li>'.$el.'</li>';
+		foreach ($title as $idx => $el) {
+			$href = $links[$idx];
+			if (strlen($href) > 0) {
+				// For convenience, if the caller specifies '@self' then make a link
+				// to the current page, including any query string.
+				if ($href == '@self') {
+					$href = $_SERVER['REQUEST_URI'];
+				}
+				if (substr($href, 0, 1) != '/') {
+					$href = '/' . $href;
+				}
+				$bc .= '<li><a href="' . htmlentities($href) . '">' . $el . '</a></li>';
+			} else {
+				$bc .= '<li>' . $el . '</li>';
+			}
 		}
 
 		$bc .= '</ol>';

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -492,12 +492,23 @@ function gentitle($title) {
 	}
 }
 
-function genhtmltitle($title, $links=array()) {
+function genhtmltitle($title, $links=true) {
+
+	$num_crumbs = count($title);
 
 	// If the array contains only one element, there are no breadcrumbs, so don't
 	// add anything else
-	if (count($title) > 1) {
+	if ($num_crumbs > 1) {
 		$bc = '<ol class="breadcrumb">';
+
+		if (!is_array($links)) {
+			$gen_default = ($links === true);
+			$links = array_fill(0, $num_crumbs, '');
+			// If no links passed, then default to a link to self on the last entry.
+			if ($gen_default) {
+				$links[$num_crumbs-1] = '@self';
+			}
+		}
 
 		foreach ($title as $idx => $el) {
 			$href = $links[$idx];

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -514,7 +514,7 @@ if (are_notices_pending()) {
 		print('<br />');
 		unset($notitle);
 	} else {
-		print(genhtmltitle($pgtitle));
+		print(genhtmltitle($pgtitle, $pglinks));
 	}
 ?>
 		<ul class="context-links">

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -514,7 +514,11 @@ if (are_notices_pending()) {
 		print('<br />');
 		unset($notitle);
 	} else {
-		print(genhtmltitle($pgtitle, $pglinks));
+		if (isset($pglinks)) {
+			print(genhtmltitle($pgtitle, $pglinks));	
+		} else {
+			print(genhtmltitle($pgtitle));
+		}
 	}
 ?>
 		<ul class="context-links">

--- a/src/usr/local/www/interfaces_bridge_edit.php
+++ b/src/usr/local/www/interfaces_bridge_edit.php
@@ -382,6 +382,7 @@ function build_port_list($selecton) {
 }
 
 $pgtitle = array(gettext("Interfaces"), gettext("Bridges"), gettext("Edit"));
+$pglinks = array("", "interfaces_bridge.php", "@self");
 $shortcut_section = "interfaces";
 include("head.inc");
 

--- a/src/usr/local/www/interfaces_gif_edit.php
+++ b/src/usr/local/www/interfaces_gif_edit.php
@@ -163,6 +163,7 @@ function build_parent_list() {
 }
 
 $pgtitle = array(gettext("Interfaces"), gettext("GIFs"), gettext("Edit"));
+$pglinks = array("", "interfaces_gif.php", "@self");
 $shortcut_section = "interfaces";
 include("head.inc");
 

--- a/src/usr/local/www/interfaces_gre_edit.php
+++ b/src/usr/local/www/interfaces_gre_edit.php
@@ -157,6 +157,7 @@ function build_parent_list() {
 }
 
 $pgtitle = array(gettext("Interfaces"), gettext("GREs"), gettext("Edit"));
+$pglinks = array("", "interfaces_gre.php", "@self");
 $shortcut_section = "interfaces";
 include("head.inc");
 

--- a/src/usr/local/www/interfaces_groups_edit.php
+++ b/src/usr/local/www/interfaces_groups_edit.php
@@ -31,6 +31,7 @@ require_once("guiconfig.inc");
 require_once("functions.inc");
 
 $pgtitle = array(gettext("Interfaces"), gettext("Interface Groups"), gettext("Edit"));
+$pglinks = array("", "interfaces_groups.php", "@self");
 $shortcut_section = "interfaces";
 
 if (!is_array($config['ifgroups']['ifgroupentry'])) {

--- a/src/usr/local/www/interfaces_lagg_edit.php
+++ b/src/usr/local/www/interfaces_lagg_edit.php
@@ -221,6 +221,7 @@ function build_member_list() {
 }
 
 $pgtitle = array(gettext("Interfaces"), gettext("LAGGs"), gettext("Edit"));
+$pglinks = array("", "interfaces_lagg.php", "@self");
 $shortcut_section = "interfaces";
 include("head.inc");
 

--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -458,6 +458,7 @@ if (isset($_POST) && is_array($_POST) && count($_POST) > 0) {
 } // end if ($_POST)
 
 $pgtitle = array(gettext("Interfaces"), gettext("PPPs"), gettext("Edit"));
+$pglinks = array("", "interfaces_ppps.php", "@self");
 $shortcut_section = "interfaces";
 include("head.inc");
 

--- a/src/usr/local/www/interfaces_qinq_edit.php
+++ b/src/usr/local/www/interfaces_qinq_edit.php
@@ -27,6 +27,7 @@
 ##|-PRIV
 
 $pgtitle = array(gettext("Interfaces"), gettext("QinQs"), gettext("Edit"));
+$pglinks = array("", "interfaces_qinq.php", "@self");
 $shortcut_section = "interfaces";
 
 require_once("guiconfig.inc");

--- a/src/usr/local/www/interfaces_vlan_edit.php
+++ b/src/usr/local/www/interfaces_vlan_edit.php
@@ -170,6 +170,7 @@ function build_interfaces_list() {
 }
 
 $pgtitle = array(gettext("Interfaces"), gettext("VLANs"), gettext("Edit"));
+$pglinks = array("", "interfaces_vlan.php", "@self");
 $shortcut_section = "interfaces";
 include("head.inc");
 

--- a/src/usr/local/www/interfaces_wireless_edit.php
+++ b/src/usr/local/www/interfaces_wireless_edit.php
@@ -163,6 +163,7 @@ function build_parent_list() {
 }
 
 $pgtitle = array(gettext("Interfaces"), gettext("Wireless"), gettext("Edit"));
+$pglinks = array("", "interfaces_wireless.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/load_balancer_monitor.php
+++ b/src/usr/local/www/load_balancer_monitor.php
@@ -71,6 +71,7 @@ if ($_GET['act'] == "del") {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Load Balancer"), gettext("Monitors"));
+$pglinks = array("", "load_balancer_pool.php", "@self");
 $shortcut_section = "relayd";
 
 include("head.inc");

--- a/src/usr/local/www/load_balancer_monitor_edit.php
+++ b/src/usr/local/www/load_balancer_monitor_edit.php
@@ -200,6 +200,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Load Balancer"), gettext("Monitors"), gettext("Edit"));
+$pglinks = array("", "load_balancer_pool.php", "load_balancer_monitor.php", "@self");
 $shortcut_section = "relayd";
 
 include("head.inc");

--- a/src/usr/local/www/load_balancer_pool.php
+++ b/src/usr/local/www/load_balancer_pool.php
@@ -85,6 +85,7 @@ for ($i = 0; isset($config['load_balancer']['lbpool'][$i]); $i++) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Load Balancer"), gettext("Pools"));
+$pglinks = array("", "@self", "@self");
 $shortcut_section = "relayd";
 
 include("head.inc");

--- a/src/usr/local/www/load_balancer_pool_edit.php
+++ b/src/usr/local/www/load_balancer_pool_edit.php
@@ -183,6 +183,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Load Balancer"), gettext("Pools"), gettext("Edit"));
+$pglinks = array("", "load_balancer_pool.php", "load_balancer_pool.php", "@self");
 $shortcut_section = "relayd";
 
 include("head.inc");

--- a/src/usr/local/www/load_balancer_setting.php
+++ b/src/usr/local/www/load_balancer_setting.php
@@ -84,6 +84,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Load Balancer"), gettext("Settings"));
+$pglinks = array("", "load_balancer_pool.php", "@self");
 $shortcut_section = "relayd";
 
 include("head.inc");

--- a/src/usr/local/www/load_balancer_virtual_server.php
+++ b/src/usr/local/www/load_balancer_virtual_server.php
@@ -105,6 +105,7 @@ function alias_idx($name, $type) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Load Balancer"), gettext("Virtual Servers"));
+$pglinks = array("", "load_balancer_pool.php", "@self");
 $shortcut_section = "relayd-virtualservers";
 
 include("head.inc");

--- a/src/usr/local/www/load_balancer_virtual_server_edit.php
+++ b/src/usr/local/www/load_balancer_virtual_server_edit.php
@@ -157,6 +157,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Load Balancer"), gettext("Virtual Servers"), gettext("Edit"));
+$pglinks = array("", "load_balancer_pool.php", "load_balancer_virtual_server.php", "@self");
 $shortcut_section = "relayd-virtualservers";
 
 include("head.inc");

--- a/src/usr/local/www/pkg.php
+++ b/src/usr/local/www/pkg.php
@@ -37,6 +37,7 @@ $xml = $_REQUEST['xml'];
 
 if ($xml == "") {
 	$pgtitle = array(gettext("Package"), gettext("Editor"));
+	$pglinks = array("", "@self");
 	include("head.inc");
 	print_info_box(gettext("No valid package defined."), 'danger', false);
 	include("foot.inc");
@@ -163,12 +164,15 @@ if ($pkg['title'] != "") {
 
 		foreach ($title as $subtitle) {
 			$pgtitle[] = gettext($subtitle);
+			$pglinks[] = "@self";
 		}
 	} else {
 		$pgtitle = array(gettext("Package"), gettext($pkg['title']));
+		$pglinks = array("", "@self");
 	}
 } else {
 	$pgtitle = array(gettext("Package"), gettext("Editor"));
+	$pglinks = array("", "@self");
 }
 
 if ($pkg['tabs'] != "") {
@@ -182,6 +186,7 @@ if ($pkg['tabs'] != "") {
 		if (isset($tab['active'])) {
 			$active = true;
 			$pgtitle[] = $tab['text'];
+			$pglinks[] = "@self";
 		} else {
 			$active = false;
 		}

--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -48,6 +48,7 @@ $xml_fullpath = realpath('/usr/local/pkg/' . $xml);
 
 if ($xml == "" || $xml_fullpath === false || substr($xml_fullpath, 0, strlen('/usr/local/pkg/')) != '/usr/local/pkg/') {
 	$pgtitle = array(gettext("Package"), gettext("Editor"));
+	$pglinks = array("", "@self");
 	include("head.inc");
 	print_info_box(gettext("No valid package defined."), 'danger', false);
 	include("foot.inc");
@@ -505,12 +506,15 @@ if ($pkg['title'] != "") {
 
 		foreach ($title as $subtitle) {
 			$pgtitle[] = gettext($subtitle);
+			$pglinks[] = ((($subtitle == "Edit") || (strlen($pkg['menu'][0]['url']) == 0)) ? "@self" : $pkg['menu'][0]['url']);
 		}
 	} else {
 		$pgtitle = array(gettext("Package"), gettext($pkg['title']));
+		$pglinks = array("", ((($subtitle == "Edit") || (strlen($pkg['menu'][0]['url']) == 0)) ? "@self" : $pkg['menu'][0]['url']));
 	}
 } else {
 	$pgtitle = array(gettext("Package"), gettext("Editor"));
+	$pglinks = array("", "@self");
 }
 
 // Create any required tabs
@@ -526,6 +530,7 @@ if ($pkg['tabs'] != "") {
 		if (isset($tab['active'])) {
 			$active = true;
 			$pgtitle[] = $tab['text'] ;
+			$pglinks[] = ((strlen($tab['url']) > 0) ? $tab['url'] : "@self");
 		} else {
 			$active = false;
 		}

--- a/src/usr/local/www/pkg_mgr.php
+++ b/src/usr/local/www/pkg_mgr.php
@@ -36,6 +36,7 @@ require_once("pkg-utils.inc");
 // if upgrade in progress, alert user
 if (is_subsystem_dirty('packagelock')) {
 	$pgtitle = array(gettext("System"), gettext("Package Manager"));
+	$pglinks = array("", "@self");
 	include("head.inc");
 	print_info_box("Please wait while packages are reinstalled in the background.");
 	include("foot.inc");
@@ -127,6 +128,7 @@ function get_pkg_table() {
 }
 
 $pgtitle = array(gettext("System"), gettext("Package Manager"), gettext("Available Packages"));
+$pglinks = array("", "pkg_mgr_installed.php", "@self");
 include("head.inc");
 
 $tab_array = array();

--- a/src/usr/local/www/pkg_mgr_install.php
+++ b/src/usr/local/www/pkg_mgr_install.php
@@ -242,10 +242,12 @@ $tab_array = array();
 
 if ($firmwareupdate) {
 	$pgtitle = array(gettext("System"), gettext("Update"), gettext("System Update"));
+	$pglinks = array("", "@self", "@self");
 	$tab_array[] = array(gettext("System Update"), true, "pkg_mgr_install.php?id=firmware");
 	$tab_array[] = array(gettext("Update Settings"), false, "system_update_settings.php");
 } else {
 	$pgtitle = array(gettext("System"), gettext("Package Manager"), gettext("Package Installer"));
+	$pglinks = array("", "pkg_mgr_installed.php", "@self");
 	$tab_array[] = array(gettext("Installed Packages"), false, "pkg_mgr_installed.php");
 	$tab_array[] = array(gettext("Available Packages"), false, "pkg_mgr.php");
 	$tab_array[] = array(gettext("Package Installer"), true, "");

--- a/src/usr/local/www/pkg_mgr_installed.php
+++ b/src/usr/local/www/pkg_mgr_installed.php
@@ -32,6 +32,7 @@ require_once("pkg-utils.inc");
 /* if upgrade in progress, alert user */
 if (is_subsystem_dirty('packagelock')) {
 	$pgtitle = array(gettext("System"), gettext("Package Manager"));
+	$pglinks = array("", "@self");
 	include("head.inc");
 	print_info_box("Please wait while packages are reinstalled in the background.");
 	include("foot.inc");
@@ -201,6 +202,7 @@ function get_pkg_table() {
 }
 
 $pgtitle = array(gettext("System"), gettext("Package Manager"), gettext("Installed Packages"));
+$pglinks = array("", "@self", "@self");
 include("head.inc");
 
 $tab_array = array();

--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -62,6 +62,7 @@ if (!is_array($config['captiveportal'])) {
 $a_cp =& $config['captiveportal'];
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Configuration"));
+$pglinks = array("", "services_captiveportal_zones.php", "@self", "@self");
 $shortcut_section = "captiveportal";
 
 if ($_GET['act'] == "viewhtml") {

--- a/src/usr/local/www/services_captiveportal_filemanager.php
+++ b/src/usr/local/www/services_captiveportal_filemanager.php
@@ -65,6 +65,7 @@ if (!is_array($config['captiveportal'])) {
 $a_cp =& $config['captiveportal'];
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("File Manager"));
+$pglinks = array("", "services_captiveportal_zones.php", "services_captiveportal.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal";
 
 if (!is_array($a_cp[$cpzone]['element'])) {

--- a/src/usr/local/www/services_captiveportal_hostname.php
+++ b/src/usr/local/www/services_captiveportal_hostname.php
@@ -60,6 +60,7 @@ if (isset($cpzone) && !empty($cpzone) && isset($a_cp[$cpzone]['zoneid'])) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Allowed Hostnames"));
+$pglinks = array("", "services_captiveportal_zones.php", "services_captiveportal.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal";
 
 if ($_GET['act'] == "del" && !empty($cpzone) && isset($cpzoneid)) {

--- a/src/usr/local/www/services_captiveportal_hostname_edit.php
+++ b/src/usr/local/www/services_captiveportal_hostname_edit.php
@@ -62,6 +62,7 @@ if (!is_array($config['captiveportal'])) {
 $a_cp =& $config['captiveportal'];
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Allowed Hostnames"), gettext("Edit"));
+$pglinks = array("", "services_captiveportal_zones.php", "services_captiveportal.php?zone=" . $cpzone, "services_captiveportal_hostname.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal";
 
 if (is_numericint($_GET['id'])) {

--- a/src/usr/local/www/services_captiveportal_ip.php
+++ b/src/usr/local/www/services_captiveportal_ip.php
@@ -60,6 +60,7 @@ if (isset($cpzone) && !empty($cpzone) && isset($a_cp[$cpzone]['zoneid'])) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Allowed IP Addresses"));
+$pglinks = array("", "services_captiveportal_zones.php", "services_captiveportal.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal";
 
 if ($_GET['act'] == "del" && !empty($cpzone) && isset($cpzoneid)) {

--- a/src/usr/local/www/services_captiveportal_ip_edit.php
+++ b/src/usr/local/www/services_captiveportal_ip_edit.php
@@ -64,6 +64,7 @@ if (!is_array($config['captiveportal'])) {
 $a_cp =& $config['captiveportal'];
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Allowed IP Addresses"), gettext("Edit"));
+$pglinks = array("", "services_captiveportal_zones.php", "services_captiveportal.php?zone=" . $cpzone, "services_captiveportal_ip.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal";
 
 if (is_numericint($_GET['id'])) {

--- a/src/usr/local/www/services_captiveportal_mac.php
+++ b/src/usr/local/www/services_captiveportal_mac.php
@@ -57,6 +57,7 @@ if (!is_array($config['captiveportal'])) {
 $a_cp =& $config['captiveportal'];
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("MACs"));
+$pglinks = array("", "services_captiveportal_zones.php", "services_captiveportal.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal";
 
 $actsmbl = array('pass' => '<i class="fa fa-check text-success"></i>&nbsp;' . gettext("Pass"),

--- a/src/usr/local/www/services_captiveportal_mac_edit.php
+++ b/src/usr/local/www/services_captiveportal_mac_edit.php
@@ -67,6 +67,7 @@ if (!is_array($config['captiveportal'])) {
 $a_cp =& $config['captiveportal'];
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("MACs"), gettext("Edit"));
+$pglinks = array("", "services_captiveportal_zones.php", "services_captiveportal.php?zone=" . $cpzone, "services_captiveportal_mac.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal";
 
 if (is_numericint($_GET['id'])) {

--- a/src/usr/local/www/services_captiveportal_vouchers.php
+++ b/src/usr/local/www/services_captiveportal_vouchers.php
@@ -76,6 +76,7 @@ if (empty($a_cp[$cpzone])) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Vouchers"));
+$pglinks = array("", "services_captiveportal_zones.php", "services_captiveportal.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal-vouchers";
 
 if (!is_array($config['voucher'][$cpzone]['roll'])) {

--- a/src/usr/local/www/services_captiveportal_vouchers_edit.php
+++ b/src/usr/local/www/services_captiveportal_vouchers_edit.php
@@ -51,6 +51,7 @@ if (!is_array($config['captiveportal'])) {
 $a_cp =& $config['captiveportal'];
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), $a_cp[$cpzone]['zone'], gettext("Vouchers"), gettext("Edit"));
+$pglinks = array("", "services_captiveportal_zones.php", "services_captiveportal.php?zone=" . $cpzone, "services_captiveportal_vouchers.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal-vouchers";
 
 if (!is_array($config['voucher'])) {

--- a/src/usr/local/www/services_captiveportal_zones_edit.php
+++ b/src/usr/local/www/services_captiveportal_zones_edit.php
@@ -33,6 +33,7 @@ require_once("shaper.inc");
 require_once("captiveportal.inc");
 
 $pgtitle = array(gettext("Services"), gettext("Captive Portal"), gettext("Add Zone"));
+$pglinks = array("", "services_captiveportal_zones.php", "@self");
 $shortcut_section = "captiveportal";
 
 if (!is_array($config['captiveportal'])) {

--- a/src/usr/local/www/services_checkip.php
+++ b/src/usr/local/www/services_checkip.php
@@ -63,6 +63,7 @@ if ($dirty) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Dynamic DNS"), gettext("Check IP Services"));
+$pglinks = array("", "services_dyndns.php", "@self");
 include("head.inc");
 
 $tab_array = array();

--- a/src/usr/local/www/services_checkip_edit.php
+++ b/src/usr/local/www/services_checkip_edit.php
@@ -104,6 +104,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Dynamic DNS"), gettext("Check IP Services"), gettext("Edit"));
+$pglinks = array("", "services_dyndns.php", "services_checkip.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -721,9 +721,11 @@ function build_pooltable() {
 }
 
 $pgtitle = array(gettext("Services"), gettext("DHCP Server"));
+$pglinks = array("", "services_dhcp.php");
 
 if (!empty($if) && isset($iflist[$if])) {
 	$pgtitle[] = $iflist[$if];
+	$pglinks[] = "@self";
 }
 $shortcut_section = "dhcp";
 

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -395,6 +395,7 @@ if (!empty($if) && isset($iflist[$if])) {
 	$ifname = $iflist[$if];
 }
 $pgtitle = array(gettext("Services"), gettext("DHCP Server"), $ifname, gettext("Edit Static Mapping"));
+$pglinks = array("", "services_dhcp.php", "services_dhcp.php?if={$if}", "@self");
 $shortcut_section = "dhcp";
 
 include("head.inc");

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -479,10 +479,13 @@ if ($_GET['act'] == "del") {
 }
 
 $pgtitle = array(gettext("Services"), htmlspecialchars(gettext("DHCPv6 Server & RA")));
+$pglinks = array("", "services_dhcpv6.php");
 
 if (!empty($if) && isset($iflist[$if])) {
 	$pgtitle[] = $iflist[$if];
+	$pglinks[] = "@self";
 	$pgtitle[] = gettext("DHCPv6 Server");
+	$pglinks[] = "@self";
 }
 $shortcut_section = "dhcp6";
 

--- a/src/usr/local/www/services_dhcpv6_edit.php
+++ b/src/usr/local/www/services_dhcpv6_edit.php
@@ -199,6 +199,7 @@ if (!empty($if) && isset($iflist[$if])) {
 	$ifname = $iflist[$if];
 }
 $pgtitle = array(gettext("Services"), htmlspecialchars(gettext("DHCPv6 Server & RA")), $ifname, gettext("DHCPv6 Server"), gettext("Edit Static Mapping"));
+$pglinks = array("", "services_dhcp.php", "services_dhcp.php?if={$if}", "services_dhcp.php?if={$if}", "@self");
 $shortcut_section = "dhcp6";
 
 include("head.inc");

--- a/src/usr/local/www/services_dnsmasq_domainoverride_edit.php
+++ b/src/usr/local/www/services_dnsmasq_domainoverride_edit.php
@@ -118,6 +118,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("DNS Forwarder"), gettext("Edit Domain Override"));
+$pglinks = array("", "services_dnsmasq.php", "@self");
 $shortcut_section = "forwarder";
 include("head.inc");
 

--- a/src/usr/local/www/services_dnsmasq_edit.php
+++ b/src/usr/local/www/services_dnsmasq_edit.php
@@ -183,6 +183,7 @@ if ($_GET['act'] == "addopt") {
 }
 
 $pgtitle = array(gettext("Services"), gettext("DNS Forwarder"), gettext("Edit Host Override"));
+$pglinks = array("", "services_dnsmasq.php", "@self");
 $shortcut_section = "forwarder";
 include("head.inc");
 

--- a/src/usr/local/www/services_dyndns.php
+++ b/src/usr/local/www/services_dyndns.php
@@ -65,6 +65,7 @@ if ($_GET['act'] == "del") {
 	}
 }
 $pgtitle = array(gettext("Services"), gettext("Dynamic DNS"), gettext("Dynamic DNS Clients"));
+$pglinks = array("", "@self", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -240,6 +240,7 @@ function build_if_list() {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Dynamic DNS"), gettext("Dynamic DNS Clients"), gettext("Edit"));
+$pglinks = array("", "services_dyndns.php", "services_dyndns.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/services_igmpproxy_edit.php
+++ b/src/usr/local/www/services_igmpproxy_edit.php
@@ -31,6 +31,7 @@
 ##|-PRIV
 
 $pgtitle = array(gettext("Services"), gettext("IGMP Proxy"), gettext("Edit"));
+$pglinks = array("", "services_igmpproxy.php", "@self");
 
 require_once("guiconfig.inc");
 

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -186,6 +186,7 @@ if (empty($pconfig['interface'])) {
 	$pconfig['interface'] = explode(",", $pconfig['interface']);
 }
 $pgtitle = array(gettext("Services"), gettext("NTP"), gettext("Settings"));
+$pglinks = array("", "@self", "@self");
 $shortcut_section = "ntp";
 include("head.inc");
 

--- a/src/usr/local/www/services_ntpd_acls.php
+++ b/src/usr/local/www/services_ntpd_acls.php
@@ -159,6 +159,7 @@ if ($_POST) {
 $pconfig = &$config['ntpd'];
 
 $pgtitle = array(gettext("Services"), gettext("NTP"), gettext("ACLs"));
+$pglinks = array("", "services_ntpd.php", "@self");
 $shortcut_section = "ntp";
 include("head.inc");
 

--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -189,6 +189,7 @@ function build_nmea_list() {
 
 $pconfig = &$config['ntpd']['gps'];
 $pgtitle = array(gettext("Services"), gettext("NTP"), gettext("Serial GPS"));
+$pglinks = array("", "services_ntpd.php", "@self");
 $shortcut_section = "ntp";
 include("head.inc");
 

--- a/src/usr/local/www/services_ntpd_pps.php
+++ b/src/usr/local/www/services_ntpd_pps.php
@@ -100,6 +100,7 @@ if ($_POST) {
 $pconfig = &$config['ntpd']['pps'];
 
 $pgtitle = array(gettext("Services"), gettext("NTP"), gettext("PPS"));
+$pglinks = array("", "services_ntpd.php", "@self");
 $shortcut_section = "ntp";
 include("head.inc");
 

--- a/src/usr/local/www/services_pppoe_edit.php
+++ b/src/usr/local/www/services_pppoe_edit.php
@@ -278,6 +278,7 @@ function build_interface_list() {
 }
 
 $pgtitle = array(gettext("Services"), gettext("PPPoE Server"), gettext("Edit"));
+$pglinks = array("", "services_pppoe.php", "@self");
 $shortcut_section = "pppoes";
 include("head.inc");
 

--- a/src/usr/local/www/services_rfc2136.php
+++ b/src/usr/local/www/services_rfc2136.php
@@ -56,6 +56,7 @@ if ($_GET['act'] == "del") {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Dynamic DNS"), gettext("RFC 2136 Clients"));
+$pglinks = array("", "services_dyndns.php", "@self");
 include("head.inc");
 
 $tab_array = array();

--- a/src/usr/local/www/services_rfc2136_edit.php
+++ b/src/usr/local/www/services_rfc2136_edit.php
@@ -146,6 +146,7 @@ function build_if_list() {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Dynamic DNS"), gettext("RFC 2136 Clients"), gettext("Edit"));
+$pglinks = array("", "services_dyndns.php", "services_rfc2136.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -249,11 +249,14 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"), htmlspecialchars(gettext("DHCPv6 Server & RA")));
+$pglinks = array("", "services_dhcpv6.php");
 
 if (!empty($if) && isset($iflist[$if])) {
 	$pgtitle[] = $iflist[$if];
+	$pglinks[] = "services_dhcpv6.php?if=" . $if;
 }
 $pgtitle[] = gettext("Router Advertisements");
+$pglinks[] = "@self";
 
 include("head.inc");
 

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -236,6 +236,7 @@ function build_if_list($selectedifs) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("DNS Resolver"), gettext("General Settings"));
+$pglinks = array("", "@self", "@self");
 $shortcut_section = "resolver";
 
 include_once("head.inc");

--- a/src/usr/local/www/services_unbound_acls.php
+++ b/src/usr/local/www/services_unbound_acls.php
@@ -174,6 +174,7 @@ $actionHelp =
 					sprintf(gettext('%sRefuse Nonlocal:%s Allow only authoritative local-data queries from hosts within the netblock defined below. Sends a DNS rcode REFUSED error message back to the client for messages that are disallowed.'), '<span class="text-success"><strong>', '</strong></span>');
 
 $pgtitle = array(gettext("Services"), gettext("DNS Resolver"), gettext("Access Lists"));
+$pglinks = array("", "services_unbound.php", "@self");
 
 if ($act == "new" || $act == "edit") {
 	$pgtitle[] = gettext('Edit');

--- a/src/usr/local/www/services_unbound_advanced.php
+++ b/src/usr/local/www/services_unbound_advanced.php
@@ -185,6 +185,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("DNS Resolver"), gettext("Advanced Settings"));
+$pglinks = array("", "services_unbound.php", "@self");
 $shortcut_section = "resolver";
 include_once("head.inc");
 

--- a/src/usr/local/www/services_unbound_domainoverride_edit.php
+++ b/src/usr/local/www/services_unbound_domainoverride_edit.php
@@ -110,6 +110,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("DNS Resolver"), gettext("General Settings"), gettext("Edit Domain Override"));
+$pglinks = array("", "services_unbound.php", "services_unbound.php", "@self");
 $shortcut_section = "resolver";
 include("head.inc");
 

--- a/src/usr/local/www/services_unbound_host_edit.php
+++ b/src/usr/local/www/services_unbound_host_edit.php
@@ -198,6 +198,7 @@ if ($_GET['act'] == "addopt") {
 }
 
 $pgtitle = array(gettext("Services"), gettext("DNS Resolver"), gettext("General Settings"), gettext("Edit Host Override"));
+$pglinks = array("", "services_unbound.php", "services_unbound.php", "@self");
 $shortcut_section = "resolver";
 include("head.inc");
 

--- a/src/usr/local/www/services_wol_edit.php
+++ b/src/usr/local/www/services_wol_edit.php
@@ -102,6 +102,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("Services"), gettext("Wake-on-LAN"), gettext("Edit"));
+$pglinks = array("", "services_wol.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/status_captiveportal.php
+++ b/src/usr/local/www/status_captiveportal.php
@@ -128,14 +128,17 @@ if ($_GET['deleteall'] && !empty($cpzone) && isset($cpzoneid)) {
 }
 
 $pgtitle = array(gettext("Status"), gettext("Captive Portal"));
+$pglinks = array("", "status_captiveportal.php");
 
 if (!empty($cpzone)) {
 	$cpdb = captiveportal_read_db();
 
 	$pgtitle[] = htmlspecialchars($a_cp[$cpzone]['zone']);
+	$pglinks[] = "status_captiveportal.php?zone=" . $cpzone;
 
 	if (isset($config['voucher'][$cpzone]['enable'])) {
 		$pgtitle[] = gettext("Active Users");
+		$pglinks[] = "status_captiveportal.php?zone=" . $cpzone;
 	}
 }
 $shortcut_section = "captiveportal";

--- a/src/usr/local/www/status_captiveportal_expire.php
+++ b/src/usr/local/www/status_captiveportal_expire.php
@@ -55,6 +55,7 @@ if (empty($cpzone)) {
 }
 
 $pgtitle = array(gettext("Status"), gettext("Captive Portal"), htmlspecialchars($a_cp[$cpzone]['zone']), gettext("Expire Vouchers"));
+$pglinks = array("", "status_captiveportal.php", "status_captiveportal.php?zone=" . $cpzone, "@self");
 
 include("head.inc");
 

--- a/src/usr/local/www/status_captiveportal_test.php
+++ b/src/usr/local/www/status_captiveportal_test.php
@@ -55,6 +55,7 @@ if (empty($cpzone)) {
 }
 
 $pgtitle = array(gettext("Status"), gettext("Captive Portal"), htmlspecialchars($a_cp[$cpzone]['zone']), gettext("Test Vouchers"));
+$pglinks = array("", "status_captiveportal.php", "status_captiveportal.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal-vouchers";
 
 include("head.inc");

--- a/src/usr/local/www/status_captiveportal_voucher_rolls.php
+++ b/src/usr/local/www/status_captiveportal_voucher_rolls.php
@@ -55,6 +55,7 @@ if (empty($cpzone)) {
 }
 
 $pgtitle = array(gettext("Status"), gettext("Captive Portal"), htmlspecialchars($a_cp[$cpzone]['zone']), gettext("Voucher Rolls"));
+$pglinks = array("", "status_captiveportal.php", "status_captiveportal.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal-vouchers";
 
 if (!is_array($config['voucher'][$cpzone]['roll'])) {

--- a/src/usr/local/www/status_captiveportal_vouchers.php
+++ b/src/usr/local/www/status_captiveportal_vouchers.php
@@ -55,6 +55,7 @@ if (empty($cpzone)) {
 }
 
 $pgtitle = array(gettext("Status"), gettext("Captive Portal"), htmlspecialchars($a_cp[$cpzone]['zone']), gettext("Active Vouchers"));
+$pglinks = array("", "status_captiveportal.php", "status_captiveportal.php?zone=" . $cpzone, "@self");
 $shortcut_section = "captiveportal-vouchers";
 
 if (!is_array($config['voucher'][$cpzone]['roll'])) {

--- a/src/usr/local/www/status_gateway_groups.php
+++ b/src/usr/local/www/status_gateway_groups.php
@@ -45,6 +45,7 @@ $changedesc = gettext("Gateway Groups") . ": ";
 $gateways_status = return_gateways_status();
 
 $pgtitle = array(gettext("Status"), gettext("Gateways"), gettext("Gateway Groups"));
+$pglinks = array("", "status_gateways.php", "@self");
 $shortcut_section = "gateway-groups";
 include("head.inc");
 

--- a/src/usr/local/www/status_gateways.php
+++ b/src/usr/local/www/status_gateways.php
@@ -39,6 +39,7 @@ $now = time();
 $year = date("Y");
 
 $pgtitle = array(gettext("Status"), gettext("Gateways"), gettext("Gateways"));
+$pglinks = array("", "@self", "@self");
 $shortcut_section = "gateways";
 include("head.inc");
 

--- a/src/usr/local/www/status_ipsec.php
+++ b/src/usr/local/www/status_ipsec.php
@@ -454,6 +454,7 @@ function print_ipsec_body() {
 }
 
 $pgtitle = array(gettext("Status"), gettext("IPsec"), gettext("Overview"));
+$pglinks = array("", "@self", "@self");
 $shortcut_section = "ipsec";
 
 include("head.inc");

--- a/src/usr/local/www/status_ipsec_leases.php
+++ b/src/usr/local/www/status_ipsec_leases.php
@@ -30,6 +30,7 @@ require_once("guiconfig.inc");
 require_once("ipsec.inc");
 
 $pgtitle = array(gettext("Status"), gettext("IPsec"), gettext("Leases"));
+$pglinks = array("", "status_ipsec.php", "@self");
 $shortcut_section = "ipsec";
 include("head.inc");
 

--- a/src/usr/local/www/status_ipsec_sad.php
+++ b/src/usr/local/www/status_ipsec_sad.php
@@ -34,6 +34,7 @@ require_once("guiconfig.inc");
 require_once("ipsec.inc");
 
 $pgtitle = array(gettext("Status"), gettext("IPsec"), gettext("SADs"));
+$pglinks = array("", "status_ipsec.php", "@self");
 $shortcut_section = "ipsec";
 include("head.inc");
 

--- a/src/usr/local/www/status_ipsec_spd.php
+++ b/src/usr/local/www/status_ipsec_spd.php
@@ -37,6 +37,7 @@ require_once("guiconfig.inc");
 require_once("ipsec.inc");
 
 $pgtitle = array(gettext("Status"), gettext("IPsec"), gettext("SPDs"));
+$pglinks = array("", "status_ipsec.php", "@self");
 $shortcut_section = "ipsec";
 include("head.inc");
 

--- a/src/usr/local/www/status_lb_pool.php
+++ b/src/usr/local/www/status_lb_pool.php
@@ -57,6 +57,7 @@ $now = time();
 $year = date("Y");
 
 $pgtitle = array(gettext("Status"), gettext("Load Balancer"), gettext("Pools"));
+$pglinks = array("", "@self", "@self");
 $shortcut_section = "relayd";
 
 include("head.inc");

--- a/src/usr/local/www/status_lb_vs.php
+++ b/src/usr/local/www/status_lb_vs.php
@@ -43,6 +43,7 @@ $a_pool = &$config['load_balancer']['lbpool'];
 $rdr_a = get_lb_redirects();
 
 $pgtitle = array(gettext("Status"), gettext("Load Balancer"), gettext("Virtual Servers"));
+$pglinks = array("", "status_lb_pool.php", "@self");
 include("head.inc");
 
 /* active tabs */

--- a/src/usr/local/www/status_logs.php
+++ b/src/usr/local/www/status_logs.php
@@ -94,8 +94,10 @@ if ($filtertext) {
 
 if (in_array($logfile, array('system', 'gateways', 'routing', 'resolver', 'wireless'))) {
 	$pgtitle = array(gettext("Status"), gettext("System Logs"), gettext("System"), $allowed_logs[$logfile]["name"]);
+	$pglinks = array("", "status_logs.php", "status_logs.php", "@self");
 } else {
 	$pgtitle = array(gettext("Status"), gettext("System Logs"), $allowed_logs[$logfile]["name"]);
+	$pglinks = array("", "status_logs.php", "@self");
 }
 include("head.inc");
 

--- a/src/usr/local/www/status_logs_filter.php
+++ b/src/usr/local/www/status_logs_filter.php
@@ -100,6 +100,7 @@ status_logs_common_code();
 
 
 $pgtitle = array(gettext("Status"), gettext("System Logs"), gettext($allowed_logs[$logfile]["name"]), $view_title);
+$pglinks = array("", "status_logs.php", "status_logs_filter.php", "@self");
 include("head.inc");
 
 if (!$input_errors && $savemsg) {

--- a/src/usr/local/www/status_logs_filter_dynamic.php
+++ b/src/usr/local/www/status_logs_filter_dynamic.php
@@ -80,6 +80,7 @@ status_logs_common_code();
 
 
 $pgtitle = array(gettext("Status"), gettext("System Logs"), gettext($allowed_logs[$logfile]["name"]), $view_title);
+$pglinks = array("", "status_logs.php", "status_logs_filter.php", "@self");
 include("head.inc");
 
 if (!$input_errors && $savemsg) {

--- a/src/usr/local/www/status_logs_filter_summary.php
+++ b/src/usr/local/www/status_logs_filter_summary.php
@@ -65,6 +65,7 @@ status_logs_common_code();
 
 
 $pgtitle = array(gettext("Status"), gettext("System Logs"), gettext($allowed_logs[$logfile]["name"]), $view_title);
+$pglinks = array("", "status_logs.php", "status_logs_filter.php", "@self");
 include("head.inc");
 
 if (!$input_errors && $savemsg) {

--- a/src/usr/local/www/status_logs_settings.php
+++ b/src/usr/local/www/status_logs_settings.php
@@ -186,6 +186,7 @@ if ($_POST['resetlogs'] == gettext("Reset Log Files")) {
 }
 
 $pgtitle = array(gettext("Status"), gettext("System Logs"), gettext("Settings"));
+$pglinks = array("", "status_logs.php", "@self");
 include("head.inc");
 
 $logfilesizeHelp =	gettext("Logs are held in constant-size circular log files. This field controls how large each log file is, and thus how many entries may exist inside the log. By default this is approximately 500KB per log file, and there are nearly 20 such log files.") .

--- a/src/usr/local/www/status_logs_vpn.php
+++ b/src/usr/local/www/status_logs_vpn.php
@@ -82,6 +82,7 @@ if ($filtertext) {
 }
 
 $pgtitle = array(gettext("Status"), gettext("System Logs"), gettext("VPN"), gettext($allowed_logs[$logfile]["name"]));
+$pglinks = array("", "status_logs.php", "status_logs_vpn.php", "@self");
 include("head.inc");
 
 if (!$input_errors && $savemsg) {

--- a/src/usr/local/www/status_pkglogs.php
+++ b/src/usr/local/www/status_pkglogs.php
@@ -69,9 +69,11 @@ if (!$apkg) { // If we aren't looking for a specific package, locate the first p
 }
 
 $pgtitle = array(gettext("Status"), gettext("Package Logs"));
+$pglinks = array("", "status_pkglogs.php");
 
 if ($pkgwithlogging && !empty($apkg)) {
 	$pgtitle[] = $apkg;
+	$pglinks[] = "@self";
 }
 include("head.inc");
 

--- a/src/usr/local/www/system_advanced_admin.php
+++ b/src/usr/local/www/system_advanced_admin.php
@@ -281,6 +281,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Advanced"), gettext("Admin Access"));
+$pglinks = array("", "@self", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_advanced_firewall.php
+++ b/src/usr/local/www/system_advanced_firewall.php
@@ -369,6 +369,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Advanced"), htmlspecialchars(gettext("Firewall & NAT")));
+$pglinks = array("", "system_advanced_admin.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_advanced_misc.php
+++ b/src/usr/local/www/system_advanced_misc.php
@@ -284,6 +284,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Advanced"), gettext("Miscellaneous"));
+$pglinks = array("", "system_advanced_admin.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -141,6 +141,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Advanced"), gettext("Networking"));
+$pglinks = array("", "system_advanced_admin.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_advanced_notifications.php
+++ b/src/usr/local/www/system_advanced_notifications.php
@@ -186,6 +186,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Advanced"), gettext("Notifications"));
+$pglinks = array("", "system_advanced_admin.php", "@self");
 include("head.inc");
 
 if ($input_errors) {

--- a/src/usr/local/www/system_advanced_sysctl.php
+++ b/src/usr/local/www/system_advanced_sysctl.php
@@ -119,9 +119,11 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Advanced"), gettext("System Tunables"));
+$pglinks = array("", "system_advanced_admin.php", "system_advanced_sysctl.php");
 
 if ($act == "edit") {
 	$pgtitle[] = gettext('Edit');
+	$pglinks[] = "@self";
 }
 include("head.inc");
 

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -401,9 +401,11 @@ if ($_POST && $input_errors) {
 }
 
 $pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Authentication Servers"));
+$pglinks = array("", "system_usermanager.php", "system_authservers.php");
 
 if ($act == "new" || $act == "edit" || $input_errors) {
 	$pgtitle[] = gettext('Edit');
+	$pglinks[] = "@self";
 }
 $shortcut_section = "authentication";
 include("head.inc");

--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -319,9 +319,11 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Certificate Manager"), gettext("CAs"));
+$pglinks = array("", "system_camanager.php", "system_camanager.php");
 
 if ($act == "new" || $act == "edit" || $act == gettext("Save") || $input_errors) {
 	$pgtitle[] = gettext('Edit');
+	$pglinks[] = "@self";
 }
 include("head.inc");
 

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -519,9 +519,11 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Certificate Manager"), gettext("Certificates"));
+$pglinks = array("", "system_camanager.php", "system_certmanager.php");
 
 if (($act == "new" || ($_POST['save'] == gettext("Save") && $input_errors)) || ($act == "csr" || ($_POST['save'] == gettext("Update") && $input_errors))) {
 	$pgtitle[] = gettext('Edit');
+	$pglinks[] = "@self";
 }
 include("head.inc");
 

--- a/src/usr/local/www/system_crlmanager.php
+++ b/src/usr/local/www/system_crlmanager.php
@@ -256,9 +256,11 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Certificate Manager"), gettext("Certificate Revocation"));
+$pglinks = array("", "system_camanager.php", "system_crlmanager.php");
 
 if ($act == "new" || $act == gettext("Save") || $input_errors || $act == "edit") {
 	$pgtitle[] = gettext('Edit');
+	$pglinks[] = "@self";
 }
 include("head.inc");
 ?>

--- a/src/usr/local/www/system_gateway_groups.php
+++ b/src/usr/local/www/system_gateway_groups.php
@@ -102,6 +102,7 @@ function gateway_exists($gwname) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Routing"), gettext("Gateway Groups"));
+$pglinks = array("", "system_gateways.php", "@self");
 $shortcut_section = "gateway-groups";
 
 include("head.inc");

--- a/src/usr/local/www/system_gateway_groups_edit.php
+++ b/src/usr/local/www/system_gateway_groups_edit.php
@@ -145,6 +145,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Routing"), gettext("Gateway Groups"), gettext("Edit"));
+$pglinks = array("", "system_gateways.php", "system_gateway_groups.php", "@self");
 $shortcut_section = "gateway-groups";
 
 function build_gateway_protocol_map (&$a_gateways) {

--- a/src/usr/local/www/system_gateways.php
+++ b/src/usr/local/www/system_gateways.php
@@ -223,6 +223,7 @@ if (isset($_POST['del_x'])) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Routing"), gettext("Gateways"));
+$pglinks = array("", "@self", "@self");
 $shortcut_section = "gateways";
 
 include("head.inc");

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -549,6 +549,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Routing"), gettext("Gateways"), gettext("Edit"));
+$pglinks = array("", "system_gateways.php", "system_gateways.php", "@self");
 $shortcut_section = "gateways";
 
 include("head.inc");

--- a/src/usr/local/www/system_groupmanager.php
+++ b/src/usr/local/www/system_groupmanager.php
@@ -255,9 +255,11 @@ function build_priv_table() {
 }
 
 $pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Groups"));
+$pglinks = array("", "system_usermanager.php", "system_groupmanager.php");
 
 if ($act == "new" || $act == "edit") {
 	$pgtitle[] = gettext('Edit');
+	$pglinks[] = "@self";
 }
 
 include("head.inc");

--- a/src/usr/local/www/system_groupmanager_addprivs.php
+++ b/src/usr/local/www/system_groupmanager_addprivs.php
@@ -33,14 +33,15 @@
 
 require_once("guiconfig.inc");
 
-$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Groups"), gettext("Edit"), gettext("Add Privileges"));
-
 if (is_numericint($_GET['groupid'])) {
 	$groupid = $_GET['groupid'];
 }
 if (isset($_POST['groupid']) && is_numericint($_POST['groupid'])) {
 	$groupid = $_POST['groupid'];
 }
+
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Groups"), gettext("Edit"), gettext("Add Privileges"));
+$pglinks = array("", "system_usermanager.php", "system_groupmanager.php", "system_groupmanager.php?act=edit&groupid=" . $groupid, "@self");
 
 $a_group = & $config['system']['group'][$groupid];
 

--- a/src/usr/local/www/system_routes.php
+++ b/src/usr/local/www/system_routes.php
@@ -211,6 +211,7 @@ if (isset($_POST['del_x'])) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Routing"), gettext("Static Routes"));
+$pglinks = array("", "system_gateways.php", "@self");
 $shortcut_section = "routing";
 
 include("head.inc");

--- a/src/usr/local/www/system_routes_edit.php
+++ b/src/usr/local/www/system_routes_edit.php
@@ -222,6 +222,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("System"), gettext("Routing"), gettext("Static Routes"), gettext("Edit"));
+$pglinks = array("", "system_gateways.php", "system_routes.php", "@self");
 $shortcut_section = "routing";
 include("head.inc");
 

--- a/src/usr/local/www/system_update_settings.php
+++ b/src/usr/local/www/system_update_settings.php
@@ -75,6 +75,7 @@ $curcfg = $config['system']['firmware'];
 $gitcfg = $config['system']['gitsync'];
 
 $pgtitle = array(gettext("System"), gettext("Update"), gettext("Update Settings"));
+$pglinks = array("", "pkg_mgr_install.php?id=firmware", "@self");
 
 // Create an array of repo names and descriptions to populate the "Branch" selector
 function build_repo_list() {

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -525,9 +525,11 @@ function build_cert_table() {
 }
 
 $pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Users"));
+$pglinks = array("", "system_usermanager.php", "system_usermanager.php");
 
 if ($act == "new" || $act == "edit" || $input_errors) {
 	$pgtitle[] = gettext('Edit');
+	$pglinks[] = "@self";
 }
 include("head.inc");
 

--- a/src/usr/local/www/system_usermanager_addprivs.php
+++ b/src/usr/local/www/system_usermanager_addprivs.php
@@ -33,8 +33,6 @@ function admusercmp($a, $b) {
 
 require_once("guiconfig.inc");
 
-$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Users"), gettext("Edit"), gettext("Add Privileges"));
-
 if (is_numericint($_GET['userid'])) {
 	$userid = $_GET['userid'];
 }
@@ -42,6 +40,9 @@ if (is_numericint($_GET['userid'])) {
 if (isset($_POST['userid']) && is_numericint($_POST['userid'])) {
 	$userid = $_POST['userid'];
 }
+
+$pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Users"), gettext("Edit"), gettext("Add Privileges"));
+$pglinks = array("", "system_usermanager.php", "system_usermanager.php", "system_usermanager.php?act=edit&userid=" . $userid, "@self");
 
 if (!isset($config['system']['user'][$userid]) && !is_array($config['system']['user'][$userid])) {
 	pfSenseHeader("system_usermanager.php");

--- a/src/usr/local/www/system_usermanager_settings.php
+++ b/src/usr/local/www/system_usermanager_settings.php
@@ -106,6 +106,7 @@ $pconfig['auth_refresh_time'] = $config['system']['webgui']['auth_refresh_time']
 
 // Page title for main admin
 $pgtitle = array(gettext("System"), gettext("User Manager"), gettext("Settings"));
+$pglinks = array("", "system_usermanager.php", "@self");
 
 $save_and_test = false;
 

--- a/src/usr/local/www/vpn_ipsec.php
+++ b/src/usr/local/www/vpn_ipsec.php
@@ -217,6 +217,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("VPN"), gettext("IPsec"), gettext("Tunnels"));
+$pglinks = array("", "@self", "@self");
 $shortcut_section = "ipsec";
 
 include("head.inc");

--- a/src/usr/local/www/vpn_ipsec_keys.php
+++ b/src/usr/local/www/vpn_ipsec_keys.php
@@ -70,6 +70,7 @@ if ($_GET['act'] == "del") {
 }
 
 $pgtitle = array(gettext("VPN"), gettext("IPsec"), gettext("Pre-Shared Keys"));
+$pglinks = array("", "vpn_ipsec.php", "@self");
 $shortcut_section = "ipsec";
 
 include("head.inc");

--- a/src/usr/local/www/vpn_ipsec_keys_edit.php
+++ b/src/usr/local/www/vpn_ipsec_keys_edit.php
@@ -120,6 +120,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("VPN"), gettext("IPsec"), gettext("Pre-Shared Keys"), gettext("Edit"));
+$pglinks = array("", "vpn_ipsec.php", "vpn_ipsec_keys.php", "@self");
 $shortcut_section = "ipsec";
 
 include("head.inc");

--- a/src/usr/local/www/vpn_ipsec_mobile.php
+++ b/src/usr/local/www/vpn_ipsec_mobile.php
@@ -304,6 +304,7 @@ if ($_POST['save']) {
 }
 
 $pgtitle = array(gettext("VPN"), gettext("IPsec"), gettext("Mobile Clients"));
+$pglinks = array("", "vpn_ipsec.php", "@self");
 $shortcut_section = "ipsec";
 
 include("head.inc");

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -625,8 +625,10 @@ function build_eal_list() {
 
 if ($pconfig['mobile']) {
 	$pgtitle = array(gettext("VPN"), gettext("IPsec"), gettext("Mobile Clients"), gettext("Edit Phase 1"));
+	$pglinks = array("", "vpn_ipsec.php", "vpn_ipsec_mobile.php", "@self");
 } else {
 	$pgtitle = array(gettext("VPN"), gettext("IPsec"), gettext("Tunnels"), gettext("Edit Phase 1"));
+	$pglinks = array("", "vpn_ipsec.php", "vpn_ipsec.php", "@self");
 }
 
 $shortcut_section = "ipsec";

--- a/src/usr/local/www/vpn_ipsec_phase2.php
+++ b/src/usr/local/www/vpn_ipsec_phase2.php
@@ -401,9 +401,11 @@ if ($_POST) {
 
 if ($pconfig['mobile']) {
 	$pgtitle = array(gettext("VPN"), gettext("IPsec"), gettext("Mobile Clients"), gettext("Edit Phase 2"));
+	$pglinks = array("", "vpn_ipsec.php", "vpn_ipsec_mobile.php", "@self");
 	$editing_mobile = true;
 } else {
 	$pgtitle = array(gettext("VPN"), gettext("IPsec"), gettext("Tunnels"), gettext("Edit Phase 2"));
+	$pglinks = array("", "vpn_ipsec.php", "vpn_ipsec.php", "@self");
 	$editing_mobile = false;
 }
 $shortcut_section = "ipsec";

--- a/src/usr/local/www/vpn_ipsec_settings.php
+++ b/src/usr/local/www/vpn_ipsec_settings.php
@@ -193,6 +193,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("VPN"), gettext("IPsec"), gettext("Advanced Settings"));
+$pglinks = array("", "vpn_ipsec.php", "@self");
 $shortcut_section = "ipsec";
 
 include("head.inc");

--- a/src/usr/local/www/vpn_l2tp.php
+++ b/src/usr/local/www/vpn_l2tp.php
@@ -171,6 +171,7 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("VPN"), gettext("L2TP"), gettext("Configuration"));
+$pglinks = array("", "@self", "@self");
 $shortcut_section = "l2tps";
 include("head.inc");
 

--- a/src/usr/local/www/vpn_l2tp_users.php
+++ b/src/usr/local/www/vpn_l2tp_users.php
@@ -27,6 +27,7 @@
 ##|-PRIV
 
 $pgtitle = array(gettext("VPN"), gettext("L2TP"), gettext("Users"));
+$pglinks = array("", "vpn_l2tp.php", "@self");
 $shortcut_section = "l2tps";
 
 require_once("guiconfig.inc");

--- a/src/usr/local/www/vpn_l2tp_users_edit.php
+++ b/src/usr/local/www/vpn_l2tp_users_edit.php
@@ -27,6 +27,7 @@
 ##|-PRIV
 
 $pgtitle = array(gettext("VPN"), gettext("L2TP"), gettext("Users"), gettext("Edit"));
+$pglinks = array("", "vpn_l2tp.php", "vpn_l2tp_users.php", "@self");
 $shortcut_section = "l2tps";
 
 function l2tpusercmp($a, $b) {

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -448,9 +448,11 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("VPN"), gettext("OpenVPN"), gettext("Clients"));
+$pglinks = array("", "vpn_openvpn_server.php", "vpn_openvpn_client.php");
 
 if ($act=="new" || $act=="edit") {
 	$pgtitle[] = gettext('Edit');
+	$pglinks[] = "@self";
 }
 $shortcut_section = "openvpn";
 

--- a/src/usr/local/www/vpn_openvpn_csc.php
+++ b/src/usr/local/www/vpn_openvpn_csc.php
@@ -281,9 +281,11 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("VPN"), gettext("OpenVPN"), gettext("Client Specific Overrides"));
+$pglinks = array("", "vpn_openvpn_server.php", "vpn_openvpn_csc.php");
 
 if ($act=="new" || $act=="edit") {
 	$pgtitle[] = gettext('Edit');
+	$pglinks[] = "@self";
 }
 $shortcut_section = "openvpn";
 

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -631,9 +631,11 @@ if ($_POST) {
 }
 
 $pgtitle = array(gettext("VPN"), gettext("OpenVPN"), gettext("Servers"));
+$pglinks = array("", "vpn_openvpn_server.php", "vpn_openvpn_server.php");
 
 if ($act=="new" || $act=="edit") {
 	$pgtitle[] = gettext('Edit');
+	$pglinks[] = "@self";
 }
 $shortcut_section = "openvpn";
 

--- a/src/usr/local/www/wizard.php
+++ b/src/usr/local/www/wizard.php
@@ -181,7 +181,9 @@ do {
 } while ($oldstepid != $stepid);
 
 $pgtitle = array(gettext("Wizard"), gettext($pkg['step'][0]['title']));	//First step is main title of the wizard in the breadcrumb
+$pglinks = array("", "wizard.php?xml=" . $xml);
 $pgtitle[] = ($stepid > 0 ? gettext($pkg['step'][$stepid]['title']):'&nbsp;');		//Following steps are sub-level breadcrumbs.
+$pglinks[] = ($stepid > 0 ? "wizard.php?xml=" . $xml . "&stepid=" . $stepid:'&nbsp;');
 $shortcut_section = "Wizard";
 include("head.inc");
 


### PR DESCRIPTION
This implements the detail of links for breadcrumbs. I enhanced genhtmltitle() so that if the $links parameter is not passed then it will generate a default link, with the last entry in the page title list having a link to self and the other items having no link. This default scenario is what is needed for "ordinary" pages that are just a simple single page (lots of the Status and Diagnostics pages are like this). It means that I did not have to touch the source code of those pages - the default action of genhtmltitle() produces the correct link.