### PR TITLE
Example of setting required items

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -2579,14 +2579,14 @@ $section->addClass('pppoe');
 
 $section->addInput(new Form_Input(
 	'pppoe_username',
-	'Username',
+	'*Username',
 	'text',
 	$pconfig['pppoe_username']
 ));
 
 $section->addPassword(new Form_Input(
 	'pppoe_password',
-	'Password',
+	'*Password',
 	'password',
 	$pconfig['pppoe_password']
 ));
@@ -3598,6 +3598,10 @@ events.push(function() {
 		$('#adv_dhcp_pt_initial_interval').val(initialinterval);
 	}
 
+	function setDialOnDemandItems() {
+		setRequired('pppoe_idletimeout', $('#pppoe_dialondemand').prop('checked'));
+	}
+
 	// ---------- On initial page load ------------------------------------------------------------
 
 	updateType($('#type').val());
@@ -3606,7 +3610,8 @@ events.push(function() {
 	hideClass('dhcp6advanced', true);
 	hideClass('dhcpadvanced', true);
 	show_dhcp6adv();
-	setDHCPoptions()
+	setDHCPoptions();
+	setDialOnDemandItems();
 
 	// Set preset buttons on page load
 	var sv = "<?=htmlspecialchars($pconfig['adv_dhcp_pt_values']);?>";
@@ -3678,6 +3683,10 @@ events.push(function() {
 	});
 
 	// On click . .
+	$('#pppoe_dialondemand').click(function () {
+		setDialOnDemandItems();
+	});
+
 	$('[name=adv_dhcp_pt_values]').click(function () {
 	   setPresets($('input[name=adv_dhcp_pt_values]:checked').val());
 	});


### PR DESCRIPTION
This is an example of what can be done to make use of the new infrastructure for marking fields as required in the UI:
1) Put an asterisk * at the start of the field label text - for fields that are always required (or at least always required when they are visible).
2) Use setRequired() in JavaScript when a field is only required under some conditions, and is sometimes not required but is visible/enterable under both conditions. Make a JavaScript event react to the dependent data condition/change and setRequired() true or false as appropriate.

This PR is just an example for discussion. If this is agreed as the way forward then people can start looking through the UI and making the needed code changes as per this "standard".