### PR TITLE
Display input error when no aliases to import

### DIFF
--- a/src/usr/local/www/firewall_aliases_import.php
+++ b/src/usr/local/www/firewall_aliases_import.php
@@ -60,9 +60,9 @@ if (!is_array($config['aliases']['alias'])) {
 }
 $a_aliases = &$config['aliases']['alias'];
 
-if ($_POST['aliasimport'] != "") {
+if ($_POST) {
 	$reqdfields = explode(" ", "name aliasimport");
-	$reqdfieldsn = array(gettext("Name"), gettext("Aliases"));
+	$reqdfieldsn = array(gettext("Name"), gettext("Aliases to import"));
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 


### PR DESCRIPTION
Currently if you put nothing in the "Aliases to import" box and press Save then the page just reloads - nothing saves and there is no message about the problem. It should tell you to that "Aliases to import" is required.