### PR TITLE
Redmine #7381 Disable detail in alias popup

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -1583,6 +1583,7 @@ function get_user_settings($username) {
 	$settings['webgui']['dashboardavailablewidgetspanel'] = isset($config['system']['webgui']['dashboardavailablewidgetspanel']);
 	$settings['webgui']['webguifixedmenu'] = isset($config['system']['webgui']['webguifixedmenu']);
 	$settings['webgui']['webguileftcolumnhyper'] = isset($config['system']['webgui']['webguileftcolumnhyper']);
+	$settings['webgui']['disablealiaspopupdetail'] = isset($config['system']['webgui']['disablealiaspopupdetail']);
 	$settings['webgui']['systemlogsfilterpanel'] = isset($config['system']['webgui']['systemlogsfilterpanel']);
 	$settings['webgui']['systemlogsmanagelogpanel'] = isset($config['system']['webgui']['systemlogsmanagelogpanel']);
 	$settings['webgui']['statusmonitoringsettingspanel'] = isset($config['system']['webgui']['statusmonitoringsettingspanel']);
@@ -1606,6 +1607,7 @@ function get_user_settings($username) {
 		$settings['webgui']['dashboardavailablewidgetspanel'] = isset($user['dashboardavailablewidgetspanel']);
 		$settings['webgui']['webguifixedmenu'] = isset($user['webguifixedmenu']);
 		$settings['webgui']['webguileftcolumnhyper'] = isset($user['webguileftcolumnhyper']);
+		$settings['webgui']['disablealiaspopupdetail'] = isset($user['disablealiaspopupdetail']);
 		$settings['webgui']['systemlogsfilterpanel'] = isset($user['systemlogsfilterpanel']);
 		$settings['webgui']['systemlogsmanagelogpanel'] = isset($user['systemlogsmanagelogpanel']);
 		$settings['webgui']['statusmonitoringsettingspanel'] = isset($user['statusmonitoringsettingspanel']);

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -320,6 +320,25 @@ function gen_webguileftcolumnhyper_field(&$section, $value) {
 	))->setHelp('If selected, clicking a label in the left column will select/toggle the first item of the group.');
 }
 
+/****f* pfsense-utils/gen_disablealiaspopupdetail_field
+ * NAME
+ *   gen_disablealiaspopupdetail_field
+ * INPUTS
+ *   Pointer to section object
+ *   Initial value for the field
+ * RESULT
+ *   no return value, section object is updated
+ ******/
+function gen_disablealiaspopupdetail_field(&$section, $value) {
+
+	$section->addInput(new Form_Checkbox(
+		'disablealiaspopupdetail',
+		'Alias Popups',
+		'Disable details in alias popups',
+		$value
+	))->setHelp('If selected, the details in alias popups will not be shown, just the alias description (e.g. in Firewall Rules).');
+}
+
 /****f* pfsense-utils/gen_pagenamefirst_field
  * NAME
  *   gen_pagenamefirst_field
@@ -363,6 +382,7 @@ function gen_user_settings_fields(&$section, $pconfig) {
 		$pconfig['systemlogsmanagelogpanel'],
 		$pconfig['statusmonitoringsettingspanel']);
 	gen_webguileftcolumnhyper_field($section, $pconfig['webguileftcolumnhyper']);
+	gen_disablealiaspopupdetail_field($section, $pconfig['disablealiaspopupdetail']);
 	gen_pagenamefirst_field($section, $pconfig['pagenamefirst']);
 }
 

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -1110,7 +1110,7 @@ function add_package_tabs($tabgroup, &$tab_array) {
 }
 
 function alias_info_popup($alias_id) {
-	global $config;
+	global $config, $user_settings;
 
 	if (!is_array($config['aliases']['alias'][$alias_id])) {
 		return;
@@ -1120,7 +1120,13 @@ function alias_info_popup($alias_id) {
 	$alias = $config['aliases']['alias'][$alias_id];
 	$content = "";
 
-	if ($alias['url']) {
+	if ($user_settings['webgui']['disablealiaspopupdetail']) {
+		if (strlen($alias['descr']) >= $maxlength) {
+			$alias['descr'] = substr($alias['descr'], 0, $maxlength) . '&hellip;';
+		}
+
+		$content .= $alias['descr'];
+	} else if ($alias['url']) {
 		// TODO: Change it when pf supports tables with ports
 		if ($alias['type'] == "urltable") {
 			exec("/sbin/pfctl -t {$alias['name']} -T show | wc -l", $total_entries);
@@ -1162,10 +1168,6 @@ function alias_info_popup($alias_id) {
 
 		$content .= "</tbody>\n";
 		$content .= "<table>\n";
-	}
-
-	if (strlen($alias['descr']) >= $maxlength) {
-		$alias['descr'] = substr($alias['descr'], 0, $maxlength) . '&hellip;';
 	}
 
 	return $content;

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -63,6 +63,7 @@ $pconfig['webguicss'] = $config['system']['webgui']['webguicss'];
 $pconfig['webguifixedmenu'] = $config['system']['webgui']['webguifixedmenu'];
 $pconfig['dashboardcolumns'] = $config['system']['webgui']['dashboardcolumns'];
 $pconfig['webguileftcolumnhyper'] = isset($config['system']['webgui']['webguileftcolumnhyper']);
+$pconfig['disablealiaspopupdetail'] = isset($config['system']['webgui']['disablealiaspopupdetail']);
 $pconfig['dashboardavailablewidgetspanel'] = isset($config['system']['webgui']['dashboardavailablewidgetspanel']);
 $pconfig['systemlogsfilterpanel'] = isset($config['system']['webgui']['systemlogsfilterpanel']);
 $pconfig['systemlogsmanagelogpanel'] = isset($config['system']['webgui']['systemlogsmanagelogpanel']);
@@ -273,6 +274,9 @@ if ($_POST) {
 
 		unset($config['system']['webgui']['webguileftcolumnhyper']);
 		$config['system']['webgui']['webguileftcolumnhyper'] = $_POST['webguileftcolumnhyper'] ? true : false;
+
+		unset($config['system']['webgui']['disablealiaspopupdetail']);
+		$config['system']['webgui']['disablealiaspopupdetail'] = $_POST['disablealiaspopupdetail'] ? true : false;
 
 		unset($config['system']['webgui']['dashboardavailablewidgetspanel']);
 		$config['system']['webgui']['dashboardavailablewidgetspanel'] = $_POST['dashboardavailablewidgetspanel'] ? true : false;
@@ -580,6 +584,7 @@ gen_associatedpanels_fields(
 	$pconfig['statusmonitoringsettingspanel']);
 gen_requirestatefilter_field($section, $pconfig['requirestatefilter']);
 gen_webguileftcolumnhyper_field($section, $pconfig['webguileftcolumnhyper']);
+gen_disablealiaspopupdetail_field($section, $pconfig['disablealiaspopupdetail']);
 
 $section->addInput(new Form_Checkbox(
 	'loginshowhost',

--- a/src/usr/local/www/system_user_settings.php
+++ b/src/usr/local/www/system_user_settings.php
@@ -47,6 +47,7 @@ if (isset($id) && $a_user[$id]) {
 	$pconfig['systemlogsmanagelogpanel'] = isset($a_user[$id]['systemlogsmanagelogpanel']);
 	$pconfig['statusmonitoringsettingspanel'] = isset($a_user[$id]['statusmonitoringsettingspanel']);
 	$pconfig['webguileftcolumnhyper'] = isset($a_user[$id]['webguileftcolumnhyper']);
+	$pconfig['disablealiaspopupdetail'] = isset($a_user[$id]['disablealiaspopupdetail']);
 	$pconfig['pagenamefirst'] = isset($a_user[$id]['pagenamefirst']);
 } else {
 	echo gettext("The settings cannot be managed for a non-local user.");
@@ -116,6 +117,13 @@ if (isset($_POST['save'])) {
 		} else {
 			$pconfig['webguileftcolumnhyper'] = false;
 			unset($userent['webguileftcolumnhyper']);
+		}
+
+		if ($_POST['disablealiaspopupdetail']) {
+			$pconfig['disablealiaspopupdetail'] = $userent['disablealiaspopupdetail'] = true;
+		} else {
+			$pconfig['disablealiaspopupdetail'] = false;
+			unset($userent['disablealiaspopupdetail']);
 		}
 
 		if ($_POST['pagenamefirst']) {

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -68,6 +68,7 @@ if (isset($id) && $a_user[$id]) {
 	$pconfig['systemlogsmanagelogpanel'] = isset($a_user[$id]['systemlogsmanagelogpanel']);
 	$pconfig['statusmonitoringsettingspanel'] = isset($a_user[$id]['statusmonitoringsettingspanel']);
 	$pconfig['webguileftcolumnhyper'] = isset($a_user[$id]['webguileftcolumnhyper']);
+	$pconfig['disablealiaspopupdetail'] = isset($a_user[$id]['disablealiaspopupdetail']);
 	$pconfig['pagenamefirst'] = isset($a_user[$id]['pagenamefirst']);
 	$pconfig['groups'] = local_user_get_groups($a_user[$id]);
 	$pconfig['utype'] = $a_user[$id]['scope'];
@@ -357,6 +358,12 @@ if ($_POST['save']) {
 			$userent['webguileftcolumnhyper'] = true;
 		} else {
 			unset($userent['webguileftcolumnhyper']);
+		}
+
+		if ($_POST['disablealiaspopupdetail']) {
+			$userent['disablealiaspopupdetail'] = true;
+		} else {
+			unset($userent['disablealiaspopupdetail']);
 		}
 
 		if ($_POST['pagenamefirst']) {
@@ -974,6 +981,7 @@ events.push(function() {
 		hideCheckbox('systemlogsmanagelogpanel', !adv);
 		hideCheckbox('statusmonitoringsettingspanel', !adv);
 		hideCheckbox('webguileftcolumnhyper', !adv);
+		hideCheckbox('disablealiaspopupdetail', !adv);
 		hideCheckbox('pagenamefirst', !adv);
 	}
 


### PR DESCRIPTION
Give the option for users to choose if they want to display alias details in the popups on Firewall Rules, NAT etc. This works like the other user preferences - there is an overall system setting in General Setup webConfigurator section, and the preference can be set per-user in User Manager/User Settings.