### PR TITLE
Parse GPS initialization commands, enable extended status for GPSs other than SureGPS and add config option for extended status.

### DIFF
--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -52,6 +52,76 @@ function set_default_gps() {
 	write_config(gettext("Setting default NTPd settings"));
 }
 
+function parse_ublox(&$nmeaset, $splitline) {
+	$id_idx = 1;
+	$msg_idx = 2;
+	$ddc_idx = 3;
+	if ($splitline[$id_idx] == '40' && $splitline[$ddc_idx]) {
+		$nmeaset['GP' . $splitline[$msg_idx]] = 1;
+	}
+}
+
+function parse_garmin(&$nmeaset, $splitline) {
+	$msg_idx = 1;
+	$mode_idx = 2;
+	if ($splitline[$mode_idx] == '1') {
+		$nmeaset[$splitline[$msg_idx]] = 1;
+	}
+}
+
+function parse_mtk(&$nmeaset, $splitline) {
+	$nmeamap = [
+		1 => 'GPGLL',
+		2 => 'GPRMC',
+		3 => 'GPVTG',
+		4 => 'GPGGA',
+		5 => 'GPGSA',
+		6 => 'GPGSV',
+		7 => 'GPGRS',
+		8 => 'GPGST',
+	];
+	for ($x = 1; $x < 9; $x++) {
+		if($splitline[$x]) {
+			$nmeaset[$nmeamap[$x]] = 1;
+		}
+	}
+}
+
+function parse_sirf(&$nmeaset, $splitline) {
+	$msg_idx = 1;
+	$mode_idx = 2;
+	$rate_idx = 3;
+	$nmeamap = [
+		0 => 'GPGGA',
+		1 => 'GPGLL',
+		2 => 'GPGSA',
+		3 => 'GPGSV',
+		4 => 'GPRMC',
+		5 => 'GPVTG',
+	];
+	if (!(int)$splitline[$mode_idx] && (int)$splitline[$rate_idx]) {
+		$nmeaset[$nmeamap[(int)$splitline[$msg_idx]]] = 1;
+	}
+}
+
+function parse_initcmd(&$nmeaset, $initcmd) {
+	$type_idx = 0;
+	$nmeaset = [];
+	$split_initcmd = preg_split('/[\s]+/', $initcmd);
+    foreach ($split_initcmd as $line) {
+        $splitline = preg_split('/[,\*]+/', $line);
+		if ($splitline[$type_idx] == '$PUBX') {
+			parse_ublox($nmeaset, $splitline);
+        } elseif ($splitline[$type_idx] == '$PGRMO') {
+			parse_garmin($nmeaset, $splitline);
+        } elseif ($splitline[$type_idx] == '$PMTK314') {
+			parse_mtk($nmeaset, $splitline);
+		} elseif ($splitline[$type_idx] == '$PSRF103') {
+			parse_sirf($nmeaset, $splitline);
+		}
+	}
+}
+
 if ($_POST) {
 	unset($input_errors);
 
@@ -146,10 +216,18 @@ if ($_POST) {
 		unset($config['ntpd']['gps']['refid']);
 	}
 
+	if (!empty($_POST['extstatus'])) {
+        $config['ntpd']['gps']['extstatus'] = $_POST['extstatus'];
+	} elseif (isset($config['ntpd']['gps']['extstatus'])) {
+		unset($config['ntpd']['gps']['extstatus']);
+	}
+
 	if (!empty($_POST['gpsinitcmd'])) {
 		$config['ntpd']['gps']['initcmd'] = base64_encode($_POST['gpsinitcmd']);
+		parse_initcmd($config['ntpd']['gps']['nmeaset'], $_POST['gpsinitcmd']);
 	} elseif (isset($config['ntpd']['gps']['initcmd'])) {
 		unset($config['ntpd']['gps']['initcmd']);
+		unset($config['ntpd']['gps']['nmeaset']);
 	}
 
 	write_config(gettext("Updated NTP GPS Settings"));
@@ -335,6 +413,13 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['subsec']
 ))->setHelp('Enabling this will rapidly fill the log, but is useful for tuning Fudge time 2.');
 
+$section->addInput(new Form_Checkbox(
+	'extstatus',
+	null,
+	'Display extended GPS status (default: checked).',
+	$pconfig['extstatus']
+))->setHelp('Enable extended GPS status if GPGSV or GPGGA are explicitly enabled by GPS initialization commands.');
+
 $section->addInput(new Form_Input(
 	'gpsrefid',
 	'Clock ID',
@@ -509,6 +594,7 @@ events.push(function() {
 		$('#gpsflag3').prop('checked', true);
 		$('#gpsflag4').prop('checked', false);
 		$('#gpssubsec').prop('checked', false);
+		$('#extstatus').prop('checked', true);
 	}
 
 	// Show advanced GPS options ==============================================

--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -52,6 +52,76 @@ function set_default_gps() {
 	write_config(gettext("Setting default NTPd settings"));
 }
 
+function parse_ublox(&$nmeaset, $splitline) {
+	$id_idx = 1;
+	$msg_idx = 2;
+	$ddc_idx = 3;
+	if ($splitline[$id_idx] == '40' && $splitline[$ddc_idx]) {
+		$nmeaset['GP' . $splitline[$msg_idx]] = 1;
+	}
+}
+
+function parse_garmin(&$nmeaset, $splitline) {
+	$msg_idx = 1;
+	$mode_idx = 2;
+	if ($splitline[$mode_idx] == '1') {
+		$nmeaset[$splitline[$msg_idx]] = 1;
+	}
+}
+
+function parse_mtk(&$nmeaset, $splitline) {
+	$nmeamap = [
+		1 => 'GPGLL',
+		2 => 'GPRMC',
+		3 => 'GPVTG',
+		4 => 'GPGGA',
+		5 => 'GPGSA',
+		6 => 'GPGSV',
+		7 => 'GPGRS',
+		8 => 'GPGST',
+	];
+	for ($x = 1; $x < 9; $x++) {
+		if($splitline[$x]) {
+			$nmeaset[$nmeamap[$x]] = 1;
+		}
+	}
+}
+
+function parse_sirf(&$nmeaset, $splitline) {
+	$msg_idx = 1;
+	$mode_idx = 2;
+	$rate_idx = 3;
+	$nmeamap = [
+		0 => 'GPGGA',
+		1 => 'GPGLL',
+		2 => 'GPGSA',
+		3 => 'GPGSV',
+		4 => 'GPRMC',
+		5 => 'GPVTG',
+	];
+	if (!(int)$splitline[$mode_idx] && (int)$splitline[$rate_idx]) {
+		$nmeaset[$nmeamap[(int)$splitline[$msg_idx]]] = 1;
+	}
+}
+
+function parse_initcmd(&$nmeaset, $initcmd) {
+	$type_idx = 0;
+	$nmeaset = [];
+	$split_initcmd = preg_split('/[\s]+/', $initcmd);
+	foreach ($split_initcmd as $line) {
+		$splitline = preg_split('/[,\*]+/', $line);
+		if ($splitline[$type_idx] == '$PUBX') {
+			parse_ublox($nmeaset, $splitline);
+		} elseif ($splitline[$type_idx] == '$PGRMO') {
+			parse_garmin($nmeaset, $splitline);
+		} elseif ($splitline[$type_idx] == '$PMTK314') {
+			parse_mtk($nmeaset, $splitline);
+		} elseif ($splitline[$type_idx] == '$PSRF103') {
+			parse_sirf($nmeaset, $splitline);
+		}
+	}
+}
+
 if ($_POST) {
 	unset($input_errors);
 
@@ -146,8 +216,15 @@ if ($_POST) {
 		unset($config['ntpd']['gps']['refid']);
 	}
 
+	if (!empty($_POST['extstatus'])) {
+		$config['ntpd']['gps']['extstatus'] = $_POST['extstatus'];
+	} elseif (isset($config['ntpd']['gps']['extstatus'])) {
+		unset($config['ntpd']['gps']['extstatus']);
+	}
+
 	if (!empty($_POST['gpsinitcmd'])) {
 		$config['ntpd']['gps']['initcmd'] = base64_encode($_POST['gpsinitcmd']);
+		parse_initcmd($config['ntpd']['gps']['nmeaset'], $_POST['gpsinitcmd']);
 	} elseif (isset($config['ntpd']['gps']['initcmd'])) {
 		unset($config['ntpd']['gps']['initcmd']);
 	}
@@ -335,6 +412,13 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['subsec']
 ))->setHelp('Enabling this will rapidly fill the log, but is useful for tuning Fudge time 2.');
 
+$section->addInput(new Form_Checkbox(
+	'extstatus',
+	null,
+	'Display extended GPS status (default: checked).',
+	$pconfig['extstatus']
+))->setHelp('Enable extended GPS status if GPGSV or GPGGA are explicitly enabled by GPS initialization commands.');
+
 $section->addInput(new Form_Input(
 	'gpsrefid',
 	'Clock ID',
@@ -509,6 +593,7 @@ events.push(function() {
 		$('#gpsflag3').prop('checked', true);
 		$('#gpsflag4').prop('checked', false);
 		$('#gpssubsec').prop('checked', false);
+		$('#extstatus').prop('checked', true);
 	}
 
 	// Show advanced GPS options ==============================================

--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -52,76 +52,6 @@ function set_default_gps() {
 	write_config(gettext("Setting default NTPd settings"));
 }
 
-function parse_ublox(&$nmeaset, $splitline) {
-	$id_idx = 1;
-	$msg_idx = 2;
-	$ddc_idx = 3;
-	if ($splitline[$id_idx] == '40' && $splitline[$ddc_idx]) {
-		$nmeaset['GP' . $splitline[$msg_idx]] = 1;
-	}
-}
-
-function parse_garmin(&$nmeaset, $splitline) {
-	$msg_idx = 1;
-	$mode_idx = 2;
-	if ($splitline[$mode_idx] == '1') {
-		$nmeaset[$splitline[$msg_idx]] = 1;
-	}
-}
-
-function parse_mtk(&$nmeaset, $splitline) {
-	$nmeamap = [
-		1 => 'GPGLL',
-		2 => 'GPRMC',
-		3 => 'GPVTG',
-		4 => 'GPGGA',
-		5 => 'GPGSA',
-		6 => 'GPGSV',
-		7 => 'GPGRS',
-		8 => 'GPGST',
-	];
-	for ($x = 1; $x < 9; $x++) {
-		if($splitline[$x]) {
-			$nmeaset[$nmeamap[$x]] = 1;
-		}
-	}
-}
-
-function parse_sirf(&$nmeaset, $splitline) {
-	$msg_idx = 1;
-	$mode_idx = 2;
-	$rate_idx = 3;
-	$nmeamap = [
-		0 => 'GPGGA',
-		1 => 'GPGLL',
-		2 => 'GPGSA',
-		3 => 'GPGSV',
-		4 => 'GPRMC',
-		5 => 'GPVTG',
-	];
-	if (!(int)$splitline[$mode_idx] && (int)$splitline[$rate_idx]) {
-		$nmeaset[$nmeamap[(int)$splitline[$msg_idx]]] = 1;
-	}
-}
-
-function parse_initcmd(&$nmeaset, $initcmd) {
-	$type_idx = 0;
-	$nmeaset = [];
-	$split_initcmd = preg_split('/[\s]+/', $initcmd);
-    foreach ($split_initcmd as $line) {
-        $splitline = preg_split('/[,\*]+/', $line);
-		if ($splitline[$type_idx] == '$PUBX') {
-			parse_ublox($nmeaset, $splitline);
-        } elseif ($splitline[$type_idx] == '$PGRMO') {
-			parse_garmin($nmeaset, $splitline);
-        } elseif ($splitline[$type_idx] == '$PMTK314') {
-			parse_mtk($nmeaset, $splitline);
-		} elseif ($splitline[$type_idx] == '$PSRF103') {
-			parse_sirf($nmeaset, $splitline);
-		}
-	}
-}
-
 if ($_POST) {
 	unset($input_errors);
 
@@ -216,18 +146,10 @@ if ($_POST) {
 		unset($config['ntpd']['gps']['refid']);
 	}
 
-	if (!empty($_POST['extstatus'])) {
-        $config['ntpd']['gps']['extstatus'] = $_POST['extstatus'];
-	} elseif (isset($config['ntpd']['gps']['extstatus'])) {
-		unset($config['ntpd']['gps']['extstatus']);
-	}
-
 	if (!empty($_POST['gpsinitcmd'])) {
 		$config['ntpd']['gps']['initcmd'] = base64_encode($_POST['gpsinitcmd']);
-		parse_initcmd($config['ntpd']['gps']['nmeaset'], $_POST['gpsinitcmd']);
 	} elseif (isset($config['ntpd']['gps']['initcmd'])) {
 		unset($config['ntpd']['gps']['initcmd']);
-		unset($config['ntpd']['gps']['nmeaset']);
 	}
 
 	write_config(gettext("Updated NTP GPS Settings"));
@@ -413,13 +335,6 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['subsec']
 ))->setHelp('Enabling this will rapidly fill the log, but is useful for tuning Fudge time 2.');
 
-$section->addInput(new Form_Checkbox(
-	'extstatus',
-	null,
-	'Display extended GPS status (default: checked).',
-	$pconfig['extstatus']
-))->setHelp('Enable extended GPS status if GPGSV or GPGGA are explicitly enabled by GPS initialization commands.');
-
 $section->addInput(new Form_Input(
 	'gpsrefid',
 	'Clock ID',
@@ -594,7 +509,6 @@ events.push(function() {
 		$('#gpsflag3').prop('checked', true);
 		$('#gpsflag4').prop('checked', false);
 		$('#gpssubsec').prop('checked', false);
-		$('#extstatus').prop('checked', true);
 	}
 
 	// Show advanced GPS options ==============================================

--- a/src/usr/local/www/status_ntpd.php
+++ b/src/usr/local/www/status_ntpd.php
@@ -103,65 +103,59 @@ if (!isset($config['ntpd']['noquery'])) {
 				$gps_vars = explode(",", $tmp);
 				$gps_ok = ($gps_vars[2] == "A");
 				$gps_lat_deg = substr($gps_vars[3], 0, 2);
-				$gps_lat_min = substr($gps_vars[3], 2);
+				$gps_lat_min = substr($gps_vars[3], 2) / 60.0;
 				$gps_lon_deg = substr($gps_vars[5], 0, 3);
-				$gps_lon_min = substr($gps_vars[5], 3);
-				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
+				$gps_lon_min = substr($gps_vars[5], 3) / 60.0;
+				$gps_lat = $gps_lat_deg + $gps_lat_min;
 				$gps_lat = $gps_lat * (($gps_vars[4] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
+				$gps_lon = $gps_lon_deg + $gps_lon_min;
 				$gps_lon = $gps_lon * (($gps_vars[6] == "E") ? 1 : -1);
-				$gps_lat_dir = $gps_vars[4];
-				$gps_lon_dir = $gps_vars[6];
+				$gps_la = $gps_vars[4];
+				$gps_lo = $gps_vars[6];
 			} elseif (substr($tmp, 0, 6) == '$GPGGA') {
 				$gps_vars = explode(",", $tmp);
 				$gps_ok = $gps_vars[6];
 				$gps_lat_deg = substr($gps_vars[2], 0, 2);
-				$gps_lat_min = substr($gps_vars[2], 2);
+				$gps_lat_min = substr($gps_vars[2], 2) / 60.0;
 				$gps_lon_deg = substr($gps_vars[4], 0, 3);
-				$gps_lon_min = substr($gps_vars[4], 3);
-				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
+				$gps_lon_min = substr($gps_vars[4], 3) / 60.0;
+				$gps_lat = $gps_lat_deg + $gps_lat_min;
 				$gps_lat = $gps_lat * (($gps_vars[3] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
+				$gps_lon = $gps_lon_deg + $gps_lon_min;
 				$gps_lon = $gps_lon * (($gps_vars[5] == "E") ? 1 : -1);
 				$gps_alt = $gps_vars[9];
 				$gps_alt_unit = $gps_vars[10];
 				$gps_sat = (int)$gps_vars[7];
-				$gps_lat_dir = $gps_vars[3];
-				$gps_lon_dir = $gps_vars[5];
+				$gps_la = $gps_vars[3];
+				$gps_lo = $gps_vars[5];
 			} elseif (substr($tmp, 0, 6) == '$GPGLL') {
 				$gps_vars = preg_split('/[,\*]+/', $tmp);
 				$gps_ok = ($gps_vars[6] == "A");
 				$gps_lat_deg = substr($gps_vars[1], 0, 2);
-				$gps_lat_min = substr($gps_vars[1], 2);
+				$gps_lat_min = substr($gps_vars[1], 2) / 60.0;
 				$gps_lon_deg = substr($gps_vars[3], 0, 3);
-				$gps_lon_min = substr($gps_vars[3], 3);
-				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
+				$gps_lon_min = substr($gps_vars[3], 3) / 60.0;
+				$gps_lat = $gps_lat_deg + $gps_lat_min;
 				$gps_lat = $gps_lat * (($gps_vars[2] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
+				$gps_lon = $gps_lon_deg + $gps_lon_min;
 				$gps_lon = $gps_lon * (($gps_vars[4] == "E") ? 1 : -1);
-				$gps_lat_dir = $gps_vars[2];
-				$gps_lon_dir = $gps_vars[4];
+				$gps_la = $gps_vars[2];
+				$gps_lo = $gps_vars[4];
 			}
 		}
 	}
 }
 
-if (isset($gps_ok) && isset($config['ntpd']['gps']['extstatus']) && ($config['ntpd']['gps']['nmeaset']['gpgsv'] || $config['ntpd']['gps']['nmeaset']['gpgga'])) {
-	$lookfor['GPGSV'] = $config['ntpd']['gps']['nmeaset']['gpgsv'];
-	$lookfor['GPGGA'] = !isset($gps_sat) && $config['ntpd']['gps']['nmeaset']['gpgga'];
-	$gpsport = fopen('/dev/gps0', 'r+');
-	while ($gpsport && ($lookfor['GPGSV'] || $lookfor['GPGGA'])) {
+if (isset($config['ntpd']['gps']['type']) && ($config['ntpd']['gps']['type'] == 'SureGPS') && (isset($gps_ok))) {
+	//GSV message is only enabled by init commands in services_ntpd_gps.php for SureGPS board
+	$gpsport = fopen("/dev/gps0", "r+");
+	while ($gpsport) {
 		$buffer = fgets($gpsport);
-		if ($lookfor['GPGSV'] && substr($buffer, 0, 6) == '$GPGSV') {
+		if (substr($buffer, 0, 6) == '$GPGSV') {
+			//echo $buffer."\n";
 			$gpgsv = explode(',', $buffer);
-			$gps_satview = (int)$gpgsv[3];
-			$lookfor['GPGSV'] = 0;
-		} elseif ($lookfor['GPGGA'] && substr($buffer, 0, 6) == '$GPGGA') {
-			$gpgga = explode(',', $buffer);
-            $gps_sat = (int)$gpgga[7];
-			$gps_alt = $gpgga[9];
-			$gps_alt_unit = $gpgga[10];
-			$lookfor['GPGGA'] = 0;
+			$gps_satview = $gpgsv[3];
+			break;
 		}
 	}
 }
@@ -217,7 +211,7 @@ function print_status() {
 }
 
 function print_gps() {
-	global 	$gps_lat, $gps_lon, $gps_lat_deg, $gps_lon_deg, $gps_lat_min, $gps_lon_min, $gps_lat_dir, $gps_lon_dir,
+	global 	$gps_lat, $gps_lon, $gps_lat_deg, $gps_lon_deg, $gps_lat_min, $gps_lon_min, $gps_la, $gps_lo,
 			$gps_alt, $gps_alt_unit, $gps_sat, $gps_satview, $gps_goo_lnk;
 
 	print("<tr>\n");
@@ -225,16 +219,16 @@ function print_gps() {
 	printf("%.5f", $gps_lat);
 	print(" (");
 	printf("%d%s", $gps_lat_deg, "&deg;");
-	printf("%.5f", $gps_lat_min);
-	print($gps_lat_dir);
+	printf("%.5f", $gps_lat_min*60);
+	print($gps_la);
 	print(")");
 	print("</td>\n");
 	print("<td>\n");
 	printf("%.5f", $gps_lon);
 	print(" (");
 	printf("%d%s", $gps_lon_deg, "&deg;");
-	printf("%.5f", $gps_lon_min);
-	print($gps_lon_dir);
+	printf("%.5f", $gps_lon_min*60);
+	print($gps_lo);
 	print(")");
 	print("</td>\n");
 

--- a/src/usr/local/www/status_ntpd.php
+++ b/src/usr/local/www/status_ntpd.php
@@ -103,59 +103,65 @@ if (!isset($config['ntpd']['noquery'])) {
 				$gps_vars = explode(",", $tmp);
 				$gps_ok = ($gps_vars[2] == "A");
 				$gps_lat_deg = substr($gps_vars[3], 0, 2);
-				$gps_lat_min = substr($gps_vars[3], 2) / 60.0;
+				$gps_lat_min = substr($gps_vars[3], 2);
 				$gps_lon_deg = substr($gps_vars[5], 0, 3);
-				$gps_lon_min = substr($gps_vars[5], 3) / 60.0;
-				$gps_lat = $gps_lat_deg + $gps_lat_min;
+				$gps_lon_min = substr($gps_vars[5], 3);
+				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
 				$gps_lat = $gps_lat * (($gps_vars[4] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min;
+				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
 				$gps_lon = $gps_lon * (($gps_vars[6] == "E") ? 1 : -1);
-				$gps_la = $gps_vars[4];
-				$gps_lo = $gps_vars[6];
+				$gps_lat_dir = $gps_vars[4];
+				$gps_lon_dir = $gps_vars[6];
 			} elseif (substr($tmp, 0, 6) == '$GPGGA') {
 				$gps_vars = explode(",", $tmp);
 				$gps_ok = $gps_vars[6];
 				$gps_lat_deg = substr($gps_vars[2], 0, 2);
-				$gps_lat_min = substr($gps_vars[2], 2) / 60.0;
+				$gps_lat_min = substr($gps_vars[2], 2);
 				$gps_lon_deg = substr($gps_vars[4], 0, 3);
-				$gps_lon_min = substr($gps_vars[4], 3) / 60.0;
-				$gps_lat = $gps_lat_deg + $gps_lat_min;
+				$gps_lon_min = substr($gps_vars[4], 3);
+				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
 				$gps_lat = $gps_lat * (($gps_vars[3] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min;
+				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
 				$gps_lon = $gps_lon * (($gps_vars[5] == "E") ? 1 : -1);
 				$gps_alt = $gps_vars[9];
 				$gps_alt_unit = $gps_vars[10];
 				$gps_sat = (int)$gps_vars[7];
-				$gps_la = $gps_vars[3];
-				$gps_lo = $gps_vars[5];
+				$gps_lat_dir = $gps_vars[3];
+				$gps_lon_dir = $gps_vars[5];
 			} elseif (substr($tmp, 0, 6) == '$GPGLL') {
 				$gps_vars = preg_split('/[,\*]+/', $tmp);
 				$gps_ok = ($gps_vars[6] == "A");
 				$gps_lat_deg = substr($gps_vars[1], 0, 2);
-				$gps_lat_min = substr($gps_vars[1], 2) / 60.0;
+				$gps_lat_min = substr($gps_vars[1], 2);
 				$gps_lon_deg = substr($gps_vars[3], 0, 3);
-				$gps_lon_min = substr($gps_vars[3], 3) / 60.0;
-				$gps_lat = $gps_lat_deg + $gps_lat_min;
+				$gps_lon_min = substr($gps_vars[3], 3);
+				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
 				$gps_lat = $gps_lat * (($gps_vars[2] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min;
+				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
 				$gps_lon = $gps_lon * (($gps_vars[4] == "E") ? 1 : -1);
-				$gps_la = $gps_vars[2];
-				$gps_lo = $gps_vars[4];
+				$gps_lat_dir = $gps_vars[2];
+				$gps_lon_dir = $gps_vars[4];
 			}
 		}
 	}
 }
 
-if (isset($config['ntpd']['gps']['type']) && ($config['ntpd']['gps']['type'] == 'SureGPS') && (isset($gps_ok))) {
-	//GSV message is only enabled by init commands in services_ntpd_gps.php for SureGPS board
-	$gpsport = fopen("/dev/gps0", "r+");
-	while ($gpsport) {
+if (isset($gps_ok) && isset($config['ntpd']['gps']['extstatus']) && ($config['ntpd']['gps']['nmeaset']['gpgsv'] || $config['ntpd']['gps']['nmeaset']['gpgga'])) {
+	$lookfor['GPGSV'] = $config['ntpd']['gps']['nmeaset']['gpgsv'];
+	$lookfor['GPGGA'] = !isset($gps_sat) && $config['ntpd']['gps']['nmeaset']['gpgga'];
+	$gpsport = fopen('/dev/gps0', 'r+');
+	while ($gpsport && ($lookfor['GPGSV'] || $lookfor['GPGGA'])) {
 		$buffer = fgets($gpsport);
-		if (substr($buffer, 0, 6) == '$GPGSV') {
-			//echo $buffer."\n";
+		if ($lookfor['GPGSV'] && substr($buffer, 0, 6) == '$GPGSV') {
 			$gpgsv = explode(',', $buffer);
-			$gps_satview = $gpgsv[3];
-			break;
+			$gps_satview = (int)$gpgsv[3];
+			$lookfor['GPGSV'] = 0;
+		} elseif ($lookfor['GPGGA'] && substr($buffer, 0, 6) == '$GPGGA') {
+			$gpgga = explode(',', $buffer);
+            $gps_sat = (int)$gpgga[7];
+			$gps_alt = $gpgga[9];
+			$gps_alt_unit = $gpgga[10];
+			$lookfor['GPGGA'] = 0;
 		}
 	}
 }
@@ -211,7 +217,7 @@ function print_status() {
 }
 
 function print_gps() {
-	global 	$gps_lat, $gps_lon, $gps_lat_deg, $gps_lon_deg, $gps_lat_min, $gps_lon_min, $gps_la, $gps_lo,
+	global 	$gps_lat, $gps_lon, $gps_lat_deg, $gps_lon_deg, $gps_lat_min, $gps_lon_min, $gps_lat_dir, $gps_lon_dir,
 			$gps_alt, $gps_alt_unit, $gps_sat, $gps_satview, $gps_goo_lnk;
 
 	print("<tr>\n");
@@ -219,16 +225,16 @@ function print_gps() {
 	printf("%.5f", $gps_lat);
 	print(" (");
 	printf("%d%s", $gps_lat_deg, "&deg;");
-	printf("%.5f", $gps_lat_min*60);
-	print($gps_la);
+	printf("%.5f", $gps_lat_min);
+	print($gps_lat_dir);
 	print(")");
 	print("</td>\n");
 	print("<td>\n");
 	printf("%.5f", $gps_lon);
 	print(" (");
 	printf("%d%s", $gps_lon_deg, "&deg;");
-	printf("%.5f", $gps_lon_min*60);
-	print($gps_lo);
+	printf("%.5f", $gps_lon_min);
+	print($gps_lon_dir);
 	print(")");
 	print("</td>\n");
 

--- a/src/usr/local/www/status_ntpd.php
+++ b/src/usr/local/www/status_ntpd.php
@@ -103,59 +103,65 @@ if (!isset($config['ntpd']['noquery'])) {
 				$gps_vars = explode(",", $tmp);
 				$gps_ok = ($gps_vars[2] == "A");
 				$gps_lat_deg = substr($gps_vars[3], 0, 2);
-				$gps_lat_min = substr($gps_vars[3], 2) / 60.0;
+				$gps_lat_min = substr($gps_vars[3], 2);
 				$gps_lon_deg = substr($gps_vars[5], 0, 3);
-				$gps_lon_min = substr($gps_vars[5], 3) / 60.0;
-				$gps_lat = $gps_lat_deg + $gps_lat_min;
+				$gps_lon_min = substr($gps_vars[5], 3);
+				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
 				$gps_lat = $gps_lat * (($gps_vars[4] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min;
+				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
 				$gps_lon = $gps_lon * (($gps_vars[6] == "E") ? 1 : -1);
-				$gps_la = $gps_vars[4];
-				$gps_lo = $gps_vars[6];
+				$gps_lat_dir = $gps_vars[4];
+				$gps_lon_dir = $gps_vars[6];
 			} elseif (substr($tmp, 0, 6) == '$GPGGA') {
 				$gps_vars = explode(",", $tmp);
 				$gps_ok = $gps_vars[6];
 				$gps_lat_deg = substr($gps_vars[2], 0, 2);
-				$gps_lat_min = substr($gps_vars[2], 2) / 60.0;
+				$gps_lat_min = substr($gps_vars[2], 2);
 				$gps_lon_deg = substr($gps_vars[4], 0, 3);
-				$gps_lon_min = substr($gps_vars[4], 3) / 60.0;
-				$gps_lat = $gps_lat_deg + $gps_lat_min;
+				$gps_lon_min = substr($gps_vars[4], 3);
+				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
 				$gps_lat = $gps_lat * (($gps_vars[3] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min;
+				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
 				$gps_lon = $gps_lon * (($gps_vars[5] == "E") ? 1 : -1);
 				$gps_alt = $gps_vars[9];
 				$gps_alt_unit = $gps_vars[10];
 				$gps_sat = (int)$gps_vars[7];
-				$gps_la = $gps_vars[3];
-				$gps_lo = $gps_vars[5];
+				$gps_lat_dir = $gps_vars[3];
+				$gps_lon_dir = $gps_vars[5];
 			} elseif (substr($tmp, 0, 6) == '$GPGLL') {
 				$gps_vars = preg_split('/[,\*]+/', $tmp);
 				$gps_ok = ($gps_vars[6] == "A");
 				$gps_lat_deg = substr($gps_vars[1], 0, 2);
-				$gps_lat_min = substr($gps_vars[1], 2) / 60.0;
+				$gps_lat_min = substr($gps_vars[1], 2);
 				$gps_lon_deg = substr($gps_vars[3], 0, 3);
-				$gps_lon_min = substr($gps_vars[3], 3) / 60.0;
-				$gps_lat = $gps_lat_deg + $gps_lat_min;
+				$gps_lon_min = substr($gps_vars[3], 3);
+				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
 				$gps_lat = $gps_lat * (($gps_vars[2] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min;
+				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
 				$gps_lon = $gps_lon * (($gps_vars[4] == "E") ? 1 : -1);
-				$gps_la = $gps_vars[2];
-				$gps_lo = $gps_vars[4];
+				$gps_lat_dir = $gps_vars[2];
+				$gps_lon_dir = $gps_vars[4];
 			}
 		}
 	}
 }
 
-if (isset($config['ntpd']['gps']['type']) && ($config['ntpd']['gps']['type'] == 'SureGPS') && (isset($gps_ok))) {
-	//GSV message is only enabled by init commands in services_ntpd_gps.php for SureGPS board
-	$gpsport = fopen("/dev/gps0", "r+");
-	while ($gpsport) {
+if (isset($gps_ok) && isset($config['ntpd']['gps']['extstatus']) && ($config['ntpd']['gps']['nmeaset']['gpgsv'] || $config['ntpd']['gps']['nmeaset']['gpgga'])) {
+	$lookfor['GPGSV'] = $config['ntpd']['gps']['nmeaset']['gpgsv'];
+	$lookfor['GPGGA'] = !isset($gps_sat) && $config['ntpd']['gps']['nmeaset']['gpgga'];
+	$gpsport = fopen('/dev/gps0', 'r+');
+	while ($gpsport && ($lookfor['GPGSV'] || $lookfor['GPGGA'])) {
 		$buffer = fgets($gpsport);
-		if (substr($buffer, 0, 6) == '$GPGSV') {
-			//echo $buffer."\n";
+		if ($lookfor['GPGSV'] && substr($buffer, 0, 6) == '$GPGSV') {
 			$gpgsv = explode(',', $buffer);
-			$gps_satview = $gpgsv[3];
-			break;
+			$gps_satview = (int)$gpgsv[3];
+			$lookfor['GPGSV'] = 0;
+		} elseif ($lookfor['GPGGA'] && substr($buffer, 0, 6) == '$GPGGA') {
+			$gpgga = explode(',', $buffer);
+			$gps_sat = (int)$gpgga[7];
+			$gps_alt = $gpgga[9];
+			$gps_alt_unit = $gpgga[10];
+			$lookfor['GPGGA'] = 0;
 		}
 	}
 }
@@ -211,7 +217,7 @@ function print_status() {
 }
 
 function print_gps() {
-	global 	$gps_lat, $gps_lon, $gps_lat_deg, $gps_lon_deg, $gps_lat_min, $gps_lon_min, $gps_la, $gps_lo,
+	global 	$gps_lat, $gps_lon, $gps_lat_deg, $gps_lon_deg, $gps_lat_min, $gps_lon_min, $gps_lat_dir, $gps_lon_dir,
 			$gps_alt, $gps_alt_unit, $gps_sat, $gps_satview, $gps_goo_lnk;
 
 	print("<tr>\n");
@@ -219,16 +225,16 @@ function print_gps() {
 	printf("%.5f", $gps_lat);
 	print(" (");
 	printf("%d%s", $gps_lat_deg, "&deg;");
-	printf("%.5f", $gps_lat_min*60);
-	print($gps_la);
+	printf("%.5f", $gps_lat_min);
+	print($gps_lat_dir);
 	print(")");
 	print("</td>\n");
 	print("<td>\n");
 	printf("%.5f", $gps_lon);
 	print(" (");
 	printf("%d%s", $gps_lon_deg, "&deg;");
-	printf("%.5f", $gps_lon_min*60);
-	print($gps_lo);
+	printf("%.5f", $gps_lon_min);
+	print($gps_lon_dir);
 	print(")");
 	print("</td>\n");
 

--- a/src/usr/local/www/widgets/widgets/ntp_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/ntp_status.widget.php
@@ -83,64 +83,58 @@ if ($_REQUEST['updateme']) {
 				$gps_vars = explode(",", $tmp);
 				$gps_ok	= ($gps_vars[2] == "A");
 				$gps_lat_deg = substr($gps_vars[3], 0, 2);
-				$gps_lat_min = substr($gps_vars[3], 2);
+				$gps_lat_min = substr($gps_vars[3], 2) / 60.0;
 				$gps_lon_deg = substr($gps_vars[5], 0, 3);
-				$gps_lon_min = substr($gps_vars[5], 3);
-				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
+				$gps_lon_min = substr($gps_vars[5], 3) / 60.0;
+				$gps_lat = $gps_lat_deg + $gps_lat_min;
 				$gps_lat = $gps_lat * (($gps_vars[4] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
+				$gps_lon = $gps_lon_deg + $gps_lon_min;
 				$gps_lon = $gps_lon * (($gps_vars[6] == "E") ? 1 : -1);
-				$gps_lat_dir = $gps_vars[4];
-				$gps_lon_dir = $gps_vars[6];
+				$gps_la = $gps_vars[4];
+				$gps_lo = $gps_vars[6];
 			} elseif (substr($tmp, 0, 6) == '$GPGGA') {
 				$gps_vars = explode(",", $tmp);
 				$gps_ok	= $gps_vars[6];
 				$gps_lat_deg = substr($gps_vars[2], 0, 2);
-				$gps_lat_min = substr($gps_vars[2], 2);
+				$gps_lat_min = substr($gps_vars[2], 2) / 60.0;
 				$gps_lon_deg = substr($gps_vars[4], 0, 3);
-				$gps_lon_min = substr($gps_vars[4], 3);
-				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
+				$gps_lon_min = substr($gps_vars[4], 3) / 60.0;
+				$gps_lat = $gps_lat_deg + $gps_lat_min;
 				$gps_lat = $gps_lat * (($gps_vars[3] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
+				$gps_lon = $gps_lon_deg + $gps_lon_min;
 				$gps_lon = $gps_lon * (($gps_vars[5] == "E") ? 1 : -1);
 				$gps_alt = $gps_vars[9];
 				$gps_alt_unit = $gps_vars[10];
 				$gps_sat = (int)$gps_vars[7];
-				$gps_lat_dir = $gps_vars[3];
-				$gps_lon_dir = $gps_vars[5];
+				$gps_la = $gps_vars[3];
+				$gps_lo = $gps_vars[5];
 			} elseif (substr($tmp, 0, 6) == '$GPGLL') {
 				$gps_vars = preg_split('/[,\*]+/', $tmp);
 				$gps_ok	= ($gps_vars[6] == "A");
 				$gps_lat_deg = substr($gps_vars[1], 0, 2);
-				$gps_lat_min = substr($gps_vars[1], 2);
+				$gps_lat_min = substr($gps_vars[1], 2) / 60.0;
 				$gps_lon_deg = substr($gps_vars[3], 0, 3);
-				$gps_lon_min = substr($gps_vars[3], 3);
-				$gps_lat = $gps_lat_deg + $gps_lat_min / 60.0;
+				$gps_lon_min = substr($gps_vars[3], 3) / 60.0;
+				$gps_lat = $gps_lat_deg + $gps_lat_min;
 				$gps_lat = $gps_lat * (($gps_vars[2] == "N") ? 1 : -1);
-				$gps_lon = $gps_lon_deg + $gps_lon_min / 60.0;
+				$gps_lon = $gps_lon_deg + $gps_lon_min;
 				$gps_lon = $gps_lon * (($gps_vars[4] == "E") ? 1 : -1);
-				$gps_lat_dir = $gps_vars[2];
-				$gps_lon_dir = $gps_vars[4];
+				$gps_la = $gps_vars[2];
+				$gps_lo = $gps_vars[4];
 			}
 		}
 	}
 
-	if (isset($gps_ok) && isset($config['ntpd']['gps']['extstatus']) && ($config['ntpd']['gps']['nmeaset']['gpgsv'] || $config['ntpd']['gps']['nmeaset']['gpgga'])) {
-		$lookfor['GPGSV'] = $config['ntpd']['gps']['nmeaset']['gpgsv'];
-		$lookfor['GPGGA'] = !isset($gps_sat) && $config['ntpd']['gps']['nmeaset']['gpgga'];
-		$gpsport = fopen('/dev/gps0', 'r+');
-		while ($gpsport && ($lookfor['GPGSV'] || $lookfor['GPGGA'])) {
+	if (isset($config['ntpd']['gps']['type']) && ($config['ntpd']['gps']['type'] == 'SureGPS') && (isset($gps_ok))) {
+		//GSV message is only enabled by init commands in services_ntpd_gps.php for SureGPS board
+		$gpsport = fopen("/dev/gps0", "r+");
+		while ($gpsport) {
 			$buffer = fgets($gpsport);
-			if ($lookfor['GPGSV'] && substr($buffer, 0, 6) == '$GPGSV') {
+			if (substr($buffer, 0, 6) == '$GPGSV') {
+				//echo $buffer."\n";
 				$gpgsv = explode(',', $buffer);
-				$gps_satview = (int)$gpgsv[3];
-				$lookfor['GPGSV'] = 0;
-			} elseif ($lookfor['GPGGA'] && substr($buffer, 0, 6) == '$GPGGA') {
-				$gpgga = explode(',', $buffer);
-				$gps_sat = (int)$gpgga[7];
-				$gps_alt = $gpgga[9];
-				$gps_alt_unit = $gpgga[10];
-				$lookfor['GPGGA'] = 0;
+				$gps_satview = $gpgsv[3];
+				break;
 			}
 		}
 	}
@@ -175,7 +169,7 @@ if ($_REQUEST['updateme']) {
 			<td>
 				<a target="_gmaps" href="http://maps.google.com/?q=<?=$gps_lat;?>,<?=$gps_lon;?>">
 				<?php
-				echo sprintf("%.5f", $gps_lat) . " " . $gps_lat_dir . ", " . sprintf("%.5f", $gps_lon) . " " . $gps_lon_dir; ?>
+				echo sprintf("%.5f", $gps_lat) . " " . $gps_la . ", " . sprintf("%.5f", $gps_lon) . " " . $gps_lo; ?>
 				</a>
 				<?php if (isset($gps_alt)) {echo " (" . $gps_alt . " " . $gps_alt_unit . " alt.)";} ?>
 			</td>


### PR DESCRIPTION
- Parse GPS initialization commands for explicitly configured GPS commands
- Add extended GPS status if GPGSV or GPGGA are explicitly configured
- Add config option to toggle extended status
- Clean up some variables on status page and widget.