### PR TITLE
Remove dummy config_lock() and config_unlock() functions

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -105,13 +105,6 @@ function clear_subsystem_dirty($subsystem = "") {
 	@unlink("{$g['varrun_path']}/{$subsystem}.dirty");
 }
 
-function config_lock() {
-	return;
-}
-function config_unlock() {
-	return;
-}
-
 /* lock configuration file */
 function lock($lock, $op = LOCK_SH) {
 	global $g;


### PR DESCRIPTION
Been no-op for ages (https://github.com/pfsense/pfsense/commit/0027de0a544438f146cfc94f005fd6f4ba9f94d7).

Note: Don't merge to RELENG_2_3 until https://github.com/pfsense/pfsense/pull/3613 is done.