### PR TITLE
Fix #7147 IPv6 compress

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3830,7 +3830,7 @@ function interface_6to4_configure($interface = "wan", $wancfg) {
 	foreach ($stfbrbinarr as $bin) {
 		$stfbrarr[] = dechex(bindec($bin));
 	}
-	$stfbrgw = Net_IPv6::compress(implode(":", $stfbrarr));
+	$stfbrgw = text_to_compressed_ip6(implode(":", $stfbrarr));
 
 	/* convert the 128 bits for the broker address back into a valid IPv6 address */
 	$stflanarr = array();
@@ -3839,9 +3839,9 @@ function interface_6to4_configure($interface = "wan", $wancfg) {
 	foreach ($stflanbinarr as $bin) {
 		$stflanarr[] = dechex(bindec($bin));
 	}
-	$stflanpr = Net_IPv6::compress(implode(":", $stflanarr));
+	$stflanpr = text_to_compressed_ip6(implode(":", $stflanarr));
 	$stflanarr[7] = 1;
-	$stflan = Net_IPv6::compress(implode(":", $stflanarr));
+	$stflan = text_to_compressed_ip6(implode(":", $stflanarr));
 
 	/* setup the stf interface */
 	if (!is_module_loaded("if_stf")) {

--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -714,7 +714,7 @@ function ipsec_get_phase1($ikeid) {
 
 function ipsec_fixup_ip($ipaddr) {
 	if (is_ipaddrv6($ipaddr) || is_subnetv6($ipaddr)) {
-		return Net_IPv6::compress(Net_IPv6::uncompress($ipaddr));
+		return text_to_compressed_ip6($ipaddr);
 	} else {
 		return $ipaddr;
 	}

--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1863,8 +1863,8 @@ function openvpn_get_interface_ipv6($ipv6, $prefix) {
 	// Is there a better way to do this math?
 	$ipv6_arr = explode(':', $basev6);
 	$last = hexdec(array_pop($ipv6_arr));
-	$ipv6_1 = Net_IPv6::compress(Net_IPv6::uncompress(implode(':', $ipv6_arr) . ':' . dechex($last + 1)));
-	$ipv6_2 = Net_IPv6::compress(Net_IPv6::uncompress(implode(':', $ipv6_arr) . ':' . dechex($last + 2)));
+	$ipv6_1 = text_to_compressed_ip6(implode(':', $ipv6_arr) . ':' . dechex($last + 1));
+	$ipv6_2 = text_to_compressed_ip6(implode(':', $ipv6_arr) . ':' . dechex($last + 2));
 	return array($ipv6_1, $ipv6_2);
 }
 

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2728,6 +2728,10 @@ function where_is_ipaddr_configured($ipaddr, $ignore_if = "", $check_localip = f
 
 	$isipv6 = is_ipaddrv6($ipaddr);
 
+	if ($isipv6) {
+		$ipaddr = text_to_compressed_ip6($ipaddr);
+	}
+
 	if ($check_subnets) {
 		$cidrprefix = intval($cidrprefix);
 		if ($isipv6) {

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2790,7 +2790,7 @@ function where_is_ipaddr_configured($ipaddr, $ignore_if = "", $check_localip = f
 	}
 
 	if ($check_localip) {
-		if (!is_array($config['l2tp']) && !empty($config['l2tp']['localip']) && (strcasecmp($ipaddr, $config['l2tp']['localip']) == 0)) {
+		if (!is_array($config['l2tp']) && !empty($config['l2tp']['localip']) && (strcasecmp($ipaddr, text_to_compressed_ip6($config['l2tp']['localip'])) == 0)) {
 			$where_entry = array();
 			$where_entry['if'] = 'l2tp';
 			$where_entry['ip_or_subnet'] = $config['l2tp']['localip'];

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2883,7 +2883,7 @@ function convert_128bit_to_ipv6($ip6bin) {
 	foreach ($ip6binarr as $binpart) {
 		$ip6arr[] = dechex(bindec($binpart));
 	}
-	$ip6addr = Net_IPv6::compress(implode(":", $ip6arr));
+	$ip6addr = text_to_compressed_ip6(implode(":", $ip6arr));
 
 	return($ip6addr);
 }
@@ -2965,7 +2965,7 @@ function merge_ipv6_delegated_prefix($prefix, $suffix, $len = 64) {
 		break;
 	}
 
-	return Net_IPv6::compress(substr($prefix, 0, $prefix_len) .
+	return text_to_compressed_ip6(substr($prefix, 0, $prefix_len) .
 	    substr($suffix, $prefix_len));
 }
 

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1449,14 +1449,14 @@ function get_configured_ipv6_addresses($linklocal_fallback = false) {
 	$interfaces = get_configured_interface_list();
 	if (is_array($interfaces)) {
 		foreach ($interfaces as $int) {
-			$ipaddrv6 = get_interface_ipv6($int, false, $linklocal_fallback);
+			$ipaddrv6 = text_to_compressed_ip6(get_interface_ipv6($int, false, $linklocal_fallback));
 			$ipv6_array[$int] = $ipaddrv6;
 		}
 	}
 	$interfaces = get_configured_vip_list('inet6');
 	if (is_array($interfaces)) {
 		foreach ($interfaces as $int => $ipaddrv6) {
-			$ipv6_array[$int] = $ipaddrv6;
+			$ipv6_array[$int] = text_to_compressed_ip6($ipaddrv6);
 		}
 	}
 	return $ipv6_array;

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -268,7 +268,7 @@ function gen_subnetv4($ipaddr, $bits) {
 /* same as gen_subnet() but accepts IPv6 only */
 function gen_subnetv6($ipaddr, $bits) {
 	if (is_ipaddrv6($ipaddr) && is_numericint($bits) && $bits <= 128) {
-		return Net_IPv6::compress(Net_IPv6::getNetmask($ipaddr, $bits));
+		return text_to_compressed_ip6(Net_IPv6::getNetmask($ipaddr, $bits));
 	}
 	return "";
 }
@@ -396,7 +396,22 @@ function bin_to_ip6($bin) {
  * Convert IPv6 binary to compressed address
  */
 function bin_to_compressed_ip6($bin) {
-	return Net_IPv6::compress(bin_to_ip6($bin));
+	return text_to_compressed_ip6(bin_to_ip6($bin));
+}
+
+/*
+ * Convert textual IPv6 address string to compressed address
+ */
+function text_to_compressed_ip6($text) {
+	// Force re-compression by passing parameter 2 (force) true.
+	// This ensures that supposedly-compressed formats are uncompressed
+	// first then re-compressed into strictly correct form.
+	// e.g. 2001:0:0:4:0:0:0:1
+	// 2001::4:0:0:0:1 is a strictly-incorrect compression,
+	// but maybe the user entered it like that.
+	// The "force" parameter will ensure it is returned as:
+	// 2001:0:0:4::1
+	return Net_IPv6::compress($text, true);
 }
 
 /* Find out how many IPs are contained within a given IP range

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -228,9 +228,9 @@ if (isset($_POST['apply'])) {
 		$_POST['prefixrange_length']) {
 		$netmask = Net_IPv6::getNetmask($_POST['prefixrange_from'],
 			$_POST['prefixrange_length']);
-		$netmask = Net_IPv6::compress($netmask);
+		$netmask = text_to_compressed_ip6($netmask);
 
-		if ($netmask != Net_IPv6::compress(strtolower(
+		if ($netmask != text_to_compressed_ip6(strtolower(
 			$_POST['prefixrange_from']))) {
 			$input_errors[] = sprintf(gettext(
 				"Prefix Delegation From address is not a valid IPv6 Netmask for %s"),
@@ -239,9 +239,9 @@ if (isset($_POST['apply'])) {
 
 		$netmask = Net_IPv6::getNetmask($_POST['prefixrange_to'],
 			$_POST['prefixrange_length']);
-		$netmask = Net_IPv6::compress($netmask);
+		$netmask = text_to_compressed_ip6($netmask);
 
-		if ($netmask != Net_IPv6::compress(strtolower(
+		if ($netmask != text_to_compressed_ip6(strtolower(
 			$_POST['prefixrange_to']))) {
 			$input_errors[] = sprintf(gettext(
 				"Prefix Delegation To address is not a valid IPv6 Netmask for %s"),


### PR DESCRIPTION
1) Make a function text_to_compressed_ip6() that forces compression even on IPv6 addresses that already "look" compressed. e.g. : 2001:0:0:2:0:0:0:1 might be written by someone as 2001::2:0:0:0:1 but should really be written 2001:0:0:2::1
2) Use text_to_compressed_ip6() everywhere that currently uses Net_IPv6::compress()
3) Use text_to_compressed_ip6() in a few new places to make sure that where_is_ipaddr_configured() works properly, and thus anyone that calls it will also work OK.

Then there are plenty more places where text_to_compressed_ip6() could be called to make sure that unusual-looking IPv6 address strings are converted to a standardized form before being used for comparison or written to conf files of utilities.