### PR TITLE
QinQ Edit fix row add delete

### DIFF
--- a/src/usr/local/www/interfaces_qinq_edit.php
+++ b/src/usr/local/www/interfaces_qinq_edit.php
@@ -105,32 +105,48 @@ if ($_POST) {
 	}
 
 	$members = "";
-	$isfirst = 0;
 
 	// Read the POSTed member array into a space separated list translating any ranges
 	// into their included values
-	foreach ($_POST['members'] as $memb) {
+	$membercounter = 0;
+	$membername = "member{$membercounter}";
+	$valid_members = array();
+
+	while (isset($_POST[$membername])) {
 		// Might be a range
-		$member = explode("-", $memb);
+		$member = explode("-", $_POST[$membername]);
 
 		if (count($member) > 1) {
-			if (preg_match("/([^0-9])+/", $member[0], $match)  || preg_match("/([^0-9])+/", $member[1], $match)) {
+			if (($member[0] == "") || ($member[1] == "") ||
+			    preg_match("/([^0-9])+/", $member[0], $match)  || preg_match("/([^0-9])+/", $member[1], $match)) {
 				$input_errors[] = gettext("Tags can contain only numbers or a range in format #-#.");
-			}
-
-			for ($i = $member[0]; $i <= $member[1]; $i++) {
-				$members .= ($isfirst == 0 ? '':' ') . $i;
-				$isfirst++;
+			} else if ($member[0] > $member[1]) {
+				$input_errors[] = gettext("Tag ranges must be entered with the lower number first.");
+			} else {
+				for ($i = $member[0]; $i <= $member[1]; $i++) {
+					$valid_members[] = $i;
+				}
 			}
 		} else { // Just a single number
-			if (preg_match("/([^0-9])+/", $memb, $match)) {
+			if (preg_match("/([^0-9])+/", $member[0], $match)) {
 				$input_errors[] = gettext("Tags can contain only numbers or a range in format #-#.");
 			} else {
-				$members .= ($isfirst == 0 ? '':' ') . $memb;
-				$isfirst++;
+				// Ignore empty rows
+				if ($member[0] != "") {
+					$valid_members[] = $member[0];
+				}
 			}
 		}
+
+		// Remember the POSTed values so they can be redisplayed if there were errors.
+		$posted_members .= ($membercounter == 0 ? '':' ') . $_POST[$membername];
+
+		$membercounter++;
+		$membername = "member{$membercounter}";
 	}
+
+	// Just use the unique valid members. There could have been overlap in the ranges or repeat of numbers entered.
+	$members = implode(" ", array_unique($valid_members));
 
 	if (!$input_errors) {
 		$qinqentry['members'] = $members;
@@ -199,7 +215,7 @@ if ($_POST) {
 	} else {
 		$pconfig['descr'] = $_POST['descr'];
 		$pconfig['tag'] = $_POST['tag'];
-		$pconfig['members'] = $members;
+		$pconfig['members'] = $posted_members;
 	}
 }
 
@@ -259,7 +275,7 @@ $section->addInput(new Form_Input(
 $section->addInput(new Form_StaticText(
 	'Member(s)',
 	'Ranges can be specified in the inputs below. Enter a range (2-3) or individual numbers.' . '<br />' .
-	'Click "Duplicate" as many times as needed to add new inputs.'
+	'Click "Add Tag" as many times as needed to add new inputs.'
 ));
 
 if (isset($id) && $a_qinqs[$id]) {
@@ -282,13 +298,12 @@ if ($members != "") {
 }
 
 foreach ($item as $ww) {
-	$member = $item[$counter];
 
 	$group = new Form_Group($counter == 0 ? 'Tag(s)':'');
 	$group->addClass('repeatable');
 
 	$group->add(new Form_Input(
-		'members[]',
+		'member' . $counter,
 		null,
 		'text',
 		$ww
@@ -317,4 +332,19 @@ $form->add($section);
 
 print($form);
 
+?>
+
+<script type="text/javascript">
+//<![CDATA[
+
+events.push(function() {
+
+	// Suppress "Delete row" button if there are fewer than two rows
+	checkLastRow();
+
+});
+//]]>
+</script>
+
+<?php
 include("foot.inc");

--- a/src/usr/local/www/interfaces_qinq_edit.php
+++ b/src/usr/local/www/interfaces_qinq_edit.php
@@ -104,6 +104,11 @@ if ($_POST) {
 		$qinqentry['autogroup'] = true;
 	}
 
+	$tag_min = 1;
+	$tag_max = 4094;
+	$tag_char_error = false;
+	$tag_value_error = false;
+	$tag_order_error = false;
 	$members = "";
 
 	// Read the POSTed member array into a space separated list translating any ranges
@@ -119,9 +124,11 @@ if ($_POST) {
 		if (count($member) > 1) {
 			if (($member[0] == "") || ($member[1] == "") ||
 			    preg_match("/([^0-9])+/", $member[0], $match)  || preg_match("/([^0-9])+/", $member[1], $match)) {
-				$input_errors[] = gettext("Tags can contain only numbers or a range in format #-#.");
+				$tag_char_error = true;
+			} elseif (($member[0] < $tag_min) || ($member[0] > $tag_max) || ($member[1] < $tag_min) || ($member[1] > $tag_max)) {
+				$tag_value_error = true;
 			} else if ($member[0] > $member[1]) {
-				$input_errors[] = gettext("Tag ranges must be entered with the lower number first.");
+				$tag_order_error = true;
 			} else {
 				for ($i = $member[0]; $i <= $member[1]; $i++) {
 					$valid_members[] = $i;
@@ -129,13 +136,14 @@ if ($_POST) {
 			}
 		} else { // Just a single number
 			if (preg_match("/([^0-9])+/", $member[0], $match)) {
-				$input_errors[] = gettext("Tags can contain only numbers or a range in format #-#.");
-			} else {
-				// Ignore empty rows
-				if ($member[0] != "") {
+				$tag_char_error = true;
+			} elseif ($member[0] != "") {
+				if (($member[0] < $tag_min) || ($member[0] > $tag_max)) {
+					$tag_value_error = true;
+				} else {
 					$valid_members[] = $member[0];
 				}
-			}
+			} // else ignore empty rows
 		}
 
 		// Remember the POSTed values so they can be redisplayed if there were errors.
@@ -143,6 +151,18 @@ if ($_POST) {
 
 		$membercounter++;
 		$membername = "member{$membercounter}";
+	}
+
+	if ($tag_char_error) {
+		$input_errors[] = gettext("Tags can contain only numbers or a range in format #-#.");
+	}
+
+	if ($tag_value_error) {
+		$input_errors[] = sprintf(gettext('Tag values must be from %1$s to %2$s.'), $tag_min, $tag_max);
+	}
+
+	if ($tag_order_error) {
+		$input_errors[] = gettext("Tag ranges must be entered with the lower number first.");
 	}
 
 	// Just use the unique valid members. There could have been overlap in the ranges or repeat of numbers entered.

--- a/src/usr/local/www/interfaces_qinq_edit.php
+++ b/src/usr/local/www/interfaces_qinq_edit.php
@@ -142,6 +142,10 @@ if ($_POST) {
 	// Just use the unique valid members. There could have been overlap in the ranges or repeat of numbers entered.
 	$members = implode(" ", array_unique($valid_members));
 
+	if ($members == "") {
+		$input_errors[] = gettext("At least one tag must be entered.");
+	}
+
 	if (!$input_errors) {
 		$qinqentry['members'] = $members;
 		$qinqentry['descr'] = $_POST['descr'];

--- a/src/usr/local/www/interfaces_qinq_edit.php
+++ b/src/usr/local/www/interfaces_qinq_edit.php
@@ -106,9 +106,7 @@ if ($_POST) {
 
 	$tag_min = 1;
 	$tag_max = 4094;
-	$tag_char_error = false;
-	$tag_value_error = false;
-	$tag_order_error = false;
+	$tag_format_error = false;
 	$members = "";
 
 	// Read the POSTed member array into a space separated list translating any ranges
@@ -118,33 +116,17 @@ if ($_POST) {
 	$valid_members = array();
 
 	while (isset($_POST[$membername])) {
-		// Might be a range
-		$member = explode("-", $_POST[$membername]);
-
-		if (count($member) > 1) {
-			if (($member[0] == "") || ($member[1] == "") ||
-			    preg_match("/([^0-9])+/", $member[0], $match)  || preg_match("/([^0-9])+/", $member[1], $match)) {
-				$tag_char_error = true;
-			} elseif (($member[0] < $tag_min) || ($member[0] > $tag_max) || ($member[1] < $tag_min) || ($member[1] > $tag_max)) {
-				$tag_value_error = true;
-			} else if ($member[0] > $member[1]) {
-				$tag_order_error = true;
-			} else {
-				for ($i = $member[0]; $i <= $member[1]; $i++) {
-					$valid_members[] = $i;
-				}
+		if (is_intrange($_POST[$membername], $tag_min, $tag_max)) {
+			$sep = (strpos($_POST[$membername], ":") === false) ? "-" : ":";
+			$member = explode($sep, $_POST[$membername]);
+			for ($i = intval($member[0]); $i <= intval($member[1]); $i++) {
+				$valid_members[] = $i;
 			}
-		} else { // Just a single number
-			if (preg_match("/([^0-9])+/", $member[0], $match)) {
-				$tag_char_error = true;
-			} elseif ($member[0] != "") {
-				if (($member[0] < $tag_min) || ($member[0] > $tag_max)) {
-					$tag_value_error = true;
-				} else {
-					$valid_members[] = $member[0];
-				}
-			} // else ignore empty rows
-		}
+		} elseif (is_numericint($_POST[$membername]) && ($_POST[$membername] >= $tag_min) && ($_POST[$membername] <= $tag_max)) {
+			$valid_members[] = intval($_POST[$membername]);
+		} elseif ($_POST[$membername] != "") {
+			$tag_format_error = true;
+		} // else ignore empty rows
 
 		// Remember the POSTed values so they can be redisplayed if there were errors.
 		$posted_members .= ($membercounter == 0 ? '':' ') . $_POST[$membername];
@@ -153,16 +135,8 @@ if ($_POST) {
 		$membername = "member{$membercounter}";
 	}
 
-	if ($tag_char_error) {
-		$input_errors[] = gettext("Tags can contain only numbers or a range in format #-#.");
-	}
-
-	if ($tag_value_error) {
-		$input_errors[] = sprintf(gettext('Tag values must be from %1$s to %2$s.'), $tag_min, $tag_max);
-	}
-
-	if ($tag_order_error) {
-		$input_errors[] = gettext("Tag ranges must be entered with the lower number first.");
+	if ($tag_format_error) {
+		$input_errors[] = sprintf(gettext('Tags can contain only numbers or a range  (in format #-#) from %1$s to %2$s.'), $tag_min, $tag_max);
 	}
 
 	// Just use the unique valid members. There could have been overlap in the ranges or repeat of numbers entered.


### PR DESCRIPTION
1) Make the row delete button actually work
2) Do not allow ranges that go backwards like 25-20 or just "-" or 1-sided ranges "-42" "42-"
3) Remember the POSTed stuff to redisplay to the user if there were input errors
4) Ranges or numbers entered could overlap - just save a list of the unique members. e.g. If the user enters 5-15 and 10-20