### PR TITLE
Use unique var names in Input.class.php

### DIFF
--- a/src/usr/local/www/classes/Form/Input.class.php
+++ b/src/usr/local/www/classes/Form/Input.class.php
@@ -60,8 +60,8 @@ class Form_Input extends Form_Element
 		if (isset($value))
 			$this->_attributes['value'] = $value;
 
-		foreach ($attributes as $name => $value)
-			$this->_attributes[$name] = $value;
+		foreach ($attributes as $attr_name => $attr_value)
+			$this->_attributes[$attr_name] = $attr_value;
 	}
 
 	public function getTitle()


### PR DESCRIPTION
Nothing is technically broken here, but it seemed "dangerous" to reuse the input parameter var names $name and $value here. It is a bit confusing to read (in the foreach, $name and $value are taking on attribute name and value), and depends on the behavior of input parameters being on the stack, and exactly what foreach does with its loop vars as it iterates.