### PR TITLE
Fix #7300 provide default value for ipprotocol for old rules

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -194,6 +194,8 @@ if (isset($id) && $a_filter[$id]) {
 
 	if (isset($a_filter[$id]['ipprotocol'])) {
 		$pconfig['ipprotocol'] = $a_filter[$id]['ipprotocol'];
+	} else {
+		$pconfig['ipprotocol'] = 'inet';
 	}
 
 	if (isset($a_filter[$id]['protocol'])) {


### PR DESCRIPTION
An alternative is to provide upgrade code that adds the 'ipprotocol' = 'inet' tag to old rules, so that there are no longer any old rules around that are missing this field.