### PR TITLE
Do not waste limited menu space (Bug #7238), add User Actions menu (Change password, Logout)

### DIFF
--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -398,10 +398,6 @@ $diagnostics_menu[] = array(gettext("Packet Capture"), "/diag_packet_capture.php
 
 $diagnostics_menu = msort(array_merge($diagnostics_menu, return_ext_menu("Diagnostics")), 0);
 
-$gold_menu = array();
-$gold_menu[] = array(gettext("pfSense Gold"), "https://www.pfsense.org/gold");
-$gold_menu = msort(array_merge($gold_menu, return_ext_menu("Gold")), 0);
-
 if (!$g['disablehelpmenu']) {
 	$help_menu = array();
 	$help_menu[] = array(gettext("About this Page"), $helpurl);
@@ -413,6 +409,7 @@ if (!$g['disablehelpmenu']) {
 	$help_menu[] = array(gettext("Documentation"), "https://www.pfsense.org/j.php?jumpto=doc");
 	$help_menu[] = array(gettext("Paid Support"), "https://www.pfsense.org/j.php?jumpto=portal");
 	$help_menu[] = array(gettext("pfSense Book"), "https://www.pfsense.org/j.php?jumpto=book");
+	$help_menu[] = array(gettext("pfSense Gold"), "https://www.pfsense.org/gold");
 	$help_menu[] = array(gettext("FreeBSD Handbook"), "https://www.pfsense.org/j.php?jumpto=fbsdhandbook");
 	$help_menu = msort(array_merge($help_menu, return_ext_menu("Help")), 0);
 }
@@ -475,7 +472,6 @@ if (are_notices_pending()) {
 					['name' => 'VPN',		     'menu' => $vpn_menu,		  'href' => null],
 					['name' => 'Status',	     'menu' => $status_menu,	  'href' => null],
 					['name' => 'Diagnostics',    'menu' => $diagnostics_menu, 'href' => null],
-					['name' => 'Gold',		     'menu' => $gold_menu,		  'href' => '_blank'],
                     ['name' => $help_menu_title, 'menu' => $help_menu,		  'href' => '_blank']
 				] as $item):
 					if ($item['name'] == 'Help' && $g['disablehelpmenu']) {

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -426,7 +426,7 @@ foreach ($config['system']['user'] as $user) {
 if ($islocal === true) {
 	$actions_menu[] = array(gettext("Change Password"), "/system_usermanager_passwordmg.php");
 }
-$actions_menu[] = array(gettext("Logout") . " (" . $_SESSION['Username'] . "@" . htmlspecialchars($system_url) . ")");
+$actions_menu[] = array(gettext("Logout") . " (" . $_SESSION['Username'] . "@" . htmlspecialchars($system_url) . ")", "/index.php?logout");
 $actions_menu = msort(array_merge($actions_menu, return_ext_menu("User Actions")), 0);
 
 $menuclass = "static";

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -414,6 +414,21 @@ if (!$g['disablehelpmenu']) {
 	$help_menu = msort(array_merge($help_menu, return_ext_menu("Help")), 0);
 }
 
+// User Actions
+$actions_menu = array();
+/* determine if user is local to system */
+$islocal = false;
+foreach ($config['system']['user'] as $user) {
+        if ($user['name'] == $_SESSION['Username']) {
+                $islocal = true;
+        }
+}
+if ($islocal === true) {
+	$actions_menu[] = array(gettext("Change Password"), "/system_usermanager_passwordmg.php");
+}
+$actions_menu[] = array(gettext("Logout") . " (" . $_SESSION['Username'] . "@" . htmlspecialchars($system_url) . ")");
+$actions_menu = msort(array_merge($actions_menu, return_ext_menu("User Actions")), 0);
+
 $menuclass = "static";
 
 if ($user_settings['webgui']['webguifixedmenu'] == "fixed") {
@@ -507,9 +522,10 @@ if (are_notices_pending()) {
 					endif;
 				?>
 					<li class="dropdown">
-						<a href="/index.php?logout" usepost>
-							<i class="fa fa-sign-out" title="<?=gettext("Logout") . " (" . $_SESSION['Username'] . "@" . htmlspecialchars($system_url) . ")"?>"></i>
-						</a>
+					<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+						<i class="fa fa-user" title="<?=gettext("User Actions")?>"></i>
+						<span class="caret"></span>
+					<ul class="dropdown-menu" role="menu"><?=output_menu($actions_menu, $actions_menu['href'], "User Actions");?></ul>
 					</li>
 			</ul>
 		</div>


### PR DESCRIPTION
1/ Shuffle "Gold" under "Help" menu.
2/ While here, I changed the "Logout" button to a dropdown and added a link to "Change Password" for local users.

(It'd be possible to add things like Reboot and Halt there as well - which are currently buried in stupid counter-intuitive places IMNSHO, but that discussion did not lead to anything productive last time I tried, so I skipped that - see https://redmine.pfsense.org/issues/6884). If pfSense guys changed their mind meanwhile, it's simply a matter of adding two lines:

```
$actions_menu[] = array(gettext("Halt System"), "/diag_halt.php");
$actions_menu[] = array(gettext("Reboot"), "/diag_reboot.php");
```
