### PR TITLE
Interface Group Name should be required

### DIFF
--- a/src/usr/local/www/interfaces_groups_edit.php
+++ b/src/usr/local/www/interfaces_groups_edit.php
@@ -60,45 +60,52 @@ if ($_POST) {
 	unset($input_errors);
 	$pconfig = $_POST;
 
-	if (!isset($id)) {
-		foreach ($a_ifgroups as $groupentry) {
-			if ($groupentry['ifname'] == $_POST['ifname']) {
-				$input_errors[] = gettext("Group name already exists!");
+	/* input validation */
+	$reqdfields = explode(" ", "ifname");
+	$reqdfieldsn = array(gettext("Group Name"));
+	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
+
+	if (!$input_errors) {
+		if (!isset($id)) {
+			foreach ($a_ifgroups as $groupentry) {
+				if ($groupentry['ifname'] == $_POST['ifname']) {
+					$input_errors[] = gettext("Group name already exists!");
+				}
 			}
 		}
-	}
 
-	if (strlen($_POST['ifname']) > 16) {
-		$input_errors[] = gettext("Group name cannot have more than 16 characters.");
-	}
-
-	if (preg_match("/([^a-zA-Z0-9-_])+/", $_POST['ifname'])) {
-		$input_errors[] = gettext("Only letters (A-Z), digits (0-9), '-' and '_' are allowed as the group name.");
-	}
-
-	if (preg_match("/[0-9]$/", $_POST['ifname'])) {
-		$input_errors[] = gettext("Group name cannot end with digit.");
-	}
-
-	/*
-	 * Packages (e.g. tinc) creates interface groups, reserve this
-	 * namespace pkg- for them
-	 */
-	if (substr($_POST['ifname'], 0, 4) == 'pkg-') {
-		$input_errors[] = gettext("Group name cannot start with pkg-");
-	}
-
-	foreach ($interface_list_disabled as $gif => $gdescr) {
-		if ($gdescr == $_POST['ifname'] || $gif == $_POST['ifname']) {
-			$input_errors[] = "The specified group name is already used by an interface. Please choose another name.";
+		if (strlen($_POST['ifname']) > 16) {
+			$input_errors[] = gettext("Group name cannot have more than 16 characters.");
 		}
-	}
 
-	/* Is the description already used as an alias name? */
-	if (is_array($config['aliases']['alias'])) {
-		foreach ($config['aliases']['alias'] as $alias) {
-			if ($alias['name'] == $_POST['ifname']) {
-				$input_errors[] = gettext("An alias with this name already exists.");
+		if (preg_match("/([^a-zA-Z0-9-_])+/", $_POST['ifname'])) {
+			$input_errors[] = gettext("Only letters (A-Z), digits (0-9), '-' and '_' are allowed as the group name.");
+		}
+
+		if (preg_match("/[0-9]$/", $_POST['ifname'])) {
+			$input_errors[] = gettext("Group name cannot end with digit.");
+		}
+
+		/*
+		 * Packages (e.g. tinc) creates interface groups, reserve this
+		 * namespace pkg- for them
+		 */
+		if (substr($_POST['ifname'], 0, 4) == 'pkg-') {
+			$input_errors[] = gettext("Group name cannot start with pkg-");
+		}
+
+		foreach ($interface_list_disabled as $gif => $gdescr) {
+			if ($gdescr == $_POST['ifname'] || $gif == $_POST['ifname']) {
+				$input_errors[] = "The specified group name is already used by an interface. Please choose another name.";
+			}
+		}
+
+		/* Is the description already used as an alias name? */
+		if (is_array($config['aliases']['alias'])) {
+			foreach ($config['aliases']['alias'] as $alias) {
+				if ($alias['name'] == $_POST['ifname']) {
+					$input_errors[] = gettext("An alias with this name already exists.");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Do not allow it to be blank. Do not bother with all the other checks on the group name if it is blank.
(At the moment I can enter an Interface Group with blank name)