### PR TITLE
Update version string at end of boot RELENG_2_3

### DIFF
--- a/src/etc/rc
+++ b/src/etc/rc
@@ -67,20 +67,25 @@ export HOME PATH
 # Set our operating platform
 PLATFORM=`/bin/cat /etc/platform`
 
-# Set our current version
-version=`/bin/cat /etc/version`
+get_version ()
+{
+	# Set our current version
+	version=`/bin/cat /etc/version`
 
-# Version patch
-version_patch="0"
-if [ -f /etc/version.patch ]; then
-	version_patch=`/bin/cat /etc/version.patch`
-fi
+	# Version patch
+	version_patch="0"
+	if [ -f /etc/version.patch ]; then
+		version_patch=`/bin/cat /etc/version.patch`
+	fi
 
-if [ "${version_patch}" = "0" ]; then
-	version_patch=""
-else
-	version_patch=" (Patch ${version_patch})"
-fi
+	if [ "${version_patch}" = "0" ]; then
+		version_patch=""
+	else
+		version_patch=" (Patch ${version_patch})"
+	fi
+}
+
+get_version
 
 # Read product_name from $g, defaults to pfSense
 # Use php -n here because we are not ready to load extensions yet
@@ -509,6 +514,7 @@ fi
 /usr/local/sbin/${product}-upgrade -y -b 3
 
 # Log product version to syslog
+get_version
 BUILDTIME=`cat /etc/version.buildtime`
 ARCH=`uname -m`
 echo "$product ($PLATFORM) ${version}${version_patch} $ARCH $BUILDTIME"


### PR DESCRIPTION
When there is an upgrade, the echo here was outputting a stale value of the version. For example, on first upgrade from 2.3.3-DEVELOPMENT to 2.3.3-RC the console had:

pfSense (pfSense) 2.3.3-DEVELOPMENT amd6 Sat Feb 11 14:24:27 CST 2017
Bootup complete

FreeBSD/amd64 (myhost.localdomain) (ttyv0)

*** Welcome to pfSense 2.3.3-RC (amd64 full-install) on myhost ***

That is a bit confusing for users to be sure which version it is at this point.