### PR TITLE
No need to check for HTML in NAT descr

### DIFF
--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -104,6 +104,10 @@ if ($_POST['save']) {
 	 *	cannot think he is slick and perform a XSS attack on the unwilling
 	 */
 	foreach ($_POST as $key => $value) {
+		if ($key == 'descr') {
+			continue;
+		}
+
 		$temp = str_replace(">", "", $value);
 		$newpost = htmlentities($temp);
 

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -114,6 +114,10 @@ if (isset($_REQUEST['dup']) && is_numericint($_REQUEST['dup'])) {
 unset($input_errors);
 
 foreach ($_REQUEST as $key => $value) {
+	if ($key == 'descr') {
+		continue;
+	}
+
 	$temp = $value;
 	$newpost = htmlentities($temp);
 

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -146,6 +146,10 @@ if ($_POST['save']) {
 	 *  cannot think he is slick and perform a XSS attack on the unwilling
 	 */
 	foreach ($_POST as $key => $value) {
+		if ($key == 'descr') {
+			continue;
+		}
+
 		$temp = str_replace(">", "", $value);
 		$newpost = htmlentities($temp);
 		if ($newpost <> $temp) {


### PR DESCRIPTION
This loop checking for htmlentities in any of the data has been in firewall_nat_edit.php etc for years. It prevents people from using some chars in the description. e.g. see forum:
https://forum.pfsense.org/index.php?topic=127350.0

This generic loop checking htmlentities is not in firewall_rules_edit.php - you can put strings in the description there like:
```
<b>bold "stuff" here</b>
```
that looks like you are trying to make it render bold in the Description and nothing bad happens. All those "special" characters are treated just as ordinary characters and are seen in the firewall rules table etc.

Other pages, like NAT 1to1 and NAT Out have slightly different code in their "htmlentities loop" which rubs out any ">" chars. Why is that done differently there?

This seems to be a classic case of breaking the DRY (Do not Repeat Yourself) rule (which is broken all the time in pfSense code) - whatever generic validation of input data is needed should be done in a common routine that can be called by every page.

The "fix" here is just a kludge to avoid doing the htmlentities check for the "descr" field. Actually somebody needs to decide what "htmlentities" protection is really needed, then implement it consistently across all pages.