### PR TITLE
Fix #7136 Start OpenVPN on ordinary VIP

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1239,7 +1239,7 @@ function openvpn_restart($mode, $settings) {
 	}
 
 	/* Do not start an instance if we are not CARP master on this vip! */
-	if (strstr($settings['interface'], "_vip") && get_carp_interface_status($settings['interface']) != "MASTER") {
+	if (strstr($settings['interface'], "_vip") && !in_array(get_carp_interface_status($settings['interface']), array("MASTER", ""))) {
 		unlock($lockhandle);
 		return;
 	}
@@ -1248,7 +1248,7 @@ function openvpn_restart($mode, $settings) {
 	$a_groups = return_gateway_groups_array();
 	if (is_array($a_groups[$settings['interface']])) {
 		/* the interface is a gateway group. If a vip is defined and its a CARP backup then do not start */
-		if (($a_groups[$settings['interface']][0]['vip'] <> "") && (get_carp_interface_status($a_groups[$settings['interface']][0]['vip']) != "MASTER")) {
+		if (($a_groups[$settings['interface']][0]['vip'] <> "") && (!in_array(get_carp_interface_status($a_groups[$settings['interface']][0]['vip']), array("MASTER", "")))) {
 			unlock($lockhandle);
 			return;
 		}


### PR DESCRIPTION
get_carp_interface_status() returns "" if the "_vipnnnn" passed in is just an ordinary VIP (not part of CARP).
So we should be happy to start an OpenVPN instance if:
a) get_carp_interface_status() returns "MASTER" (this is currently MASTER in CARP) or;
b) get_carp_interface_status() returns "" (this VIP is not part of CARP)

Maybe it would be nice for get_carp_interface_status() to explicitly return some string like "NOTACARPVIP" for this case, rather than just returning "" - that would make it easier to read code that checks the return values and understand the intention. But I think it works just as it is.