### PR TITLE
Remove no longer needed split() re-implementation

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2034,14 +2034,6 @@ function update_progress_bar($percent, $first_time) {
 	}
 }
 
-/* Split() is being DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 6.0.0. Relying on this feature is highly discouraged. */
-if (!function_exists("split")) {
-	function split($separator, $haystack, $limit = null) {
-		log_error("deprecated split() call with separator '{$separator}'");
-		return preg_split($separator, $haystack, $limit);
-	}
-}
-
 function update_alias_names_upon_change($section, $field, $new_alias_name, $origname) {
 	global $g, $config, $pconfig, $debug;
 	if (!$origname) {


### PR DESCRIPTION
The last use of split() in pfSense removed in https://github.com/pfsense/FreeBSD-ports/pull/322 AFAICT.