### PR TITLE
Vendor MAC Retention, Restore Logic, Consolidate

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -6005,12 +6005,10 @@ function get_interface_vendor_mac($interface) {
 	global $g;
 
 	$mac = "";
-	$mac_file = "{$g['vardb_path']}/vendor_mac_($interface)";
+	$mac_file = "{$g['vardb_path']}/vendor_mac";
 	if (file_exists($mac_file)) {
-		$mac = file_get_contents($mac_file);
-		if (!is_macaddr($mac)) {
-			$mac = "";
-		}
+		$vendor_mac_arr = json_decode(file_get_contents($mac_file), true);
+		$mac = (is_macaddr($vendor_mac_arr[$interface])) ? $vendor_mac_arr[$interface] : '';
 	}
 
 	return $mac;

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3274,16 +3274,16 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 
 	$current_mac = get_interface_mac($realhwif);
 	$vendor_mac = get_interface_vendor_mac($realhwif);
-	$spoof_mac = $wancfg['spoofmac'] ?: $vendor_mac;
+	$mac_addr = $wancfg['spoofmac'] ?: $vendor_mac;
 	/*
-	 * Don't try to reapply the spoofed MAC if it's already applied.
+	 * Don't try to reapply the MAC if it's already applied.
 	 * When ifconfig link is used, it cycles the interface down/up, which triggers
-	 * the interface config again, which attempts to spoof the MAC again,
+	 * the interface config again, which attempts to apply the MAC again,
 	 * which cycles the link again...
 	 */
-	if (!empty($spoof_mac) && ($spoof_mac != $current_mac)) {
+	if (!empty($mac_addr) && ($mac_addr != $current_mac)) {
 		mwexec("/sbin/ifconfig " . escapeshellarg($realhwif) .
-			" link " . escapeshellarg($spoof_mac));
+			" link " . escapeshellarg($mac_addr));
 	} elseif ($current_mac == "ff:ff:ff:ff:ff:ff") {
 		/*   this is not a valid mac address.  generate a
 		 *   temporary mac address so the machine can get online.

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3272,8 +3272,13 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 		interface_wireless_configure($realif, $wancfg, $wancfg['wireless']);
 	}
 
+	/* Get the vendor MAC.  Use source dependent upon whether or not booting. */
 	$current_mac = get_interface_mac($realhwif);
-	$vendor_mac = get_interface_vendor_mac($realhwif);
+	if (platform_booting()) {
+		$vendor_mac = $current_mac;
+	} else {
+		$vendor_mac = get_interface_vendor_mac($realhwif);
+	}
 	$mac_addr = $wancfg['spoofmac'] ?: $vendor_mac;
 	/*
 	 * Don't try to reapply the MAC if it's already applied.

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -6005,7 +6005,7 @@ function get_interface_vendor_mac($interface) {
 	global $g;
 
 	$mac = "";
-	$mac_file = "{$g['cf_conf_path']}/vendor_mac_{$interface}";
+	$mac_file = "{$g['vardb_path']}/vendor_mac_($interface)";
 	if (file_exists($mac_file)) {
 		$mac = file_get_contents($mac_file);
 		if (!is_macaddr($mac)) {

--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -113,7 +113,7 @@ echo "done.\n";
 if (mwexec("/bin/kenv -q pfSense.boot 2>/dev/null") != 0) {
 	/* Collect vendor MAC address for all interfaces */
 	$ifs = pfSense_interface_listget();
-	unlink_if_exists("{$g['vardb_path']}/vendor_mac_*");
+	unlink_if_exists("{$g['vardb_path']}/vendor_mac");
 	foreach ($ifs as $if) {
 		$if_details = pfSense_get_interface_addresses($if);
 		if (isset($if_details['iftype']) &&
@@ -126,10 +126,10 @@ if (mwexec("/bin/kenv -q pfSense.boot 2>/dev/null") != 0) {
 			continue;
 		}
 
-		@file_put_contents("{$g['vardb_path']}/vendor_mac_{$if}",
-		    $if_details['macaddr']);
+		$vendor_mac_arr[$if] = $if_details['macaddr'];
 	}
-	unset($ifs, $if);
+	@file_put_contents("{$g['vardb_path']}/vendor_mac", json_encode($vendor_mac_arr));
+	unset($ifs, $if, $vendor_mac_arr);
 	mwexec("/bin/kenv pfSense.boot=1");
 }
 

--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -113,7 +113,7 @@ echo "done.\n";
 if (mwexec("/bin/kenv -q pfSense.boot 2>/dev/null") != 0) {
 	/* Collect vendor MAC address for all interfaces */
 	$ifs = pfSense_interface_listget();
-	unlink_if_exists("{$g['cf_conf_path']}/vendor_mac_*");
+	unlink_if_exists("{$g['vardb_path']}/vendor_mac_*");
 	foreach ($ifs as $if) {
 		$if_details = pfSense_get_interface_addresses($if);
 		if (isset($if_details['iftype']) &&
@@ -126,7 +126,7 @@ if (mwexec("/bin/kenv -q pfSense.boot 2>/dev/null") != 0) {
 			continue;
 		}
 
-		@file_put_contents("{$g['cf_conf_path']}/vendor_mac_{$if}",
+		@file_put_contents("{$g['vardb_path']}/vendor_mac_{$if}",
 		    $if_details['macaddr']);
 	}
 	unset($ifs, $if);


### PR DESCRIPTION
Spoof MAC Var Name

Rename 'spoof_mac' var to generic 'mac_addr'.
 a) It may be the vendor MAC or a spoofed MAC.
 b) Update the comment re: not reapplying an already applied MAC.


Vendor MAC Restore Logic

Only use the vendor MAC retention file for restoring the vendor MAC when not booting.
 a) During boot up the current MAC that is obtained from the system is the vendor MAC.
 b) Using this eliminates the inefficient need to open the vendor MAC retention file for every interface during system boot up.


Vendor MAC Retention File Relocate

Relocate the vendor MAC retention file to /var/db directory.
 a) It's more at home here with other network interface stuff.
 b) Friendlier to write cycle sensitive media in a RAM disk enabled system.


Vendor MAC Retention File Consolidate

Use a single file for vendor MAC retention (vendor_mac).
 a) Writes only one file during boot up rather than a file for each interface.
 b) More efficient than numerous tiny files.
 c) Friendlier to write cycle sensitive media in a RAM disk disabled system.