### PR TITLE
Fix #7173 Interface Group Name cannot contain dash

### DIFF
--- a/src/usr/local/www/interfaces_groups_edit.php
+++ b/src/usr/local/www/interfaces_groups_edit.php
@@ -55,7 +55,7 @@ if (isset($id) && $a_ifgroups[$id]) {
 
 $interface_list = get_configured_interface_with_descr();
 $interface_list_disabled = get_configured_interface_with_descr(false, true);
-$ifname_allowed_chars_text = gettext("Only letters (A-Z), digits (0-9), '-' and '_' are allowed.");
+$ifname_allowed_chars_text = gettext("Only letters (A-Z), digits (0-9) and '_' are allowed.");
 $ifname_no_digit_text = gettext("The group name cannot end with a digit.");
 
 
@@ -81,7 +81,7 @@ if ($_POST) {
 			$input_errors[] = gettext("Group name cannot have more than 16 characters.");
 		}
 
-		if (preg_match("/([^a-zA-Z0-9-_])+/", $_POST['ifname'])) {
+		if (preg_match("/([^a-zA-Z0-9_])+/", $_POST['ifname'])) {
 			$input_errors[] = $ifname_allowed_chars_text . " " . gettext("Please choose another group name.");
 		}
 


### PR DESCRIPTION
This makes the allowed chars the same as for an interface or an alias.