### PR TITLE
Allow control of Gold menu item display

### DIFF
--- a/src/etc/inc/priv/user.priv.inc
+++ b/src/etc/inc/priv/user.priv.inc
@@ -16,6 +16,10 @@ $priv_list['page-help-all']['descr'] = gettext("Show all items on help menu and 
 $priv_list['page-help-all']['match'] = array();
 $priv_list['page-help-all']['match'][] = "*help.php";
 
+$priv_list['page-gold-all'] = array();
+$priv_list['page-gold-all']['name'] = gettext("WebCfg - Gold pages");
+$priv_list['page-gold-all']['descr'] = gettext("Show all items on the Gold menu");
+
 $priv_list['page-dashboard-all'] = array();
 $priv_list['page-dashboard-all']['name'] = gettext("WebCfg - Dashboard (all)");
 $priv_list['page-dashboard-all']['descr'] = gettext("Allow access to all pages required for the dashboard.");

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -185,7 +185,10 @@ function return_ext_menu($section) {
 function output_menu($arrayitem, $target = null, $section = "") {
 	foreach ($arrayitem as $item) {
 		/* If the user has access to help pages, also show the full help menu. See #5909 */
-		if (isAllowedPage($item[1]) || $item[1] == "/index.php?logout" || (($section == "Help") && isAllowedPage("help.php"))) {
+		if (isAllowedPage($item[1]) ||
+		    $item[1] == "/index.php?logout" ||
+		    (($section == "Help") && isAllowedPage("help.php")) ||
+		    (($section == "Gold") && userHasPrivilege(getUserEntry($_SESSION['Username']), "page-gold-all"))) {
 			$attr = sprintf("href=\"%s\"", htmlentities($item[1]));
 			if ($target) {
 				$attr .= sprintf(" target=\"%s\"", htmlentities($target));


### PR DESCRIPTION
Mentioned in forum post https://forum.pfsense.org/index.php?topic=123520.0
At the moment, if the user has "all pages" or "all privs"... then the Gold menu entry is displayed. Otherwise it is not (just an empty Gold menu header is shown.

This is a way to let the display of "Gold" menu items be controlled, similar to the existing "Help" pages priv. It makes the menu-priv system a bit more consistent, whatever you think of the existence of the Gold menu.