### PR TITLE
Allow specific gateways to be excluded from default gatway switching

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -597,6 +597,12 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 				$gateway['action_disable'] = true;
 			}
 
+			if (isset($gateway['no_defgw_switch'])) {
+				$gateway['no_defgw_switch'] = true;
+			} else {
+				$gateway['no_defgw_switch'] = false;
+			}
+
 			$gateway['friendlyiface'] = $gateway['interface'];
 
 			/* special treatment for tunnel interfaces */
@@ -885,7 +891,13 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 		/* Keep a record of the last up gateway */
 		/* XXX: Blacklist lan for now since it might cause issues to those who have a gateway set for it */
 		if (empty($upgw) && ($gwsttng['ipprotocol'] == $ipprotocol) && (isset($gwsttng['monitor_disable']) || isset($gwsttng['action_disable']) || $gateways_status[$gwname]['status'] == "none") && $gwsttng[$gwname]['friendlyiface'] != "lan") {
-			$upgw = $gwname;
+			if ($gwsttng['no_defgw_switch']) {
+				// do not elect this gateway if the `skip` option is set
+				log_error(sprintf(gettext('Found UP gateway %1$s but it was administratively skipped due to gateway settings'), $gwname));
+			} else {
+				// log_error(sprintf(gettext('Found UP gateway %1$s'), $gwname));
+				$upgw = $gwname;
+			}
 		}
 		if ($dfltgwdown == true && !empty($upgw)) {
 			break;
@@ -902,7 +914,6 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 			$gateways_arr[$upgw]['gateway'] = get_interface_gateway($gateways_arr[$upgw]['friendlyiface']);
 		}
 		if (is_ipaddr($gateways_arr[$upgw]['gateway'])) {
-			log_error("Default gateway down setting {$upgw} as default!");
 			if (is_ipaddrv6($gateways_arr[$upgw]['gateway'])) {
 				$inetfamily = "-inet6";
 				if (is_linklocal($gateways_arr[$upgw]['gateway']) && get_ll_scope($gateways_arr[$upgw]['gateway']) == '') {
@@ -911,6 +922,7 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 			} else {
 				$inetfamily = "-inet";
 			}
+			log_error(sprintf(gettext('Default gateway down, setting default to %1$s'), $upgw));
 			route_add_or_change("{$inetfamily} default {$gateways_arr[$upgw]['gateway']}");
 		}
 	} else if (!empty($dfltgwname)) {
@@ -930,6 +942,7 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 			}
 		}
 		if ($defaultgw != $gateways_arr[$dfltgwname]['gateway']) {
+			log_error(sprintf(gettext('Default gateway down, setting default to %1$s'), $gateways_arr[$dfltgwname]));
 			route_add_or_change("-{$ipprotocol} default {$gateways_arr[$dfltgwname]['gateway']}");
 		}
 	}

--- a/src/usr/local/www/system_advanced_misc.php
+++ b/src/usr/local/www/system_advanced_misc.php
@@ -384,8 +384,11 @@ $section->addInput(new Form_Checkbox(
 	'Enable default gateway switching',
 	$pconfig['gw_switch_default']
 ))->setHelp('If the default gateway goes down, switch the default gateway to '.
-	'another available one. This is not enabled by default, as it\'s unnecessary in '.
-	'most all scenarios, which instead use gateway groups.');
+	'another available one. If you do not enable this option, traffic originating '.
+	'from the firewall itself (e.g. SMTP notifications) may fail if the default '.
+	'gateway is down, even if other gateways are still up. Individual gateways '.
+	'can be omitted from being marked as default by enabling the "Skip Default" '.
+	'checkbox on their respective %1$sGateway Settings%2$s page.','<a href="system_gateways.php">','</a>');
 
 $form->add($section);
 $section = new Form_Section('Power Savings');

--- a/src/usr/local/www/system_gateways.php
+++ b/src/usr/local/www/system_gateways.php
@@ -253,6 +253,7 @@ display_top_tabs($tab_array);
 					<tr>
 						<th></th>
 						<th><?=gettext("Name")?></th>
+						<th><?=gettext("Skip Def.")?></th>
 						<th><?=gettext("Interface")?></th>
 						<th><?=gettext("Gateway")?></th>
 						<th><?=gettext("Monitor IP")?></th>
@@ -286,6 +287,9 @@ foreach ($a_gateways as $i => $gateway):
 				echo " <strong>(default)</strong>";
 			}
 ?>
+						</td>
+						<td>
+							<?=$gateway['no_defgw_switch'] ? '<i class="fa fa-arrow-circle-o-down" title="This gateway will be skipped during default gateway switching"></i>' : '&nbsp;'?>
 						</td>
 						<td>
 							<?=htmlspecialchars(convert_friendly_interface_to_friendly_descr($gateway['friendlyiface']))?>

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -86,6 +86,7 @@ if (isset($id) && $a_gateways[$id]) {
 	$pconfig['descr'] = $a_gateways[$id]['descr'];
 	$pconfig['attribute'] = $a_gateways[$id]['attribute'];
 	$pconfig['disabled'] = isset($a_gateways[$id]['disabled']);
+	$pconfig['no_defgw_switch'] = $a_gateways[$id]['no_defgw_switch'];
 }
 
 if (isset($_REQUEST['dup']) && is_numericint($_REQUEST['dup'])) {
@@ -477,6 +478,15 @@ if ($_POST['save']) {
 			$gateway['defaultgw'] = true;
 		}
 
+		if ($_POST['no_defgw_switch'] == "yes" || $_POST['no_defgw_switch'] == "on") {
+			if (!isset($gateway['defaultgw'])) {
+				$gateway['no_defgw_switch'] = true;
+			} else {
+				/* marking a gateway as the default is mutually exclusive with this option */
+				$gateway['no_defgw_switch'] = false;
+			}
+		}
+
 		if ($_POST['latencylow']) {
 			$gateway['latencylow'] = $_POST['latencylow'];
 		}
@@ -636,7 +646,22 @@ $section->addInput(new Form_Checkbox(
 	'Default Gateway',
 	'This will select the above gateway as the default gateway.',
 	$pconfig['defaultgw']
-));
+))->toggles('.toggle-nodefgwswitch');
+
+$group = new Form_Group('Skip Default');
+$group->addClass('toggle-nodefgwswitch', 'collapse');
+
+if ($pconfig['defaultgw'] == false)
+	$group->addClass('in');
+
+$group->add(new Form_Checkbox(
+	'no_defgw_switch',
+	null,
+	'Not eligible to become the default gateway.',
+	$pconfig['no_defgw_switch']
+))->setHelp('If checked, this gateway will not be chosen during default gateway switching (see %1$sSystem &gt; Advanced%2$s).','<a href="system_advanced_misc.php">','</a>');
+
+$section->add($group);
 
 $section->addInput(new Form_Checkbox(
 	'monitor_disable',


### PR DESCRIPTION
This commit adds a feature to allow you to optionally prevent gateways from being chosen as default during Gateway Switching operations in a multi-WAN environment when the "Enable default gateway switching" option is enabled. Some possible use cases:
- non-internet-facing gateways
- metered connections
- VPN gateways

This only controls the default gateway of the firewall itself; it does not change the behavior of Policy Based Routing.

**Changes/new features**
- adds a `no_defgw_switch` flag to gateway config that will cause a gateway to be excluded from the default gw selection process
- indicate this setting (as an icon) in the System > Gateway list view
- updated help text for Default gateway switching in System > Advanced > Misc to better describe the usage of that feature
- adds some debug logging for gw change events
- selecting a gw as the default gw automatically hides this option, as having both enabled would not make sense (input validation automatically disables the `no_defgw_switch` bool when saving a gateway you've marked as default from the GUI)

**Files changed:**
/etc/inc/gwlb.inc
/usr/local/www/system_advanced_misc.php
/usr/local/www/system_gateways.php
/usr/local/www/system_gateways_edit.php