### PR TITLE
Only save valid widget locations in config

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -423,8 +423,13 @@ function updateWidgets(newWidget) {
 	$('.container .col-md-<?=$columnWidth?>').each(function(idx, col) {
 		$('.panel', col).each(function(idx, widget) {
 			var isOpen = $('.panel-body', widget).hasClass('in');
+			var widget_basename = widget.id.split('-')[1];
 
-			sequence += widget.id.split('-')[1] + ':' + col.id.split('-')[1] + ':' + (isOpen ? 'open' : 'close') + ',';
+			// Only save details for panels that have id's like'widget-*'
+			// Some widgets create other panels, so ignore any of those.
+			if ((widget.id.split('-')[0] == 'widget') && (typeof widget_basename !== 'undefined')) {
+				sequence += widget_basename + ':' + col.id.split('-')[1] + ':' + (isOpen ? 'open' : 'close') + ',';
+			}
 		});
 	});
 


### PR DESCRIPTION
Some widgets create extra panels, e.g. the widgets that now have the filter functionality. Those panels are processed in the ".each" at line 424. They do not have an id in the form "widget-*" and when the old code tries to find the "*" part it gets "undefined". This results in the layout being saved like:
```
<sequence>interface_statistics:col1:open,undefined:col1:close,system_information:col2:open,undefined:col2:close,picture:col3:open,rss:col3:open,ntp_status:col2:open</sequence>
```

This PR puts extra checks in place so that the "undefined" stuff does not get written into the widget sequence string. With the fixed code (and me moving widgets on my dashboard), the sequence looks like:
```
<sequence>picture:col1:open,interface_statistics:col1:open,system_information:col2:open,ntp_status:col2:open,rss:col3:open</sequence>
```
