### PR TITLE
Required fields in NAT pages

### DIFF
--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -466,12 +466,12 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_IpAddress(
 	'external',
-	'External subnet IP',
+	'*External subnet IP',
 	$pconfig['external']
 ))->setHelp('Enter the external (usually on a WAN) subnet\'s starting address for the 1:1 mapping. ' .
 			'The subnet mask from the internal address below will be applied to this IP address.');
 
-$group = new Form_Group('Internal IP');
+$group = new Form_Group('*Internal IP');
 
 $group->add(new Form_Checkbox(
 	'srcnot',

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -788,7 +788,7 @@ $group->setHelp('Specify the source port or port range for this rule. This is us
 
 $section->add($group);
 
-$group = new Form_Group('Destination');
+$group = new Form_Group('*Destination');
 
 $group->add(new Form_Checkbox(
 	'dstnot',
@@ -813,7 +813,7 @@ $group->add(new Form_IpAddress(
 
 $section->add($group);
 
-$group = new Form_Group('Destination port range');
+$group = new Form_Group('*Destination port range');
 $group->addClass('dstportrange');
 
 $group->add(new Form_Select(
@@ -851,13 +851,13 @@ $section->add($group);
 
 $section->addInput(new Form_IpAddress(
 	'localip',
-	'Redirect target IP',
+	'*Redirect target IP',
 	$pconfig['localip'],
 	'ALIASV4V6'
 ))->setHelp('Enter the internal IP address of the server on which to map the ports.' . '<br />' .
 			'e.g.: 192.168.1.12');
 
-$group = new Form_Group('Redirect target port');
+$group = new Form_Group('*Redirect target port');
 $group->addClass('lclportrange');
 
 $group->add(new Form_Select(

--- a/src/usr/local/www/firewall_nat_npt_edit.php
+++ b/src/usr/local/www/firewall_nat_npt_edit.php
@@ -211,7 +211,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_IpAddress(
 	'src',
-	'Address',
+	'*Address',
 	$pconfig['src'],
 	'V6'
 ))->addMask('srcmask', $pconfig['srcmask'])->setHelp('Internal (LAN) ULA IPv6 Prefix for the Network Prefix translation. ' .
@@ -226,7 +226,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_IpAddress(
 	'dst',
-	'Address',
+	'*Address',
 	$pconfig['dst'],
 	'V6'
 ))->addMask('dstmask', $pconfig['dstmask'])->setHelp('Global Unicast routable IPv6 prefix');

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -485,7 +485,7 @@ $section->addInput(new Form_Select(
 	array_combine(explode(" ", strtolower($protocols)), explode(" ", $protocols))
 ))->setHelp('Choose which protocol this rule should match. In most cases "any" is specified.');
 
-$group = new Form_Group('Source');
+$group = new Form_Group('*Source');
 
 $group->add(new Form_Select(
 	'source_type',


### PR DESCRIPTION
This is a good one to highlight and discuss the issues about what should be marked as "required".

Example 1) Fields with dropdown lists - e.g. Interface, Protocol
They are "required" by the back-end but the UI already enforces selecting something from the valid list. The user can (and often does) leave them at the provided default selections. And there is no way that the user can not select/input in these fields.
**Should we mark these fields as required?**
It seems to me that it looks a bit odd to have the "required" underlining on fields further down, but not on Interface and Protocol. Without Interface and Protocol being underlined, some users might ask why? how are those fields not required?

Example 2) firewall_nat_edit.php
"Destination" is a combination of selecting from a dropdown, plus sometimes entering an address/mask. A default value is selected that does not require the user to enter anything else - they can just keep the default. So in that sense the form group is not "required". But if the user selects "Single host or alias" or "Network" then they are required to enter an address/mask.
If the answer to (1) is "yes", then this field will be marked required. If "no" then I guess we should put JavaScript here that responds to changing the selection in the dropdown?

There are similar issues in firewall_nat_1to1_edit.php and firewall_nat_out_edit.php - and will be similar on other UI pages.