### PR TITLE
Standardize rules reloading message

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -174,12 +174,9 @@ if ($_POST) {
 
 	if ($_POST['apply']) {
 		$retval = 0;
-		$retval = filter_configure();
+		$retval |= filter_configure();
 
 		clear_subsystem_dirty('filter');
-
-		$savemsg = sprintf(gettext("The settings have been applied. The firewall rules are now reloading in the background.<br />%s Monitor %s the reload progress."),
-									"<a href='status_filter_reload.php'>", "</a>");
 	}
 }
 
@@ -329,6 +326,10 @@ $nrules = 0;
 
 if ($savemsg) {
 	print_info_box($savemsg, 'success');
+}
+
+if ($_POST['apply']) {
+	print_apply_result_box($retval);
 }
 
 if (is_subsystem_dirty('filter')) {

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -379,7 +379,7 @@ function print_callout($msg, $class = 'info', $heading = '') {
 
 function get_std_save_message($retval) {
 	$filter_related = false;
-	$filter_pages = array("nat", "filter");
+	$filter_pages = array("firewall_aliases", "firewall_nat", "firewall_rules", "status_logs_filter");
 	if ($retval === 0) {
 		// 0 is success
 		$to_return = gettext("The changes have been applied successfully.");
@@ -393,7 +393,8 @@ function get_std_save_message($retval) {
 		}
 	}
 	if ($filter_related) {
-		$to_return .= "<br />" . gettext("<a href=\"status_filter_reload.php\">Monitor</a> the filter reload progress.");
+		$to_return .= " " . gettext("The firewall rules are now reloading in the background.") . "<br />" .
+		    sprintf(gettext("%sMonitor%s the filter reload progress."), "<a href='status_filter_reload.php'>", "</a>");
 	}
 	return $to_return;
 }


### PR DESCRIPTION
After Apply from Firewall Rules page the message about "The firewall rules are now reloading in the background." is a little different to when it is done from NAT or status_logs_filter pages.
After Apply from Aliases page(s) only the standard message is given, but actually a filter_configure() has been started, so the message here should be like the others.

Make this all work through the same piece of code.