### PR TITLE
RTSOLD lock creation, dhcp6c launch & kill changes,

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3022,13 +3022,40 @@ function find_dhcp6c_process($interface) {
 }
 
 function kill_dhcp6client_process($interface) {
+	global $g;
+
 	if (empty($interface) || !does_interface_exist($interface)) {
 		return;
 	}
 
 	if (($pid = find_dhcp6c_process($interface)) != 0) {
-		mwexec("kill -9 {$pid}");
-		sleep(1);
+		/* Kill -9 caused the pid to get left behind, also if we need a */
+		/* relase sent then it needs to be -15, this then allows dhcp6c */
+		/* to send the release, it will also clean up after itself */
+		// Debug - next line remove if not required
+		mwexec("/usr/bin/logger -t info 'shutting down dhcp6c process'");
+		mwexec("kill -15 {$pid}"); 
+		sleep(2); //Allow dhcp6c to send releae and exit gracefully if needed.	
+	}
+	/* Clear the RTSOLD script created lock  & tidy up */
+	unlink_if_exists("/tmp/dhcp6c_{$interface}_lock");
+	unlink_if_exists("{$g['varrun_path']}/dhcp6c_{$interface}.pid"); // just in case!
+}
+
+function run_dhcp6client_process($interface, $wancfg) {
+	global $g;
+
+	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
+	$noreleaseOption = isset($wancfg['dhcp6norelease']) ? "-n" : "";
+	// Only run this if the lock does not exist. In theory the lock being there in this mode means the user has selected dhcp6withoutRA while a session is active in the other mode
+	// It should not happen as the process should have been killed and the lock deleted.
+	if(!file_exists("/tmp/dhcp6c_{$interface}_lock"))
+	{
+		kill_dhcp6client_process($interface); //Should not be required, but belts and braces
+
+		// The -x option here, we'll let the RA do the script. Script will not run on receipt of Reply only)
+		mwexec("/usr/local/sbin/dhcp6c {$debugOption} {$noreleaseOption} -x -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$interface}.pid {$interface}"); 
+		mwexec("/usr/bin/logger -t info 'Starting dhcp6 client for interface wan({$wanif} in DHCP6 without RA mode)'");
 	}
 }
 
@@ -3964,6 +3991,9 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	unset($dhcp6cscript);
 	@chmod("{$g['varetc_path']}/dhcp6c_{$interface}_script.sh", 0755);
 
+	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
+	$noreleaseOption = isset($wancfg['dhcp6norelease']) ? "-n" : "";
+
 	$rtsoldscript = "#!/bin/sh\n";
 	$rtsoldscript .= "# This shell script launches dhcp6c and configured gateways for this interface.\n";
 	$rtsoldscript .= "echo $2 > {$g['tmp_path']}/{$wanif}_routerv6\n";
@@ -3972,22 +4002,29 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 
 	/* non ipoe Process */
 	if (!isset($wancfg['dhcp6withoutra'])) {
+		// We only want this script to run once, and if it runs twice then do not launch dhcp6c again, this only happens if dhcpwithoutra is not set
+		// Check for a lock file, trying to prevent multiple instances of dhcp6c being launched
+		$rtsoldscript .= "if [ ! -f /tmp/dhcp6c_{$wanif}_lock ]; then\n";
 		$rtsoldscript .= "if [ -f {$g['varrun_path']}/dhcp6c_{$wanif}.pid ]; then\n";
-		$rtsoldscript .= "\t/bin/pkill -F {$g['varrun_path']}/dhcp6c_{$wanif}.pid\n";
+		$rtsoldscript .= "\t/bin/pkill -15 -F {$g['varrun_path']}/dhcp6c_{$wanif}.pid\n";
+		$rtsoldscript .= "\t/bin/rm -f {$g['varrun_path']}/dhcp6c_{$wanif}.pid\n";
 		$rtsoldscript .= "\t/bin/sleep 1\n";
 		$rtsoldscript .= "fi\n";
-	} else {
-		$rtsoldscript .= "{$g['varetc_path']}/dhcp6c_{$interface}_script.sh\n";
-		$rtsoldscript .= "/bin/sleep 1\n";
-	}
-	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
-	$noreleaseOption = isset($wancfg['dhcp6norelease']) ? "-n" : "";
-
-
-	/* add the start of dhcp6c to the rtsold script if we are going to wait for ra */
-	if (!isset($wancfg['dhcp6withoutra'])) {
+		// No -x option for dhcp6c as we want it to run the script on receipt of REQUEST
+		// Create the lock file, trying to prevent multiple instances of dhcp6c being launched
+		$rtsoldscript .= "/usr/bin/touch /tmp/dhcp6c_{$wanif}_lock\n";
 		$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} {$noreleaseOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
 		$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
+		// else statement is really just debugger info and can be removed if not required.
+		$rtsoldscript .= "else\n";
+		$rtsoldscript .= "/usr/bin/logger -t rtsold \"RTSOLD Lock in place\"\n";
+		$rtsoldscript .= "fi\n";
+	} else {
+		$rtsoldscript .= "if [ -f {$g['varrun_path']}/dhcp6c_{$wanif}.pid ]; then\n";
+		$rtsoldscript .= "/usr/bin/touch /tmp/dhcp6c_{$wanif}_lock\n"; // if this lock is in place then we have already got a running dhcp6 process and do not want to kill it.
+		$rtsoldscript .= "fi\n";
+		$rtsoldscript .= "{$g['varetc_path']}/dhcp6c_{$interface}_script.sh\n"; // The script needs to run again in dhcp6withoutra mode as RA may not have been received, or there can be a delay with certain ISPs
+		$rtsoldscript .= "/bin/sleep 1\n";
 	}
 	/* Add wide-dhcp6c shell script here. Because we can not pass a argument to it. */
 	if (!@file_put_contents("{$g['varetc_path']}/rtsold_{$wanif}_script.sh", $rtsoldscript)) {
@@ -4002,18 +4039,17 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	log_error("Accept router advertisements on interface {$wanif} ");
 	mwexec("/sbin/ifconfig {$wanif} inet6 accept_rtadv");
 
-	/* fire up rtsold for IPv6 RAs first, this backgrounds immediately. It will call dhcp6c */
+	/* start dhcp6c here if we don't want to wait for ra - calls seprate function */
+	if (isset($wancfg['dhcp6withoutra'])) {
+		mwexec("/usr/bin/logger -t info 'Calling Run dhcpclient Process'");
+		run_dhcp6client_process($wanif,$wancfg);
+		// Wait for return of process before launching rtsold
+		sleep(1);
+	}
+	/* fire up rtsold for IPv6 RAs, this backgrounds immediately. It will call dhcp6c if dhcpwihtoutra is not set*/
 	if (isvalidpid("{$g['varrun_path']}/rtsold_{$wanif}.pid")) {
 		killbypid("{$g['varrun_path']}/rtsold_{$wanif}.pid");
 		sleep(2);
-	}
-
-	/* start dhcp6c here if we don't want to wait for ra */
-	if (isset($wancfg['dhcp6withoutra'])) {
-		kill_dhcp6client_process($wanif);
-
-		mwexec("/usr/local/sbin/dhcp6c {$debugOption} {$noreleaseOption} -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
-		mwexec("/usr/bin/logger -t info 'Starting dhcp6 client for interface wan({$wanif} in DHCP6 without RA mode)'");
 	}
 	mwexec("/usr/sbin/rtsold -1 -p {$g['varrun_path']}/rtsold_{$wanif}.pid -O {$g['varetc_path']}/rtsold_{$wanif}_script.sh {$wanif}");
 


### PR DESCRIPTION
Added lock file creation and check to RTSOLD script creation. This is to
prevent mutliple launches of dhcp6c, this appears to happen when multiple
RA's are received in rapid succession at the start of a session. Once
created dhcp6c cannot be launched again until the lock file is deleted,
this is done within the kill_dhcp6_client process locking the two
together.

The kill -9 used to kill the dhcp6c client is changed to -15, -9 causes
the process to exit without sending a release if required, and if the
timing is just rignt can cause the pid file to be left behind; -15
allows for a graceful exit and if the release flag is not set then it
sends and waits for the release confirnation.

The launch of dhcp6c when in dhcp6withoutRA is moved to its own
function, as much as anything this makes the code tidy around the bottom
of interface_dhcpv6_configure().

These changes require the use of a new dhcp6c client, the PR for this is
#258 and this has also been PR'd upstream. The new client contains an
extra flag '-x' . This flag is used to prevent the execution of the same
script by dhcp6c and RTOSOLD at the same time, the flag causes dhcp6c to
not execute the script on receipt of a reply to a request. In
dhcp6cwithoutRA mode then RTSOLD will execute the script after dhcp6c
has been launched and when the RA has been received. This should also
prevent a problem where some ISP's BNG's are tardy when it comes to
replying to the RS.

This has been tested to death on ISP's that require dhcp6withoutRA and I
have tested it using a second pfSense unit as a sub off my main..