### PR TITLE
Fix #7134 Interface Stats widget ifdescrs not defined

### DIFF
--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -33,6 +33,8 @@ require_once("pfsense-utils.inc");
 require_once("functions.inc");
 require_once("/usr/local/www/widgets/include/interface_statistics.inc");
 
+$ifdescrs = get_configured_interface_with_descr();
+
 // Compose the table contents and pass it back to the ajax caller
 if ($_REQUEST && $_REQUEST['ajax']) {
 
@@ -46,10 +48,6 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 		'collisions' => gettext('Collisions'),
 	);
 
-	$ifdescrs = get_configured_interface_with_descr();
-	if (!is_array($ifdescrs)) {
-		$ifdescrs = array();
-	}
 	$skipinterfaces = explode(",", $user_settings['widgets']['interface_statistics']['iffilter']);
 
 	print("<thead>");
@@ -94,10 +92,6 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	exit;
 } else if ($_POST) {
 
-	$ifdescrs = get_configured_interface_with_descr();
-	if (!is_array($ifdescrs)) {
-		$ifdescrs = array();
-	}
 	$validNames = array();
 
 	foreach ($ifdescrs as $ifdescr => $ifname) {


### PR DESCRIPTION
When doing testing I had the Interfaces widget open as well as Interface Statistics. $ifdescrs was already populated as an array by the Interfaces widget, so Interface Statistics had (accidentally) gained the benefit.
If you have just the Interface Statistics widget on the dashboard then you get the reported PHP error, in the code that sets up the checkbox array of selectable interfaces. The problem is fixed by always calling get_configured_interface_with_descr() at the top of this code, rather than calls that were just inside various if() cases.
Note: get_configured_interface_with_descr() in util.inc always returns an array, even if an empty one, so the ```if (!is_array($ifdescrs))``` testing should not be needed.