### PR TITLE
certificatemanager, link certificate to the proper CA after completing the CSR request

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -427,11 +427,9 @@ function csr_generate(& $cert, $keylen, $dn, $digest_alg = "sha256") {
 }
 
 function csr_complete(& $cert, $str_crt) {
-
-	// return our request information
-	$cert['crt'] = base64_encode($str_crt);
+	$str_key = base64_decode($cert['prv']);
+	cert_import($cert, $str_crt, $str_key);
 	unset($cert['csr']);
-
 	return true;
 }
 


### PR DESCRIPTION
certificatemanager, link certificate to the proper CA after completing the CSR request