### PR TITLE
Do not report misleading 3G service status (Bug #4287)

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3011,6 +3011,7 @@ function huawei_service_to_string($state) {
 	$modes[2] = gettext("Valid Service");
 	$modes[3] = gettext("Restricted Regional Service");
 	$modes[4] = gettext("Powersaving Service");
+	$modes[255] = gettext("Unknown Service");
 	$string = $modes[$state];
 	return $string;
 }

--- a/src/usr/local/bin/3gstats.php
+++ b/src/usr/local/bin/3gstats.php
@@ -22,7 +22,7 @@
 
 ini_set("max_execution_time", "0");
 
-if(empty($argv[1])) {
+if (empty($argv[1])) {
 	echo "No modem device given \n";
 	exit(0);
 }
@@ -37,7 +37,7 @@ $i = 0;
 
 $record = array();
 $handle = fopen($device, "r");
-if(! $handle) {
+if (!$handle) {
 	echo "Can not open modem stats device\n";
 	exit(1);
 }
@@ -51,8 +51,8 @@ $record['sent'] = 0;
 $record['received'] = 0;
 $record['bwupstream'] = 0;
 $record['bwdownstream'] = 0;
-$record['simstate'] = 0;
-$record['service'] = 0;
+$record['simstate'] = 255;
+$record['service'] = 255;
 
 while (true) {
 	$string = "";


### PR DESCRIPTION
If the ^SIMST or ^SRVST  info was never received from the device, report missing/unknown states instead.