### PR TITLE
Fix #7306 Correctly filter log widget entries by interface description

### DIFF
--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -71,6 +71,8 @@ if ($_POST) {
 	exit(0);
 }
 
+$iface_descr_arr = get_configured_interface_with_descr();
+
 $nentries = isset($user_settings['widgets']['filterlogentries']) ? $user_settings['widgets']['filterlogentries'] : 5;
 
 //set variables for log
@@ -79,7 +81,7 @@ $nentriesinterfaces = isset($user_settings['widgets']['filterlogentriesinterface
 
 $filterfieldsarray = array(
 	"act" => $nentriesacts,
-	"interface" => $nentriesinterfaces
+	"interface" => isset($iface_descr_arr[$nentriesinterfaces]) ? $iface_descr_arr[$nentriesinterfaces] : $nentriesinterfaces
 );
 
 $nentriesinterval = isset($user_settings['widgets']['filterlogentriesinterval']) ? $user_settings['widgets']['filterlogentriesinterval'] : 60;
@@ -240,7 +242,7 @@ $pconfig['nentriesinterval'] = isset($user_settings['widgets']['filterlogentries
 			</label>
 			<div class="col-sm-6 checkbox">
 				<select name="filterlogentriesinterfaces" id="filterlogentriesinterfaces" class="form-control">
-			<?php foreach (array("All" => "ALL") + get_configured_interface_with_descr() as $iface => $ifacename):?>
+			<?php foreach (array("All" => "ALL") + $iface_descr_arr as $iface => $ifacename):?>
 				<option value="<?=$iface?>"
 						<?=($nentriesinterfaces==$iface?'selected':'')?>><?=htmlspecialchars($ifacename)?></option>
 			<?php endforeach;?>


### PR DESCRIPTION
conv_log_filter() needs to be passed the interface description "MYLAN", "MYEXTRAIFACE" or whatever rather than the internal interface name "lan", "opt1" etc.

It all works fine when these have not been changed from the defaults (passing "LAN", "OPT1"... is fine). But not when the interface description has been modified.