### PR TITLE
NTPd GPS Autoset baud rate

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1615,6 +1615,45 @@ function system_timezone_configure() {
 	}
 }
 
+function check_gps_speed($device, $baud) {
+	usleep(1000);
+	// Set timeout to 5s
+	$timeout=microtime(true)+5;
+	if($fp = fopen($device, 'r')) {
+		stream_set_blocking($fp, 0);
+		stream_set_timeout($fp, 5);
+		$contents = "";
+		$cnt = 0;
+		$buffersize = 256;
+		do {
+			$c = fread($fp, $buffersize - $cnt);
+
+			// Wait for data to arive
+			if($c === false || strlen($c) == 0) {
+				usleep(10000);
+				continue;
+			}
+
+			$contents.=$c;
+			$cnt = $cnt + strlen($c);
+		} while($cnt < $buffersize && microtime(true)<$timeout);
+		fclose($fp);
+
+		$nmeasentences = ['RMC', 'GGA', 'GLL', 'ZDA', 'ZDG', 'PGRMF'];
+		foreach ($nmeasentences as $sentence) {
+			if(strpos($contents, $sentence) > 0) {
+				@file_put_contents("/tmp/testread".$baud.$sentence, $contents);
+				return true;
+			}
+		}
+		if (strpos($contents, "0") > 0 && strpos($contents, "`") === false && strpos($contents, "??") === false) {
+			@file_put_contents("/tmp/testread".$baud, $contents);
+			return true;
+		}
+	}
+	return false;
+}
+
 function system_ntp_setup_gps($serialport) {
 	global $config, $g;
 	$gps_device = '/dev/gps0';
@@ -1629,28 +1668,37 @@ function system_ntp_setup_gps($serialport) {
 	@symlink($serialport, $gps_device);
 
 	$gpsbaud = '4800';
-	if (is_array($config['ntpd']) && is_array($config['ntpd']['gps']) && !empty($config['ntpd']['gps']['speed'])) {
-		switch ($config['ntpd']['gps']['speed']) {
-			case '16':
-				$gpsbaud = '9600';
-				break;
-			case '32':
-				$gpsbaud = '19200';
-				break;
-			case '48':
-				$gpsbaud = '38400';
-				break;
-			case '64':
-				$gpsbaud = '57600';
-				break;
-			case '80':
-				$gpsbaud = '115200';
-				break;
-		}
+	$speeds=[0 => '4800', 16 => '9600', 32 => '19200', 48 => '38400', 64 => '57600', 80 => '115200'];
+	$revspeeds=['4800' => 0, '9600' => 16, '19200' => 32, '38400' => 48, '57600' => 64, '115200' => 80];
+	if($config['ntpd']['gps']['speed'] && array_key_exists($config['ntpd']['gps']['speed'], $speeds)) {
+		$gpsbaud = $speeds[$config['ntpd']['gps']['speed']];
 	}
 
 	/* Configure the serial port for raw IO and set the speed */
 	mwexec("stty -f {$serialport}.init raw speed {$gpsbaud}");
+
+	$autospeed = ($config['ntpd']['gps']['speed'] == 'autoalways' || $config['ntpd']['gps']['speed'] == 'autoset');
+	if($autospeed || ($config['ntpd']['gps']['autobaudinit'] && !check_gps_speed($gps_device, $gpsbaud))) {
+		$found = false;
+		foreach ($speeds as $baud) {
+			mwexec("stty -f {$serialport}.init raw speed {$baud}");
+			@file_put_contents("/tmp/testreadcheck".$baud, 'dffsd');
+			if($found = check_gps_speed($gps_device, $baud)) {
+				if($autospeed) {
+					$saveconfig = ($config['ntpd']['gps']['speed'] == 'autoset');
+					$config['ntpd']['gps']['speed'] = $revspeeds[$baud];
+					if($saveconfig) {
+						write_config(sprintf(gettext('Autoset GPS baud rate to %s'), $baud));
+					}
+				}
+				break;
+			}
+		}
+		if($found === false) {
+			log_error(gettext("Could not find correct GPS baud rate."));
+			return false;
+		}
+	}
 
 	/* Send the following to the GPS port to initialize the GPS */
 	if (is_array($config['ntpd']) && is_array($config['ntpd']['gps']) && !empty($config['ntpd']['gps']['type'])) {
@@ -1659,15 +1707,22 @@ function system_ntp_setup_gps($serialport) {
 		$gps_init = base64_decode('JFBVQlgsNDAsR1NWLDAsMCwwLDAqNTkNCiRQVUJYLDQwLEdMTCwwLDAsMCwwKjVDDQokUFVCWCw0MCxaREEsMCwwLDAsMCo0NA0KJFBVQlgsNDAsVlRHLDAsMCwwLDAqNUUNCiRQVUJYLDQwLEdTViwwLDAsMCwwKjU5DQokUFVCWCw0MCxHU0EsMCwwLDAsMCo0RQ0KJFBVQlgsNDAsR0dBLDAsMCwwLDANCiRQVUJYLDQwLFRYVCwwLDAsMCwwDQokUFVCWCw0MCxSTUMsMCwwLDAsMCo0Ng0KJFBVQlgsNDEsMSwwMDA3LDAwMDMsNDgwMCwwDQokUFVCWCw0MCxaREEsMSwxLDEsMQ==');
 	}
 
-	/* XXX: Why not file_put_contents to the device */
-	@file_put_contents('/tmp/gps.init', $gps_init);
-	mwexec("cat /tmp/gps.init > {$serialport}");
+	@file_put_contents($gps_device, $gps_init);
+
+	if ($found && $config['ntpd']['gps']['autobaudinit']) {
+		mwexec("stty -f {$serialport}.init raw speed {$gpsbaud}");
+	}
+
+	/* Remove old /etc/remote entry if it exists */
+	if (intval(`grep -c "^gps0" /etc/remote`) != 0) {
+		mwexec("sed -n '/gps0/!p' /etc/remote > /etc/remote.new");
+		mwexec('mv /etc/remote.new /etc/remote');
+	}
 
 	/* Add /etc/remote entry in case we need to read from the GPS with tip */
 	if (intval(`grep -c '^gps0' /etc/remote`) == 0) {
 		@file_put_contents("/etc/remote", "gps0:dv={$serialport}:br#{$gpsbaud}:pa=none:\n", FILE_APPEND);
 	}
-
 
 	return true;
 }
@@ -1704,6 +1759,12 @@ function system_ntp_configure() {
 		$config['ntpd'] = array();
 	}
 
+	/* if ntpd is running, kill it */
+	while (isvalidpid("{$g['varrun_path']}/ntpd.pid")) {
+		killbypid("{$g['varrun_path']}/ntpd.pid");
+	}
+	@unlink("{$g['varrun_path']}/ntpd.pid");
+
 	$ntpcfg = "# \n";
 	$ntpcfg .= "# pfSense ntp configuration file \n";
 	$ntpcfg .= "# \n\n";
@@ -1721,8 +1782,8 @@ function system_ntp_configure() {
 
 	/* Add PPS configuration */
 	if (is_array($config['ntpd']['pps']) && !empty($config['ntpd']['pps']['port']) &&
-	    file_exists('/dev/'.$config['ntpd']['pps']['port']) &&
-	    system_ntp_setup_pps($config['ntpd']['pps']['port'])) {
+		file_exists('/dev/'.$config['ntpd']['pps']['port']) &&
+		system_ntp_setup_pps($config['ntpd']['pps']['port'])) {
 		$ntpcfg .= "\n";
 		$ntpcfg .= "# PPS Setup\n";
 		$ntpcfg .= 'server 127.127.22.0';
@@ -1760,8 +1821,7 @@ function system_ntp_configure() {
 
 	/* Add GPS configuration */
 	if (is_array($config['ntpd']['gps']) && !empty($config['ntpd']['gps']['port']) &&
-	    file_exists('/dev/'.$config['ntpd']['gps']['port']) &&
-	    system_ntp_setup_gps($config['ntpd']['gps']['port'])) {
+		system_ntp_setup_gps($config['ntpd']['gps']['port'])) {
 		$ntpcfg .= "\n";
 		$ntpcfg .= "# GPS Setup\n";
 		$ntpcfg .= 'server 127.127.20.0 mode ';
@@ -1825,8 +1885,7 @@ function system_ntp_configure() {
 		}
 		$ntpcfg .= "\n";
 	} elseif (is_array($config['ntpd']) && !empty($config['ntpd']['gpsport']) &&
-	    file_exists('/dev/'.$config['ntpd']['gpsport']) &&
-	    system_ntp_setup_gps($config['ntpd']['gpsport'])) {
+		system_ntp_setup_gps($config['ntpd']['gpsport'])) {
 		/* This handles a 2.1 and earlier config */
 		$ntpcfg .= "# GPS Setup\n";
 		$ntpcfg .= "server 127.127.20.0 mode 0 minpoll 4 maxpoll 4 prefer\n";
@@ -1842,7 +1901,7 @@ function system_ntp_configure() {
 	/* foreach through ntp servers and write out to ntpd.conf */
 	foreach (explode(' ', $config['system']['timeservers']) as $ts) {
 		if ((substr_compare($ts, $auto_pool_suffix, strlen($ts) - strlen($auto_pool_suffix), strlen($auto_pool_suffix)) === 0)
-		    || substr_count($config['ntpd']['ispool'], $ts)) {
+			|| substr_count($config['ntpd']['ispool'], $ts)) {
 			$ntpcfg .= 'pool ';
 			$have_pools = true;
 		} else {
@@ -2021,12 +2080,6 @@ function system_ntp_configure() {
 		log_error(sprintf(gettext("Could not open %s/ntpd.conf for writing"), $g['varetc_path']));
 		return;
 	}
-
-	/* if ntpd is running, kill it */
-	while (isvalidpid("{$g['varrun_path']}/ntpd.pid")) {
-		killbypid("{$g['varrun_path']}/ntpd.pid");
-	}
-	@unlink("{$g['varrun_path']}/ntpd.pid");
 
 	/* if /var/empty does not exist, create it */
 	if (!is_dir("/var/empty")) {

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1645,13 +1645,13 @@ function check_gps_speed($device) {
 				return true;
 			}
 		}
-		$filters = ['`', '?', '/', '~'];
-		foreach ($filters as $filter) {
-			if(strpos($contents, $filter) !== false) {
-				return false;
+		if (strpos($contents, '0') > 0) {
+			$filters = ['`', '?', '/', '~'];
+			foreach ($filters as $filter) {
+				if(strpos($contents, $filter) !== false) {
+					return false;
+				}
 			}
-		}
-		if (strpos($contents, '0')) {
 			return true;
 		}
 	}

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1692,6 +1692,7 @@ function system_ntp_setup_gps($serialport) {
 				if($autospeed) {
 					$saveconfig = ($config['ntpd']['gps']['speed'] == 'autoset');
 					$config['ntpd']['gps']['speed'] = $revspeeds[$baud];
+					$gpsbaud = $baud;
 					if($saveconfig) {
 						write_config(sprintf(gettext('Autoset GPS baud rate to %s'), $baud));
 					}
@@ -1721,8 +1722,7 @@ function system_ntp_setup_gps($serialport) {
 
 	/* Remove old /etc/remote entry if it exists */
 	if (intval(`grep -c "^gps0" /etc/remote`) != 0) {
-		mwexec("sed -n '/gps0/!p' /etc/remote > /etc/remote.new");
-		mwexec('mv /etc/remote.new /etc/remote');
+		mwexec("sed -i '' -n '/gps0/!p' /etc/remote");
 	}
 
 	/* Add /etc/remote entry in case we need to read from the GPS with tip */

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1615,7 +1615,7 @@ function system_timezone_configure() {
 	}
 }
 
-function check_gps_speed($device, $baud) {
+function check_gps_speed($device) {
 	usleep(1000);
 	// Set timeout to 5s
 	$timeout=microtime(true)+5;
@@ -1676,11 +1676,11 @@ function system_ntp_setup_gps($serialport) {
 	mwexec("stty -f {$serialport}.init raw speed {$gpsbaud}");
 
 	$autospeed = ($config['ntpd']['gps']['speed'] == 'autoalways' || $config['ntpd']['gps']['speed'] == 'autoset');
-	if($autospeed || ($config['ntpd']['gps']['autobaudinit'] && !check_gps_speed($gps_device, $gpsbaud))) {
+	if($autospeed || ($config['ntpd']['gps']['autobaudinit'] && !check_gps_speed($gps_device))) {
 		$found = false;
 		foreach ($speeds as $baud) {
 			mwexec("stty -f {$serialport}.init raw speed {$baud}");
-			if($found = check_gps_speed($gps_device, $baud)) {
+			if($found = check_gps_speed($gps_device)) {
 				if($autospeed) {
 					$saveconfig = ($config['ntpd']['gps']['speed'] == 'autoset');
 					$config['ntpd']['gps']['speed'] = $revspeeds[$baud];

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1642,12 +1642,10 @@ function check_gps_speed($device, $baud) {
 		$nmeasentences = ['RMC', 'GGA', 'GLL', 'ZDA', 'ZDG', 'PGRMF'];
 		foreach ($nmeasentences as $sentence) {
 			if(strpos($contents, $sentence) > 0) {
-				@file_put_contents("/tmp/testread".$baud.$sentence, $contents);
 				return true;
 			}
 		}
 		if (strpos($contents, "0") > 0 && strpos($contents, "`") === false && strpos($contents, "??") === false) {
-			@file_put_contents("/tmp/testread".$baud, $contents);
 			return true;
 		}
 	}
@@ -1682,7 +1680,6 @@ function system_ntp_setup_gps($serialport) {
 		$found = false;
 		foreach ($speeds as $baud) {
 			mwexec("stty -f {$serialport}.init raw speed {$baud}");
-			@file_put_contents("/tmp/testreadcheck".$baud, 'dffsd');
 			if($found = check_gps_speed($gps_device, $baud)) {
 				if($autospeed) {
 					$saveconfig = ($config['ntpd']['gps']['speed'] == 'autoset');

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1630,7 +1630,7 @@ function check_gps_speed($device) {
 
 			// Wait for data to arive
 			if($c === false || strlen($c) == 0) {
-				usleep(10000);
+				usleep(500);
 				continue;
 			}
 
@@ -1645,7 +1645,13 @@ function check_gps_speed($device) {
 				return true;
 			}
 		}
-		if (strpos($contents, "0") > 0 && strpos($contents, "`") === false && strpos($contents, "??") === false) {
+		$filters = ['`', '?', '/', '~'];
+		foreach ($filters as $filter) {
+			if(strpos($contents, $filter) !== false) {
+				return false;
+			}
+		}
+		if (strpos($contents, '0')) {
 			return true;
 		}
 	}
@@ -1667,18 +1673,20 @@ function system_ntp_setup_gps($serialport) {
 
 	$gpsbaud = '4800';
 	$speeds=[0 => '4800', 16 => '9600', 32 => '19200', 48 => '38400', 64 => '57600', 80 => '115200'];
-	$revspeeds=['4800' => 0, '9600' => 16, '19200' => 32, '38400' => 48, '57600' => 64, '115200' => 80];
+	$revspeeds = array_flip($speeds);
 	if($config['ntpd']['gps']['speed'] && array_key_exists($config['ntpd']['gps']['speed'], $speeds)) {
 		$gpsbaud = $speeds[$config['ntpd']['gps']['speed']];
 	}
 
 	/* Configure the serial port for raw IO and set the speed */
+	mwexec("stty -f {$serialport} raw speed {$gpsbaud}");
 	mwexec("stty -f {$serialport}.init raw speed {$gpsbaud}");
 
 	$autospeed = ($config['ntpd']['gps']['speed'] == 'autoalways' || $config['ntpd']['gps']['speed'] == 'autoset');
 	if($autospeed || ($config['ntpd']['gps']['autobaudinit'] && !check_gps_speed($gps_device))) {
 		$found = false;
 		foreach ($speeds as $baud) {
+			mwexec("stty -f {$serialport} raw speed {$baud}");
 			mwexec("stty -f {$serialport}.init raw speed {$baud}");
 			if($found = check_gps_speed($gps_device)) {
 				if($autospeed) {
@@ -1707,6 +1715,7 @@ function system_ntp_setup_gps($serialport) {
 	@file_put_contents($gps_device, $gps_init);
 
 	if ($found && $config['ntpd']['gps']['autobaudinit']) {
+		mwexec("stty -f {$serialport} raw speed {$gpsbaud}");
 		mwexec("stty -f {$serialport}.init raw speed {$gpsbaud}");
 	}
 

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1721,8 +1721,8 @@ function system_ntp_setup_gps($serialport) {
 	}
 
 	/* Remove old /etc/remote entry if it exists */
-	if (intval(`grep -c "^gps0" /etc/remote`) != 0) {
-		mwexec("sed -i '' -n '/gps0/!p' /etc/remote");
+	if (intval(`/usr/bin/grep -c "^gps0" /etc/remote`) != 0) {
+		mwexec("/usr/bin/sed -i '' -n '/gps0/!p' /etc/remote");
 	}
 
 	/* Add /etc/remote entry in case we need to read from the GPS with tip */

--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -392,7 +392,7 @@ if (!empty($serialports)) {
 		null,
 		'Check baud rate before sending init commands (default: unchecked).',
 		$pconfig['autobaudinit']
-		))->setHelp('Before sending the initialization commands, check the baud rate is correct. If it is not correct try to find the correct baud rate automatically, send the initialization commands if the correct rate is found, and then set the baud rate to the configured speed.%1$s' . 'This is useful if the GPS device resets back to a default rate on power loss or when changing the baud rate.', '<br /><br />');
+		))->setHelp('Before sending the initialization commands, check the GPS baud rate. If it is not correct try to find the correct baud rate automatically, send the initialization commands if the correct rate is found, and then set the baud rate to the configured speed.%1$s' . 'This is useful if the GPS device resets back to a default rate on power loss or when changing the baud rate.', '<br /><br />');
 }
 
 $nmealist = build_nmea_list();

--- a/src/usr/local/www/services_ntpd_gps.php
+++ b/src/usr/local/www/services_ntpd_gps.php
@@ -164,8 +164,17 @@ if ($_POST) {
 
 	if (!empty($_POST['gpsspeed'])) {
 		$config['ntpd']['gps']['speed'] = $_POST['gpsspeed'];
+		if($_POST['gpsspeed'] == 'autoalways') {
+			$fixghost = true;
+		}
 	} elseif (isset($config['ntpd']['gps']['speed'])) {
 		unset($config['ntpd']['gps']['speed']);
+	}
+	
+	if (!empty($_POST['autobaudinit'])) {
+		$config['ntpd']['gps']['autobaudinit'] = $_POST['autobaudinit'];
+	} elseif (isset($config['ntpd']['gps']['autobaudinit'])) {
+		unset($config['ntpd']['gps']['autobaudinit']);
 	}
 
 	if (!empty($_POST['gpsnmea']) && ($_POST['gpsnmea'][0] === "0")) {
@@ -275,6 +284,9 @@ if ($_POST) {
 	$changes_applied = true;
 	$retval = 0;
 	$retval |= system_ntp_configure();
+	if ($fixghost) {
+		$config['ntpd']['gps']['speed'] = 'autoalways';
+	}
 } else {
 	/* set defaults if they do not already exist */
 	if (!is_array($config['ntpd']) || !is_array($config['ntpd']['gps']) || empty($config['ntpd']['gps']['type'])) {
@@ -368,10 +380,19 @@ if (!empty($serialports)) {
 		'gpsspeed',
 		null,
 		$pconfig['speed'],
-		[0 => '4800', 16 => '9600', 32 => '19200', 48 => '38400', 64 => '57600', 80 => '115200']
+		[0 => '4800', 16 => '9600', 32 => '19200', 48 => '38400', 64 => '57600', 80 => '115200', 'autoset' => 'Autoset', 'autoalways' => 'Always Auto']
 
 	))->setHelp('A higher baud rate is generally only helpful if the GPS is sending too many sentences. ' .
-				'It is recommended to configure the GPS to send only one sentence at a baud rate of 4800 or 9600.');
+				'It is recommended to configure the GPS to send only one sentence at a baud rate of 4800 or 9600.%1$s' .
+				'Autoset tries to find the correct baud rate of the GPS device and then saves the configuration.%1$s' .
+				'Always Auto tries to find the correct baud rate of the GPS device every time NTPd is started.', '<br /><br />');
+	
+	$section->addInput(new Form_Checkbox(
+		'autobaudinit',
+		null,
+		'Check baud rate before sending init commands (default: unchecked).',
+		$pconfig['autobaudinit']
+		))->setHelp('Before sending the initialization commands, check the baud rate is correct. If it is not correct try to find the correct baud rate automatically, send the initialization commands if the correct rate is found, and then set the baud rate to the configured speed.%1$s' . 'This is useful if the GPS device resets back to a default rate on power loss or when changing the baud rate.', '<br /><br />');
 }
 
 $nmealist = build_nmea_list();
@@ -603,6 +624,7 @@ events.push(function() {
 		$('#gpsnmea').val(0);
 		$('#processpgrmf').prop('checked', false);
 		$('#gpsspeed').val(0);
+		$('#autobaudinit').prop('checked', false);
 		$('#gpsfudge1').val(0);
 		$('#gpsinitcmd').val(get_gps_string(type));
 


### PR DESCRIPTION
- Adds option to check the baud rate before sending the initialization commands and tries auto correcting the baud rate, after sending the init commands it reloads the configured baud rate.
- Adds option to try to find the correct baud rate automatically and save the configuration.
- Adds option to try to find the correct baud rate automatically every time NTPd is started.