### PR TITLE
Handle widgets having no items selected for display

### DIFF
--- a/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
@@ -125,7 +125,7 @@ if ($_REQUEST['getdyndnsstatus']) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['dyn_dns_status']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['dyn_dns_status']['filter'] = "";
+		$user_settings['widgets']['dyn_dns_status']['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Dynamic DNS Filter via Dashboard."));
@@ -204,6 +204,13 @@ function get_dyndns_service_text($dyndns_type) {
 		</td>
 	</tr>
 	<?php endforeach;?>
+	<?php if ($rowid == -1):?>
+	<tr>
+		<td colspan="4" class="text-center">
+			<?=gettext('All Dyn DNS entries are hidden.');?>
+		</td>
+	</tr>
+	<?php endif;?>
 	</tbody>
 </table>
 </div>

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -48,17 +48,17 @@ if ($_POST) {
 		$user_settings["widgets"]["gateways_widget"]["display_type"] = $_POST["display_type"];
 	}
 
+	$validNames = array();
+	$a_gateways = return_gateways_array();
+
+	foreach ($a_gateways as $gname => $gateway) {
+		array_push($validNames, $gname);
+	}
+
 	if (is_array($_POST['show'])) {
-		$validNames = array();
-		$a_gateways = return_gateways_array();
-
-		foreach ($a_gateways as $gname => $gateway) {
-			array_push($validNames, $gname);
-		}
-
 		$user_settings["widgets"]["gateways_widget"]["gatewaysfilter"] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings["widgets"]["gateways_widget"]["gatewaysfilter"] = "";
+		$user_settings["widgets"]["gateways_widget"]["gatewaysfilter"] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Updated gateways widget settings via dashboard."));
@@ -319,7 +319,7 @@ function compose_table_body_contents() {
 
 	if (!$gw_displayed) {
 		$rtnstr .= '<tr>';
-		$rtnstr .= 	'<td colspan="5">';
+		$rtnstr .= 	'<td colspan="5" class="text-center">';
 		if (count($a_gateways)) {
 			$rtnstr .= gettext('All gateways are hidden.');
 		} else {

--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -49,6 +49,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	);
 
 	$skipinterfaces = explode(",", $user_settings['widgets']['interface_statistics']['iffilter']);
+	$interface_is_displayed = false;
 
 	print("<thead>");
 	print(	"<tr>");
@@ -57,7 +58,12 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	foreach ($ifdescrs as $ifdescr => $ifname) {
 		if (!in_array($ifdescr, $skipinterfaces)) {
 			print(		"<th>" . $ifname . "</th>");
+			$interface_is_displayed = true;
 		}
+	}
+
+	if (!$interface_is_displayed) {
+		print("<th>" . gettext('All interfaces are hidden.') . "</th>");
 	}
 
 	print(		"</tr>");
@@ -101,7 +107,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['interface_statistics']['iffilter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['interface_statistics']['iffilter'] = "";
+		$user_settings['widgets']['interface_statistics']['iffilter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Interface Statistics Filter via Dashboard."));

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -40,7 +40,7 @@ if ($_POST) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['interfaces']['iffilter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['interfaces']['iffilter'] = "";
+		$user_settings['widgets']['interfaces']['iffilter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Interfaces Filter via Dashboard."));
@@ -54,12 +54,14 @@ if ($_POST) {
 		<tbody>
 <?php
 $skipinterfaces = explode(",", $user_settings['widgets']['interfaces']['iffilter']);
+$interface_is_displayed = false;
 
 foreach ($ifdescrs as $ifdescr => $ifname):
 	if (in_array($ifdescr, $skipinterfaces)) {
 		continue;
 	}
 
+	$interface_is_displayed = true;
 	$ifinfo = get_interface_info($ifdescr);
 	if ($ifinfo['pppoelink'] || $ifinfo['pptplink'] || $ifinfo['l2tplink']) {
 		/* PPP link (non-cell) - looks like a modem */
@@ -127,6 +129,16 @@ foreach ($ifdescrs as $ifdescr => $ifname):
 	</tr>
 <?php
 endforeach;
+if (!$interface_is_displayed):
+?>
+	<tr>
+		<td class="text-center">
+			<?=gettext('All interfaces are hidden.');?>
+		</td>
+	</tr>
+
+<?php
+endif;
 ?>
 		</tbody>
 	</table>

--- a/src/usr/local/www/widgets/widgets/openvpn.widget.php
+++ b/src/usr/local/www/widgets/widgets/openvpn.widget.php
@@ -65,7 +65,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['openvpn']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['openvpn']['filter'] = "";
+		$user_settings['widgets']['openvpn']['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved OpenVPN Filter via Dashboard."));
@@ -83,11 +83,14 @@ function printPanel() {
 	$skipovpns = explode(",", $user_settings['widgets']['openvpn']['filter']);
 
 	$opstring = "";
+	$got_ovpn_server = false;
 
 	foreach ($servers as $server):
 		if (in_array($server['vpnid'], $skipovpns)) {
 			continue;
 		}
+
+		$got_ovpn_server = true;
 
 	$opstring .= "<div class=\"widget panel panel-default\">";
 	$opstring .=	"<div class=\"panel-heading\"><h2 class=\"panel-title\">" . htmlspecialchars($server['name']) . "</h2></div>";
@@ -302,7 +305,15 @@ function printPanel() {
 	endif;
 
 	if ((empty($clients)) && (empty($servers)) && (empty($sk_servers))) {
-		print(gettext("No OpenVPN instances defined"));
+		$none_to_display_text = gettext("No OpenVPN instances defined");
+	} else if (!$got_ovpn_server && !$got_sk_server && !$got_ovpn_client) {
+		$none_to_display_text = gettext("All OpenVPN instances are hidden");
+	} else {
+		$none_to_display_text = "";
+	}
+	
+	if (strlen($none_to_display_text) > 0) {
+		print('<table class="table"><tbody><td class="text-center">' . $none_to_display_text . '</td></tbody></table>');
 	}
 }
 

--- a/src/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/services_status.widget.php
@@ -59,7 +59,7 @@ if ($_POST) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['servicestatusfilter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['servicestatusfilter'] = "";
+		$user_settings['widgets']['servicestatusfilter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Service Status Filter via Dashboard."));
@@ -83,11 +83,14 @@ $skipservices = explode(",", $user_settings['widgets']['servicestatusfilter']);
 
 if (count($services) > 0) {
 	uasort($services, "service_dispname_compare");
+	$service_is_displayed = false;
 
 	foreach ($services as $service) {
 		if ((!$service['dispname']) || (in_array($service['dispname'], $skipservices)) || (!is_service_enabled($service['dispname']))) {
 			continue;
 		}
+
+		$service_is_displayed = true;
 
 		if (empty($service['description'])) {
 			$service['description'] = get_pkg_descr($service['name']);
@@ -103,8 +106,12 @@ if (count($services) > 0) {
 			</tr>
 <?php
 	}
+
+	if (!$service_is_displayed) {
+		echo "<tr><td colspan=\"4\" class=\"text-center\">" . gettext("All services are hidden") . ". </td></tr>\n";
+	}
 } else {
-	echo "<tr><td colspan=\"3\" class=\"text-center\">" . gettext("No services found") . ". </td></tr>\n";
+	echo "<tr><td colspan=\"4\" class=\"text-center\">" . gettext("No services found") . ". </td></tr>\n";
 }
 ?>
 		</tbody>

--- a/src/usr/local/www/widgets/widgets/smart_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/smart_status.widget.php
@@ -47,7 +47,7 @@ if ($_POST) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['smart_status']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['smart_status']['filter'] = "";
+		$user_settings['widgets']['smart_status']['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved SMART Status Filter via Dashboard."));
@@ -69,6 +69,7 @@ if ($_POST) {
 	<tbody>
 <?php
 $skipsmart = explode(",", $user_settings['widgets']['smart_status']['filter']);
+$smartdrive_is_displayed = false;
 
 if (count($devs) > 0)  {
 	foreach ($devs as $dev)  { ## for each found drive do
@@ -76,6 +77,7 @@ if (count($devs) > 0)  {
 			continue;
 		}
 
+		$smartdrive_is_displayed = true;
 		$dev_ident = exec("diskinfo -v /dev/$dev | grep ident   | awk '{print $1}'"); ## get identifier from drive
 		$dev_state = trim(exec("smartctl -H /dev/$dev | awk -F: '/^SMART overall-health self-assessment test result/ {print $2;exit}
 /^SMART Health Status/ {print $2;exit}'")); ## get SMART state from drive
@@ -101,6 +103,16 @@ if (count($devs) > 0)  {
 			<td><?=$dev?></td>
 			<td><?=$dev_ident?></td>
 			<td><?=ucfirst($dev_state)?></td>
+		</tr>
+<?php
+	}
+
+	if (!$smartdrive_is_displayed) {
+?>
+		<tr>
+			<td colspan="4" class="text-center">
+				<?=gettext('All SMART drives are hidden.');?>
+			</td>
 		</tr>
 <?php
 	}

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -107,7 +107,7 @@ if ($_REQUEST['getupdatestatus']) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['system_information']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['system_information']['filter'] = "";
+		$user_settings['widgets']['system_information']['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved System Information Widget Filter via Dashboard."));
@@ -123,6 +123,7 @@ $widgetperiod += 1000;
 $filesystems = get_mounted_filesystems();
 
 $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']['filter']);
+$rows_displayed = false;
 ?>
 
 <div class="table-responsive">
@@ -130,6 +131,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 	<tbody>
 <?php
 	if (!in_array('name', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Name");?></th>
@@ -138,6 +140,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('system', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("System");?></th>
@@ -157,6 +160,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('version', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Version");?></th>
@@ -178,6 +182,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('cpu_type', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("CPU Type");?></th>
@@ -195,6 +200,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('hwcrypto', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<?php if ($hwcrypto): ?>
 		<tr>
@@ -205,6 +211,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('uptime', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Uptime");?></th>
@@ -213,6 +220,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('current_datetime', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Current date/time");?></th>
@@ -221,6 +229,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('dns_servers', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("DNS server(s)");?></th>
@@ -238,6 +247,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('last_config_change', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<?php if ($config['revision']): ?>
 		<tr>
@@ -248,6 +258,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('state_table_size', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("State table size");?></th>
@@ -266,6 +277,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('mbuf_usage', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("MBUF Usage");?></th>
@@ -284,6 +296,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('temperature', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<?php if (get_temp() != ""): ?>
 		<tr>
@@ -301,6 +314,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('load_average', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Load average");?></th>
@@ -311,6 +325,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('cpu_usage', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("CPU usage");?></th>
@@ -326,6 +341,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('memory_usage', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Memory usage");?></th>
@@ -342,6 +358,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('swap_usage', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<?php if ($showswap == true): ?>
 		<tr>
@@ -360,6 +377,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('disk_usage', $skipsysinfoitems)):
+		$rows_displayed = true;
 		$diskidx = 0;
 		foreach ($filesystems as $fs):
 ?>
@@ -376,6 +394,15 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 			$diskidx++;
 		endforeach;
+	endif;
+	if (!$rows_displayed):
+?>
+		<tr>
+			<td class="text-center">
+				<?=gettext('All System Information items are hidden.');?>
+			</td>
+		</tr>
+<?php
 	endif;
 ?>
 

--- a/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
+++ b/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
@@ -47,7 +47,7 @@ if ($_POST) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['wol']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['wol']['filter'] = "";
+		$user_settings['widgets']['wol']['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Wake on LAN Filter via Dashboard."));
@@ -70,11 +70,14 @@ if ($_POST) {
 $skipwols = explode(",", $user_settings['widgets']['wol']['filter']);
 
 if (count($wolcomputers) > 0):
+	$wol_entry_is_displayed = false;
+
 	foreach ($wolcomputers as $wolent):
 		if (in_array(get_wolent_key($wolent), $skipwols)) {
 			continue;
 		}
 
+		$wol_entry_is_displayed = true;
 		$is_active = exec("/usr/sbin/arp -an |/usr/bin/grep {$wolent['mac']}| /usr/bin/wc -l|/usr/bin/awk '{print $1;}'");
 		$status = exec("/usr/sbin/arp -an | /usr/bin/awk '$4 == \"{$wolent['mac']}\" { print $7 }'");
 		?>
@@ -101,8 +104,15 @@ if (count($wolcomputers) > 0):
 				</a>
 			</td>
 		</tr>
-<?php	endforeach;
-else: ?>
+<?php
+	endforeach;
+	if (!$wol_entry_is_displayed):
+?>
+		<tr><td colspan="4" class="text-center"><?=gettext("All WoL entries are hidden.")?></td></tr>
+<?php
+	endif;
+else:
+?>
 	<tr><td colspan="4" class="text-center"><?= gettext("No saved WoL addresses") ?></td></tr>
 <?php
 endif;


### PR DESCRIPTION
1) The existing code is a bit "surprising". If the user unchecks all items and presses save, then it behaves as if all items are checked (i.e. everything displays).

2) If there were some items checked for display (e.g. some WoL entries or...) and those items have since been deleted from the config, then in practice there will be no entries that get displayed.

For both cases it seems useful/reasonable that the widget displays the fact that there is nothing selected for display. Without doing this, users are likely to wonder why the widget is empty.