### PR TITLE
Fix #7226 Package installation message is incomplete

### DIFF
--- a/src/usr/local/www/pkg_mgr_install.php
+++ b/src/usr/local/www/pkg_mgr_install.php
@@ -412,6 +412,7 @@ if ($confirmed):
 ?>
 	<input type="hidden" name="id" value="<?=$_REQUEST['id']?>" />
 	<input type="hidden" name="mode" value="<?=$pkgmode?>" />
+	<input type="hidden" name="pkg" value="<?=$pkgname?>" />
 	<input type="hidden" name="completed" value="true" />
 	<input type="hidden" name="confirmed" value="true" />
 	<input type="hidden" id="reboot_needed" name="reboot_needed" value="no" />


### PR DESCRIPTION
This makes it remember pkgname after the install finishes and the form is re-submitted.