### PR TITLE
Allow 5 dashboard columns to work

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -359,7 +359,7 @@ foreach ($widgets as $widgetname => $widgetconfig) {
 
 <div class="row">
 <?php
-	$columnWidth = 12 / $numColumns;
+	$columnWidth = (int) (12 / $numColumns);
 
 	for ($currentColumnNumber = 1; $currentColumnNumber <= $numColumns; $currentColumnNumber++) {
 


### PR DESCRIPTION
Selecting 1,2,3,4 or 6 dashboards columns results in an exact integer result here and all is good. But 5 columns results in "2.4" and "col-sm-2.4" is not a thing in bootstrap.
We need just the best int we can choose here, which is one that is just the int part of the division. That ensures that the 5 columns extend over less than the standard bootstrap total of 12 "units" wide.