### PR TITLE
Add GUI entry for ip_change_kill_states config parameter

### DIFF
--- a/src/etc/rc.newwanip
+++ b/src/etc/rc.newwanip
@@ -200,12 +200,13 @@ if (platform_booting()) {
 if (!is_ipaddr($oldip) || $curwanip != $oldip || !is_ipaddrv4($config['interfaces'][$interface]['ipaddr'])) {
 	/* IP changed, kill states accordingly */
 	if ($curwanip != $oldip) {
-		log_error("IP has changed, killing states on former IP $oldip.");
-		pfSense_kill_states($oldip);
 		if (isset($config['system']['ip_change_kill_states'])) {
-			/* hidden config option to wipe all states if needed */
-			log_error("Killing all states post-IP change.");
+			log_error("IP has changed, killing all states (ip_change_kill_states is set).");
+			pfSense_kill_states($oldip);
 			filter_flush_state_table();
+		} else {
+			log_error("IP has changed, killing states on former IP $oldip.");
+			pfSense_kill_states($oldip);
 		}
 	}
 

--- a/src/etc/rc.newwanip
+++ b/src/etc/rc.newwanip
@@ -201,11 +201,11 @@ if (!is_ipaddr($oldip) || $curwanip != $oldip || !is_ipaddrv4($config['interface
 	/* IP changed, kill states accordingly */
 	if ($curwanip != $oldip) {
 		if (isset($config['system']['ip_change_kill_states'])) {
-			log_error("IP has changed, killing all states (ip_change_kill_states is set).");
+			log_error("IP Address has changed, killing all states (ip_change_kill_states is set).");
 			pfSense_kill_states($oldip);
 			filter_flush_state_table();
 		} else {
-			log_error("IP has changed, killing states on former IP $oldip.");
+			log_error("IP Address has changed, killing states on former IP Address $oldip.");
 			pfSense_kill_states($oldip);
 		}
 	}

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -46,6 +46,7 @@ $pconfig['sharednet'] = $config['system']['sharednet'];
 $pconfig['disablechecksumoffloading'] = isset($config['system']['disablechecksumoffloading']);
 $pconfig['disablesegmentationoffloading'] = isset($config['system']['disablesegmentationoffloading']);
 $pconfig['disablelargereceiveoffloading'] = isset($config['system']['disablelargereceiveoffloading']);
+$pconfig['ip_change_kill_states'] = isset($config['system']['ip_change_kill_states']);
 
 if ($_POST) {
 
@@ -122,6 +123,12 @@ if ($_POST) {
 			$config['system']['disablelargereceiveoffloading'] = true;
 		} else {
 			unset($config['system']['disablelargereceiveoffloading']);
+		}
+
+		if ($_POST['ip_change_kill_states'] == "yes") {
+			$config['system']['ip_change_kill_states'] = true;
+		} else {
+			unset($config['system']['ip_change_kill_states']);
 		}
 
 		setup_microcode();
@@ -273,6 +280,15 @@ $section->addInput(new Form_Checkbox(
 	isset($pconfig['sharednet'])
 ))->setHelp('This option will suppress ARP log messages when multiple interfaces '.
 	'reside on the same broadcast domain.');
+
+$section->addInput(new Form_Checkbox(
+	'ip_change_kill_states',
+	'Reset all states',
+	'Reset all states if WAN IP changes',
+	isset($pconfig['ip_change_kill_states'])
+))->setHelp('This option will reset all states if a WAN IP changes instead of only '.
+    'reset states associated to old IP. This can help to kill zombie states associated '.
+    'to outdate WAN IPs when WAN IPs change too often.');
 
 if (get_freebsd_version() == 8) {
 	$section->addInput(new Form_Checkbox(

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -283,12 +283,11 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'ip_change_kill_states',
-	'Reset all states',
-	'Reset all states if WAN IP changes',
+	'Reset All States',
+	'Reset all states if WAN IP Address changes',
 	isset($pconfig['ip_change_kill_states'])
-))->setHelp('This option will reset all states if a WAN IP changes instead of only '.
-    'reset states associated to old IP. This can help to kill zombie states associated '.
-    'to outdate WAN IPs when WAN IPs change too often.');
+))->setHelp('This option resets all states when a WAN IP Address changes instead of only '.
+    'states associated with the previous IP Address.');
 
 if (get_freebsd_version() == 8) {
 	$section->addInput(new Form_Checkbox(


### PR DESCRIPTION
The hidden parameter is present in pfsense since November 2014 but there was no GUI entry to enable/disable this parameter. This parameter is extremly helpful for unstable WAN connections using VOIP.

This is my first contribution to pfsense. I hope my commits are compliant to the pfsense coding style.