### PR TITLE
Remove deprecated unused function

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -3789,12 +3789,6 @@ function filter_rules_spoofcheck_generate($ifname, $ifcfg, $log) {
 	return $ipfrules;
 }
 
-/* COMPAT Function */
-function tdr_install_cron($should_install) {
-	log_error(gettext("Please use filter_tdr_install_cron() function tdr_install_cron will be deprecated!"));
-	filter_tdr_install_cron($should_install);
-}
-
 /****f* filter/filter_tdr_install_cron
  * NAME
  *   filter_tdr_install_cron


### PR DESCRIPTION
Not used anywhere and deprecated for ages (https://github.com/pfsense/pfsense/commit/fe9afce65fc36f278e18edf8959669de2e9ddeef)