### PR TITLE
vpn_openvpn_server: fix missing parameter

### DIFF
--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -736,6 +736,7 @@ if ($act=="new" || $act=="edit"):
 	$section->addInput(new Form_Textarea(
 		'tls',
 		'*Key',
+		$pconfig['tls']
 	))->setHelp('Paste the shared key here');
 
 	if (count($a_ca)) {


### PR DESCRIPTION
Also fixes a PHP fatal error when loading this page.
Thanks!