### PR TITLE
Mechanism to change required field from JavaScript

### DIFF
--- a/src/usr/local/www/classes/Form/Group.class.php
+++ b/src/usr/local/www/classes/Form/Group.class.php
@@ -154,8 +154,11 @@ EOT;
 			// 'element-required'. Text decoration can then be added in the CSS to indicate that this is a
 			// required field
 			if (substr($title, 0, 1 ) === "*" ) {
-				 $title = '<span class="element-required">' . substr($title, 1) . '</span>';
+				$special_class = ' class="element-required"';
+				$title = substr($title, 1);
 			}
+
+			$title = '<span id=pfgui-label-span-' . $target . $special_class . '>' . $title . '</span>';
 		}
 
 		return <<<EOT

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -2579,14 +2579,14 @@ $section->addClass('pppoe');
 
 $section->addInput(new Form_Input(
 	'pppoe_username',
-	'Username',
+	'*Username',
 	'text',
 	$pconfig['pppoe_username']
 ));
 
 $section->addPassword(new Form_Input(
 	'pppoe_password',
-	'Password',
+	'*Password',
 	'password',
 	$pconfig['pppoe_password']
 ));
@@ -3598,6 +3598,16 @@ events.push(function() {
 		$('#adv_dhcp_pt_initial_interval').val(initialinterval);
 	}
 
+	function setDialOnDemandItems() {
+		var dod = $('#pppoe_dialondemand').prop('checked');
+
+		if (dod) {
+			$("#pfgui-label-span-pppoe_idletimeout").addClass('element-required');
+		} else {
+			$("#pfgui-label-span-pppoe_idletimeout").removeClass('element-required');
+		}
+	}
+
 	// ---------- On initial page load ------------------------------------------------------------
 
 	updateType($('#type').val());
@@ -3606,7 +3616,8 @@ events.push(function() {
 	hideClass('dhcp6advanced', true);
 	hideClass('dhcpadvanced', true);
 	show_dhcp6adv();
-	setDHCPoptions()
+	setDHCPoptions();
+	setDialOnDemandItems();
 
 	// Set preset buttons on page load
 	var sv = "<?=htmlspecialchars($pconfig['adv_dhcp_pt_values']);?>";
@@ -3678,6 +3689,10 @@ events.push(function() {
 	});
 
 	// On click . .
+	$('#pppoe_dialondemand').click(function () {
+		setDialOnDemandItems();
+	});
+
 	$('[name=adv_dhcp_pt_values]').click(function () {
 	   setPresets($('input[name=adv_dhcp_pt_values]:checked').val());
 	});


### PR DESCRIPTION
Sometimes a field is only required based on the value of some other field.
In many cases the required field/fields are hidden and only displayed when they are required (e.g. as different IPv4 Configuration Type is selected for an interface, a whole relevant block of input fields is shown and other blocks are hidden.) For those cases it is easy to hard-code the required fields (e.g. pppoe_username in the diff of interfaces.php). Whenever the field is visible it is required.
But sometimes the field is optional, but becomes required depending on the value of other fields - e.g. pppoe_idletimeout is required when pppoe_dialondemand is checked. So the element-required class needs to be added to or removed from the pppoe_idletimeout label as pppoe_dialondemand changes.

Here is one way to do it:
1) Add a unique id to the span tag of the label of the group item, so it can be found and referenced - I made and id starting with "pfgui-label-span-".
2) Do this for every label, so the labels can be referenced if some class needs to be added to them later.
3) Add JS to reference the id and addClass('element-required') removeClass('element-required') as the user does stuff in the UI.

There might be much cleaner ways to do this - happy to get suggestions.
