### PR TITLE
Make breadcrumb links work

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -310,12 +310,13 @@ foreach ($iflist as $ifent => $ifname) {
 foreach ($tab_array as $dtab) {
 	if ($dtab[1]) {
 		$bctab = $dtab[0];
+		$bclink = $dtab[2];
 		break;
 	}
 }
 
 $pgtitle = array(gettext("Firewall"), gettext("Rules"), $bctab);
-$pglinks = array("", "firewall_rules.php", "@self");
+$pglinks = array("", "firewall_rules.php", $bclink);
 $shortcut_section = "firewall";
 
 include("head.inc");

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1096,7 +1096,26 @@ if ($if == "FloatingRules" || isset($pconfig['floating'])) {
 }
 
 $pgtitle[] = gettext("Edit");
-$pglinks[] = "@self";
+$linkref = "firewall_rules_edit.php";
+$special_char = "?";
+if ($if != "") {
+	$linkref .= $special_char . "if=" . $if;
+	$special_char = "&";
+}
+if ($_POST['id'] != "") {
+	$linkref .= $special_char . "id=" . $_POST['id'];
+	$special_char = "&";
+}
+if ($_POST['dup'] != "") {
+	$linkref .= $special_char . "dup=" . $_POST['dup'];
+	$special_char = "&";
+}
+if ($_POST['after'] != "") {
+	$linkref .= $special_char . "after=" . $_POST['after'];
+	$special_char = "&";
+}
+$pglinks[] = $linkref;
+
 $shortcut_section = "firewall";
 
 $page_filename = "firewall_rules_edit.php";

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -555,7 +555,7 @@ function genhtmltitle($title, $links=true) {
 				if (substr($href, 0, 1) != '/') {
 					$href = '/' . $href;
 				}
-				$bc .= '<li><a href="' . htmlentities($href) . '">' . $el . '</a></li>';
+				$bc .= '<li><a href="' . htmlentities($href) . '" usepost>' . $el . '</a></li>';
 			} else {
 				$bc .= '<li>' . $el . '</li>';
 			}
@@ -1056,7 +1056,11 @@ function display_top_tabs(& $tab_array, $no_drop_down = false, $type = 'pills', 
 		echo "</select>\n<p>&nbsp;</p>";
 		echo "<script type=\"text/javascript\">";
 		echo "\n//<![CDATA[\n";
-		echo " function tabs_will_go(obj){ document.location = obj.value; }\n";
+		if ($usepost == 'usepost') {
+			echo " function tabs_will_go(obj){ var target = obj.value.split(\"?\"); postSubmit(get2post(target[1]),target[0]); }\n";
+		} else {
+			echo " function tabs_will_go(obj){ document.location = obj.value; }\n";
+		}
 		echo "//]]>\n";
 		echo "</script>";
 	} else {


### PR DESCRIPTION
To make breadcrumb links work again with the new "POST not GET" code, something like this can be done.
1) In guiconfig.inc set breadcrumb links to "usepost"
2) In each place that uses the "@self" reference, instead we have to build the link with URL parameters based on what POST parameters are needed for each page. I have done that for firewal_rules and firewall_rules_edit as examples.

This gives an idea of what would be required.

Of course it still means that the user cannot bookmark a link directly to the rules of a particular interface...