### PR TITLE
get_service_status_icon fix description_state format

### DIFF
--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -482,11 +482,11 @@ function get_service_status_icon($service, $withtext = true, $smallicon = false,
 	if ($title == "state") {
 		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"{$statustext}\"></i>{$spacer}";
 	} elseif ($title == "service_state") {
-		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"" . sprintf(gettext("%s Service is %s"), $service["name"], $statustext) . "\"></i>{$spacer}";
+		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"" . sprintf(gettext('%1$s Service is %2$s'), $service["name"], $statustext) . "\"></i>{$spacer}";
 	} elseif ($title == "description_state") {
-		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"" . sprintf(gettext("%s, %s Service is %s"), $service["description"], $statustext) . "\"></i>{$spacer}";
+		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"" . sprintf(gettext('%1$s Service is %2$s'), $service["description"], $statustext) . "\"></i>{$spacer}";
 	} elseif ($title == "description_service_state") {
-		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"" . sprintf(gettext("%s, %s Service is %s"), $service["description"], $service["name"], $statustext) . "\"></i>{$spacer}";
+		$output = "<i class=\"{$text_class} {$fa_class} {$fa_size}\" title=\"" . sprintf(gettext('%1$s, %2$s Service is %3$s'), $service["description"], $service["name"], $statustext) . "\"></i>{$spacer}";
 	}
 
 	$spacer = ($withtext) ? " " : "";
@@ -500,62 +500,6 @@ function get_service_status_icon($service, $withtext = true, $smallicon = false,
 
 	return $output;
 }
-
-/* This function is no longer required since services now use the POST method via JavaScript
-   Commenting out for now. It should be removed in the next version
-
-// This version proved GET formatted links
-function get_service_control_GET_links($service, $addname = false) {
-	global $g;
-	$output = "";
-	$stitle = ($addname) ? $service['name'] . " " : "";
-
-	switch ($service['name']) {
-		case "openvpn":
-			$link = '<a title="%s" href="status_services.php?mode=%s&amp;service='.$service['name'] . '&amp;vpnmode=' . $service['mode'] . '&amp;id=' . $service['vpnid'] . '">';
-		break;
-		case "captiveportal":
-			$link = '<a title="%s" href="status_services.php?mode=%s&amp;service=' . $service['name'] . '&amp;zone=' . $service['zone'] . '">';
-		break;
-		default:
-			$link = '<a title="%s" href="/status_services.php?mode=%s&amp;service=' . $service['name'] . '">';
-	}
-
-	if (get_service_status($service)) {
-		switch ($service['name']) {
-			case "openvpn":
-				$output .= "<a href=\"status_services.php?mode=restartservice&amp;service={$service['name']}&amp;vpnmode={$service['mode']}&amp;id={$service['vpnid']}\">";
-				break;
-			case "captiveportal":
-				$output .= "<a href=\"status_services.php?mode=restartservice&amp;service={$service['name']}&amp;zone={$service['zone']}\">";
-				break;
-			default:
-				$output .= "<a href=\"/status_services.php?mode=restartservice&amp;service={$service['name']}\">";
-		}
-		$output .= "<i class=\"fa fa-repeat\" title=\"" . sprintf(gettext("Restart %sService"), $stitle) . "\"></i></a>\n";
-		switch ($service['name']) {
-			case "openvpn":
-				$output .= "<a href=\"status_services.php?mode=stopservice&amp;service={$service['name']}&amp;vpnmode={$service['mode']}&amp;id={$service['vpnid']}\">";
-				break;
-			case "captiveportal":
-				$output .= "<a href=\"status_services.php?mode=stopservice&amp;service={$service['name']}&amp;zone={$service['zone']}\">";
-				break;
-			default:
-				$output .= "<a href=\"/status_services.php?mode=stopservice&amp;service={$service['name']}\">";
-		}
-		$output .= "<i class=\"fa fa-stop-circle-o\" title=\"" . sprintf(gettext("Stop %sService"), $stitle) . "\"></i></a>";
-	} else {
-		$service_enabled = is_service_enabled($service['name']);
-
-		if ($service['name'] == 'openvpn' || $service['name'] == 'captiveportal' || $service_enabled) {
-			$output .= sprintf($link, sprintf(gettext("Start %sService"), $stitle), 'startservice');
-			$output .= '<i class="fa fa-play-circle"></i></a> ';
-		}
-	}
-
-	return $output;
-}
-*/
 
 function get_service_control_links($service, $addname = false) {
 	global $g;


### PR DESCRIPTION
If "description_state" is requested here, there are too many "%s" substitutions in the string for sprintf().

Also, to help translators, number all the "%s" substitutions. Then translators can rearrange the text and variable order if they need to.

I removed the commented-out get_service_control_GET_links() while I am here, because it also contained sprintf() strings that had multiple "%s" substitutions. So I had found it when searching for lines containing multiple "%s". Might as well remove it "in the next version" as the comment says.