### PR TITLE
Test fix for hanging check_reload_status

### DIFF
--- a/src/etc/rc.php-fpm_restart
+++ b/src/etc/rc.php-fpm_restart
@@ -22,6 +22,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo ">>> Killing check_reload_status"
+/bin/pkill -9 check_reload_status
+sleep 2
+
 echo ">>> Killing php-fpm"
 /bin/pkill -F /var/run/php-fpm.pid
 sleep 2
@@ -40,3 +44,6 @@ echo ">>> Restarting php-fpm" | /usr/bin/logger -p daemon.info -i -t rc.php-fpm_
 echo ">>> Starting php-fpm"
 /usr/local/sbin/php-fpm -c /usr/local/etc/php.ini -y /usr/local/lib/php-fpm.conf -RD 2>&1 >/dev/null
 
+# restart check_reload_status
+echo ">>> Starting check_reload_status"
+/usr/bin/nice -n20 /usr/local/sbin/check_reload_status


### PR DESCRIPTION
After killing php-fpm (console opt 16) check_reload_status would sometimes hang, consuming 100% of 1 cpu core. I found a reference https://redmine.pfsense.org/issues/3884#note-4 saying that check_reload_status depends on php-fpm. This patch wraps the restart of php-fpm with a stop/start of check_reload_status. In my limited testing, this has eliminated the hangs, which were pretty easily reproducible before.

I submitted this for comment on the forum (https://forum.pfsense.org/index.php?topic=126684.0) but received no feedback. I have been using this patch for a few days with no ill effects, so I am submitting it as PR - hoping for a merge or at least, some comments.