### PR TITLE
Fix the pkg_call() and set the timeout to a sane value (Bug #6594)

### DIFF
--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -140,7 +140,7 @@ function pkg_call($params, $mute = false, $extra_env = array()) {
 	stream_set_blocking($pipes[2], 0);
 
 	/* XXX: should be a tunnable? */
-	$timeout = 300; // seconds
+	$timeout = 60; // seconds
 	$error_log = '';
 
 	do {
@@ -148,7 +148,7 @@ function pkg_call($params, $mute = false, $extra_env = array()) {
 		$read = array($pipes[1], $pipes[2]);
 		$except = array();
 
-		$stream = stream_select($read, $write, $except, null, $timeout);
+		$stream = stream_select($read, $write, $except, $timeout);
 		if ($stream !== FALSE && $stream > 0) {
 			foreach ($read as $pipe) {
 				$content = stream_get_contents($pipe);


### PR DESCRIPTION
What was the idea here?! http://php.net/manual/en/function.stream-select.php
```int stream_select (array &$read, array &$write, array &$except, int $tv_sec [, int $tv_usec = 0 ])```

If ```tv_sec``` is NULL ```stream_select()``` can *block indefinitely*, returning only when an event on one of the watched streams occurs (or if a signal interrupts the system call). So, that original 300 sure like hell is not 300 seconds (as suggested by the comment on line 143). This thing will basically never timeout as is.