### PR TITLE
Do not pass empty string to gettext

### DIFF
--- a/src/usr/local/www/classes/Form/Button.class.php
+++ b/src/usr/local/www/classes/Form/Button.class.php
@@ -32,6 +32,12 @@ class Form_Button extends Form_Input
 
 	public function __construct($name, $title, $link = null, $icon = null)
 	{
+		if (!empty($title) || is_numeric($title)) {
+			$title_str = gettext($title);
+		} else {
+			$title_str = "";
+		}
+
 		// If we have a link; we're actually an <a class='btn'>
 		if (isset($link))
 		{
@@ -47,13 +53,13 @@ class Form_Button extends Form_Input
 		{
 			$this->_tagSelfClosing = false;
 			$this->_tagName = 'button';
-			$this->_attributes['value'] = gettext($title);
+			$this->_attributes['value'] = $title_str;
 			$this->_attributes['icon'] = $icon;
 		}
 		else
 		{
 			$this->_tagSelfClosing = true;
-			$this->_attributes['value'] = gettext($title);
+			$this->_attributes['value'] = $title_str;
 			$this->addClass('btn-primary');
 		}
 

--- a/src/usr/local/www/classes/Form/Checkbox.class.php
+++ b/src/usr/local/www/classes/Form/Checkbox.class.php
@@ -56,9 +56,9 @@ class Form_Checkbox extends Form_Input
 	{
 		$input = parent::_getInput();
 
-		if (empty($this->_description))
-			return '<label class="chkboxlbl">'. $input .'</label>';
+		if (!empty($this->_description) || is_numeric($this->_description))
+			return '<label class="chkboxlbl">'. $input .' '. htmlspecialchars(gettext($this->_description)) .'</label>';
 
-		return '<label class="chkboxlbl">'. $input .' '. htmlspecialchars(gettext($this->_description)) .'</label>';
+		return '<label class="chkboxlbl">'. $input .'</label>';
 	}
 }

--- a/src/usr/local/www/classes/Form/Group.class.php
+++ b/src/usr/local/www/classes/Form/Group.class.php
@@ -57,8 +57,9 @@ class Form_Group extends Form_Element
 	public function setHelp()
 	{
 		$args = func_get_args();
+		$arg0_len = strlen($args[0]);
 
-		if (strlen($args[0]) < 4096) {
+		if (($arg0_len > 0) && ($arg0_len < 4096)) {
 			$args[0] = gettext($args[0]);
 		}
 

--- a/src/usr/local/www/classes/Form/Input.class.php
+++ b/src/usr/local/www/classes/Form/Input.class.php
@@ -113,8 +113,9 @@ class Form_Input extends Form_Element
 	public function setHelp()
 	{
 		$args = func_get_args();
+		$arg0_len = strlen($args[0]);
 
-		if (strlen($args[0]) < 4096) {
+		if (($arg0_len > 0) && ($arg0_len < 4096)) {
 			$args[0] = gettext($args[0]);
 		}
 

--- a/src/usr/local/www/classes/Form/MultiCheckboxGroup.class.php
+++ b/src/usr/local/www/classes/Form/MultiCheckboxGroup.class.php
@@ -39,7 +39,10 @@ class Form_MultiCheckboxGroup extends Form_Group
 		$label = new Form_Element('label');
 		$label->addClass('col-sm-'.Form::LABEL_WIDTH, 'control-label');
 
-		$title = htmlspecialchars(gettext($this->_title));
+		if (!empty(trim($this->_title)) || is_numeric($this->_title))
+			$title = htmlspecialchars(gettext($this->_title));
+		else
+			$title = '';
 
 		return <<<EOT
 	{$element}


### PR DESCRIPTION
For example, system.php DNS Servers. Switch to a non-English language. Have more than 1 DNS Server specified. The setHelp text for the last row comes out fine, because it is "real text". For all but the last row, it does setHelp('') and when in non-English it spews out a bunch of text about the POT file...

So I tried a bunch of other form elements and used blank titles, checkbox descriptions and so on. They all behave the same.

Often sending blank for a title, description or whatever is a silly thing to do, and we could just recode all callers so they never bother to make the call if the text is blank. But it seems better to make sure to allow blank text in the calling parameter and handle it better.