### PR TITLE
trafficgraph, dont update the on screen visual graph while invisible

### DIFF
--- a/src/usr/local/www/js/traffic-graphs.js
+++ b/src/usr/local/www/js/traffic-graphs.js
@@ -90,7 +90,6 @@ function draw_graph(refreshInterval, then, backgroundupdate) {
 			charts[value].interactiveLayer.tooltip.contentGenerator(function(data) {
 
 				var units = 'b/s';
-				console.log(localStorage.getItem('size'));
 				if(localStorage.getItem('size') === "1") {
 					units = 'B/s'
 				}
@@ -197,8 +196,11 @@ function draw_graph(refreshInterval, then, backgroundupdate) {
 				myData[key][0].values.shift();
 				myData[key][1].values.shift();
 
-				charts[key].update();			
-
+				if (!Visibility.hidden()) {
+					//dont draw graph when tab is not visible
+					//this also prevents lots of timers stacking up waiting for a frame update.
+					charts[key].update();
+				}
 			});
 
 		});

--- a/src/usr/local/www/vendor/nvd3/nv.d3.js
+++ b/src/usr/local/www/vendor/nvd3/nv.d3.js
@@ -1949,7 +1949,10 @@ nv.utils.arrayEquals = function (array1, array2) {
             scale = _;
             axis.scale(scale);
             isOrdinal = typeof scale.rangeBands === 'function';
-            nv.utils.inheritOptionsD3(chart, scale, ['domain', 'range', 'rangeBand', 'rangeBands']);
+
+            //code 'leaks' memory. (builds an ever groing string of the same options..)
+            //nv.utils.inheritOptionsD3(chart, scale, ['domain', 'range', 'rangeBand', 'rangeBands']);
+            nv.utils.inheritOptionsD3(chart, scale, []);
         }}
     });
 

--- a/src/usr/local/www/vendor/nvd3/nv.d3.js
+++ b/src/usr/local/www/vendor/nvd3/nv.d3.js
@@ -1950,7 +1950,7 @@ nv.utils.arrayEquals = function (array1, array2) {
             axis.scale(scale);
             isOrdinal = typeof scale.rangeBands === 'function';
 
-            //code 'leaks' memory. (builds an ever groing string of the same options..)
+            //code 'leaks' memory. (builds an ever growing string of the same options..)
             //nv.utils.inheritOptionsD3(chart, scale, ['domain', 'range', 'rangeBand', 'rangeBands']);
             nv.utils.inheritOptionsD3(chart, scale, []);
         }}


### PR DESCRIPTION
trafficgraph, dont update the on screen visual graph while invisible (which avoids creating a large queue of pending timer objects waiting for the next requestAnimationFrame to happen)

Should fix: https://redmine.pfsense.org/issues/7157