### PR TITLE
Add username to logout menu and icon

### DIFF
--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -216,7 +216,7 @@ $ext_menu_path_data = read_ext_menu_path_data();
 
 // System
 $system_menu = array();
-$system_menu[] = array(gettext("Logout"), "/index.php?logout");
+$system_menu[] = array(gettext("Logout") . " " . $_SESSION['Username'], "/index.php?logout");
 $system_menu[] = array(gettext("Advanced"), "/system_advanced_admin.php");
 $system_menu[] = array(gettext("Update"), "/pkg_mgr_install.php?id=firmware");
 $system_menu[] = array(gettext("General Setup"), "/system.php");
@@ -497,7 +497,7 @@ if (are_notices_pending()) {
 				?>
 					<li class="dropdown">
 						<a href="/index.php?logout">
-							<i class="fa fa-sign-out" title="<?=gettext("Log out")?>"></i>
+							<i class="fa fa-sign-out" title="<?=gettext("Log out") . " " . $_SESSION['Username']?>"></i>
 						</a>
 					</li>
 			</ul>

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -28,11 +28,12 @@ require_once('notices.inc');
 header('Content-Type: text/html; charset=utf-8');
 
 $pagetitle = gentitle($pgtitle);
+$system_url = $config['system']['hostname'] . "." . $config['system']['domain'];
 
 if ($user_settings['webgui']['pagenamefirst']) {
-	$tabtitle = $pagetitle . " - " . htmlspecialchars($config['system']['hostname'] . "." . $config['system']['domain']);
+	$tabtitle = $pagetitle . " - " . htmlspecialchars($system_url);
 } else {
-	$tabtitle = htmlspecialchars($config['system']['hostname'] . "." . $config['system']['domain']) . " - " . $pagetitle;
+	$tabtitle = htmlspecialchars($system_url) . " - " . $pagetitle;
 }
 
 $cssfile = "/css/pfSense.css";
@@ -216,7 +217,7 @@ $ext_menu_path_data = read_ext_menu_path_data();
 
 // System
 $system_menu = array();
-$system_menu[] = array(gettext("Logout") . " " . $_SESSION['Username'], "/index.php?logout");
+$system_menu[] = array(gettext("Logout") . " (" . $_SESSION['Username'] . ")", "/index.php?logout");
 $system_menu[] = array(gettext("Advanced"), "/system_advanced_admin.php");
 $system_menu[] = array(gettext("Update"), "/pkg_mgr_install.php?id=firmware");
 $system_menu[] = array(gettext("General Setup"), "/system.php");
@@ -443,7 +444,7 @@ if (are_notices_pending()) {
 				<span class="icon-bar"></span>
 				<span class="icon-bar"></span>
 			</button>
-			<a class="navbar-brand" href="/"><img src="/logo.png" alt="pfSense" title="<?=$config['system']['hostname'] . '.' . $config['system']['domain']?>"/></a>
+			<a class="navbar-brand" href="/"><img src="/logo.png" alt="pfSense" title="<?=$system_url?>"/></a>
 		</div>
 		<div class="collapse navbar-collapse" id="pf-navbar">
 			<ul class="nav navbar-nav">
@@ -452,7 +453,7 @@ if (are_notices_pending()) {
                     $help_menu_title = htmlspecialchars($config['system']['hostname']);
                 }
                 elseif ($user_settings['webgui']['webguihostnamemenu'] == 'fqdn') {
-                    $help_menu_title = htmlspecialchars($config['system']['hostname'] . "." . $config['system']['domain']);
+                    $help_menu_title = htmlspecialchars($system_url);
                 }
                 else {
                     $help_menu_title = 'Help';
@@ -497,7 +498,7 @@ if (are_notices_pending()) {
 				?>
 					<li class="dropdown">
 						<a href="/index.php?logout">
-							<i class="fa fa-sign-out" title="<?=gettext("Log out") . " " . $_SESSION['Username']?>"></i>
+							<i class="fa fa-sign-out" title="<?=gettext("Logout") . " (" . $_SESSION['Username'] . "@" . htmlspecialchars($system_url) . ")"?>"></i>
 						</a>
 					</li>
 			</ul>


### PR DESCRIPTION
I find it difficult to work out who I am logged in as. Other software often provides some indication of who is the current logged-in user. An easy way to do this is to add it to the "Log out" text. Then it can be seen either by hovering over the "Log out" icon, or in the System menu.

I added it to both places. But maybe it should just be associated with the icon, and not the System->Logout menu entry?

I also notice that the System menu has "Logout" (all one word), and the hover text for the icon is "Log out" (2 words). These should be consistent - but which one is preferred?