### PR TITLE
Fix DNS wildcard support for EasyDNS

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -450,6 +450,8 @@
 					break;
 				case 'easydns':
 					$needsIP = TRUE;
+					if (isset($this->_dnsWildcard))
+						$this->_dnsWildcard = "ON";
 					curl_setopt($ch, CURLOPT_USERPWD, $this->_dnsUser.':'.$this->_dnsPass);
 					$server = "https://members.easydns.com/dyn/dyndns.php";
 					$port = "";


### PR DESCRIPTION
DNS wildcard is currently broken for EasyDNS. This patch fixes that issue.