### PR TITLE
Update BIND zones when adding static DHCP leases if needed (Bug #3710)

### DIFF
--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -652,6 +652,7 @@ if ((isset($_POST['save']) || isset($_POST['apply'])) && (!$input_errors)) {
 			$bindzone = array();
 		}
 		for ($x = 0; $x < sizeof($bindzone); $x++) {
+			$zone = $bindzone[$x];
 			if ($zone['regdhcpstatic'] == 'on') {
 				$reloadbind = true;
 				break;

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -640,6 +640,30 @@ if ((isset($_POST['save']) || isset($_POST['apply'])) && (!$input_errors)) {
 			clear_subsystem_dirty('staticmaps');
 		}
 	}
+	/* BIND package - Bug #3710 */
+	if (!function_exists('is_package_installed')) {
+		require_once('pkg-utils.inc');
+	}
+	if (is_package_installed('pfSense-pkg-bind') && isset($config['installedpackages']['bind']['config'][0]['enable_bind'])) {
+		$reloadbind = false;
+		if (is_array($config['installedpackages']['bindzone'])) {
+			$bindzone = $config['installedpackages']['bindzone']['config'];
+		} else {
+			$bindzone = array();
+		}
+		for ($x = 0; $x < sizeof($bindzone); $x++) {
+			if ($zone['regdhcpstatic'] == 'on') {
+				$reloadbind = true;
+				break;
+			}
+		}
+		if ($reloadbind === true) {
+			if (file_exists("/usr/local/pkg/bind.inc")) {
+				require_once("/usr/local/pkg/bind.inc");
+				bind_sync();
+			}
+		}
+	}
 	if ($dhcpd_enable_changed) {
 		$retvalfc |= filter_configure();
 	}

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -61,6 +61,30 @@ function dhcpv6_apply_changes($dhcpdv6_enable_changed) {
 			clear_subsystem_dirty('staticmaps');
 		}
 	}
+	/* BIND package - Bug #3710 */
+	if (!function_exists('is_package_installed')) {
+		require_once('pkg-utils.inc');
+	}
+	if (is_package_installed('pfSense-pkg-bind') && isset($config['installedpackages']['bind']['config'][0]['enable_bind'])) {
+		$reloadbind = false;
+		if (is_array($config['installedpackages']['bindzone'])) {
+			$bindzone = $config['installedpackages']['bindzone']['config'];
+		} else {
+			$bindzone = array();
+		}
+		for ($x = 0; $x < sizeof($bindzone); $x++) {
+			if ($zone['regdhcpstatic'] == 'on') {
+				$reloadbind = true;
+				break;
+			}
+		}
+		if ($reloadbind === true) {
+			if (file_exists("/usr/local/pkg/bind.inc")) {
+				require_once("/usr/local/pkg/bind.inc");
+				bind_sync();
+			}
+		}
+	}
 	if ($dhcpdv6_enable_changed) {
 		$retvalfc |= filter_configure();
 	}

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -73,6 +73,7 @@ function dhcpv6_apply_changes($dhcpdv6_enable_changed) {
 			$bindzone = array();
 		}
 		for ($x = 0; $x < sizeof($bindzone); $x++) {
+			$zone = $bindzone[$x];
 			if ($zone['regdhcpstatic'] == 'on') {
 				$reloadbind = true;
 				break;


### PR DESCRIPTION
Check whether pfSense-pkg-bind is installed (checking for bind itself is no good due to the whacky version-dependent package naming). If BIND is installed and enabled and DHCP static registration is enabled for any zone, resync BIND settings on saving DHCP(6) server configuration.