### PR TITLE
Captive portal: fix disconnect all button in 2.3.3

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -1017,6 +1017,7 @@ function captiveportal_disconnect_all($term_cause = 6, $logoutReason = "DISCONNE
 	}
 
 	/* reinit ipfw rules */
+	mwexec("/sbin/ipfw zone {$cpzoneid} destroy", true);
 	captiveportal_init_rules(true);
 
 	unlock($cpdblck);


### PR DESCRIPTION
Release 2.3.3 cherry-picked from master the commits that added the "Disconnect All Users" button to the captive portal status page, including 47f967856ef25557d87430026e8b208a8852381f. That commit works in master because captiveportal_init_rules() calls captiveportal_delete_rules() to remove the existing rules before adding the new ones.

Unfortunately captiveportal_init_rules() in 2.3 doesn't do that, so the users are apparently disconnected but they can still access the internet and the rules that allow that will never be removed unless the captive portal is disabled and enabled again.

The commit in this PR deletes the rules in captiveportal_disconnect_all() before re-initializing the captive portal. In alternative, captiveportal_init_rules() could be fixed to match the 2.4 behaviour, adding the same line before loading the new set of rules (around line 627).