### PR TITLE
Only start dhcpleases if DHCP server is enabled (Bug #6750)

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -570,12 +570,15 @@ function system_hosts_generate() {
 
 function system_dhcpleases_configure() {
 	global $config, $g;
-
+	if (!function_exists('is_dhcp_server_enabled')) {
+		require_once('pfsense-utils.inc');
+	}
 	$pidfile = "{$g['varrun_path']}/dhcpleases.pid";
 
 	/* Start the monitoring process for dynamic dhcpclients. */
-	if ((isset($config['dnsmasq']['enable']) && isset($config['dnsmasq']['regdhcp'])) ||
-	    (isset($config['unbound']['enable']) && isset($config['unbound']['regdhcp']))) {
+	if (((isset($config['dnsmasq']['enable']) && isset($config['dnsmasq']['regdhcp'])) ||
+	    (isset($config['unbound']['enable']) && isset($config['unbound']['regdhcp']))) &&
+	    (is_dhcp_server_enabled())) {
 		/* Make sure we do not error out */
 		mwexec("/bin/mkdir -p {$g['dhcpd_chroot_path']}/var/db");
 		if (!file_exists("{$g['dhcpd_chroot_path']}/var/db/dhcpd.leases")) {

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -417,6 +417,16 @@ if (isset($_POST['save'])) {
 		$input_errors[] = sprintf(gettext("The DHCP relay on the %s interface must be disabled before enabling the DHCP server."), $iflist[$if]);
 	}
 
+	/* If disabling DHCP Server, make sure that DHCP registration isn't enabled for DNS forwarder/resolver */
+	if (!$_POST['enable']) {
+		if (isset($config['dnsmasq']['enable']) && (isset($config['dnsmasq']['regdhcp']) || isset($config['dnsmasq']['regdhcpstatic']) || isset($config['dnsmasq']['dhcpfirst']))) {
+			$input_errors[] = gettext("Disable DHCP Registration features in DNS Forwarder before disabling DHCP Server.");
+		}
+		if (isset($config['unbound']['enable']) && (isset($config['unbound']['regdhcp']) || isset($config['unbound']['regdhcpstatic']))) {
+			$input_errors[] = gettext("Disable DHCP Registration features in DNS Resolver before disabling DHCP Server.");
+		}
+	}
+
 	// If nothing is wrong so far, and we have range from and to, then check conditions related to the values of range from and to.
 	if (!$input_errors && $_POST['range_from'] && $_POST['range_to']) {
 		/* make sure the range lies within the current subnet */

--- a/src/usr/local/www/services_dnsmasq.php
+++ b/src/usr/local/www/services_dnsmasq.php
@@ -34,6 +34,7 @@
 require_once("guiconfig.inc");
 require_once("functions.inc");
 require_once("filter.inc");
+require_once("pfsense-utils.inc");
 require_once("shaper.inc");
 require_once("system.inc");
 
@@ -145,6 +146,10 @@ if ($_POST['save']) {
 		if ($_POST['port'] == $config['unbound']['port']) {
 			$input_errors[] = gettext("The DNS Resolver is enabled using this port. Choose a non-conflicting port, or disable DNS Resolver.");
 		}
+	}
+
+	if ((isset($_POST['regdhcp']) || isset($_POST['regdhcpstatic']) || isset($_POST['dhcpfirst'])) && !is_dhcp_server_enabled()) {
+		$input_errors[] = gettext("DHCP Server must be enabled for DHCP Registration to work in DNS Forwarder.");
 	}
 
 	if ($_POST['port']) {

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -29,6 +29,7 @@
 
 require_once("guiconfig.inc");
 require_once("unbound.inc");
+require_once("pfsense-utils.inc");
 require_once("system.inc");
 
 if (!is_array($config['unbound'])) {
@@ -151,6 +152,10 @@ if ($_POST['save']) {
 	if (is_array($pconfig['active_interface']) && !empty($pconfig['active_interface'])) {
 		$display_active_interface = $pconfig['active_interface'];
 		$pconfig['active_interface'] = implode(",", $pconfig['active_interface']);
+	}
+
+	if ((isset($pconfig['regdhcp']) || isset($pconfig['regdhcpstatic'])) && !is_dhcp_server_enabled()) {
+		$input_errors[] = gettext("DHCP Server must be enabled for DHCP Registration to work in DNS Resolver.");
 	}
 
 	$display_custom_options = $pconfig['custom_options'];


### PR DESCRIPTION
As noted on the bug, it doesn't make sense to have a process watch a lease file that will never be populated because dhcpd isn't running. Also, enabling DHCP-related options in forwarder/resolver should only be allowed when we are actually using DHCP server on pfSense.