### PR TITLE
Code with multiple %s in etc

### DIFF
--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -221,9 +221,9 @@ if (isset($user_settings['webgui']['webguicss'])) {
 }
 
 if (isset($config['system']['webgui']['loginshowhost'])) {
-$hoststr = sprintf(gettext(" on %s.%s"), htmlspecialchars($config['system']['hostname']), htmlspecialchars($config['system']['domain']));
+	$loginbannerstr = sprintf(gettext('Login to %1$s on %2$s.%3$s'), $g['product_name'], htmlspecialchars($config['system']['hostname']), htmlspecialchars($config['system']['domain']));
 } else {
-	$hoststr = "";
+	$loginbannerstr = sprintf(gettext('Login to %1$s'), $g['product_name']);
 }
 
 ?>
@@ -254,7 +254,7 @@ $hoststr = sprintf(gettext(" on %s.%s"), htmlspecialchars($config['system']['hos
 
 				<div class="panel panel-default">
 					<div class="panel-heading">
-						<h2 class="panel-title"><?=sprintf(gettext("Login to %s %s"), $g['product_name'], $hoststr)?></h2>
+						<h2 class="panel-title"><?=$loginbannerstr?></h2>
 					</div>
 
 					<div class="panel-body">

--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -1746,7 +1746,7 @@ function captiveportal_write_elements() {
 				unlink_if_exists("{$g['captiveportal_element_path']}/{$data['name']}");
 				touch("{$g['captiveportal_element_path']}/{$data['name']}");
 			} elseif (!@file_put_contents("{$g['captiveportal_element_path']}/{$data['name']}", base64_decode($data['content']))) {
-				printf(gettext("Error: cannot open '%s' in captiveportal_write_elements()%s"), $data['name'], "\n");
+				printf(gettext('Error: cannot open \'%1$s\' in captiveportal_write_elements()%2$s'), $data['name'], "\n");
 				return 1;
 			}
 			if (!file_exists("{$g['captiveportal_path']}/{$data['name']}")) {

--- a/src/etc/inc/config.console.inc
+++ b/src/etc/inc/config.console.inc
@@ -38,8 +38,8 @@ function set_networking_interfaces_ports() {
 	if ($physmem < $g['minimum_ram_warning']) {
 		echo "\n\n\n";
 		echo gettext("DANGER!  WARNING!  ACHTUNG!") . "\n\n";
-		printf(gettext("%s requires *AT LEAST* %s RAM to function correctly.%s"), $g['product_name'], $g['minimum_ram_warning_text'], "\n");
-		printf(gettext("Only (%s) MB RAM has been detected, with (%s) available to %s.%s"), $realmem, $physmem, $g['product_name'], "\n");
+		printf(gettext('%1$s requires *AT LEAST* %2$s RAM to function correctly.%3$s'), $g['product_name'], $g['minimum_ram_warning_text'], "\n");
+		printf(gettext('Only (%1$s) MB RAM has been detected, with (%2$s) available to %3$s.%4$s'), $realmem, $physmem, $g['product_name'], "\n");
 		echo "\n" . gettext("Press ENTER to continue.") . " ";
 		fgets($fp);
 		echo "\n";
@@ -114,7 +114,7 @@ EOD;
 
 	do {
 		echo "\n" . gettext("Enter the WAN interface name or 'a' for auto-detection") . " ";
-		printf(gettext("%s(%s or a): "), "\n", trim($ifsmallist));
+		printf(gettext('%1$s(%2$s or a): '), "\n", trim($ifsmallist));
 		$wanif = chop(fgets($fp));
 		if ($wanif === "") {
 			return;
@@ -122,7 +122,7 @@ EOD;
 		if ($wanif === "a") {
 			$wanif = autodetect_interface("WAN", $fp);
 		} else if (!array_key_exists($wanif, $iflist)) {
-			printf(gettext("%sInvalid interface name '%s'%s"), "\n", $wanif, "\n");
+			printf(gettext('%1$sInvalid interface name \'%2$s\'%3$s'), "\n", $wanif, "\n");
 			unset($wanif);
 			continue;
 		}
@@ -130,9 +130,9 @@ EOD;
 	} while (!$wanif);
 
 	do {
-		printf(gettext("%sEnter the LAN interface name or 'a' for auto-detection %s" .
-			"NOTE: this enables full Firewalling/NAT mode.%s" .
-			"(%s a or nothing if finished):%s"), "\n", "\n", "\n", trim($ifsmallist), " ");
+		printf(gettext('%1$sEnter the LAN interface name or \'a\' for auto-detection %2$s' .
+			'NOTE: this enables full Firewalling/NAT mode.%3$s' .
+			'(%4$s a or nothing if finished):%5$s'), "\n", "\n", "\n", trim($ifsmallist), " ");
 
 		$lanif = chop(fgets($fp));
 
@@ -148,7 +148,7 @@ EOD;
 		if ($lanif === "a") {
 			$lanif = autodetect_interface("LAN", $fp);
 		} else if (!array_key_exists($lanif, $iflist)) {
-			printf(gettext("%sInvalid interface name '%s'%s"), "\n", $lanif, "\n");
+			printf(gettext('%1$sInvalid interface name \'%2$s\'%3$s'), "\n", $lanif, "\n");
 			unset($lanif);
 			continue;
 		}
@@ -167,11 +167,11 @@ EOD;
 			$io = $i + 1;
 
 			if ($config['interfaces']['opt' . $io]['descr']) {
-				printf(gettext("%sOptional interface %s description found: %s"), "\n", $io, $config['interfaces']['opt' . $io]['descr']);
+				printf(gettext('%1$sOptional interface %2$s description found: %3$s'), "\n", $io, $config['interfaces']['opt' . $io]['descr']);
 			}
 
-			printf(gettext("%sEnter the Optional %s interface name or 'a' for auto-detection%s" .
-				"(%s a or nothing if finished):%s"), "\n", $io, "\n", trim($ifsmallist), " ");
+			printf(gettext('%1$sEnter the Optional %2$s interface name or \'a\' for auto-detection%3$s' .
+				'(%4$s a or nothing if finished):%5$s'), "\n", $io, "\n", trim($ifsmallist), " ");
 
 			$optif[$i] = chop(fgets($fp));
 
@@ -184,7 +184,7 @@ EOD;
 						unset($optif[$i]);
 					}
 				} else if (!array_key_exists($optif[$i], $iflist)) {
-					printf(gettext("%sInvalid interface name '%s'%s"), "\n", $optif[$i], "\n");
+					printf(gettext('%1$sInvalid interface name \'%2$s\'%3$s'), "\n", $optif[$i], "\n");
 					unset($optif[$i]);
 					continue;
 				}
@@ -393,7 +393,7 @@ EOD;
 
 	foreach ($iflist_prev as $ifn => $ifa) {
 		if (!$ifa['up'] && $iflist[$ifn]['up']) {
-			printf(gettext("Detected link-up on interface %s.%s"), $ifn, "\n");
+			printf(gettext('Detected link-up on interface %1$s.%2$s'), $ifn, "\n");
 			return $ifn;
 		}
 	}
@@ -456,7 +456,7 @@ function vlan_setup() {
 		if ($vlan['if']) {
 			if (!array_key_exists($vlan['if'], $iflist) || 
 			    !is_jumbo_capable($vlan['if'])) {
-				printf(gettext("%sInvalid interface name '%s'%s"), "\n", $vlan['if'], "\n");
+				printf(gettext('%1$sInvalid interface name \'%2$s\'%3$s'), "\n", $vlan['if'], "\n");
 				continue;
 			}
 		} else {
@@ -467,7 +467,7 @@ function vlan_setup() {
 		$vlan['tag'] = chop(fgets($fp));
 		$vlan['vlanif'] = "{$vlan['if']}_vlan{$vlan['tag']}";
 		if (!is_numericint($vlan['tag']) || ($vlan['tag'] < 1) || ($vlan['tag'] > 4094)) {
-			printf(gettext("%sInvalid VLAN tag '%s'%s"), "\n", $vlan['tag'], "\n");
+			printf(gettext('%1$sInvalid VLAN tag \'%2$s\'%3$s'), "\n", $vlan['tag'], "\n");
 			continue;
 		}
 

--- a/src/etc/inc/config.inc
+++ b/src/etc/inc/config.inc
@@ -102,7 +102,7 @@ if (platform_booting(true)) {
 						$cfgdevice = $mountdisk;
 						$cfgpartition = $cfgdevice . "a";
 						$cfgfstype = "ufs";
-						printf(gettext("Found configuration on %s.%s"), $cfgdevice, "\n");
+						printf(gettext('Found configuration on %1$s.%2$s'), $cfgdevice, "\n");
 					}
 
 					mwexec("/sbin/umount -f {$g['cf_path']}");
@@ -120,7 +120,7 @@ if (platform_booting(true)) {
 						$cfgdevice = $mountdisk;
 						$cfgpartition = $cfgdevice . "d";
 						$cfgfstype = "ufs";
-						printf(gettext("Found configuration on %s.%s"), $cfgdevice, "\n");
+						printf(gettext('Found configuration on %1$s.%2$s'), $cfgdevice, "\n");
 					}
 
 					mwexec("/sbin/umount -f {$g['cf_path']}");

--- a/src/etc/inc/config.lib.inc
+++ b/src/etc/inc/config.lib.inc
@@ -474,7 +474,7 @@ function write_config($desc="Unknown", $backup = true, $write_config_only = fals
 	if (!safe_write_file("{$g['cf_conf_path']}/config.xml", $xmlconfig)) {
 		log_error(gettext("WARNING: Config contents could not be saved. Could not open file!"));
 		unlock($lockkey);
-		file_notice("config.xml", sprintf(gettext("Unable to open %s/config.xml for writing in write_config()%s"), $g['cf_conf_path'], "\n"));
+		file_notice("config.xml", sprintf(gettext('Unable to open %1$s/config.xml for writing in write_config()%2$s'), $g['cf_conf_path'], "\n"));
 		return -1;
 	}
 

--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -1070,7 +1070,7 @@
 					} else if (preg_match('/403/i', $data)) {
 						$status = $status_intro . $error_str . gettext("Database Error - There was a server-sided database error.");
 					} else if (preg_match('/405/i', $data)) {
-						$status = $status_intro . $error_str . sprintf(gettext("Hostname Error - The hostname (%s) doesn't belong to user (%s)."), $this->_dnsHost, $this->_dnsUser);
+						$status = $status_intro . $error_str . sprintf(gettext('Hostname Error - The hostname (%1$s) doesn\'t belong to user (%2$s).'), $this->_dnsHost, $this->_dnsUser);
 					} else if (preg_match('/200/i', $data)) {
 						$status = $status_intro . $success_str . gettext("IP Address Updated Successfully!");
 						$successful_update = true;
@@ -1497,7 +1497,7 @@
 				}
 				if ($this->_useIPv6 == true && $wan_ip > 0) {
 					$currentTime = time();
-					notify_all_remote(sprintf(gettext("DynDNS updated IPv6 Address on %s (%s) to %s"), convert_real_interface_to_friendly_descr($this->_if), $this->_if, $wan_ip));
+					notify_all_remote(sprintf(gettext('DynDNS updated IPv6 Address on %1$s (%2$s) to %3$s'), convert_real_interface_to_friendly_descr($this->_if), $this->_if, $wan_ip));
 					log_error(sprintf(gettext('phpDynDNS: updating cache file %1$s: %2$s'), $this->_cacheFile_v6, $wan_ip));
 					@file_put_contents($this->_cacheFile_v6, "{$wan_ip}|{$currentTime}");
 				} else {

--- a/src/etc/inc/notices.inc
+++ b/src/etc/inc/notices.inc
@@ -380,7 +380,7 @@ function notify_via_growl($message, $force=false) {
 	try {
 		$growl = Net_Growl::singleton($name, null, $password, $options);
 		//$name = 'GROWL_NOTIFY_STATUS';
-		$title = sprintf(gettext("%s (%s) - Notification"), $g['product_name'], $hostname);
+		$title = sprintf(gettext('%1$s (%2$s) - Notification'), $g['product_name'], $hostname);
 		$growl->publish($name, $title, $message);
 	} catch (Net_Growl_Exception $e) {
 		$err_msg = sprintf(gettext(

--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -717,7 +717,7 @@ function install_package_xml($package_name) {
 	update_status($to_output);
 
 	if (($pkgid = get_package_id($package_name)) == -1) {
-		update_status(sprintf(gettext("The %s package is not installed.%sInstallation aborted."), $package_name, "\n\n"));
+		update_status(sprintf(gettext('The %1$s package is not installed.%2$sInstallation aborted.'), $package_name, "\n\n"));
 
 		uninstall_package($package_name);
 		write_config($changedesc);
@@ -846,7 +846,7 @@ function delete_package_xml($package_name, $when = "post-deinstall") {
 
 	$pkgid = get_package_id($package_name);
 	if ($pkgid == -1) {
-		update_status(sprintf(gettext("The %s package is not installed.%sDeletion aborted."), $package_name, "\n\n"));
+		update_status(sprintf(gettext('The %1$s package is not installed.%2$sDeletion aborted.'), $package_name, "\n\n"));
 		ob_flush();
 		sleep(1);
 		return;

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -771,7 +771,7 @@ EOPP;
 				// If the user has changed the subnet from the interfaces page and applied,
 				// but has not updated the DHCP range, then the range to/from of the pool can be outside the subnet.
 				// This can also happen when implementing the batch of changes when the setup wizard reloads the new settings.
-				$error_msg = sprintf(gettext("Invalid DHCP pool %s - %s for %s subnet %s/%s detected. Please correct the settings in Services, DHCP Server"), $poolconf['range']['from'], $poolconf['range']['to'], convert_real_interface_to_friendly_descr($dhcpif), $subnet, $ifcfgsn);
+				$error_msg = sprintf(gettext('Invalid DHCP pool %1$s - %2$s for %3$s subnet %4$s/%5$s detected. Please correct the settings in Services, DHCP Server'), $poolconf['range']['from'], $poolconf['range']['to'], convert_real_interface_to_friendly_descr($dhcpif), $subnet, $ifcfgsn);
 				$do_file_notice = true;
 				$conf_ipv4_address = $ifcfg['ipaddr'];
 				$conf_ipv4_subnetmask = $ifcfg['subnet'];

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1552,7 +1552,7 @@ EOD;
 
 	$fd = fopen("{$filename}", "w");
 	if (!$fd) {
-		printf(gettext("Error: cannot open %s in system_generate_nginx_config().%s"), $filename, "\n");
+		printf(gettext('Error: cannot open %1$s in system_generate_nginx_config().%2$s'), $filename, "\n");
 		return 1;
 	}
 	fwrite($fd, $nginx_config);

--- a/src/etc/inc/voucher.inc
+++ b/src/etc/inc/voucher.inc
@@ -102,7 +102,7 @@ EOF;
 
 	if (is_array($resp['voucher']['roll'])) {
 		$config['voucher'][$cpzone]['roll'] = $resp['voucher']['roll'];
-		write_config(sprintf(gettext("Captive Portal Voucher database synchronized with %s:%s"), $syncip, $port));
+		write_config(sprintf(gettext('Captive Portal Voucher database synchronized with %1$s:%2$s'), $syncip, $port));
 		voucher_configure_zone(true);
 		unset($resp['voucher']);
 	} else if (!isset($resp['timeleft'])) {

--- a/src/etc/rc.initial.setlanip
+++ b/src/etc/rc.initial.setlanip
@@ -101,7 +101,7 @@ function prompt_for_enable_dhcp_server($version = 4) {
 
 	$label_DHCP = ($version === 6) ? "DHCP6" : "DHCP";
 	$upperifname = strtoupper($interface);
-	return console_prompt_for_yn (sprintf(gettext("Do you want to enable the %s server on %s?"), $label_DHCP, $upperifname));
+	return console_prompt_for_yn (sprintf(gettext('Do you want to enable the %1$s server on %2$s?'), $label_DHCP, $upperifname));
 }
 
 function get_interface_config_description($iface) {
@@ -251,7 +251,7 @@ function console_configure_ip_address($version) {
 	$upperifname = strtoupper($interface);
 
 	if ($interface == "wan") {
-		if (console_prompt_for_yn (sprintf(gettext("Configure %s address %s interface via %s?"), $label_IPvX, $upperifname, $label_DHCP))) {
+		if (console_prompt_for_yn (sprintf(gettext('Configure %1$s address %2$s interface via %3$s?'), $label_IPvX, $upperifname, $label_DHCP))) {
 			$ifppp = console_get_interface_from_ppp(get_real_interface("wan"));
 			if (!empty($ifppp)) {
 				$ifaceassigned = $ifppp;
@@ -266,7 +266,7 @@ function console_configure_ip_address($version) {
 	if ($isintdhcp == false or $interface <> "wan") {
 		while (true) {
 			do {
-				echo "\n" . sprintf(gettext("Enter the new %s %s address.  Press <ENTER> for none:"),
+				echo "\n" . sprintf(gettext('Enter the new %1$s %2$s address.  Press <ENTER> for none:'),
 							$upperifname, $label_IPvX) . "\n> ";
 				$intip = chop(fgets($fp));
 				$is_ipaddr = ($version === 6) ? is_ipaddrv6($intip) : is_ipaddrv4($intip);
@@ -293,7 +293,7 @@ function console_configure_ip_address($version) {
 				}
 				do {
 					$upperifname = strtoupper($interface);
-					echo "\n" . sprintf(gettext("Enter the new %s %s subnet bit count (1 to %s):"),
+					echo "\n" . sprintf(gettext('Enter the new %1$s %2$s subnet bit count (1 to %3$s):'),
 								$upperifname, $label_IPvX, $maxbits) . "\n> ";
 					$intbits = chop(fgets($fp));
 					$intbits_ok = is_numeric($intbits) && (($intbits >= 1) && ($intbits <= $maxbits));
@@ -318,7 +318,7 @@ function console_configure_ip_address($version) {
 					$subnet = gen_subnet($intip, $intbits);
 				}
 				do {
-					echo "\n" . sprintf(gettext("For a WAN, enter the new %s %s upstream gateway address."), $upperifname, $label_IPvX) . "\n" .
+					echo "\n" . sprintf(gettext('For a WAN, enter the new %1$s %2$s upstream gateway address.'), $upperifname, $label_IPvX) . "\n" .
 								gettext("For a LAN, press <ENTER> for none:") . "\n> ";
 					$gwip = chop(fgets($fp));
 					$is_ipaddr = ($version === 6) ? is_ipaddrv6($gwip) : is_ipaddrv4($gwip);
@@ -491,21 +491,19 @@ if (!$dry_run) {
 
 if ($intip != '') {
 	if (is_ipaddr($intip)) {
-		echo "\n\n" . sprintf(gettext("The IPv4 %s address has been set to %s"),
-							  $upperifname, "{$intip}/{$intbits}") . "\n";
+		$intipstr = "{$intip}/{$intbits}";
 	} else {
-		echo "\n\n" . sprintf(gettext("The IPv4 %s address has been set to %s"),
-							  $upperifname, $intip) . "\n";
+		$intipstr = $intip;
 	}
+	echo "\n\n" . sprintf(gettext('The IPv4 %1$s address has been set to %2$s'), $upperifname, $intipstr) . "\n";
 }
 if ($intip6 != '') {
 	if (is_ipaddr($intip6)) {
-		echo "\n\n" . sprintf(gettext("The IPv6 %s address has been set to %s"),
-							  $upperifname, "${intip6}/${intbits6}") . "\n";
+		$intip6str = "${intip6}/${intbits6}";
 	} else {
-		echo "\n\n" . sprintf(gettext("The IPv6 %s address has been set to %s"),
-							  $upperifname, $intip6) . "\n";
+		$intip6str = $intip6;
 	}
+	echo "\n\n" . sprintf(gettext('The IPv6 %1$s address has been set to %2$s'), $upperifname, $intip6str) . "\n";
 }
 
 if ($intip != '' || $intip6 != '') {


### PR DESCRIPTION
When the format string in gettext("Translate me") has multiple "%s" substitutions it restricts the translation team from being able to reorganize the sentence with the substituted values in a different order. That can be a hassle for languages that say things in a different order to English.

I have updated all these to number the substitutions, allowing translators to freely move around the order of substitution.

I did it for all cases, even those where the extra "%s" is just to put a newline at the end of a string. It seemed easier to be consistent - every string with multiple "%s" that needs to be translated shoud have the "%s" numbered.

These are the ones I found in /etc tree.