### PR TITLE
Required fields - Alias Type

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -674,7 +674,7 @@ $section->addInput(new Form_Input(
 
 $section->addInput(new Form_Select(
 	'type',
-	'Type',
+	'*Type',
 	isset($pconfig['type']) ? $pconfig['type'] : $tab,
 	$types
 ));


### PR DESCRIPTION
should be a required field. And this 1-char change can also be backported to RELENG_2_3. I noticed this while looking at GUI pages in 2.3.3