### PR TITLE
Fix #7372 Cannot filter ICMP Type SKIP

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2793,7 +2793,9 @@ function filter_generate_user_rule($rule) {
 
 	if ($rule['protocol'] == "icmp" && $rule['icmptype'] && ($rule['icmptype'] != 'any')) {
 		$icmptype_key = ($rule['ipprotocol'] == 'inet6' ? 'icmp6-type' : 'icmp-type');
-		$icmptype_text = (strpos($rule['icmptype'], ",") === false ? $rule['icmptype'] : '{ ' . $rule['icmptype'] . ' }');
+		// XXX: Bug #7372
+		$icmptype_text = replace_element_in_list($rule['icmptype'], ',', 'skip', '39');
+		$icmptype_text = (strpos($icmptype_text, ",") === false ? $icmptype_text : '{ ' . $icmptype_text . ' }');
 		$aline[$icmptype_key] = "{$icmptype_key} {$icmptype_text} ";
 	}
 	

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2368,6 +2368,23 @@ function explode_assoc($delimiter, $string) {
 	return $result;
 }
 
+/*
+ * Given a string of text with some delimiter, look for occurrences
+ * of some string and replace all of those.
+ * $text - the text string (e.g. "abc,defg,x123,ipv4,xyz")
+ * $delimiter - the delimiter (e.g. ",")
+ * $element - the element to match (e.g. "defg")
+ * $replacement - the string to replace it with (e.g. "42")
+ * Returns the resulting delimited string (e.g. "abc,42,x123,ipv4,xyz")
+ */
+function replace_element_in_list($text, $delimiter, $element, $replacement) {
+	$textArray = explode($delimiter, $text);
+	while (($entry = array_search($element, $textArray)) !== false) {
+		$textArray[$entry] = $replacement;
+	}
+	return implode(',', $textArray);
+}
+
 /* Try to change a static route, if it doesn't exist, add it */
 function route_add_or_change($args) {
 	global $config;


### PR DESCRIPTION
Replace 'skip' with '39', the ICMP type code. pf handles the numbered code OK, but barfs when fed the pf keyword "skip".