### PR TITLE
Add setHelp() to Unbound -> host/domain override, and their edit pages

### DIFF
--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -442,7 +442,7 @@ events.push(function() {
 				<tr>
 					<th><?=gettext("Host")?></th>
 					<th><?=gettext("Parent domain of host")?></th>
-					<th><?=gettext("IP returned for host")?></th>
+					<th><?=gettext("IP to return for host")?></th>
 					<th><?=gettext("Description")?></th>
 					<th><?=gettext("Actions")?></th>
 				</tr>

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -441,8 +441,8 @@ events.push(function() {
 			<thead>
 				<tr>
 					<th><?=gettext("Host")?></th>
-					<th><?=gettext("Host's parent domain")?></th>
-					<th><?=gettext("IP to return")?></th>
+					<th><?=gettext("Parent domain of host")?></th>
+					<th><?=gettext("IP returned for host")?></th>
 					<th><?=gettext("Description")?></th>
 					<th><?=gettext("Actions")?></th>
 				</tr>

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -508,7 +508,8 @@ endforeach;
 	Enter any individual hosts for which the resolver's standard DNS lookup process should be overridden and a specific
 	IPv4 or IPv6 address should automatically be returned by the resolver. Standard and also non-standard names and parent domains 
 	can be entered, such as 'test', 'mycompany.localdomain', '1.168.192.in-addr.arpa', or 'somesite.com'. Any lookup attempt for 
-	the host will automatically return the given IP, and the usual lookup server for the domain will not be queried for the host's records.
+	the host will automatically return the given IP address, and the usual lookup server for the domain will not be queried for 
+	the host's records.
 </span>
 
 <nav class="action-buttons">
@@ -525,7 +526,7 @@ endforeach;
 			<thead>
 				<tr>
 					<th><?=gettext("Domain")?></th>
-					<th><?=gettext("IP of lookup server")?></th>
+					<th><?=gettext("Lookup Server IP Address")?></th>
 					<th><?=gettext("Description")?></th>
 					<th><?=gettext("Actions")?></th>
 				</tr>

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -441,8 +441,8 @@ events.push(function() {
 			<thead>
 				<tr>
 					<th><?=gettext("Host")?></th>
-					<th><?=gettext("Domain")?></th>
-					<th><?=gettext("IP")?></th>
+					<th><?=gettext("Host's parent domain")?></th>
+					<th><?=gettext("IP to return")?></th>
 					<th><?=gettext("Description")?></th>
 					<th><?=gettext("Actions")?></th>
 				</tr>
@@ -504,6 +504,13 @@ endforeach;
 	</div>
 </div>
 
+<span class="help-block">
+	Enter any individual hosts for which the resolver's standard DNS lookup process should be overridden and a specific
+	IPv4 or IPv6 address should automatically be returned by the resolver. Standard and also non-standard names and parent domains 
+	can be entered, such as 'test', 'mycompany.localdomain', '1.168.192.in-addr.arpa', or 'somesite.com'. Any lookup attempt for 
+	the host will automatically return the given IP, and the usual lookup server for the domain will not be queried for the host's records.
+</span>
+
 <nav class="action-buttons">
 	<a href="services_unbound_host_edit.php" class="btn btn-sm btn-success">
 		<i class="fa fa-plus icon-embed-btn"></i>
@@ -518,7 +525,7 @@ endforeach;
 			<thead>
 				<tr>
 					<th><?=gettext("Domain")?></th>
-					<th><?=gettext("IP")?></th>
+					<th><?=gettext("IP of lookup server")?></th>
 					<th><?=gettext("Description")?></th>
 					<th><?=gettext("Actions")?></th>
 				</tr>

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -553,6 +553,13 @@ endforeach;
 	</div>
 </div>
 
+<span class="help-block">
+	Enter any domains for which the resolver's standard DNS lookup process should be overridden and a different (non-standard) 
+	lookup server should be queried instead. Non-standard, 'invalid' and local domains, and subdomains, can also be entered, 
+	such as 'test', 'mycompany.localdomain', '1.168.192.in-addr.arpa', or 'somesite.com'. The IP address is treated as the 
+	authoritative lookup server for the domain (including all of its subdomains), and other lookup servers will not be queried.
+</span>
+
 <nav class="action-buttons">
 	<a href="services_unbound_domainoverride_edit.php" class="btn btn-sm btn-success">
 		<i class="fa fa-plus icon-embed-btn"></i>

--- a/src/usr/local/www/services_unbound_domainoverride_edit.php
+++ b/src/usr/local/www/services_unbound_domainoverride_edit.php
@@ -146,11 +146,16 @@ if (isset($id) && $a_domainOverrides[$id]) {
 	));
 }
 
-$section->setHelp("This page is used to specify domains for which the resolver's standard DNS lookup process will be overridden, " .
-"and the resolver will query a different (non-standard) lookup server instead. It is possible to enter 'non-standard', 'invalid' " .
-"and 'local' domains such as 'test', 'mycompany.localdomain', or '1.168.192.in-addr.arpa', as well as usual publicly resolvable " .
-"domains such as 'org', 'info', or 'google.co.uk'.  The IP address entered will be treated as the IP address of an authoritative " .
-"lookup server for the domain (including all of its subdomains), and other lookup servers will not be queried.");
+$section->addInput(new Form_StaticText(
+	'',
+	'<span class="help-block">' .
+	gettext("This page is used to specify domains for which the resolver's standard DNS lookup process will be overridden, " .
+	"and the resolver will query a different (non-standard) lookup server instead. It is possible to enter 'non-standard', 'invalid' " .
+	"and 'local' domains such as 'test', 'mycompany.localdomain', or '1.168.192.in-addr.arpa', as well as usual publicly resolvable " .
+	"domains such as 'org', 'info', or 'google.co.uk'.  The IP address entered will be treated as the IP address of an authoritative " .
+	"lookup server for the domain (including all of its subdomains), and other lookup servers will not be queried.") .
+	'</span>'
+));
 
 $form->add($section);
 

--- a/src/usr/local/www/services_unbound_domainoverride_edit.php
+++ b/src/usr/local/www/services_unbound_domainoverride_edit.php
@@ -127,7 +127,7 @@ $section->addInput(new Form_IpAddress(
 	'ip',
 	'*IP Address',
 	$pconfig['ip']
-))->setHelp('IP address of the authoritative DNS server for this domain. e.g.: 192.168.100.100%1$s' .
+))->setHelp('IPv4 or IPv6 address of the authoritative DNS server for this domain. e.g.: 192.168.100.100%1$s' .
 			'To use a non-default port for communication, append an \'@\' with the port number.', '<br />')->setPattern('[a-zA-Z0-9@.:]+');
 
 $section->addInput(new Form_Input(

--- a/src/usr/local/www/services_unbound_domainoverride_edit.php
+++ b/src/usr/local/www/services_unbound_domainoverride_edit.php
@@ -147,7 +147,7 @@ if (isset($id) && $a_domainOverrides[$id]) {
 }
 
 $section->setHelp("This page is used to specify domains for which the resolver's standard DNS lookup process will be overridden, " .
-"and the resolver will query a different (non-standard) lookup server instead. It is possible to enter \'non-standard\', 'invalid' " .
+"and the resolver will query a different (non-standard) lookup server instead. It is possible to enter 'non-standard', 'invalid' " .
 "and 'local' domains such as 'test', 'mycompany.localdomain', or '1.168.192.in-addr.arpa', as well as usual publicly resolvable " .
 "domains such as 'org', 'info', or 'google.co.uk'.  The IP entered will be treated as the IP of an authoritative lookup server for " .
 "the domain (including all of its subdomains), and other lookup servers will not be queried.");

--- a/src/usr/local/www/services_unbound_domainoverride_edit.php
+++ b/src/usr/local/www/services_unbound_domainoverride_edit.php
@@ -114,14 +114,14 @@ if ($input_errors) {
 
 $form = new Form();
 
-$section = new Form_Section('Domain Override');
+$section = new Form_Section('Domains to Override with Custom Lookup Servers');
 
 $section->addInput(new Form_Input(
 	'domain',
 	'*Domain',
 	'text',
 	$pconfig['domain']
-))->setHelp('Domain to override (NOTE: this does not have to be a valid TLD!) e.g.: test or mycompany.localdomain or 1.168.192.in-addr.arpa');
+))->setHelp('Domain whose lookups will be directed to a user-specified DNS lookup server.');
 
 $section->addInput(new Form_IpAddress(
 	'ip',
@@ -145,6 +145,12 @@ if (isset($id) && $a_domainOverrides[$id]) {
 		$id
 	));
 }
+
+$section->setHelp("This page is used to specify domains for which the resolver's standard DNS lookup process will be overridden, " .
+"and the resolver will query a different (non-standard) lookup server instead. It is possible to enter \'non-standard\', 'invalid' " .
+"and 'local' domains such as 'test', 'mycompany.localdomain', or '1.168.192.in-addr.arpa', as well as usual publicly resolvable " .
+"domains such as 'org', 'info', or 'google.co.uk'.  The IP entered will be treated as the IP of an authoritative lookup server for " .
+"the domain (including all of its subdomains), and other lookup servers will not be queried.");
 
 $form->add($section);
 

--- a/src/usr/local/www/services_unbound_domainoverride_edit.php
+++ b/src/usr/local/www/services_unbound_domainoverride_edit.php
@@ -149,8 +149,8 @@ if (isset($id) && $a_domainOverrides[$id]) {
 $section->setHelp("This page is used to specify domains for which the resolver's standard DNS lookup process will be overridden, " .
 "and the resolver will query a different (non-standard) lookup server instead. It is possible to enter 'non-standard', 'invalid' " .
 "and 'local' domains such as 'test', 'mycompany.localdomain', or '1.168.192.in-addr.arpa', as well as usual publicly resolvable " .
-"domains such as 'org', 'info', or 'google.co.uk'.  The IP entered will be treated as the IP of an authoritative lookup server for " .
-"the domain (including all of its subdomains), and other lookup servers will not be queried.");
+"domains such as 'org', 'info', or 'google.co.uk'.  The IP address entered will be treated as the IP address of an authoritative " .
+"lookup server for the domain (including all of its subdomains), and other lookup servers will not be queried.");
 
 $form->add($section);
 

--- a/src/usr/local/www/services_unbound_host_edit.php
+++ b/src/usr/local/www/services_unbound_host_edit.php
@@ -225,11 +225,17 @@ if (isset($id) && $a_hosts[$id]) {
 	));
 }
 
-$section->setHelp("This page is used to override the usual lookup process for a specific host. A host is defined by its name" .
-	"and parent domain (e.g., 'somesite.google.com' is entered as host='somesite' and parent domain='google.com'). Any " .
-	"attempt to lookup that host will automatically return the given IP, and any usual external lookup server for the domain " .
-	"will not be queried. Both the name and parent domain can contain 'non-standard', 'invalid' and 'local' domains " .
-	"such as 'test', 'mycompany.localdomain', or '1.168.192.in-addr.arpa', as well as usual publicly resolvable names such as 'www' or 'google.co.uk'.");
+$section->addInput(new Form_StaticText(
+	'',
+	'<span class="help-block">' .
+	gettext("This page is used to override the usual lookup process for a specific host. A host is defined by its name" .
+		"and parent domain (e.g., 'somesite.google.com' is entered as host='somesite' and parent domain='google.com'). Any " .
+		"attempt to lookup that host will automatically return the given IP address, and any usual external lookup server for " .
+		"the domain will not be queried. Both the name and parent domain can contain 'non-standard', 'invalid' and 'local' " .
+		"domains such as 'test', 'mycompany.localdomain', or '1.168.192.in-addr.arpa', as well as usual publicly resolvable names ".
+		"such as 'www' or 'google.co.uk'.") .
+	'</span>'
+));
 
 $form->add($section);
 
@@ -287,7 +293,12 @@ $form->addGlobal(new Form_Button(
 	'fa-plus'
 ))->removeClass('btn-primary')->addClass('btn-success addbtn');
 
-$section->setHelp("If the host can be accessed using multiple names, then enter any other names for the host which should also be overridden.");
+$section->addInput(new Form_StaticText(
+	'',
+	'<span class="help-block">'.
+	gettext("If the host can be accessed using multiple names, then enter any other names for the host which should also be overridden.") .
+	'</span>'
+));
 
 $form->add($section);
 print($form);

--- a/src/usr/local/www/services_unbound_host_edit.php
+++ b/src/usr/local/www/services_unbound_host_edit.php
@@ -228,7 +228,7 @@ if (isset($id) && $a_hosts[$id]) {
 $section->addInput(new Form_StaticText(
 	'',
 	'<span class="help-block">' .
-	gettext("This page is used to override the usual lookup process for a specific host. A host is defined by its name" .
+	gettext("This page is used to override the usual lookup process for a specific host. A host is defined by its name " .
 		"and parent domain (e.g., 'somesite.google.com' is entered as host='somesite' and parent domain='google.com'). Any " .
 		"attempt to lookup that host will automatically return the given IP address, and any usual external lookup server for " .
 		"the domain will not be queried. Both the name and parent domain can contain 'non-standard', 'invalid' and 'local' " .

--- a/src/usr/local/www/services_unbound_host_edit.php
+++ b/src/usr/local/www/services_unbound_host_edit.php
@@ -192,21 +192,21 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['host']
 ))->setHelp('Name of the host, without the domain part%1$s' .
-			'e.g.: "myhost"', '<br />');
+			'e.g. enter "myhost" if the full domain name is "myhost.example.com"', '<br />');
 
 $section->addInput(new Form_Input(
 	'domain',
 	'*Domain',
 	'text',
 	$pconfig['domain']
-))->setHelp('Domain of the host%1$s' .
-			'e.g.: "example.com"', '<br />');
+))->setHelp('Parent domain of the host%1$s' .
+			'e.g. enter "example.com" for "myhost.example.com"', '<br />');
 
 $section->addInput(new Form_IpAddress(
 	'ip',
 	'*IP Address',
 	$pconfig['ip']
-))->setHelp('IP address of the host%1$s' .
+))->setHelp('IPv4 or IPv6 address to be returned for the host%1$s' .
 			'e.g.: 192.168.100.100 or fd00:abcd::1', '<br />');
 
 $section->addInput(new Form_Input(
@@ -224,6 +224,12 @@ if (isset($id) && $a_hosts[$id]) {
 		$pconfig['id']
 	));
 }
+
+$section->setHelp("This page is used to override the usual lookup process for a specific host. A host is defined by its name" .
+	"and parent domain (e.g., 'somesite.google.com' is entered as host='somesite' and parent domain='google.com'). Any " .
+	"attempt to lookup that host will automatically return the given IP, and any usual external lookup server for the domain " .
+	"will not be queried. Both the name and parent domain can contain 'non-standard', 'invalid' and 'local' domains " .
+	"such as 'test', 'mycompany.localdomain', or '1.168.192.in-addr.arpa', as well as usual publicly resolvable names such as 'www' or 'google.co.uk'.");
 
 $form->add($section);
 
@@ -280,6 +286,8 @@ $form->addGlobal(new Form_Button(
 	null,
 	'fa-plus'
 ))->removeClass('btn-primary')->addClass('btn-success addbtn');
+
+$section->setHelp("If the host can be accessed using multiple names, then enter any other names for the host which should also be overridden.");
 
 $form->add($section);
 print($form);


### PR DESCRIPTION
Not totally clear from GUI what they do, without consulting docs, because no help text provided either on unbound config page or the edit pages for these two overrides.

Added help text and slightly improved existing section wordings to reflect this. Kept existing term "override" as it's in docs and will be expected (and is correct description) but made a bit clearer.