### PR TITLE
Part fix #7233 keep correct staticmap_array_index

### DIFF
--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -300,8 +300,9 @@ foreach ($config['interfaces'] as $ifname => $ifarr) {
 				$slease['online'] = in_array(strtolower($slease['mac']), $arpdata_mac) ? $online_string : $offline_string;
 				$slease['staticmap_array_index'] = $staticmap_array_index;
 				$leases[] = $slease;
-				$staticmap_array_index++;
 			}
+
+			$staticmap_array_index++;
 		}
 	}
 }


### PR DESCRIPTION
staticmap_array_index needs to be incremented even for entries that were skipped for display because they (for whatever reason) have no MAC or CID set.