### PR TITLE
Redmine #7301 Provide word-break opportunity for dynamic DNS host names

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -439,6 +439,10 @@ function pprint_port($port) {
 	return $pport;
 }
 
+function insert_word_breaks_in_domain_name($domain_name) {
+	return str_replace('.', '.<wbr>', $domain_name);
+}
+
 function firewall_check_for_advanced_options(&$item) {
 	$item_set = "";
 	if ($item['os']) {

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -440,7 +440,7 @@ function pprint_port($port) {
 }
 
 function insert_word_breaks_in_domain_name($domain_name) {
-	return str_replace('.', '.<wbr>', $domain_name);
+	return str_replace('.', '<wbr>.', $domain_name);
 }
 
 function firewall_check_for_advanced_options(&$item) {

--- a/src/usr/local/www/services_dyndns.php
+++ b/src/usr/local/www/services_dyndns.php
@@ -142,7 +142,7 @@ foreach ($a_dyndns as $dyndns):
 							</td>
 							<td>
 <?php
-	print(htmlspecialchars($hostname));
+	print(insert_word_breaks_in_domain_name(htmlspecialchars($hostname)));
 ?>
 							</td>
 							<td>

--- a/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
@@ -197,7 +197,7 @@ function get_dyndns_service_text($dyndns_type) {
 		<?=htmlspecialchars(get_dyndns_service_text($dyndns['type']));?>
 		</td>
 		<td>
-		<?=htmlspecialchars(get_dyndns_hostname_text($dyndns));?>
+		<?=insert_word_breaks_in_domain_name(htmlspecialchars(get_dyndns_hostname_text($dyndns)));?>
 		</td>
 		<td>
 		<div id="dyndnsstatus<?= $rowid;?>"><?= gettext("Checking ...");?></div>


### PR DESCRIPTION
This can later also be extended very easily to places like firewall_aliases.php etc that show full host/domain FQDN names in a column.

And it is easily modified in 1 place if we want to also break on any other characters that might be convenient.