### PR TITLE
Captive portal: add a captive portal detection bypass feature

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1338,6 +1338,7 @@ function system_generate_nginx_config($filename,
 	if ($captive_portal !== false) {
 		$cp_interfaces = explode(",", $config['captiveportal'][$captive_portal]['interface']);
 		$cp_hostcheck = "";
+		$cp_bypass = "";
 		foreach ($cp_interfaces as $cpint) {
 			$cpint_ip = get_interface_ip($cpint);
 			if (is_ipaddr($cpint_ip)) {
@@ -1345,6 +1346,25 @@ function system_generate_nginx_config($filename,
 				$cp_hostcheck .= "\t\t\tset \$cp_redirect no;\n";
 				$cp_hostcheck .= "\t\t}\n";
 			}
+		}
+		if (isset($config['captiveportal'][$captive_portal]['bypass_android'])) {
+			$cp_bypass .= "\t\tif (\$http_host ~* connectivitycheck.gstatic.com) {\n";
+			$cp_bypass .= "\t\t\treturn 204;\n";
+			$cp_bypass .= "\t\t}\n";
+			$cp_bypass .= "\t\tif (\$http_host ~* connectivitycheck.android.com) {\n";
+			$cp_bypass .= "\t\t\treturn 204;\n";
+			$cp_bypass .= "\t\t}\n";
+			$cp_bypass .= "\t\tif (\$http_host ~* clients3.google.com) {\n";
+			$cp_bypass .= "\t\t\treturn 204;\n";
+			$cp_bypass .= "\t\t}\n";
+			$cp_bypass .= "\t\tif (\$request_uri ~* generate_204$) {\n";
+			$cp_bypass .= "\t\t\treturn 204;\n";
+			$cp_bypass .= "\t\t}\n";
+		}
+		if (isset($config['captiveportal'][$captive_portal]['bypass_ios'])) {
+			$cp_bypass .= "\t\tif (\$http_user_agent ~* ^CaptiveNetworkSupport.*wispr$) {\n";
+			$cp_bypass .= "\t\t\treturn 200 \"<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>\";\n";
+			$cp_bypass .= "\t\t}\n";
 		}
 		if (isset($config['captiveportal'][$captive_portal]['httpsname']) &&
 		    is_domain($config['captiveportal'][$captive_portal]['httpsname'])) {
@@ -1474,6 +1494,7 @@ EOD;
 		$nginx_config .= <<<EOD
 $captive_portal_maxprocperip
 $cp_hostcheck
+$cp_bypass
 $cp_rewrite
 		log_not_found off;
 

--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -167,6 +167,8 @@ if ($a_cp[$cpzone]) {
 	$pconfig['bwdefaultdn'] = $a_cp[$cpzone]['bwdefaultdn'];
 	$pconfig['bwdefaultup'] = $a_cp[$cpzone]['bwdefaultup'];
 	$pconfig['nomacfilter'] = isset($a_cp[$cpzone]['nomacfilter']);
+	$pconfig['bypass_android'] = isset($a_cp[$cpzone]['bypass_android']);
+	$pconfig['bypass_ios'] = isset($a_cp[$cpzone]['bypass_ios']);
 	$pconfig['noconcurrentlogins'] = isset($a_cp[$cpzone]['noconcurrentlogins']);
 	$pconfig['radius_protocol'] = $a_cp[$cpzone]['radius_protocol'];
 	$pconfig['redirurl'] = $a_cp[$cpzone]['redirurl'];
@@ -387,6 +389,8 @@ if ($_POST['save']) {
 		} else {
 			unset($newcp['bwdefaultup']);
 		}
+		$newcp['bypass_android'] = $_POST['bypass_android'] ? true : false;
+		$newcp['bypass_ios'] = $_POST['bypass_ios'] ? true : false;
 		$newcp['certref'] = $_POST['certref'];
 		$newcp['nohttpsforwards'] = $_POST['nohttpsforwards'] ? true : false;
 		$newcp['logoutwin_enable'] = $_POST['logoutwin_enable'] ? true : false;
@@ -600,6 +604,28 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['logoutwin_enable']
 ))->setHelp('If enabled, a popup window will appear when clients are allowed through the captive portal. ' .
 			'This allows clients to explicitly disconnect themselves before the idle or hard timeout occurs.');
+
+$group = new Form_Group('Captive portal detection bypass');
+$group->addClass("bypass");
+
+$group->add(new Form_Checkbox(
+        'bypass_android',
+        null,
+        'Android',
+        $pconfig['bypass_android']
+));
+
+$group->add(new Form_Checkbox(
+        'bypass_ios',
+        null,
+        'iOS',
+        $pconfig['bypass_ios']
+));
+
+$group->setHelp('When captive portal detection bypass is enabled, the users\' devices will not be able to detect the presence of a captive portal ' .
+			'and the users will need to login launching a full-fledged browser instead of using the reduced-function pop-up window.' .
+			'The feature can be enabled independently for iOS and Android devices.');
+$section->add($group);
 
 $section->addInput(new Form_Input(
 	'preauthurl',
@@ -1237,6 +1263,7 @@ events.push(function() {
 		hideCheckbox('peruserbw', hide);
 		hideInput('bwdefaultdn', hide);
 		hideInput('bwdefaultup', hide);
+		hideClass("bypass", hide);
 	}
 
 	// ---------- Click checkbox handlers ---------------------------------------------------------


### PR DESCRIPTION
Both Android and iOS include a captive portal detection feature that's supposed to help users notice immediately when they're using a network that requires authenticating on a captive portal. The rationale of this feature is that captive portals assume the user will use a browser and be intercepted and redirected to the login page, but, especially on mobile devices, the browser is just one of many apps running, and it's likely that the user will not launch it at all. If this happens every connection will be blocked, background apps will not be able to connect to the internet and pretty much everything (mail synchronization, social media apps, instant messaging, notifications) will silently stop functioning.

The basic mechanism of a detection feature is simple: the device tries to connect to well-known services that always return well-known results; if the device receives what it's expecting, it assumes the internet connection is working: if it gets anything else it opens a pop-up with a browser that gets duly intercepted and redirected to the captive portal login page, allowing the user to input his credentials and gain access, or to leave the network.

The pop-up window used to be an instance of the system browser, but starting with iOS 7 and Android 5 it relies on a reduced-function browser; in both Android and iOS the CNA/NPD browsers don't support JavaScript and cookies, can't access information stored on the device, including saved password, can't open links on new windows or panes of the system browser, etc. The Android implementation has even more restrictions: the pop-up window doesn't allow special links to open in other apps (for example the Play Store) and as soon as the device detects a working connection (using the method described above) the pop-up window is automatically closed.

While the feature as it is implemented works well enough in most cases, its limitations can still be a problem: for example it's very hard if not impossible to implement authentication via third party services (OAuth, Facebook, etc. etc.) on the limited-function browser, and, on Android, to show the user useful information via a post-authentication landing page (the NPD browser is closed too soon) or directing him to the Play Store to download an app. These issues have been noticed and reported several times (https://code.google.com/p/android/issues/detail?id=173980 for example), but a solution is not forthcoming, so several vendors who provide captive portal features implemented mechanisms to work around the problems, preventing the device from detecting the presence of a captive portal so that the user can login using the full-fledged system browser. Cisco (http://www.cisco.com/c/en/us/td/docs/wireless/controller/7-4/configuration/guides/consolidated/b_cg74_CONSOLIDATED/b_cg74_CONSOLIDATED_chapter_01010101.html), Aruba (https://community.arubanetworks.com/t5/Controller-Based-WLANs/Apple-iOS7-Captive-Network-Assistant-bypass-with-controller/ta-p/181094) and Ruckus (https://support.ruckuswireless.com/answers/000002368), for example, are among these vendors.

This PR implements a similar feature on the captive portal. It's been tested on Android 4.2-7 and iOS 10, and with captive portal bypass enabled the devices never show the pop-up CNA/NPD window. Since the iOS CNA browser is a lot more functional than the Android NPD's one, the bypass feature can be enabled for each OS independently from the other. The behavior of the CNA/NPD feature is little documented if not completely undocumented, so it's possible that future releases will need tweaks, though the basic mechanism hasn't changed in a while.




