### PR TITLE
Fix copy-paste of ipsec.widget.php file name

### DIFF
--- a/src/usr/local/www/widgets/widgets/ipsec.widget.php
+++ b/src/usr/local/www/widgets/widgets/ipsec.widget.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * gmirror_status.widget.php
+ * ipsec.widget.php
  *
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)


### PR DESCRIPTION
Noticed while looking in widget code, might as well fix it.