### PR TITLE
Disallow IPv6 for RADIUS auth server

### DIFF
--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -287,7 +287,7 @@ if ($_POST['save']) {
 	}
 
 	// https://redmine.pfsense.org/issues/4154
-	if ($pconfig['type'] == "radius_host") {
+	if ($pconfig['type'] == "radius") {
 		if (is_ipaddrv6($_POST['radius_host'])) {
 			$input_errors[] = gettext("IPv6 does not work for RADIUS authentication, see Bug #4154.");
 		}

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -286,6 +286,13 @@ if ($_POST['save']) {
 		}
 	}
 
+	// https://redmine.pfsense.org/issues/4154
+	if ($pconfig['type'] == "radius_host") {
+		if (is_ipaddrv6($_POST['radius_host'])) {
+			$input_errors[] = gettext("IPv6 does not work for RADIUS authentication, see Bug #4154.");
+		}
+	}
+
 	if (!$input_errors) {
 		$server = array();
 		$server['refid'] = uniqid();


### PR DESCRIPTION
See https://redmine.pfsense.org/issues/4154. No need for users to waste their time with debugging packets black hole.