### PR TITLE
Remove unused ntpWidgetUpdateFromServer() from NTP widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/ntp_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/ntp_status.widget.php
@@ -197,27 +197,6 @@ if ($_REQUEST['updateme']) {
 
 <script type="text/javascript">
 //<![CDATA[
-function ntpWidgetUpdateFromServer() {
-	$.ajax({
-		type: 'get',
-		url: '/widgets/widgets/ntp_status.widget.php',
-		dataFilter: function(raw){
-			// We reload the entire widget, strip this block of javascript from it
-			return raw.replace(/<script>([\s\S]*)<\/script>/gi, '');
-		},
-		dataType: 'html',
-		success: function(data){
-			console.log(data);
-			$('#ntp_status_widget').html(data);
-		}
-	});
-}
-
-//]]>
-</script>
-
-<script type="text/javascript">
-//<![CDATA[
 var d = new Date('<?=date_format(date_create(), 'c')?>');
 var tz = '<?=date('T');?>';
 


### PR DESCRIPTION
I don;t see where this is used at all. Nothing seems to break if I remove it.