### PR TITLE
interfaces.php display correct descr in group name message

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -509,7 +509,7 @@ if ($_POST['apply']) {
 	if (is_array($config['ifgroups']['ifgroupentry'])) {
 		foreach ($config['ifgroups']['ifgroupentry'] as $ifgroupentry) {
 			if ($ifgroupentry['ifname'] == $_POST['descr']) {
-				$input_errors[] = sprintf(gettext("Sorry, an interface group with the name %s already exists."), $wancfg['descr']);
+				$input_errors[] = sprintf(gettext("Sorry, an interface group with the name %s already exists."), $_POST['descr']);
 			}
 		}
 	}


### PR DESCRIPTION
Use the description that the user attempted to enter, not the original (and probably valid) description.