### PR TITLE
Interface description must be unique including case

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -175,7 +175,7 @@ if ($_POST) {
 
 	/* check for name interface description conflicts */
 	foreach ($config['interfaces'] as $interface) {
-		if ($interface['descr'] == $_POST['name']) {
+		if (strcasecmp($interface['descr'], $_POST['name']) == 0) {
 			$input_errors[] = gettext("An interface description with this name already exists.");
 			break;
 		}

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -490,7 +490,7 @@ if ($_POST['apply']) {
 	}
 	/* description unique? */
 	foreach ($ifdescrs as $ifent => $ifdescr) {
-		if ($if != $ifent && $ifdescr == $_POST['descr']) {
+		if ($if != $ifent && (strcasecmp($ifdescr, $_POST['descr']) == 0)) {
 			$input_errors[] = gettext("An interface with the specified description already exists.");
 			break;
 		}
@@ -499,7 +499,7 @@ if ($_POST['apply']) {
 	/* Is the description already used as an alias name? */
 	if (is_array($config['aliases']['alias'])) {
 		foreach ($config['aliases']['alias'] as $alias) {
-			if ($alias['name'] == $_POST['descr']) {
+			if (strcasecmp($alias['name'], $_POST['descr']) == 0) {
 				$input_errors[] = sprintf(gettext("Sorry, an alias with the name %s already exists."), $_POST['descr']);
 			}
 		}
@@ -508,7 +508,7 @@ if ($_POST['apply']) {
 	/* Is the description already used as an interface group name? */
 	if (is_array($config['ifgroups']['ifgroupentry'])) {
 		foreach ($config['ifgroups']['ifgroupentry'] as $ifgroupentry) {
-			if ($ifgroupentry['ifname'] == $_POST['descr']) {
+			if (strcasecmp($ifgroupentry['ifname'], $_POST['descr']) == 0) {
 				$input_errors[] = sprintf(gettext("Sorry, an interface group with the name %s already exists."), $wancfg['descr']);
 			}
 		}

--- a/src/usr/local/www/interfaces_groups_edit.php
+++ b/src/usr/local/www/interfaces_groups_edit.php
@@ -89,7 +89,7 @@ if ($_POST) {
 	}
 
 	foreach ($interface_list_disabled as $gif => $gdescr) {
-		if ($gdescr == $_POST['ifname'] || $gif == $_POST['ifname']) {
+		if ((strcasecmp($gdescr, $_POST['ifname']) == 0) || (strcasecmp($gif, $_POST['ifname']) == 0)) {
 			$input_errors[] = "The specified group name is already used by an interface. Please choose another name.";
 		}
 	}


### PR DESCRIPTION
Strictly-speaking the uppercase of an interface description must not be the same as:
- the uppercase of another interface description
- an alias name
- an interface group name

e.g. interface descriptions "Interface" and "InterFace" can be input to 2 different interfaces at present, and then bad things happen.
Enter an Interface Description "Interface" then make an alias "INTERFACE" - bad things happen.
Enter an Interface Description "Interface" then make an interface group "INTERFACE" - bad things happen.

Mixed case interface groups seem to co-exist "IfGroup" and "IFGROUP" and "ifgroup" will work happily a 3 different interface groups, even along with aliases called "IFgroup" and "ifGROUP".

Same for aliases, "MyAlias", "MYALIAS", "myalias" all coexist as 3 different aliases, along with interface groups like "MYalias" and "myALIAS".

The checks I have added here could just check against the uppercase of the interface description, because that is what is used in the rules... But it seems really dumb to let people name their aliases or interface groups to be the same as an interface description apart from case.