### PR TITLE
Fix #7118 icmp-type any

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2784,7 +2784,7 @@ function filter_generate_user_rule($rule) {
 	}
 	$aline['dst'] = "to $dst ";
 
-	if ($rule['protocol'] == "icmp" && $rule['icmptype']) {
+	if ($rule['protocol'] == "icmp" && $rule['icmptype'] && ($rule['icmptype'] != 'any')) {
 		$icmptype_key = ($rule['ipprotocol'] == 'inet6' ? 'icmp6-type' : 'icmp-type');
 		$icmptype_text = (strpos($rule['icmptype'], ",") === false ? $rule['icmptype'] : '{ ' . $rule['icmptype'] . ' }');
 		$aline[$icmptype_key] = "{$icmptype_key} {$icmptype_text} ";


### PR DESCRIPTION
When 'any' is selected as the ICMP type, do not write 'icmp-type any' in the rule, just leave it out.