### PR TITLE
Fix #7364 Console assigned VLAN disappears after reboot

### DIFF
--- a/src/etc/inc/config.console.inc
+++ b/src/etc/inc/config.console.inc
@@ -377,6 +377,10 @@ EOD;
 
 		touch("{$g['tmp_path']}/assign_complete");
 
+		if (file_exists("/conf/trigger_initial_wizard")) {
+			// Let the system know that the interface assign part of initial setup has been done.
+			touch("{$g['conf_path']}/assign_complete");
+		}
 	}
 }
 

--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -138,7 +138,10 @@ if (mwexec("/bin/kenv -q pfSense.boot 2>/dev/null") != 0) {
 /* run any early shell commands specified in config.xml */
 system_do_shell_commands(1);
 
-if (file_exists("/conf/trigger_initial_wizard")) {
+// Only do the alternate interface checks if:
+// 1) The user has not yet run the initial wizard; and
+// 2) The user has not used the console menu to setup interface assignments
+if (file_exists("/conf/trigger_initial_wizard") && !file_exists("/conf/assign_complete")) {
 	check_for_alternate_interfaces();
 }
 

--- a/src/usr/local/www/wizards/setup_wizard.xml
+++ b/src/usr/local/www/wizards/setup_wizard.xml
@@ -35,6 +35,7 @@
 	</fields>
 	<stepbeforeformdisplay>
 		unlink_if_exists('/conf/trigger_initial_wizard');
+		unlink_if_exists('/conf/assign_complete');
 	</stepbeforeformdisplay>
 </step>
 <step>


### PR DESCRIPTION
If trigger_initial_wizard is still waiting to happen, then if the user sets up interface assignment/VLAN stuff from the console, we need to let the system know that has been done. Then not try to cross-check any of that at boot time.