### PR TITLE
Handle DHCP Lease when the assigned Gateway is Outside of Subnet

### DIFF
--- a/src/usr/local/sbin/pfSense-dhclient-script
+++ b/src/usr/local/sbin/pfSense-dhclient-script
@@ -172,6 +172,10 @@ delete_old_routes() {
 	# Only allow the default route to be overridden if it's on our own interface
 	if [ -f "/tmp/${interface}_defaultgw" ]; then
 		for router in $old_routers; do
+			# delete local route to the router ip address.
+			#  cleans up our route to a gateway possibly outside of the assigned subnet
+			$ROUTE delete -host $router -iface $interface
+
 			$ROUTE delete default $router >/dev/null 2>&1
 			/bin/rm -f /tmp/${interface}_router
 		done
@@ -229,6 +233,13 @@ add_new_routes() {
 					echo $router > /tmp/${interface}_router
 				fi
 			else
+                                # add local route to the router ip address.
+                                #  this will not cause any harm if the router is within the subnet
+                                #  but it will prevent route troubles if the router is outside of the subnet
+                                #  this is useful for captive subnets or similar gateway out-of-subnet situations
+                                $ROUTE add -host $router -iface $interface
+                                echo $ROUTE add -host $router -iface $interface | $LOGGER
+
 				$ROUTE add default $router
 				echo $ROUTE add default $router | $LOGGER
 				echo $router > /tmp/${interface}_router


### PR DESCRIPTION
When deploying PFSense in OVH's public cloud, they assign a IPv4 address via DHCP in a /32 subnet. Naturally, with such a captive subnet, the default gateway will reside outside of the subnet. This causes problems with the /usr/local/sbin/pfSense-dhclient-script.  The route command will not add a default gateway if there is no route to the host. 

I've added a route command to insert the host route to the gateway upon DHCP lease acquisition, and release it upon lease release.  

I am successfully running with this change in my PFSense OVH cloud instance.

For accompanying report see: https://redmine.pfsense.org/issues/7380.