### PR TITLE
option to make default deny a reject vs. block

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -3074,6 +3074,11 @@ function filter_rules_generate() {
 	if (isset($config['syslog']['nologdefaultpass'])) {
 		$log['pass'] = "log";
 	}
+	if (!isset($config['system']['fwblockreturn'])) {
+		$block_rule = "block";
+	} else {
+		$block_rule = "block return";
+	}
 
 	$saved_tracker = $tracker;
 
@@ -3104,10 +3109,10 @@ EOD;
 #---------------------------------------------------------------------------
 # default deny rules
 #---------------------------------------------------------------------------
-block in {$log['block']} inet all tracker {$increment_tracker($tracker)} label "Default deny rule IPv4"
-block out {$log['block']} inet all tracker {$increment_tracker($tracker)} label "Default deny rule IPv4"
-block in {$log['block']} inet6 all tracker {$increment_tracker($tracker)} label "Default deny rule IPv6"
-block out {$log['block']} inet6 all tracker {$increment_tracker($tracker)} label "Default deny rule IPv6"
+{$block_rule} in {$log['block']} inet all tracker {$increment_tracker($tracker)} label "Default deny rule IPv4"
+{$block_rule} out {$log['block']} inet all tracker {$increment_tracker($tracker)} label "Default deny rule IPv4"
+{$block_rule} in {$log['block']} inet6 all tracker {$increment_tracker($tracker)} label "Default deny rule IPv6"
+{$block_rule} out {$log['block']} inet6 all tracker {$increment_tracker($tracker)} label "Default deny rule IPv6"
 
 EOD;
 

--- a/src/usr/local/www/system_advanced_firewall.php
+++ b/src/usr/local/www/system_advanced_firewall.php
@@ -56,6 +56,7 @@ $pconfig['enablebinatreflection'] = $config['system']['enablebinatreflection'];
 $pconfig['reflectiontimeout'] = $config['system']['reflectiontimeout'];
 $pconfig['bypassstaticroutes'] = isset($config['filter']['bypassstaticroutes']);
 $pconfig['disablescrub'] = isset($config['system']['disablescrub']);
+$pconfig['fwblockreturn'] = isset($config['system']['fwblockreturn']);
 $pconfig['tftpinterface'] = explode(",", $config['system']['tftpinterface']);
 $pconfig['disablevpnrules'] = isset($config['system']['disablevpnrules']);
 $pconfig['tcpfirsttimeout'] = $config['system']['tcpfirsttimeout'];
@@ -326,6 +327,12 @@ if ($_POST) {
 			unset($config['system']['disablescrub']);
 		}
 
+		if ($_POST['fwblockreturn'] == "yes") {
+			$config['system']['fwblockreturn'] = $_POST['fwblockreturn'];
+		} else {
+			unset($config['system']['fwblockreturn']);
+		}
+
 		if ($_POST['tftpinterface']) {
 			$config['system']['tftpinterface'] = implode(",", $_POST['tftpinterface']);
 		} else {
@@ -434,6 +441,13 @@ $section->addInput(new Form_Checkbox(
 	'Disable Firewall Scrub',
 	'Disables the PF scrubbing option which can sometimes interfere with NFS traffic.',
 	isset($config['system']['disablescrub'])
+));
+
+$section->addInput(new Form_Checkbox(
+	'fwblockreturn',
+	'Reject by default',
+	'Use reject instead of block for default deny rules.',
+	isset($config['system']['fwblockreturn'])
 ));
 
 $group = new Form_Group('Firewall Adaptive Timeouts');


### PR DESCRIPTION
I have found a scenario where I would like the default deny rule to use `block return` instead of `block` so that the TCP connection does not continually re-try.
It's currently hard-coded into the system, this pull request makes it an option under System / Advanced / Firewall.

Thanks!