### PR TITLE
Fix #7299 and other stuff

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2678,7 +2678,7 @@ function filter_generate_user_rule($rule) {
 			$aline['ipprotocol'] = "inet6";
 			break;
 		default:
-			$aline['ipprotocol'] = "";
+			$aline['ipprotocol'] = "inet";
 			break;
 	}
 


### PR DESCRIPTION
As far as I can see, filter_generate_user_rule() is always supposed to be called with 'ipprotocol' set to 'inet' or 'inet6'. The cases of rules for both ('inet46') are handled by calling filter_generate_user_rule() twice, passing 'inet' then 'inet6'.

So at this point, if 'ipprotocol' is blank, then it is from an old rule, and it [can|should|must] default to 'inet'.

This would provide a generic fix for old rules that do not have 'ipprotocol' specified.

The other thing that could be done is make some upgrade code that fills in 'ipprotocol' on old rules at upgrade.