### PR TITLE
Sanitize linebreaks for textarea fields in packages on save (Bug #5306)

### DIFF
--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -33,6 +33,7 @@ require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");
 require_once("pkg-utils.inc");
+require_once("util.inc");
 
 /* dummy stubs needed by some code that was MFC'd */
 function pfSenseHeader($location) {
@@ -159,7 +160,6 @@ if ($_POST) {
 		}
 	}
 
-	// donotsave is enabled.  lets simply exit.
 	if (empty($pkg['donotsave'])) {
 
 		// store values in xml configuration file.
@@ -175,11 +175,24 @@ if ($_POST) {
 							foreach ($_POST as $key => $value) {
 								$matches = array();
 								if (preg_match("/^{$rowhelperfield['fieldname']}(\d+)$/", $key, $matches)) {
-									$pkgarr[$rowhelpername][$matches[1]][$rowhelperfield['fieldname']] = $value;
+									if ($rowhelperfield['type'] == "textarea") {
+										$pkgarr[$rowhelpername][$matches[1]][$rowhelperfield['fieldname']] = unixnewlines($value);
+									} else {
+										$pkgarr[$rowhelpername][$matches[1]][$rowhelperfield['fieldname']] = $value;
+									}
 								}
 							}
 						}
 						break;
+					case "textarea":
+						$fieldname = $fields['fieldname'];
+						$fieldvalue = unixnewlines(trim($_POST[$fieldname]));
+						if ($fields['encoding'] == 'base64') {
+							$fieldvalue = base64_encode($fieldvalue);
+						}
+						if ($fieldname) {
+							$pkgarr[$fieldname] = $fieldvalue;
+						}
 					default:
 						$fieldname = $fields['fieldname'];
 						if ($fieldname == "interface_array") {
@@ -243,6 +256,7 @@ if ($_POST) {
 			$get_from_post = true;
 		}
 	} elseif (!$input_errors) {
+		// donotsave is enabled.  lets simply exit.
 		exit;
 	}
 }


### PR DESCRIPTION
The goal here being to avoid cruft like [this](https://github.com/pfsense/FreeBSD-ports/blob/devel/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc#L73) in packages. 