### PR TITLE
use nameservers from active interface only

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -229,6 +229,22 @@ function system_resolvconf_generate($dynupdate = false) {
 
 	return 0;
 }
+function get_dns_glob_pattern() {
+       // names of interfaces to use dns settings from
+        $dns_interfaces = array();
+        $dns_glob_pattern = "*"; // default to using all interfaces
+
+        // get current gateway groups state
+        $gwgroups = return_gateway_groups_array();
+        foreach ($gwgroups as $group) {
+		if (count($group) > 0) {
+			$dns_interfaces[]=$group[0]['int']; // one active tier at a time
+		        // update the glob pattern,
+                        $dns_glob_pattern="{".implode(",",array_unique($dns_interfaces))."}";
+		}
+        }
+	return $dns_glob_pattern;
+}
 
 function get_searchdomains() {
 	global $config, $g;
@@ -236,7 +252,7 @@ function get_searchdomains() {
 	$master_list = array();
 
 	// Read in dhclient nameservers
-	$search_list = glob("/var/etc/searchdomain_*");
+	$search_list = glob("/var/etc/searchdomain_".get_dns_glob_pattern(), GLOB_BRACE);
 	if (is_array($search_list)) {
 		foreach ($search_list as $fdns) {
 			$contents = file($fdns, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
@@ -259,7 +275,7 @@ function get_nameservers() {
 	$master_list = array();
 
 	// Read in dhclient nameservers
-	$dns_lists = glob("/var/etc/nameserver_*");
+	$dns_lists = glob("/var/etc/nameserver_".get_dns_glob_pattern(), GLOB_BRACE);
 	if (is_array($dns_lists)) {
 		foreach ($dns_lists as $fdns) {
 			$contents = file($fdns, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);

--- a/src/etc/rc.gateway_alarm
+++ b/src/etc/rc.gateway_alarm
@@ -23,6 +23,7 @@ if [ -z "$GW" ]; then
 fi
 
 /usr/local/sbin/pfSctl \
+	-c "service reload dns" \
 	-c "service reload dyndns ${GW}" \
 	-c "service reload ipsecdns" \
 	-c "service reload openvpn ${GW}" \

--- a/src/etc/rc.newwanip
+++ b/src/etc/rc.newwanip
@@ -39,6 +39,9 @@ require_once("rrd.inc");
 function restart_packages() {
 	global $oldip, $curwanip, $g;
 
+	/* reload dns */
+	send_event("service reload dns");
+
 	/* restart packages */
 	log_error("{$g['product_name']} package system has detected an IP change or dynamic WAN reconnection - $oldip ->  $curwanip - Restarting packages.");
 	send_event("service reload packages");


### PR DESCRIPTION
Currently there doesn't seem to be a way to only use DNS servers assigned by the active tier ISP in a multi WAN setup.

Please see this forum thread for details
https://forum.pfsense.org/index.php?topic=126017.0

This patch updates the DNS configuration as gateway group state changes and fixes the issue described above. I did not have the opportunity for regression testing on other possible configurations.
