### PR TITLE
IPv4 Tunnel Network is required for OpenVPN server

### DIFF
--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -446,7 +446,7 @@ if ($_POST['save']) {
 
 	if ($pconfig['dev_mode'] != "tap") {
 		$reqdfields[] = 'tunnel_network';
-		$reqdfieldsn[] = gettext('Tunnel network');
+		$reqdfieldsn[] = gettext('IPv4 Tunnel network');
 	} else {
 		if ($pconfig['serverbridge_dhcp'] && $pconfig['tunnel_network']) {
 			$input_errors[] = gettext("Using a tunnel network and server bridge settings together is not allowed.");


### PR DESCRIPTION
I noticed that this message is not specific. The user would not know if it is the IPv4 or IPv6 Tunnel Network that they are required to enter.

Might as well fix the message. Then consider that maybe nowadays you could have an OpenVPN server that passes only IPv6 over the tunnel, so maybe what is required is actually just one of IPv4 or IPv6 Tunnel Network?