### PR TITLE
6RD Border Relay input error message

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -621,7 +621,7 @@ if ($_POST['apply']) {
 				}
 			}
 			if (!is_ipaddrv4($_POST['gateway-6rd'])) {
-				$input_errors[] = gettext("6RD Border Gateway must be an IPv4 address.");
+				$input_errors[] = gettext("6RD Border Relay must be an IPv4 address.");
 			}
 			if (in_array($wancfg['ipaddrv6'], array())) {
 				$input_errors[] = sprintf(gettext("The interface must be reassigned to configure as %s."), $_POST['type6']);


### PR DESCRIPTION
This field is labelled "6RD Border Relay" on the main UI. It confused me for a moment when I got this message "6RD Border Gateway must be an IPv4 address." since there was no field with that label in the 6RD section of the UI.
It would be good to use the same terminology in both places.