### PR TITLE
enhancements to services_dhcp_edit.php

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1811,22 +1811,25 @@ function alias_expand_urltable($name) {
 	return null;
 }
 
-/* obtain MAC address given an IP address by looking at the ARP table */
+/* obtain MAC address given an IP address by looking at the ARP/NDP table */
 function arp_get_mac_by_ip($ip) {
-	mwexec("/sbin/ping -c 1 -t 1 " . escapeshellarg($ip), true);
-	$arpoutput = "";
-	exec("/usr/sbin/arp -n " . escapeshellarg($ip), $arpoutput);
-
-	if ($arpoutput[0]) {
-		$arpi = explode(" ", $arpoutput[0]);
-		$macaddr = $arpi[3];
+	unset($arp_ndp_output);
+	switch (is_ipaddr($ip)) {
+		case 4:
+			mwexec("/sbin/ping -c 1 -t 1 " . escapeshellarg($ip), true);
+			exec("/usr/sbin/arp -n " . escapeshellarg($ip) . " | /usr/bin/awk '{print $4}'", $arp_ndp_output);
+			break;
+		case 6:
+			mwexec("/sbin/ping6 -c 1 -X 1 " . escapeshellarg($ip), true);
+			exec("/usr/sbin/ndp -n " . escapeshellarg($ip) . " | /usr/bin/tail -n+2 | /usr/bin/awk '{print $2}'", $arp_ndp_output);
+			break;
+	}
+	if ($arp_ndp_output[0]) {
+		$macaddr = $arp_ndp_output[0];
 		if (is_macaddr($macaddr)) {
 			return $macaddr;
-		} else {
-			return false;
 		}
 	}
-
 	return false;
 }
 

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1813,24 +1813,23 @@ function alias_expand_urltable($name) {
 
 /* obtain MAC address given an IP address by looking at the ARP/NDP table */
 function arp_get_mac_by_ip($ip) {
-	unset($arp_ndp_output);
+	unset($macaddr);
+	$retval = 1;
 	switch (is_ipaddr($ip)) {
 		case 4:
 			mwexec("/sbin/ping -c 1 -t 1 " . escapeshellarg($ip), true);
-			exec("/usr/sbin/arp -n " . escapeshellarg($ip) . " | /usr/bin/awk '{print $4}'", $arp_ndp_output);
+			$macaddr = exec("/usr/sbin/arp -n " . escapeshellarg($ip) . " | /usr/bin/awk '{print $4}'", $output, $retval);
 			break;
 		case 6:
 			mwexec("/sbin/ping6 -c 1 -X 1 " . escapeshellarg($ip), true);
-			exec("/usr/sbin/ndp -n " . escapeshellarg($ip) . " | /usr/bin/tail -n+2 | /usr/bin/awk '{print $2}'", $arp_ndp_output);
+			$macaddr = exec("/usr/sbin/ndp -n " . escapeshellarg($ip) . " | /usr/bin/awk '{print $2}'", $output, $retval);
 			break;
 	}
-	if ($arp_ndp_output[0]) {
-		$macaddr = $arp_ndp_output[0];
-		if (is_macaddr($macaddr)) {
-			return $macaddr;
-		}
+	if ($retval == 0 && is_macaddr($macaddr)) {
+		return $macaddr;
+	} else {
+		return false;
 	}
-	return false;
 }
 
 /* return a fieldname that is safe for xml usage */

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1812,7 +1812,7 @@ function alias_expand_urltable($name) {
 }
 
 /* obtain MAC address given an IP address by looking at the ARP/NDP table */
-function arp_get_mac_by_ip($ip, $do_ping = false) {
+function arp_get_mac_by_ip($ip, $do_ping = true) {
 	unset($macaddr);
 	$retval = 1;
 	switch (is_ipaddr($ip)) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1812,16 +1812,20 @@ function alias_expand_urltable($name) {
 }
 
 /* obtain MAC address given an IP address by looking at the ARP/NDP table */
-function arp_get_mac_by_ip($ip) {
+function arp_get_mac_by_ip($ip, $do_ping = false) {
 	unset($macaddr);
 	$retval = 1;
 	switch (is_ipaddr($ip)) {
 		case 4:
-			mwexec("/sbin/ping -c 1 -t 1 " . escapeshellarg($ip), true);
+			if ($do_ping === true) {
+				mwexec("/sbin/ping -c 1 -t 1 " . escapeshellarg($ip), true);
+			}
 			$macaddr = exec("/usr/sbin/arp -n " . escapeshellarg($ip) . " | /usr/bin/awk '{print $4}'", $output, $retval);
 			break;
 		case 6:
-			mwexec("/sbin/ping6 -c 1 -X 1 " . escapeshellarg($ip), true);
+			if ($do_ping === true) {
+				mwexec("/sbin/ping6 -c 1 -X 1 " . escapeshellarg($ip), true);
+			}
 			$macaddr = exec("/usr/sbin/ndp -n " . escapeshellarg($ip) . " | /usr/bin/awk '{print $2}'", $output, $retval);
 			break;
 	}

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -385,8 +385,6 @@ if ($_POST) {
 
 // Get our MAC address
 $ip = $_SERVER['REMOTE_ADDR'];
-
-unset($mymac);
 $mymac = arp_get_mac_by_ip($ip);
 
 $iflist = get_configured_interface_with_descr();

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -385,8 +385,19 @@ if ($_POST) {
 
 // Get our MAC address
 $ip = $_SERVER['REMOTE_ADDR'];
-$mymac = `/usr/sbin/arp -an | grep '('{$ip}')' | cut -d" " -f4`;
-$mymac = str_replace("\n", "", $mymac);
+
+switch (is_ipaddr($ip)) {
+	case 4:
+		$mymac = exec("/usr/sbin/arp -an | grep '('{$ip}')' | head -n 1 | cut -d' ' -f4");
+		$mymac = str_replace("\n", "", $mymac);
+        break;
+    case 6:
+		$mymac = exec("/usr/sbin/ndp -na | /usr/bin/grep '{$ip}' | /usr/bin/head -n 1 | /usr/bin/awk '{ print $2 }'");
+		$mymac = str_replace("\n", "", $mymac);
+		break;
+	default:
+		unset($mymac);
+}
 
 $iflist = get_configured_interface_with_descr();
 $ifname = '';
@@ -415,7 +426,6 @@ $macaddress = new Form_Input(
 	$pconfig['mac'],
 	['placeholder' => 'xx:xx:xx:xx:xx:xx']
 );
-
 $btnmymac = new Form_Button(
 	'btnmymac',
 	'Copy My MAC',
@@ -424,10 +434,11 @@ $btnmymac = new Form_Button(
 	);
 
 $btnmymac->setAttribute('type','button')->removeClass('btn-primary')->addClass('btn-success btn-sm');
-
 $group = new Form_Group('MAC Address');
 $group->add($macaddress);
-$group->add($btnmymac);
+if (!empty($mymac)) {
+	$group->add($btnmymac);
+}
 $group->setHelp('MAC address (6 hex octets separated by colons)');
 $section->add($group);
 

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -385,7 +385,7 @@ if ($_POST) {
 
 // Get our MAC address
 $ip = $_SERVER['REMOTE_ADDR'];
-$mymac = arp_get_mac_by_ip($ip);
+$mymac = arp_get_mac_by_ip($ip, false);
 
 $iflist = get_configured_interface_with_descr();
 $ifname = '';

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -386,18 +386,8 @@ if ($_POST) {
 // Get our MAC address
 $ip = $_SERVER['REMOTE_ADDR'];
 
-switch (is_ipaddr($ip)) {
-	case 4:
-		$mymac = exec("/usr/sbin/arp -an | grep '('{$ip}')' | head -n 1 | cut -d' ' -f4");
-		$mymac = str_replace("\n", "", $mymac);
-        break;
-    case 6:
-		$mymac = exec("/usr/sbin/ndp -na | /usr/bin/grep '{$ip}' | /usr/bin/head -n 1 | /usr/bin/awk '{ print $2 }'");
-		$mymac = str_replace("\n", "", $mymac);
-		break;
-	default:
-		unset($mymac);
-}
+unset($mymac);
+$mymac = arp_get_mac_by_ip($ip);
 
 $iflist = get_configured_interface_with_descr();
 $ifname = '';
@@ -426,6 +416,7 @@ $macaddress = new Form_Input(
 	$pconfig['mac'],
 	['placeholder' => 'xx:xx:xx:xx:xx:xx']
 );
+
 $btnmymac = new Form_Button(
 	'btnmymac',
 	'Copy My MAC',
@@ -434,6 +425,7 @@ $btnmymac = new Form_Button(
 	);
 
 $btnmymac->setAttribute('type','button')->removeClass('btn-primary')->addClass('btn-success btn-sm');
+
 $group = new Form_Group('MAC Address');
 $group->add($macaddress);
 if (!empty($mymac)) {


### PR DESCRIPTION
- added ndp call to get MAC addr if remote client is connected via IPv6
- automatically hide `Copy MAC` button if arp/ndp returns null
- switch to exec() instead of backticks for calls to arp
- uses builtin is_ipaddr() function from util.inc

_(supersedes https://github.com/pfsense/pfsense/pull/3483 and https://github.com/pfsense/pfsense/pull/3489)_