### PR TITLE
Remaining required fields for Diag pages

### DIFF
--- a/src/usr/local/www/diag_authentication.php
+++ b/src/usr/local/www/diag_authentication.php
@@ -88,7 +88,7 @@ foreach (auth_get_authserver_list() as $auth_server) {
 
 $section->addInput(new Form_Select(
 	'authmode',
-	'Authentication Server',
+	'*Authentication Server',
 	$pconfig['authmode'],
 	$serverlist
 ))->setHelp('Select the authentication server to test against.');

--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -277,7 +277,7 @@ $section = new Form_Section('Packet Capture Options');
 
 $section->addInput(new Form_Select(
 	'interface',
-	'Interface',
+	'*Interface',
 	$selectedif,
 	$interfaces
 ))->setHelp('Select the interface on which to capture traffic. ');
@@ -294,7 +294,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Select(
 	'fam',
-	'Address Family',
+	'*Address Family',
 	$fam,
 	array('' => 'Any',
 		  'ip' => gettext('IPv4 Only'),
@@ -304,7 +304,7 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_Select(
 	'proto',
-	'Protocol',
+	'*Protocol',
 	$proto,
 	$protocollist
 ))->setHelp('Select the protocol to capture, or "Any". ');

--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -136,14 +136,14 @@ $section->addInput(new Form_Input(
 
 $section->addInput(new Form_Select(
 	'ipproto',
-	'IP Protocol',
+	'*IP Protocol',
 	$ipproto,
 	['ipv4' => 'IPv4', 'ipv6' => 'IPv6']
 ));
 
 $section->addInput(new Form_Select(
 	'sourceip',
-	'Source address',
+	'*Source address',
 	$sourceip,
 	array('' => gettext('Automatically selected (default)')) + get_possible_traffic_source_addresses(true)
 ))->setHelp('Select source address for the ping.');

--- a/src/usr/local/www/diag_testport.php
+++ b/src/usr/local/www/diag_testport.php
@@ -249,14 +249,14 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Select(
 	'sourceip',
-	'Source Address',
+	'*Source Address',
 	$sourceip,
 	['' => 'Any'] + get_possible_traffic_source_addresses(true)
 ))->setHelp('Select source address for the trace.');
 
 $section->addInput(new Form_Select(
 	'ipprotocol',
-	'IP Protocol',
+	'*IP Protocol',
 	$ipprotocol,
 	array('ipv4' => 'IPv4', 'ipv6' => 'IPv6')
 ))->setHelp("If IPv4 or IPv6 is forced and a hostname is used that does not contain a result using that protocol, it will result in an error." .

--- a/src/usr/local/www/diag_traceroute.php
+++ b/src/usr/local/www/diag_traceroute.php
@@ -130,14 +130,14 @@ $section->addInput(new Form_Input(
 
 $section->addInput(new Form_Select(
 	'ipproto',
-	'IP Protocol',
+	'*IP Protocol',
 	$ipproto,
 	array('ipv4' => 'IPv4', 'ipv6' => 'IPv6')
 ))->setHelp('Select the protocol to use.');
 
 $section->addInput(new Form_Select(
 	'sourceip',
-	'Source Address',
+	'*Source Address',
 	$sourceip,
 	array('any' => gettext('Any')) + get_possible_traffic_source_addresses(true)
 ))->setHelp('Select source address for the trace.');

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1162,7 +1162,7 @@ if ($if == "FloatingRules" || isset($pconfig['floating'])) {
 
 $section->addInput(new Form_Select(
 	'type',
-	'Action',
+	'*Action',
 	$pconfig['type'],
 	$values
 ))->setHelp('Choose what to do with packets that match the criteria specified '.
@@ -1228,7 +1228,7 @@ if ($edit_disabled) {
 if ($if == "FloatingRules" || isset($pconfig['floating'])) {
 	$section->addInput($input = new Form_Select(
 		'interface',
-		'Interface',
+		'*Interface',
 		$pconfig['interface'],
 		build_if_list(),
 		true
@@ -1236,7 +1236,7 @@ if ($if == "FloatingRules" || isset($pconfig['floating'])) {
 } else {
 	$section->addInput($input = new Form_Select(
 		'interface',
-		'Interface',
+		'*Interface',
 		$pconfig['interface'],
 		build_if_list()
 	))->setHelp('Choose the interface from which packets must come to match this rule.');
@@ -1245,7 +1245,7 @@ if ($if == "FloatingRules" || isset($pconfig['floating'])) {
 if ($if == "FloatingRules" || isset($pconfig['floating'])) {
 	$section->addInput(new Form_Select(
 		'direction',
-		'Direction',
+		'*Direction',
 		$pconfig['direction'],
 		array(
 			'any' => gettext('any'),
@@ -1264,7 +1264,7 @@ if ($if == "FloatingRules" || isset($pconfig['floating'])) {
 
 $section->addInput(new Form_Select(
 	'ipprotocol',
-	'Address Family',
+	'*Address Family',
 	$pconfig['ipprotocol'],
 	array(
 		'inet' => 'IPv4',
@@ -1275,7 +1275,7 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_Select(
 	'proto',
-	'Protocol',
+	'*Protocol',
 	$pconfig['proto'],
 	array(
 		'any' => gettext('Any'),
@@ -1315,7 +1315,7 @@ $form->add($section);
 foreach (['src' => 'Source', 'dst' => 'Destination'] as $type => $name) {
 	$section = new Form_Section($name);
 
-	$group = new Form_Group($name);
+	$group = new Form_Group('*' . $name);
 	$group->add(new Form_Checkbox(
 		$type .'not',
 		$name .' not',

--- a/src/usr/local/www/firewall_schedule_edit.php
+++ b/src/usr/local/www/firewall_schedule_edit.php
@@ -353,7 +353,7 @@ $section = new Form_Section('Schedule Information');
 
 $input = new Form_Input(
 	'name',
-	'Schedule Name',
+	'*Schedule Name',
 	'text',
 	$pconfig['name']
 );
@@ -382,11 +382,11 @@ $section->addInput(new Form_Select(
 ));
 
 $section->addInput(new Form_StaticText(
-	'Date',
+	'*Date',
 	 build_date_table()
 ));
 
-$group = new Form_Group('Time');
+$group = new Form_Group('*Time');
 
 $group->add(new Form_Select(
 	'starttimehour',

--- a/src/usr/local/www/firewall_virtual_ip_edit.php
+++ b/src/usr/local/www/firewall_virtual_ip_edit.php
@@ -321,7 +321,7 @@ $form = new Form();
 
 $section = new Form_Section('Edit Virtual IP');
 
-$group = new Form_Group('Type');
+$group = new Form_Group('*Type');
 
 $group->add(new Form_Checkbox(
 	'mode',
@@ -359,7 +359,7 @@ $section->add($group);
 
 $section->addInput(new Form_Select(
 	'interface',
-	'Interface',
+	'*Interface',
 	$pconfig['interface'],
 	build_if_list()
 ));
@@ -376,7 +376,7 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_IpAddress(
 	'subnet',
-	'Address(es)',
+	'*Address(es)',
 	$pconfig['subnet']
 ))->addMask('subnet_bits', $pconfig['subnet_bits'])->setHelp('<span id="address_note"></span>');
 
@@ -483,10 +483,14 @@ events.push(function() {
 		disableInput('password', true);
 		disableInput('password_confirm', true);
 		hideCheckbox('noexpand', true);
+		setRequired('password', false);
+		setRequired('vhid', false);
+		setRequired('advbase', false);
 
 		if (mode == 'ipalias') {
 			$('#address_note').html("<?=$ipaliashelp?>");
 			$('#type').val('single');
+			setRequired('type', false);
 			disableInput('subnet_bits', false);
 
 		} else if (mode == 'carp') {
@@ -498,14 +502,20 @@ events.push(function() {
 			disableInput('password_confirm', false);
 			disableInput('subnet_bits', false);
 			$('#type').val('single');
+			setRequired('type', false);
+			setRequired('password', true);
+			setRequired('vhid', true);
+			setRequired('advbase', true);
 		} else if (mode == 'proxyarp') {
 			$('#address_note').html("<?=$proxyarphelp?>");
 			disableInput('type', false);
+			setRequired('type', true);
 			disableInput('subnet_bits', ($('#type').val() == 'single'));
 			hideCheckbox('noexpand', false);
 		} else {
 			$('#address_note').html('');
 			disableInput('type', false);
+			setRequired('type', true);
 			disableInput('subnet_bits', ($('#type').val() == 'single'));
 			hideCheckbox('noexpand', false);
 		}


### PR DESCRIPTION
Note: There is a small policy discussion still to have. There are 3 categories of required selectors:
1) Required but a valid default is not selected automatically for a new entry - these definitely should be marked "required".
2) Required and "important" - i.e. the user probably should think about if the default value is actually what they want. These should also be marked "required" - stuff like "protocol" or "IP address type/family".
3) Required, the default value selected is 99% useful and the "care factor" is low. For example "Maximum number of pings" for Diagnostics->Ping. Technically these are required, but there is no need to draw user attention to them, in the same way that loads of checkboxes are "required" (they must be on or off) but we don't draw the user's attention to those.

My suggested policy is (1) and (2) are marked "required", (3) is not.