### PR TITLE
Fix #7294 keep full rule description

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -102,6 +102,8 @@ $icmptypes = array(
 define("ANTILOCKOUT_TRACKER", 10000);
 define("BOGONS_TRACKER", 11000);
 define("RFC1918_TRACKER", 12000);
+define("PFLABEL_MAXLEN", 63);
+define("USER_LABEL_INTRO", "USER_RULE: ");
 
 $tracker = 1000000000;
 $negate_tracker = 10000000;
@@ -119,10 +121,15 @@ function filter_negaterule_tracker() {
         return "tracker {$negate_tracker} ";
 }
 
+function user_rule_descr_maxlen() {
+	return PFLABEL_MAXLEN - strlen(USER_LABEL_INTRO);
+}
+
 function fix_rule_label($descr) {
 	$descr = str_replace('"', '', $descr);
-	if (strlen($descr) > 63) {
-		return substr($descr, 0, 60) . "...";
+	if (strlen($descr) > PFLABEL_MAXLEN) {
+		$dots = "...";
+		return substr($descr, 0, PFLABEL_MAXLEN - strlen($dots)) . $dots;
 	} else {
 		return $descr;
 	}
@@ -2374,7 +2381,7 @@ function filter_generate_user_rule_arr($rule) {
 	$ret['rule'] = $line;
 	$ret['interface'] = $rule['interface'];
 	if ($rule['descr'] != "" and $line != "") {
-		$ret['descr'] = "label \"" . fix_rule_label("USER_RULE: {$rule['descr']}") . "\"";
+		$ret['descr'] = "label \"" . fix_rule_label(USER_LABEL_INTRO . "{$rule['descr']}") . "\"";
 	} else {
 		$ret['descr'] = "label \"USER_RULE\"";
 	}

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -876,7 +876,8 @@ if ($_POST['save']) {
 		} else {
 			unset($filterent['log']);
 		}
-		strncpy($filterent['descr'], $_POST['descr'], 52);
+
+		$filterent['descr'] = trim($_POST['descr']);
 
 		if ($_POST['gateway'] != "") {
 			$filterent['gateway'] = $_POST['gateway'];
@@ -1455,7 +1456,9 @@ $section->addInput(new Form_Input(
 	'Description',
 	'text',
 	$pconfig['descr']
-))->setHelp('A description may be entered here for administrative reference.');
+))->setHelp('A description may be entered here for administrative reference. ' .
+	'A maximum of %s characters will be used in the ruleset and displayed in the firewall log.',
+	user_rule_descr_maxlen());
 
 $btnadv = new Form_Button(
 	'btnadvopts',


### PR DESCRIPTION
- Store the full rule description in the config, so it can be seen in the rule list
- Trim the rule description, seemed a shame to store accidental spaces at the end (or start)
- Add setHelp text to let the user know up to how many characters can be passed through to the ruleset and thus seen in the firewall log
- Refactor a bit of stuff so the magic number 63 and "USER_RULE: " can be defined just once and then used wherever needed.