### PR TITLE
Add config options to DNS Resolver that mitigate a bug w/ Unifi (and maybe others)

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -345,6 +345,8 @@ function system_hosts_local_entries() {
 
 /* Read host override entries from dnsmasq or unbound */
 function system_hosts_override_entries($dnscfg) {
+	global $config;
+	$syscfg = $config['system'];
 	$hosts = array();
 
 	if (!is_array($dnscfg) ||
@@ -358,11 +360,16 @@ function system_hosts_override_entries($dnscfg) {
 		if ($host['host'] || $host['host'] == "0") {
 			$fqdn .= "{$host['host']}.";
 		}
-		$fqdn .= $host['domain'];
-
+		if ($host['track_system_domain']) {
+			$fqdn .= $syscfg['domain'];
+		} else {
+			$fqdn .= $host['domain'];
+		}
 		$hosts[] = array(
 		    'ipaddr' => $host['ip'],
-		    'fqdn' => $fqdn
+		    'fqdn' => $fqdn,
+		    'name' => $host['host'],
+		    'add_unqualified' => $host['add_unqualified']
 		);
 
 		if (!is_array($host['aliases']) ||

--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -564,6 +564,9 @@ function unbound_add_host_entries($cfgsubdir = "") {
 			$added_ptr[$host['ipaddr']] = true;
 		}
 		$unbound_entries .= "local-data: \"{$host['fqdn']} {$type} {$host['ipaddr']}\"\n";
+		if ($host['add_unqualified']) {
+			$unbound_entries .= "local-data: \"{$host['name']} {$type} {$host['ipaddr']}\"\n";
+		}
 	}
 
 	// Write out entries

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -442,6 +442,8 @@ events.push(function() {
 				<tr>
 					<th><?=gettext("Host")?></th>
 					<th><?=gettext("Domain")?></th>
+					<th><?=gettext("Track")?></th>
+					<th><?=gettext("Unqual")?></th>
 					<th><?=gettext("IP")?></th>
 					<th><?=gettext("Description")?></th>
 					<th><?=gettext("Actions")?></th>
@@ -457,7 +459,19 @@ foreach ($a_hosts as $hostent):
 						<?=$hostent['host']?>
 					</td>
 					<td>
-						<?=$hostent['domain']?>
+					<?php
+						if ($hostent['track_system_domain']) {
+							print '<span class="text-success">' . $hostent['domain'] . '</span>';
+						} else {
+							print $hostent['domain'];
+						}
+					?>
+					</td>
+					<td>
+						<?=$hostent['track_system_domain'] ? '<i class="fa fa-check" title="Domain is being dynamically set based on the setting in System &gt; General"></i>' : '&nbsp;'?>
+					</td>
+					<td>
+						<?=$hostent['add_unqualified'] ? '<i class="fa fa-check" title="Both qualified and unqualified entries have been created for this host"></i>' : '&nbsp;'?>
 					</td>
 					<td>
 						<?=$hostent['ip']?>
@@ -481,6 +495,12 @@ foreach ($a_hosts as $hostent):
 					</td>
 					<td>
 						<?=$alias['domain']?>
+					</td>
+					<td>
+						&nbsp;
+					</td>
+					<td>
+						&nbsp;
 					</td>
 					<td>
 						<?=gettext("Alias for ");?><?=$hostent['host'] ? $hostent['host'] . '.' . $hostent['domain'] : $hostent['domain']?>

--- a/src/usr/local/www/services_unbound_host_edit.php
+++ b/src/usr/local/www/services_unbound_host_edit.php
@@ -47,6 +47,7 @@ function hosts_sort() {
 }
 
 require_once("guiconfig.inc");
+require_once("system.inc");
 
 if (!is_array($config['unbound']['hosts'])) {
 	$config['unbound']['hosts'] = array();
@@ -58,6 +59,8 @@ $id = $_REQUEST['id'];
 if (isset($id) && $a_hosts[$id]) {
 	$pconfig['host'] = $a_hosts[$id]['host'];
 	$pconfig['domain'] = $a_hosts[$id]['domain'];
+	$pconfig['track_system_domain'] = $a_hosts[$id]['track_system_domain'];
+	$pconfig['add_unqualified'] = $a_hosts[$id]['add_unqualified'];
 	$pconfig['ip'] = $a_hosts[$id]['ip'];
 	$pconfig['descr'] = $a_hosts[$id]['descr'];
 	$pconfig['aliases'] = $a_hosts[$id]['aliases'];
@@ -142,8 +145,8 @@ if ($_POST['save']) {
 		}
 
 		if (($hostent['host'] == $_POST['host']) &&
-		    ($hostent['domain'] == $_POST['domain']) &&
-		    ((is_ipaddrv4($hostent['ip']) && is_ipaddrv4($_POST['ip'])) || (is_ipaddrv6($hostent['ip']) && is_ipaddrv6($_POST['ip'])))) {
+			($hostent['domain'] == $_POST['domain']) &&
+			((is_ipaddrv4($hostent['ip']) && is_ipaddrv4($_POST['ip'])) || (is_ipaddrv6($hostent['ip']) && is_ipaddrv6($_POST['ip'])))) {
 			$input_errors[] = gettext("This host/domain already exists.");
 			break;
 		}
@@ -153,6 +156,8 @@ if ($_POST['save']) {
 		$hostent = array();
 		$hostent['host'] = $_POST['host'];
 		$hostent['domain'] = $_POST['domain'];
+		$hostent['track_system_domain'] = $_POST['track_system_domain'];
+		$hostent['add_unqualified'] = $_POST['add_unqualified'];
 		$hostent['ip'] = $_POST['ip'];
 		$hostent['descr'] = $_POST['descr'];
 		$hostent['aliases']['item'] = $aliases;
@@ -202,6 +207,24 @@ $section->addInput(new Form_Input(
 ))->setHelp('Domain of the host%1$s' .
 			'e.g.: "example.com"', '<br />');
 
+$group = new Form_Group('Options');
+
+$group->add(new Form_Checkbox(
+	'track_system_domain',
+	'track_system_domain',
+	'Automatically track system domain',
+	$pconfig['track_system_domain']
+))->setHelp('The domain will be dynamically updated based on the setting in %1$sSystem &gt; General Setup%2$s','<a href="system.php">','</a>');
+
+$group->add(new Form_Checkbox(
+	'add_unqualified',
+	null,
+	'Also add unqualified (short) hostname',
+	$pconfig['add_unqualified']
+))->setHelp('Creates an entry for e.g. "foo" in addition to "foo.example.com"');
+
+$section->add($group);
+
 $section->addInput(new Form_IpAddress(
 	'ip',
 	'*IP Address',
@@ -221,7 +244,7 @@ if (isset($id) && $a_hosts[$id]) {
 		'id',
 		null,
 		'hidden',
-		$pconfig['id']
+		$id
 	));
 }
 
@@ -283,5 +306,25 @@ $form->addGlobal(new Form_Button(
 
 $form->add($section);
 print($form);
+?>
 
-include("foot.inc");
+<script type="text/javascript">
+//<![CDATA[
+events.push(function() {
+	function setDomainFromSystem() {
+		var s_track = $('#track_system_domain').prop('checked');
+		if (s_track) {
+			$('#domain').val('<?=$config['system']['domain'];?>');
+		} else {
+			$('#domain').val('<?=$pconfig['domain'];?>');
+		}
+	}
+
+	$('#track_system_domain').click(function () {
+		setDomainFromSystem();
+	});
+});
+//]]>
+</script>
+
+<?php include("foot.inc");


### PR DESCRIPTION
This PR adds some configuration options to Unbound (DNS Resolver) that mitigate a bug with Unifi gear failing to reach the controller due to unqualified DNS lookups to 'unifi.' post 2.3.3+/2.4 master.

- adds ability to specify on a host-by-host basis whether to create both qualified and unqualified DNS entries
- adds option to auto-track 'domain' according to System > General - can be nice time saver / safety net when you have a lot of overrides within the default domain
- Unbound overview page displays these as checkmarks/additional columns, domain will be shown in green if it is set to 'track'
- fixes a bug (seemingly caused by commit 13541a81e1173fc02af9af8ab7fe46df2a51007d) that caused an 'host/domain already exists' error to print when trying to edit an existing Host Override
- minimal testing done - "it works for me!"

_references:_
[reddit thread](https://www.reddit.com/r/PFSENSE/comments/5vdjel/cant_ping_hostname_just_fqdn_since_233_upgrade/)
[2.3.3 changes - DNS](https://doc.pfsense.org/index.php/2.3.3_New_Features_and_Changes#DNS_.2F_Resolver_.2F_Forwarder)
[redmine 6064](https://redmine.pfsense.org/issues/6064)
