### PR TITLE
Fix incorrect sorting for various dropdown lists.

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -630,6 +630,9 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 		}
 	}
 	unset($gateway);
+	
+	//Sort the array by GW name before moving on.
+	ksort($gateways_arr, SORT_STRING | SORT_FLAG_CASE);
 
 	/* Loop through all interfaces with a gateway and add it to a array */
 	if ($disabled == false) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1420,7 +1420,8 @@ function get_configured_interface_with_descr($only_opt = false, $withdisabled = 
 			}
 		}
 	}
-
+	
+	asort($iflist);
 	return $iflist;
 }
 

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -583,14 +583,16 @@ function build_dsttype_list() {
 			$list[$ifent . 'ip'] = $ifdesc . ' address';
 		}
 	}
-
+	
+	//Temporary array so we can sort IPs
+	$templist = array();
 	if (is_array($config['virtualip']['vip'])) {
 		foreach ($config['virtualip']['vip'] as $sn) {
 			if (is_ipaddrv6($sn['subnet'])) {
 				continue;
 			}
 			if (($sn['mode'] == "proxyarp" || $sn['mode'] == "other") && $sn['type'] == "network") {
-				$list[$sn['subnet'] . '/' . $sn['subnet_bits']] = 'Subnet: ' . $sn['subnet'] . '/' . $sn['subnet_bits'] . ' (' . $sn['descr'] . ')';
+				$templist[$sn['subnet'] . '/' . $sn['subnet_bits']] = 'Subnet: ' . $sn['subnet'] . '/' . $sn['subnet_bits'] . ' (' . $sn['descr'] . ')';
 				if (isset($sn['noexpand'])) {
 					continue;
 				}
@@ -601,13 +603,18 @@ function build_dsttype_list() {
 				for ($i = 0; $i <= $len; $i++) {
 					$snip = long2ip32($start+$i);
 
-					$list[$snip] = $snip . ' (' . $sn['descr'] . ')';
+					$templist[$snip] = $snip . ' (' . $sn['descr'] . ')';
 				}
 			} else {
-				$list[$sn['subnet']] = $sn['subnet'] . ' (' . $sn['descr'] . ')';
+				$templist[$sn['subnet']] = $sn['subnet'] . ' (' . $sn['descr'] . ')';
 			}
 		}
 	}
+	
+	//Sort temp IP array and append onto main array
+	asort($templist);
+	$list = array_merge($list, $templist);
+	unset($templist);
 
 	return($list);
 }

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -406,10 +406,12 @@ function build_target_list() {
 
 	$list[""] = gettext('Interface Address');
 
+	//Temporary array so we can sort IPs
+	$templist = array();
 	if (is_array($config['virtualip']['vip'])) {
 		foreach ($config['virtualip']['vip'] as $sn) {
 			if (($sn['mode'] == "proxyarp" || $sn['mode'] == "other") && $sn['type'] == "network") {
-				$list['S' . $sn['subnet'] . '/' . $sn['subnet_bits']] = gettext('Subnet: ') . $sn['subnet'] . '/' . $sn['subnet_bits'] . ' (' . $sn['descr'] . ')';
+				$templist['S' . $sn['subnet'] . '/' . $sn['subnet_bits']] = gettext('Subnet: ') . $sn['subnet'] . '/' . $sn['subnet_bits'] . ' (' . $sn['descr'] . ')';
 				if (isset($sn['noexpand'])) {
 					continue;
 				}
@@ -419,13 +421,17 @@ function build_target_list() {
 				for ($i = 0; $i <= $len; $i++) {
 					$snip = long2ip32($start+$i);
 
-					$list['I' . $snip] = $snip . ' (' . $sn['descr'] . ')';
+					$templist['I' . $snip] = $snip . ' (' . $sn['descr'] . ')';
 				}
 			} else {
-				$list['I' . $sn['subnet']] = $sn['subnet'] . ' (' . $sn['descr'] . ')';
+				$templist['I' . $sn['subnet']] = $sn['subnet'] . ' (' . $sn['descr'] . ')';
 			}
 		}
 	}
+	asort($templist);
+	//Append sorted IP array onto main array
+	$list = array_merge($list, $templist);
+	unset($templist);
 
 	foreach ($a_aliases as $alias) {
 		if ($alias['type'] != "host") {


### PR DESCRIPTION
Many dropdown lists across pfSense currently have little or illogical sorting. I've worked through many of these.

Incorrectly sorted dropdowns that have been fixed listed below:

- Port Forward - Destination dropdown - Interface names and IP addresses are now sorted correctly, but still remain grouped.

- Outbound NAT - Translation address dropdown - IP addresses are now sorted correctly.

- Routing - Gateways - Previously listed in a random order, now sorted alphabetically by name.
- Static Routes gateway dropdown - Previously listed in a random order, now sorted alphabetically by name.

- Firewall rules - Interfaces dropdown - Interface names now sorted alphabetically.
- Firewall rules - Source/Destination dropdown - Interface names now sorted alphabetically.
- Gateways - Interface dropdown - Interface names now sorted alphabetically.
- Port Forward - Interface dropdown - Interface names now sorted alphabetically.
- Outbound NAT - Interface dropdown - Interface names now sorted alphabetically.
- NAT 1:1 - Interface dropdown - Interface names now sorted alphabetically.
- NAT NPt - Interface dropdown - Interface names now sorted alphabetically.