### PR TITLE
Add a '.' to the help text for consistency

### DIFF
--- a/src/usr/local/www/system_advanced_firewall.php
+++ b/src/usr/local/www/system_advanced_firewall.php
@@ -463,7 +463,7 @@ $group->add(new Form_Input(
 
 $group->setHelp('Timeouts for states can be scaled adaptively as the number of '.
 	'state table entries grows. Leave blank to use default values, set to '.
-	'0 to disable Adaptive Timeouts');
+	'0 to disable Adaptive Timeouts.');
 
 $section->add($group);
 


### PR DESCRIPTION
Was about to submit a full patch for the unescaped ` %'s ` but @sbeaver-netgate [beat me to it](https://redmine.pfsense.org/issues/7202#note-9) by a couple of minutes. So here's my minuscule contribution!