### PR TITLE
Fix ldap_get_groups return value when down

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -1132,7 +1132,7 @@ function ldap_get_groups($username, $authcfg) {
 
 	if ($error == true) {
 		log_error(sprintf(gettext("ERROR! ldap_get_groups() Could not connect to server %s."), $ldapname));
-		return memberof;
+		return $memberof;
 	}
 
 	ldap_set_option($ldap, LDAP_OPT_REFERRALS, 0);
@@ -1161,7 +1161,7 @@ function ldap_get_groups($username, $authcfg) {
 	} else if (!($res = @ldap_bind($ldap, $ldapbindun, $ldapbindpw))) {
 		log_error(sprintf(gettext("ERROR! ldap_get_groups() could not bind to server %s."), $ldapname));
 		@ldap_close($ldap);
-		return memberof;
+		return $memberof;
 	}
 
 	/* get groups from DN found */


### PR DESCRIPTION
In some places ldap_get_groups has:
```
return memberof;
```
It should have the "$" in front, so it will return the $memberof array (that is empty when this happens).

This causes issues for callers that expect to have a return value that is either false, an empty array, or an array of the groups.