### PR TITLE
Allow get_pkg_info() to fallback on "pkg info" for local pkgs if "pkg search" cannot access a local catalog copy (resubmit)

### DIFF
--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -337,11 +337,13 @@ function get_package_internal_name($package_data) {
 }
 
 // Get information about packages.
-function get_pkg_info($pkgs = 'all', $only_local = false) {
+function get_pkg_info($pkgs = 'all', $local_only = false, $installed_only = false) {
+
 	global $g, $input_errors;
 
 	$out = '';
 	$err = '';
+	$rc = 0;
 
 	unset($pkg_filter);
 	if (is_array($pkgs)) {
@@ -350,7 +352,7 @@ function get_pkg_info($pkgs = 'all', $only_local = false) {
 	}
 
 	if ($pkgs == 'all') {
-		$pkgs = $g['pkg_prefix'];
+		$pkgs = $g['pkg_prefix'] . '*'; // Allows same prefix to work with both pkg search + pkg info
 	}
 
 	if (!function_exists('is_subsystem_dirty')) {
@@ -359,21 +361,46 @@ function get_pkg_info($pkgs = 'all', $only_local = false) {
 
 	/* Do not run remote operations if pkg has a lock */
 	if (is_subsystem_dirty('pkg')) {
-		$only_local = true;
+		$local_only = true;
 		$lock = false;
 	} else {
 		$lock = true;
 	}
 
 	$extra_param = "";
-	if ($only_local) {
+	if ($local_only) {
 		$extra_param = "-U ";
 	}
 
 	if ($lock) {
 		mark_subsystem_dirty('pkg');
 	}
-	$rc = pkg_exec("search {$extra_param}-R --raw-format json-compact " . $pkgs, $out, $err);
+
+	if (!$installed_only) {
+		// repo catalog search (either remote or local_only)
+		$rc = pkg_exec("search {$extra_param}-R --raw-format json-compact " . $pkgs, $out, $err);
+	}
+	if ($installed_only || ($local_only && $rc != 0)) {
+		/* use pkg info if (1) installed pkg search or (2) local catalog copy search requested + failed.
+		 *
+		 * The local repo catalog copy may be cleared if a previous call to pkg search couldn't get the
+		 * remote repo catalog.
+		 *
+		 * If the calling code would have accepted local copy info (which isn't assumed up to date) then it
+		 * makes sense to fall back on pkg info to at least return the known info about installed pkgs (pkg
+		 * info should still work), instead of failing and returning no info at all. For example, this
+		 * enables offline view + management of installed pkgs.
+		 */
+
+		// pkg info errors if none match, unlike pkg search, so test it will work beforehand...
+		$tmp1 = $tmp2 = '';
+		$tmprc = pkg_exec("info -e -R --raw-format json-compact " . $pkgs, $tmp1, $tmp2);
+		
+		if ($tmprc == 0) {
+			// ok, packages match, so pkg info can be safely called
+			$rc = pkg_exec("info -R --raw-format json-compact " . $pkgs, $out, $err);
+		} // else we already have empty values for $out etc which are correct if none matched
+	}
 	if ($lock) {
 		clear_subsystem_dirty('pkg');
 	}
@@ -453,7 +480,8 @@ function get_pkg_info($pkgs = 'all', $only_local = false) {
 function register_all_installed_packages() {
 	global $g, $config, $pkg_interface;
 
-	$pkg_info = get_pkg_info('all', true);
+	$pkg_info = get_pkg_info('all', true, true);
+
 
 	foreach ($pkg_info as $pkg) {
 		if (!isset($pkg['installed'])) {

--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -337,70 +337,70 @@ function get_package_internal_name($package_data) {
 }
 
 // Get information about packages.
-function get_pkg_info($pkgs = 'all', $local_only = false, $installed_only = false) {
+function get_pkg_info($pkgs = 'all', $remote_repo_usage_disabled = false, $installed_pkgs_only = false) {
 
 	global $g, $input_errors;
 
-	$out = '';
-	$err = '';
+	$out = $err = $extra_param = '';
 	$rc = 0;
 
 	unset($pkg_filter);
+
 	if (is_array($pkgs)) {
 		$pkg_filter = $pkgs;
-		$pkgs = 'all';
+		$pkgs = $g['pkg_prefix'] . '*';
+	} elseif ($pkgs == 'all') {
+		$pkgs = $g['pkg_prefix'] . '*';
 	}
 
-	if ($pkgs == 'all') {
-		$pkgs = $g['pkg_prefix'] . '*'; // Allows same prefix to work with both pkg search + pkg info
-	}
-
+	
 	if (!function_exists('is_subsystem_dirty')) {
 		require_once("util.inc");
 	}
 
 	/* Do not run remote operations if pkg has a lock */
 	if (is_subsystem_dirty('pkg')) {
-		$local_only = true;
+		$remote_repo_usage_disabled = true;
 		$lock = false;
 	} else {
 		$lock = true;
-	}
-
-	$extra_param = "";
-	if ($local_only) {
-		$extra_param = "-U ";
 	}
 
 	if ($lock) {
 		mark_subsystem_dirty('pkg');
 	}
 
-	if (!$installed_only) {
-		// repo catalog search (either remote or local_only)
+	if ($remote_repo_usage_disabled) {
+		$extra_param = "-U ";
+	}
+
+	if (!$installed_pkgs_only) {
 		$rc = pkg_exec("search {$extra_param}-R --raw-format json-compact " . $pkgs, $out, $err);
 	}
-	if ($installed_only || ($local_only && $rc != 0)) {
-		/* use pkg info if (1) installed pkg search or (2) local catalog copy search requested + failed.
+	if (($installed_pkgs_only || ($rc != 0 && $remote_repo_usage_disabled)) && is_package_installed($pkgs)) {
+		/* Fall back on pkg info to return locally installed matching pkgs instead, if 
 		 *
-		 * The local repo catalog copy may be cleared if a previous call to pkg search couldn't get the
-		 * remote repo catalog.
+		 *   (1) only installed pkgs needed, or
+		 *       we tried to check the local catalog copy (implying that we would have accepted incomplete/outdated pkg info)
+		 *       but it didn't have any contents, or for other reasons returned an error. 
+		 *   AND
+		 *   (2) at least some pkgs matching <pattern> are installed
 		 *
-		 * If the calling code would have accepted local copy info (which isn't assumed up to date) then it
-		 * makes sense to fall back on pkg info to at least return the known info about installed pkgs (pkg
-		 * info should still work), instead of failing and returning no info at all. For example, this
-		 * enables offline view + management of installed pkgs.
-		 */
-
-		// pkg info errors if none match, unlike pkg search, so test it will work beforehand  
-		// is_package_installed() is a wrapper for pkg info -e <pattern> which is what we need here.  
-
-		if (is_package_installed($pkgs)) {  
-			// ok, 1 or more packages match, so pkg info can be safely called to get the pkg list  
-			$rc = pkg_exec("info -R --raw-format json-compact " . $pkgs, $out, $err);  
- 		} // else we already have empty values for $out etc which are correct if none matched  
-
+		 * Following an unsuccessful attempt to access a remote repo catalog, the local copy is wiped clear. Thereafter any
+		 * "pkg search" will return an error until online+updated again. If the calling code would have accepted local copy info
+		 * (which could be incomplete/out of date), then it makes sense to fall back on pkg info to at least return the known
+		 * info about installed pkgs (pkg info should still work), instead of failing and returning no info at all. 
+		 * For example, this at least enables offline view + management of installed pkgs in GUI/console.
+		 *
+		 * We skip this step if no matching pkgs are installed, because then pkg info would return a "no matching pkgs"
+		 * RC code, even though this wouldn't be considered an "error" (and $out+$err would be correct empty strings if none match).
+		 * Note that is_package_installed() is a wrapper for pkg info -e <pattern> which is what we need here.
+		*/
+		
+		// ok, 1 or more packages match, so pkg info can be safely called to get the pkg list  
+		$rc = pkg_exec("info -R --raw-format json-compact " . $pkgs, $out, $err);  
 	}
+
 	if ($lock) {
 		clear_subsystem_dirty('pkg');
 	}

--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -392,40 +392,14 @@ function get_pkg_info($pkgs = 'all', $local_only = false, $installed_only = fals
 		 * enables offline view + management of installed pkgs.
 		 */
 
-		// pkg info errors if none match, unlike pkg search, so test it will work beforehand...
-		if (
+		// pkg info errors if none match, unlike pkg search, so test it will work beforehand  
+		// is_package_installed() is a wrapper for pkg info -e <pattern> which is what we need here.  
 
-	$extra_param = "";
-	if ($local_only) {
-		$extra_param = "-U ";
-	}
+		if (is_package_installed($pkgs)) {  
+			// ok, 1 or more packages match, so pkg info can be safely called to get the pkg list  
+			$rc = pkg_exec("info -R --raw-format json-compact " . $pkgs, $out, $err);  
+ 		} // else we already have empty values for $out etc which are correct if none matched  
 
-	if ($lock) {
-		mark_subsystem_dirty('pkg');
-	}
-
-	if (!$installed_only) {
-		// repo catalog search (either remote or local_only)
-		$rc = pkg_exec("search {$extra_param}-R --raw-format json-compact " . $pkgs, $out, $err);
-	}
-	if ($installed_only || ($local_only && $rc != 0)) {
-		/* use pkg info if (1) installed pkg search or (2) local catalog copy search requested + failed.
-		 *
-		 * The local repo catalog copy may be cleared if a previous call to pkg search couldn't get the
-		 * remote repo catalog.
-		 *
-		 * If the calling code would have accepted local copy info (which isn't assumed up to date) then it
-		 * makes sense to fall back on pkg info to at least return the known info about installed pkgs (pkg
-		 * info should still work), instead of failing and returning no info at all. For example, this
-		 * enables offline view + management of installed pkgs.
-		 */
-
-		// pkg info errors if none match, unlike pkg search, so test it will work beforehand
-		// is_package_installed() is a wrapper for pkg info -e <pattern> which is what we need here.
-		if (is_package_installed($pkgs)) {
-			// ok, 1 or more packages match, so pkg info can be safely called to get the pkg list
-			$rc = pkg_exec("info -R --raw-format json-compact " . $pkgs, $out, $err);
-		} // else we already have empty values for $out etc which are correct if none matched
 	}
 	if ($lock) {
 		clear_subsystem_dirty('pkg');

--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -393,11 +393,37 @@ function get_pkg_info($pkgs = 'all', $local_only = false, $installed_only = fals
 		 */
 
 		// pkg info errors if none match, unlike pkg search, so test it will work beforehand...
-		$tmp1 = $tmp2 = '';
-		$tmprc = pkg_exec("info -e -R --raw-format json-compact " . $pkgs, $tmp1, $tmp2);
-		
-		if ($tmprc == 0) {
-			// ok, packages match, so pkg info can be safely called
+		if (
+
+	$extra_param = "";
+	if ($local_only) {
+		$extra_param = "-U ";
+	}
+
+	if ($lock) {
+		mark_subsystem_dirty('pkg');
+	}
+
+	if (!$installed_only) {
+		// repo catalog search (either remote or local_only)
+		$rc = pkg_exec("search {$extra_param}-R --raw-format json-compact " . $pkgs, $out, $err);
+	}
+	if ($installed_only || ($local_only && $rc != 0)) {
+		/* use pkg info if (1) installed pkg search or (2) local catalog copy search requested + failed.
+		 *
+		 * The local repo catalog copy may be cleared if a previous call to pkg search couldn't get the
+		 * remote repo catalog.
+		 *
+		 * If the calling code would have accepted local copy info (which isn't assumed up to date) then it
+		 * makes sense to fall back on pkg info to at least return the known info about installed pkgs (pkg
+		 * info should still work), instead of failing and returning no info at all. For example, this
+		 * enables offline view + management of installed pkgs.
+		 */
+
+		// pkg info errors if none match, unlike pkg search, so test it will work beforehand
+		// is_package_installed() is a wrapper for pkg info -e <pattern> which is what we need here.
+		if (is_package_installed($pkgs)) {
+			// ok, 1 or more packages match, so pkg info can be safely called to get the pkg list
 			$rc = pkg_exec("info -R --raw-format json-compact " . $pkgs, $out, $err);
 		} // else we already have empty values for $out etc which are correct if none matched
 	}


### PR DESCRIPTION
Resubmit of PR #3157 with fix.

The issue was down to the behaviour of `pkg info`, which errors out rather than providing an empty return, if no packages matched locally (as will be the case in @NYOB's clean install). The fix is to test specifically if there are zero installed packages matching, before using `pkg info` to get the list of local matching pkgs.

For details of the underlying issue being fixed, and the issue that this resubmit fixes, see the original PR.

_Amended code_

This PR is identical to #3157 apart from the new lines 395-402, which wrap the old lines in a `pkg info -e` call with dummy args to skip the `pkg info` call if it'll hit "no matches".


_Detail_

`pkg info` gives an error "No packages match [$pkgs]" if none match, whereas `pkg search` doesn't (usually!).

The simplest fix, which seems to work nicely, is that if no repo copy exists or we're going to inquire about local pkgs, wrap the `pkg info` call with a test using `pkg info -e`, to detect whether pkg info will hit a "no packages exist" issue or not. If `pkg info -e` returns 0 then it's safe to call `pkg info`,  as there's at least one matching installed pkg so we won't hit this issue (any other errors are allowed to occur and be detected as usual). Otherwise skip the main `pkg info` (which leaves $out and other variables at the correct values they need anyway, for null match/none found).

