### PR TITLE
Captive Portal auth method is required

### DIFF
--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -212,8 +212,8 @@ if ($_POST) {
 
 	/* input validation */
 	if ($_POST['enable']) {
-		$reqdfields = explode(" ", "zone cinterface");
-		$reqdfieldsn = array(gettext("Zone name"), gettext("Interface"));
+		$reqdfields = explode(" ", "zone cinterface auth_method");
+		$reqdfieldsn = array(gettext("Zone name"), gettext("Interface"), gettext("Authentication method"));
 
 		if (isset($_POST['auth_method']) && $_POST['auth_method'] == "radius") {
 			$reqdfields[] = "radius_protocol";
@@ -238,6 +238,10 @@ if ($_POST) {
 					}
 				}
 			}
+		}
+
+		if ($_POST['auth_method'] && !in_array($_POST['auth_method'], array('none', 'local', 'radius'))) {
+			$input_errors[] = sprintf(gettext("Authentication method %s is invalid."), $_POST['auth_method']);
 		}
 
 		if ($_POST['httpslogin_enable']) {


### PR DESCRIPTION
When creating a new Captive Portal Zone the user can fail to select any of the Authorization Method radio buttons. No default radio button is selected - that is probably good, as the user has to think and click to decide which authorization method they will use.
But the form validation should check that some valid value is POSTed when the CP is enabled.