### PR TITLE
Fix parsing "::/0" as "::/128" on OpenVPN IPv6 Tunnel Remote network

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1929,7 +1929,7 @@ function openvpn_gen_route_ipv4($network, $iroute = false) {
 function openvpn_gen_route_ipv6($network, $iroute = false) {
 	$i = ($iroute) ? "i" : "";
 	list($ipv6, $prefix) = explode('/', trim($network));
-	if (empty($prefix)) {
+	if (empty($prefix) && !($prefix === "0")) {
 		$prefix = "128";
 	}
 	return "{$i}route-ipv6 ${ipv6}/${prefix}";


### PR DESCRIPTION
Currently specifying "::/0" in OpenVPN's IPv6 Tunnel Remote network(s) generates OpenVPN config as "route-ipv6 ::/128". The fix parses "::/0" properly as "route-ipv6 ::/0".

The root cause is that beacause empty("0") is true and replaces prefix with "128".

As written in OpenVPN document, setting "2000::/3" is recommended. But also "::/0" should be applicable for redirecting outbound traffic on client-side.
- https://community.openvpn.net/openvpn/wiki/IPv6#PushingIPv6routes