### PR TITLE
DNS Forwarder Host Override - host is required

### DIFF
--- a/src/usr/local/www/services_dnsmasq_edit.php
+++ b/src/usr/local/www/services_dnsmasq_edit.php
@@ -59,8 +59,8 @@ if ($_POST) {
 	$pconfig = $_POST;
 
 	/* input validation */
-	$reqdfields = explode(" ", "domain ip");
-	$reqdfieldsn = array(gettext("Domain"), gettext("IP address"));
+	$reqdfields = explode(" ", "host domain ip");
+	$reqdfieldsn = array(gettext("Host"), gettext("Domain"), gettext("IP address"));
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 


### PR DESCRIPTION
At the moment you can leave the Host field empty and it saves.
I assume it should be required, or am I missing something?