### PR TITLE
firewall_nat_edit function name typo

### DIFF
--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -1111,7 +1111,7 @@ events.push(function() {
 				disableInput('localbeginport', true);
 				disableInput('localbeginport_cust', true);
 				disableInput('dstendport_cust', false);
-				ddisableInput('localbeginport', false);
+				disableInput('localbeginport', false);
 				disableInput('localbeginport_cust', false);
 			}
 


### PR DESCRIPTION
This unrelated fix is in a big diff listing of other stuff related to a proposed RADIUS enhancement https://github.com/pfsense/pfsense/pull/3407/files#diff-f080be89fa12ff3c28d7467b12985d09
The accidental typo should be fixed, rather than getting stuck in that other PR.