### PR TITLE
Fix #7317 Widget Filter All button

### DIFF
--- a/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
@@ -279,7 +279,7 @@ function get_dyndns_service_text($dyndns_type) {
 	}
 	events.push(function(){
 		$("#showalldyndns").click(function() {
-			$("[id^=show]").each(function() {
+			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
 				$(this).prop("checked", true);
 			});
 		});

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -189,7 +189,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 
 	events.push(function(){
 		$("#showallgateways").click(function() {
-			$("[id^=show]").each(function() {
+			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
 				$(this).prop("checked", true);
 			});
 		});

--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -180,7 +180,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 
 	events.push(function(){
 		$("#showallinterfacesforstats").click(function() {
-			$("[id^=show]").each(function() {
+			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
 				$(this).prop("checked", true);
 			});
 		});

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -173,7 +173,7 @@ endforeach;
 //<![CDATA[
 	events.push(function(){
 		$("#showallinterfaces").click(function() {
-			$("[id^=show]").each(function() {
+			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
 				$(this).prop("checked", true);
 			});
 		});

--- a/src/usr/local/www/widgets/widgets/openvpn.widget.php
+++ b/src/usr/local/www/widgets/widgets/openvpn.widget.php
@@ -354,7 +354,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 
 	events.push(function(){
 		$("#showallovpns").click(function() {
-			$("[id^=show]").each(function() {
+			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
 				$(this).prop("checked", true);
 			});
 		});

--- a/src/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/services_status.widget.php
@@ -158,7 +158,7 @@ if (count($services) > 0) {
 //<![CDATA[
 	events.push(function(){
 		$("#showallservices").click(function() {
-			$("[id^=show]").each(function() {
+			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
 				$(this).prop("checked", true);
 			});
 		});

--- a/src/usr/local/www/widgets/widgets/smart_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/smart_status.widget.php
@@ -151,7 +151,7 @@ if (count($devs) > 0)  {
 //<![CDATA[
 	events.push(function(){
 		$("#showallsmartdrives").click(function() {
-			$("[id^=show]").each(function() {
+			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
 				$(this).prop("checked", true);
 			});
 		});

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -460,7 +460,7 @@ function updateMeters() {
 <?php if (!isset($config['system']['firmware']['disablecheck'])): ?>
 events.push(function(){
 	$("#showallsysinfoitems").click(function() {
-		$("[id^=show]").each(function() {
+		$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
 			$(this).prop("checked", true);
 		});
 	});

--- a/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
+++ b/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
@@ -174,7 +174,7 @@ if (is_array($config['dhcpd'])) {
 //<![CDATA[
 	events.push(function(){
 		$("#showallwols").click(function() {
-			$("[id^=show]").each(function() {
+			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
 				$(this).prop("checked", true);
 			});
 		});


### PR DESCRIPTION
Make the "All" button less enthusiastic about checking checkboxes. It should only check the selections related to its own widget.