### PR TITLE
System Info Widget enable All button when disable firmware check is set

### DIFF
--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -439,6 +439,8 @@ function systemStatusGetUpdateStatus() {
 		}
 	});
 }
+
+setTimeout('systemStatusGetUpdateStatus()', 4000);
 <?php endif; ?>
 
 function updateMeters() {
@@ -457,17 +459,13 @@ function updateMeters() {
 
 }
 
-<?php if (!isset($config['system']['firmware']['disablecheck'])): ?>
 events.push(function(){
 	$("#showallsysinfoitems").click(function() {
 		$("[id^=show]").each(function() {
 			$(this).prop("checked", true);
 		});
 	});
-
-	setTimeout('systemStatusGetUpdateStatus()', 4000);
 });
-<?php endif; ?>
 
 var update_interval = "<?=$widgetperiod?>";
 


### PR DESCRIPTION
If system firmware disablecheck is set, then the click event for the filter "All" button is also not included in the JS, so the "All" button is not effective.

The setTimeout for systemStatusGetUpdateStatus() can be moved up just below where it is declared and inside the existing "if" that conditionally includes that function - no need for it to be inside events.push

Then the PHP condition around events.push can be removed, so that the "All" button will always be effective.