### PR TITLE
Do not nag people about passwords mismatch when notifications are disabled (Bug #7129)

### DIFF
--- a/src/usr/local/www/system_advanced_notifications.php
+++ b/src/usr/local/www/system_advanced_notifications.php
@@ -129,7 +129,10 @@ if ($_POST) {
 			if ($_POST['smtppassword'] == $_POST['smtppassword_confirm']) {
 				$config['notifications']['smtp']['password'] = $_POST['smtppassword'];
 			} else {
-				$input_errors[] = gettext("SMTP passwords must match");
+				if ($_POST['disable_smtp'] != "yes") {
+					// Bug #7129 - do not nag people about passwords mismatch when SMTP notifications are disabled
+					$input_errors[] = gettext("SMTP passwords must match");
+				}
 			}
 		}
 

--- a/src/usr/local/www/system_advanced_notifications.php
+++ b/src/usr/local/www/system_advanced_notifications.php
@@ -96,7 +96,10 @@ if ($_POST) {
 			if ($_POST['password'] == $_POST['password_confirm']) {
 				$config['notifications']['growl']['password'] = $_POST['password'];
 			} else {
-				$input_errors[] = gettext("Growl passwords must match");
+				// Bug #7129 - do not nag people about passwords mismatch when growl is disabled
+				if ($_POST['disable_growl'] != "yes") {
+					$input_errors[] = gettext("Growl passwords must match");
+				}
 			}
 		}
 


### PR DESCRIPTION
These fields tend to get "helpfully" pre-filled with random crap by built-in browser password managers or extensions such as LastPass. No need to bother people with these when the feature is disabled.