### PR TITLE
Show PPPoE/PPTP/L2TP uptime on the Interfaces widget (Feature #6032)

### DIFF
--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -104,7 +104,11 @@ foreach ($ifdescrs as $ifdescr => $ifname):
 			<?php endif; ?>
 		</td>
 		<td>
-			<?=htmlspecialchars($ifinfo['media']);?>
+			<?php if ($ifinfo['pppoelink'] == "up" || $ifinfo['pptplink']  == "up" || $ifinfo['l2tplink']  == "up"):?>
+				<?=sprintf(gettext("Uptime: %s"), htmlspecialchars($ifinfo['ppp_uptime']));?>
+			<?php else: ?>
+				<?=htmlspecialchars($ifinfo['media']);?>
+			<?php endif; ?>
 		</td>
 
 		<td <?=($ifinfo['dhcplink'] ? ' title="via dhcp"':'')?>>


### PR DESCRIPTION
Put the uptime in place of the non-existent media info in the widget for these types of interfaces.