### PR TITLE
Interface description should be required

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -492,7 +492,7 @@ if ($_POST['apply']) {
 	/* input validation */
 	$reqdfields = explode(" ", "descr");
 	$reqdfieldsn = array(gettext("Description"));
-	do_input_validation($_REQUEST, $reqdfields, $reqdfieldsn, $input_errors);
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	if (!$input_errors) {
 		/* description unique? */

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -488,36 +488,44 @@ if ($_POST['apply']) {
 		unset($_POST['pppoe_resetdate']);
 		unset($_POST['pppoe_pr_preset_val']);
 	}
-	/* description unique? */
-	foreach ($ifdescrs as $ifent => $ifdescr) {
-		if ($if != $ifent && $ifdescr == $_POST['descr']) {
-			$input_errors[] = gettext("An interface with the specified description already exists.");
-			break;
-		}
-	}
 
-	/* Is the description already used as an alias name? */
-	if (is_array($config['aliases']['alias'])) {
-		foreach ($config['aliases']['alias'] as $alias) {
-			if ($alias['name'] == $_POST['descr']) {
-				$input_errors[] = sprintf(gettext("Sorry, an alias with the name %s already exists."), $_POST['descr']);
-			}
-		}
-	}
-
-	/* Is the description already used as an interface group name? */
-	if (is_array($config['ifgroups']['ifgroupentry'])) {
-		foreach ($config['ifgroups']['ifgroupentry'] as $ifgroupentry) {
-			if ($ifgroupentry['ifname'] == $_POST['descr']) {
-				$input_errors[] = sprintf(gettext("Sorry, an interface group with the name %s already exists."), $wancfg['descr']);
-			}
-		}
-	}
-
-	if (is_numeric($_POST['descr'])) {
-		$input_errors[] = gettext("The interface description cannot contain only numbers.");
-	}
 	/* input validation */
+	$reqdfields = explode(" ", "descr");
+	$reqdfieldsn = array(gettext("Description"));
+	do_input_validation($_REQUEST, $reqdfields, $reqdfieldsn, $input_errors);
+
+	if (!$input_errors) {
+		/* description unique? */
+		foreach ($ifdescrs as $ifent => $ifdescr) {
+			if ($if != $ifent && $ifdescr == $_POST['descr']) {
+				$input_errors[] = gettext("An interface with the specified description already exists.");
+				break;
+			}
+		}
+
+		/* Is the description already used as an alias name? */
+		if (is_array($config['aliases']['alias'])) {
+			foreach ($config['aliases']['alias'] as $alias) {
+				if ($alias['name'] == $_POST['descr']) {
+					$input_errors[] = sprintf(gettext("Sorry, an alias with the name %s already exists."), $_POST['descr']);
+				}
+			}
+		}
+
+		/* Is the description already used as an interface group name? */
+		if (is_array($config['ifgroups']['ifgroupentry'])) {
+			foreach ($config['ifgroups']['ifgroupentry'] as $ifgroupentry) {
+				if ($ifgroupentry['ifname'] == $_POST['descr']) {
+					$input_errors[] = sprintf(gettext("Sorry, an interface group with the name %s already exists."), $wancfg['descr']);
+				}
+			}
+		}
+
+		if (is_numeric($_POST['descr'])) {
+			$input_errors[] = gettext("The interface description cannot contain only numbers.");
+		}
+	}
+
 	if (isset($config['dhcpd']) && isset($config['dhcpd'][$if]['enable'])) {
 		if (!preg_match("/^staticv4/", $_POST['type'])) {
 			$input_errors[] = gettext("The DHCP Server is active " .


### PR DESCRIPTION
I was blanking out stuff to see what input error messages came about fields that are required. I was surprised that the Interface Description would save empty. The system did not immediately explode (I was playing with a bonus interface I had created in a VM) but I don't think it is desirable to have interfaces with no description.
The change here also only does the other checks on the description if it has actually been entered - no point checking a whole lot of other dependent stuff if the description is not even entered.