### PR TITLE
services_dhcp_relay fix setHelp array parameter

### DIFF
--- a/src/usr/local/www/services_dhcp_relay.php
+++ b/src/usr/local/www/services_dhcp_relay.php
@@ -165,7 +165,7 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['agentoption']
 ))->setHelp(
 	'If this is checked, the DHCP relay will append the circuit ID (%s interface number) and the agent ID to the DHCP request.',
-	[$g['product_name']]
+	$g['product_name']
 	);
 
 $counter = 0;


### PR DESCRIPTION
Another one using the old array format.