### PR TITLE
Add mising gettext() calls

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1435,7 +1435,7 @@ foreach (['src' => 'Source', 'dst' => 'Destination'] as $type => $name) {
 		(isset($portValues[ $pconfig[$type .'endport'] ]) ? null : $pconfig[$type .'endport'])
 	))->setHelp('Custom');
 
-	$group->setHelp(sprintf('Specify the %s port or port range for this rule. The "To" field may be left empty if only filtering a single port.',strtolower($name)));
+	$group->setHelp(sprintf(gettext('Specify the %s port or port range for this rule. The "To" field may be left empty if only filtering a single port.'), strtolower($name)));
 
 	$group->addClass(($type == 'src') ? 'srcprtr':'dstprtr');
 	$section->add($group);

--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -724,7 +724,7 @@ $section->addInput(new Form_Checkbox(
 	'Uptime logging',
 	'Enable persistent logging of connection uptime. ',
 	isset($pconfig['uptime'])
-))->setHelp(sprintf('Causes cumulative uptime to be recorded and displayed on the %1$sStatus->Interfaces%2$s page.', '<a href="status_interfaces.php">', '</a>'));
+))->setHelp(sprintf(gettext('Causes cumulative uptime to be recorded and displayed on the %1$sStatus->Interfaces%2$s page.'), '<a href="status_interfaces.php">', '</a>'));
 
 if ($pconfig['type'] == 'pppoe') {
 	$group = new Form_Group('Service name');

--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -645,10 +645,10 @@ $section->addInput(new Form_Checkbox(
 	'Pass-through MAC Auto Entry',
 	'Enable Pass-through MAC automatic additions',
 	$pconfig['passthrumacadd']
-))->setHelp(sprintf('When enabled, a MAC passthrough entry is automatically added after the user has successfully authenticated. Users of that MAC address will ' .
+))->setHelp(sprintf(gettext('When enabled, a MAC passthrough entry is automatically added after the user has successfully authenticated. Users of that MAC address will ' .
 			'never have to authenticate again. To remove the passthrough MAC entry either log in and remove it manually from the ' .
-			'%s or send a POST from another system. '  .
-			'If this is enabled, RADIUS MAC authentication cannot be used. Also, the logout window will not be shown.', '<a href="services_captiveportal_mac.php">MAC tab</a>'));
+			'%s or send a POST from another system. ' .
+			'If this is enabled, RADIUS MAC authentication cannot be used. Also, the logout window will not be shown.'), '<a href="services_captiveportal_mac.php">MAC tab</a>'));
 
 $section->addInput(new Form_Checkbox(
 	'passthrumacaddusername',

--- a/src/usr/local/www/services_dnsmasq.php
+++ b/src/usr/local/www/services_dnsmasq.php
@@ -255,11 +255,11 @@ $section->addInput(new Form_Checkbox(
 	'DHCP Registration',
 	'Register DHCP leases in DNS forwarder',
 	$pconfig['regdhcp']
-))->setHelp(sprintf('If this option is set, then machines that specify'.
+))->setHelp(sprintf(gettext('If this option is set, then machines that specify'.
 			' their hostname when requesting a DHCP lease will be registered'.
 			' in the DNS forwarder, so that their name can be resolved.'.
 			' The domain in %1$sSystem: General Setup%2$s should also'.
-			' be set to the proper value.','<a href="system.php">','</a>'))
+			' be set to the proper value.'),'<a href="system.php">','</a>'))
 	->addClass('toggle-dhcp');
 
 $section->addInput(new Form_Checkbox(
@@ -267,10 +267,10 @@ $section->addInput(new Form_Checkbox(
 	'Static DHCP',
 	'Register DHCP static mappings in DNS forwarder',
 	$pconfig['regdhcpstatic']
-))->setHelp(sprintf('If this option is set, then DHCP static mappings will '.
+))->setHelp(sprintf(gettext('If this option is set, then DHCP static mappings will '.
 					'be registered in the DNS forwarder, so that their name can be '.
 					'resolved. The domain in %1$sSystem: General Setup%2$s should also '.
-					'be set to the proper value.','<a href="system.php">','</a>'))
+					'be set to the proper value.'),'<a href="system.php">','</a>'))
 	->addClass('toggle-dhcp');
 
 $section->addInput(new Form_Checkbox(
@@ -278,9 +278,9 @@ $section->addInput(new Form_Checkbox(
 	'Prefer DHCP',
 	'Resolve DHCP mappings first',
 	$pconfig['dhcpfirst']
-))->setHelp(sprintf("If this option is set, then DHCP mappings will ".
-					"be resolved before the manual list of names below. This only ".
-					"affects the name given for a reverse lookup (PTR)."))
+))->setHelp("If this option is set, then DHCP mappings will ".
+	"be resolved before the manual list of names below. This only ".
+	"affects the name given for a reverse lookup (PTR).")
 	->addClass('toggle-dhcp');
 
 $group = new Form_Group('DNS Query Forwarding');
@@ -290,28 +290,28 @@ $group->add(new Form_Checkbox(
 	'DNS Query Forwarding',
 	'Query DNS servers sequentially',
 	$pconfig['strict_order']
-))->setHelp(sprintf("If this option is set, %s DNS Forwarder (dnsmasq) will ".
+))->setHelp(sprintf(gettext("If this option is set, %s DNS Forwarder (dnsmasq) will ".
 					"query the DNS servers sequentially in the order specified (<i>System - General Setup - DNS Servers</i>), ".
-					"rather than all at once in parallel. ", $g['product_name']));
+					"rather than all at once in parallel."), $g['product_name']));
 
 $group->add(new Form_Checkbox(
 	'domain_needed',
 	null,
 	'Require domain',
 	$pconfig['domain_needed']
-))->setHelp(sprintf("If this option is set, %s DNS Forwarder (dnsmasq) will ".
+))->setHelp(sprintf(gettext("If this option is set, %s DNS Forwarder (dnsmasq) will ".
 					"not forward A or AAAA queries for plain names, without dots or domain parts, to upstream name servers.	 ".
-					"If the name is not known from /etc/hosts or DHCP then a \"not found\" answer is returned. ", $g['product_name']));
+					"If the name is not known from /etc/hosts or DHCP then a \"not found\" answer is returned."), $g['product_name']));
 
 $group->add(new Form_Checkbox(
 	'no_private_reverse',
 	null,
 	'Do not forward private reverse lookups',
 	$pconfig['no_private_reverse']
-))->setHelp(sprintf("If this option is set, %s DNS Forwarder (dnsmasq) will ".
-					"not forward reverse DNS lookups (PTR) for private addresses (RFC 1918) to upstream name servers.  ".
+))->setHelp(sprintf(gettext("If this option is set, %s DNS Forwarder (dnsmasq) will ".
+					"not forward reverse DNS lookups (PTR) for private addresses (RFC 1918) to upstream name servers. ".
 					"Any entries in the Domain Overrides section forwarding private \"n.n.n.in-addr.arpa\" names to a specific server are still forwarded. ".
-					"If the IP to name is not known from /etc/hosts, DHCP or a specific domain override then a \"not found\" answer is immediately returned. ", $g['product_name']));
+					"If the IP to name is not known from /etc/hosts, DHCP or a specific domain override then a \"not found\" answer is immediately returned."), $g['product_name']));
 
 $section->add($group);
 

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -318,26 +318,26 @@ $section->addInput(new Form_Checkbox(
 	'DNS Query Forwarding',
 	'Enable Forwarding Mode',
 	$pconfig['forwarding']
-))->setHelp(sprintf('If this option is set, DNS queries will be forwarded to the upstream DNS servers defined under'.
+))->setHelp(sprintf(gettext('If this option is set, DNS queries will be forwarded to the upstream DNS servers defined under'.
 					' %1$sSystem &gt; General Setup%2$s or those obtained via DHCP/PPP on WAN'.
-					' (if DNS Server Override is enabled there).','<a href="system.php">','</a>'));
+					' (if DNS Server Override is enabled there).'), '<a href="system.php">', '</a>'));
 
 $section->addInput(new Form_Checkbox(
 	'regdhcp',
 	'DHCP Registration',
 	'Register DHCP leases in the DNS Resolver',
 	$pconfig['regdhcp']
-))->setHelp(sprintf('If this option is set, then machines that specify their hostname when requesting a DHCP lease will be registered'.
+))->setHelp(sprintf(gettext('If this option is set, then machines that specify their hostname when requesting a DHCP lease will be registered'.
 					' in the DNS Resolver, so that their name can be resolved.'.
-					' The domain in %1$sSystem &gt; General Setup%2$s should also be set to the proper value.','<a href="system.php">','</a>'));
+					' The domain in %1$sSystem &gt; General Setup%2$s should also be set to the proper value.'), '<a href="system.php">', '</a>'));
 
 $section->addInput(new Form_Checkbox(
 	'regdhcpstatic',
 	'Static DHCP',
 	'Register DHCP static mappings in the DNS Resolver',
 	$pconfig['regdhcpstatic']
-))->setHelp(sprintf('If this option is set, then DHCP static mappings will be registered in the DNS Resolver, so that their name can be resolved. '.
-					'The domain in %1$sSystem &gt; General Setup%2$s should also be set to the proper value.','<a href="system.php">','</a>'));
+))->setHelp(sprintf(gettext('If this option is set, then DHCP static mappings will be registered in the DNS Resolver, so that their name can be resolved. '.
+					'The domain in %1$sSystem &gt; General Setup%2$s should also be set to the proper value.'), '<a href="system.php">', '</a>'));
 
 $btnadv = new Form_Button(
 	'btnadvcustom',


### PR DESCRIPTION
As reported in forum https://forum.pfsense.org/index.php?topic=124734.msg689931#msg689931 , sprintf() inside a setHelp() method call means that the text string is not picked up in the ".pot" file for translation. In some places these already have an explicit gettext() put around them. These are the remaining places with a setHelp(sprintf()) sequence that need a gettext() added.