### PR TITLE
Allow saving of CA when in non-English language

### DIFF
--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -153,7 +153,7 @@ if ($act == "expkey") {
 	exit;
 }
 
-if ($_POST['save'] == 'Save') {
+if ($_POST['save'] == gettext('Save')) {
 
 	unset($input_errors);
 	$input_errors = array();


### PR DESCRIPTION
1) Switch to Brazilian
2) Add a CA, try to "Salvar". It does not save.

I wonder how many other places there are like this in the code?