### PR TITLE
Fix #7299 Old rules with ICMP types

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2788,6 +2788,9 @@ function filter_generate_user_rule($rule) {
 		$icmptype_key = ($rule['ipprotocol'] == 'inet6' ? 'icmp6-type' : 'icmp-type');
 		$icmptype_text = (strpos($rule['icmptype'], ",") === false ? $rule['icmptype'] : '{ ' . $rule['icmptype'] . ' }');
 		$aline[$icmptype_key] = "{$icmptype_key} {$icmptype_text} ";
+		if ($rule['ipprotocol'] == '') {
+			$aline['ipprotocol'] = 'inet';
+		}
 	}
 	
 	if (!empty($rule['tag'])) {


### PR DESCRIPTION
This is a minimal patch to just make sure that when there are ICMP types, the 'ipprotocol' gets set to 'inet' if it is not specified in the rule.

It fixes the reported behavior that I managed to reproduce in 2.3.3 - so the patch needs to be back-ported there.