### PR TITLE
Bug #7164 Limit NTP time source fields to the maximum number saved to configuration.

### DIFF
--- a/src/usr/local/www/js/pfSenseHelpers.js
+++ b/src/usr/local/www/js/pfSenseHelpers.js
@@ -290,7 +290,16 @@ function checkLastRow() {
 
 function add_row() {
 	// Find the last repeatable group
-	var lastRepeatableGroup = $('.repeatable:last');
+    var lastRepeatableGroup = $('.repeatable:last');
+
+    // If the number of repeats exceeds the maximum, do not add another clone
+    if ($('.repeatable').length >= lastRepeatableGroup.attr('max_repeats')) {
+        // Alert user if alert message is specified
+        if (typeof lastRepeatableGroup.attr('max_repeats_alert') !== 'undefined') {
+            alert(lastRepeatableGroup.attr('max_repeats_alert'));
+        }
+        return;
+    }
 
 	// Clone it
 	var newGroup = lastRepeatableGroup.clone();

--- a/src/usr/local/www/js/pfSenseHelpers.js
+++ b/src/usr/local/www/js/pfSenseHelpers.js
@@ -290,16 +290,16 @@ function checkLastRow() {
 
 function add_row() {
 	// Find the last repeatable group
-    var lastRepeatableGroup = $('.repeatable:last');
+	var lastRepeatableGroup = $('.repeatable:last');
 
-    // If the number of repeats exceeds the maximum, do not add another clone
-    if ($('.repeatable').length >= lastRepeatableGroup.attr('max_repeats')) {
-        // Alert user if alert message is specified
-        if (typeof lastRepeatableGroup.attr('max_repeats_alert') !== 'undefined') {
-            alert(lastRepeatableGroup.attr('max_repeats_alert'));
-        }
-        return;
-    }
+	// If the number of repeats exceeds the maximum, do not add another clone
+	if ($('.repeatable').length >= lastRepeatableGroup.attr('max_repeats')) {
+		// Alert user if alert message is specified
+		if (typeof lastRepeatableGroup.attr('max_repeats_alert') !== 'undefined') {
+			alert(lastRepeatableGroup.attr('max_repeats_alert'));
+		}
+		return;
+	}
 
 	// Clone it
 	var newGroup = lastRepeatableGroup.clone();

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -227,7 +227,9 @@ $maxrows = max(count($timeservers), 1);
 $auto_pool_suffix = "pool.ntp.org";
 for ($counter=0; $counter < $maxrows; $counter++) {
 	$group = new Form_Group($counter == 0 ? 'Time Servers':'');
-	$group->addClass('repeatable');
+    $group->addClass('repeatable');
+    $group->setAttribute('max_repeats', NUMTIMESERVERS);
+    $group->setAttribute('max_repeats_alert', NUMTIMESERVERS . ' is the maximum number of configured servers.');
 
 	$group->add(new Form_Input(
 		'server' . $counter,

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -229,7 +229,7 @@ for ($counter=0; $counter < $maxrows; $counter++) {
 	$group = new Form_Group($counter == 0 ? 'Time Servers':'');
     $group->addClass('repeatable');
     $group->setAttribute('max_repeats', NUMTIMESERVERS);
-    $group->setAttribute('max_repeats_alert', NUMTIMESERVERS . ' is the maximum number of configured servers.');
+    $group->setAttribute('max_repeats_alert', sprintf(gettext('%d is the maximum number of configured servers.'), NUMTIMESERVERS));
 
 	$group->add(new Form_Input(
 		'server' . $counter,

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -227,9 +227,9 @@ $maxrows = max(count($timeservers), 1);
 $auto_pool_suffix = "pool.ntp.org";
 for ($counter=0; $counter < $maxrows; $counter++) {
 	$group = new Form_Group($counter == 0 ? 'Time Servers':'');
-    $group->addClass('repeatable');
-    $group->setAttribute('max_repeats', NUMTIMESERVERS);
-    $group->setAttribute('max_repeats_alert', sprintf(gettext('%d is the maximum number of configured servers.'), NUMTIMESERVERS));
+	$group->addClass('repeatable');
+	$group->setAttribute('max_repeats', NUMTIMESERVERS);
+	$group->setAttribute('max_repeats_alert', sprintf(gettext('%d is the maximum number of configured servers.'), NUMTIMESERVERS));
 
 	$group->add(new Form_Input(
 		'server' . $counter,


### PR DESCRIPTION
Only allow the creation of fields for as many time sources as will actually be saved to the config.