### PR TITLE
 Traffic Graphs Widget handle no items selected for display

### DIFF
--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -37,6 +37,7 @@ define('DMYPWD', "********");
 
 global $g;
 $g = array(
+	"base_packages" => "siproxd",
 	"event_address" => "unix:///var/run/check_reload_status",
 	"factory_shipped_username" => "admin",
 	"factory_shipped_password" => "pfsense",
@@ -70,7 +71,7 @@ $g = array(
 	"disablecrashreporter" => false,
 	"crashreporterurl" => "https://crashreporter.pfsense.org/crash_reporter.php",
 	"debug" => false,
-	"latest_config" => "16.2",
+	"latest_config" => "16.3",
 	"minimum_ram_warning" => "101",
 	"minimum_ram_warning_text" => "128 MB",
 	"wan_interface_name" => "wan",

--- a/src/etc/inc/upgrade_config.inc
+++ b/src/etc/inc/upgrade_config.inc
@@ -5157,4 +5157,39 @@ function upgrade_161_to_162() {
 		$config['system']['crypto_hardware'] = "cryptodev";
 	}
 }
+
+/* Traffic graphs widget settings are now stored in a layout similar
+ * to other widgets. Migrate any old settings.
+ */
+function upgrade_162_to_163() {
+	require_once("ipsec.inc");
+	global $config;
+
+	foreach (array('refreshinterval', 'invert', 'size', 'backgroundupdate') as $setting) {
+		if (isset($config['widgets']['trafficgraphs'][$setting])) {
+			$config['widgets']['traffic_graphs'][$setting] = $config['widgets']['trafficgraphs'][$setting];
+			unset($config['widgets']['trafficgraphs'][$setting]);
+		}
+	}
+
+	if (isset($config['widgets']['trafficgraphs']['shown'])) {
+		if (is_array($config['widgets']['trafficgraphs']['shown']['item'])) {
+			$ifdescrs = get_configured_interface_with_descr();
+
+			if (ipsec_enabled()) {
+				$ifdescrs['enc0'] = "IPsec";
+			}
+
+			$validNames = array();
+
+			foreach ($ifdescrs as $ifdescr => $ifname) {
+				array_push($validNames, $ifdescr);
+			}
+
+			$config['widgets']['traffic_graphs']['filter'] = implode(',', array_diff($validNames, $config['widgets']['trafficgraphs']['shown']['item']));
+		}
+
+		unset($config['widgets']['trafficgraphs']['shown']);
+	}
+}
 ?>

--- a/src/usr/local/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/usr/local/www/widgets/widgets/traffic_graphs.widget.php
@@ -70,7 +70,7 @@ if ($_POST) {
 	if (is_array($_POST['show'])) {
 		$user_settings["widgets"]["traffic_graphs"]["filter"] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings["widgets"]["traffic_graphs"]["filter"] = "";
+		$user_settings["widgets"]["traffic_graphs"]["filter"] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Updated traffic graphs widget settings via dashboard."));
@@ -131,6 +131,12 @@ $tg_displayed_ifs_array = [];
 		$tg_displayed_ifs_array[] = $ifdescr;
 		echo '<div id="traffic-chart-' . $ifdescr . '" class="d3-chart traffic-widget-chart">';
 		echo '	<svg></svg>';
+		echo '</div>';
+	}
+
+	if (!$tg_displayed) {
+		echo '<div id="traffic-chartnone" class="d3-chart traffic-widget-chart">';
+		echo gettext('All traffic graphs are hidden.');
 		echo '</div>';
 	}
 ?>
@@ -257,7 +263,7 @@ events.push(function() {
 	localStorage.setItem('size', <?=$tg_size?>);
 	localStorage.setItem('backgroundupdate', <?=$tg_backgroundupdate?>);
 
-	window.interfaces = InterfaceString.split("|");
+	window.interfaces = InterfaceString.split("|").filter(function(entry) { return entry.trim() != ''; });
 	window.charts = {};
     window.myData = {};
     window.updateIds = 0;
@@ -295,7 +301,9 @@ events.push(function() {
 
 	});
 
-	draw_graph(refreshInterval, then, backgroundupdate);
+	if (window.interfaces.length > 0) {
+		draw_graph(refreshInterval, then, backgroundupdate);
+	}
 
 	//re-draw graph when the page goes from inactive (in it's window) to active
 	Visibility.change(function (e, state) {
@@ -332,7 +340,9 @@ events.push(function() {
 
 			});
 
-			draw_graph(refreshInterval, then, backgroundupdate);
+			if (window.interfaces.length > 0) {
+				draw_graph(refreshInterval, then, backgroundupdate);
+			}
 
 		}
 	});

--- a/src/usr/local/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/usr/local/www/widgets/widgets/traffic_graphs.widget.php
@@ -33,7 +33,7 @@
 //apply css change to Status > Monitoring
 //show interface name and latest in/out in upper left
 //add stacked overall graph?
-    //also show pie graph of lastest precentages of total? (split 50/50 on width)
+    //also show pie graph of lastest percentages of total? (split 50/50 on width)
     //make this an option?
 
 $nocsrf = true;
@@ -60,7 +60,7 @@ if (!is_array($config["widgets"]["trafficgraphs"])) {
 	$config["widgets"]["trafficgraphs"]["shown"] = array();
 	$config["widgets"]["trafficgraphs"]["shown"]["item"] = array();
 
-	foreach($ifdescrs as $ifname => $ifdescr) {
+	foreach ($ifdescrs as $ifname => $ifdescr) {
 
 		$ifinfo = get_interface_info($ifname);
 
@@ -74,17 +74,18 @@ if (!is_array($config["widgets"]["trafficgraphs"])) {
 
 }
 
-if(!isset($config["widgets"]["trafficgraphs"]["size"])) {
+if (!isset($config["widgets"]["trafficgraphs"]["size"])) {
 	$config["widgets"]["trafficgraphs"]["size"] = 1;
 }
 
-if(!isset($config["widgets"]["trafficgraphs"]["invert"])) {
+if (!isset($config["widgets"]["trafficgraphs"]["invert"])) {
 	$config["widgets"]["trafficgraphs"]["invert"] = "true";
 }
 
-if(!isset($config["widgets"]["trafficgraphs"]["backgroundupdate"])) {
+if (!isset($config["widgets"]["trafficgraphs"]["backgroundupdate"])) {
 	$config["widgets"]["trafficgraphs"]["backgroundupdate"] = "true";
 }
+
 $a_config = &$config["widgets"]["trafficgraphs"];
 
 // save new default config options that have been submitted
@@ -100,13 +101,13 @@ if ($_POST) {
 		die('{ "error" : "Refresh Interval is not a valid number between 1 and 10." }');
 	}
 
-	if($_POST["traffic-graph-invert"] === "true" || $_POST["traffic-graph-invert"] === "false") {
+	if ($_POST["traffic-graph-invert"] === "true" || $_POST["traffic-graph-invert"] === "false") {
 		$a_config["invert"] = $_POST["traffic-graph-invert"];
 	} else {
 		die('{ "error" : "Invert is not a boolean of true or false." }');
 	}
 
-	if($_POST["traffic-graph-backgroundupdate"] === "true" || $_POST["traffic-graph-backgroundupdate"] === "false") {
+	if ($_POST["traffic-graph-backgroundupdate"] === "true" || $_POST["traffic-graph-backgroundupdate"] === "false") {
 		$a_config["backgroundupdate"] = $_POST["traffic-graph-backgroundupdate"];
 	} else {
 		die('{ "error" : "Backgroundupdate is not a boolean of true or false." }');
@@ -151,7 +152,7 @@ $allifs = implode("|", $ifsarray);
 	<div id="traffic-chart-error" class="alert alert-danger" style="display: none;"></div>
 
 	<?php
-	foreach($a_config["shown"]["item"] as $ifname) {
+	foreach ($a_config["shown"]["item"] as $ifname) {
 		echo '<div id="traffic-chart-' . $ifname . '" class="d3-chart traffic-widget-chart">';
 		echo '	<svg></svg>';
 		echo '</div>';
@@ -203,13 +204,13 @@ events.push(function() {
 		var itemOut = new Object();
 
 		itemIn.key = value + " (in)";
-		if(localStorage.getItem('invert') === "true") { itemIn.area = true; }
+		if (localStorage.getItem('invert') === "true") { itemIn.area = true; }
 		itemIn.first = true;
 		itemIn.values = [{x: nowTime, y: 0}];
 		myData[value].push(itemIn);
 
 		itemOut.key = value + " (out)";
-		if(localStorage.getItem('invert') === "true") { itemOut.area = true; }
+		if (localStorage.getItem('invert') === "true") { itemOut.area = true; }
 		itemOut.first = true;
 		itemOut.values = [{x: nowTime, y: 0}];
 		myData[value].push(itemOut);
@@ -220,10 +221,10 @@ events.push(function() {
 
 	//re-draw graph when the page goes from inactive (in it's window) to active
 	Visibility.change(function (e, state) {
-		if($('#traffic-graph-backgroundupdate').val() === "true"){
+		if ($('#traffic-graph-backgroundupdate').val() === "true"){
 			return;
 		}
-		if(state === "visible") {
+		if (state === "visible") {
 
 			now = then = new Date(Date.now());
 
@@ -240,13 +241,13 @@ events.push(function() {
 				var itemOut = new Object();
 
 				itemIn.key = value + " (in)";
-				if(localStorage.getItem('invert') === "true") { itemIn.area = true; }
+				if (localStorage.getItem('invert') === "true") { itemIn.area = true; }
 				itemIn.first = true;
 				itemIn.values = [{x: nowTime, y: 0}];
 				myData[value].push(itemIn);
 
 				itemOut.key = value + " (out)";
-				if(localStorage.getItem('invert') === "true") { itemOut.area = true; }
+				if (localStorage.getItem('invert') === "true") { itemOut.area = true; }
 				itemOut.first = true;
 				itemOut.values = [{x: nowTime, y: 0}];
 				myData[value].push(itemOut);
@@ -259,30 +260,28 @@ events.push(function() {
 	});
 
 	// save new config defaults
-    $( '#traffic-graph-form' ).submit(function(event) {
+    $('#traffic-graph-form').submit(function(event) {
 
 		var error = false;
 		$("#traffic-chart-error").hide();
 
-		var interfaces = $( "#traffic-graph-interfaces" ).val();
-		refreshInterval = parseInt($( "#traffic-graph-interval" ).val());
-		var invert = $( "#traffic-graph-invert" ).val();
-		var size = $( "#traffic-graph-size" ).val();
-		var backgroundupdate = $( "#traffic-graph-backgroundupdate" ).val();
+		var interfaces = $("#traffic-graph-interfaces").val();
+		refreshInterval = parseInt($("#traffic-graph-interval").val());
+		var invert = $("#traffic-graph-invert").val();
+		var size = $("#traffic-graph-size").val();
+		var backgroundupdate = $("#traffic-graph-backgroundupdate").val();
 
 		//TODO validate interfaces data and throw error
 
-		if(!Number.isInteger(refreshInterval) || refreshInterval < 1 || refreshInterval > 10) {
+		if (!Number.isInteger(refreshInterval) || refreshInterval < 1 || refreshInterval > 10) {
 			error = 'Refresh Interval is not a valid number between 1 and 10.';
 		}
 
-		if(invert != "true" && invert != "false") {
-
+		if (invert != "true" && invert != "false") {
 			error = 'Invert is not a boolean of true or false.';
-
 		}
 
-		if(!error) {
+		if (!error) {
 
 			var formData = {
 				'traffic-graph-interfaces'       : interfaces,
@@ -301,13 +300,13 @@ events.push(function() {
 			})
 			.done(function(message) {
 
-				if(message.success) {
+				if (message.success) {
 
 					Visibility.stop(updateIds);
 					clearInterval(updateTimerIds);
 
 					//remove all old graphs (divs/svgs)
-					$( ".traffic-widget-chart" ).remove();
+					$(".traffic-widget-chart").remove();
 
 					window.interfaces = interfaces;
 					localStorage.setItem('interval', refreshInterval);
@@ -333,13 +332,13 @@ events.push(function() {
 						var itemOut = new Object();
 
 						itemIn.key = value + " (in)";
-						if(localStorage.getItem('invert') === "true") { itemIn.area = true; }
+						if (localStorage.getItem('invert') === "true") { itemIn.area = true; }
 						itemIn.first = true;
 						itemIn.values = [{x: nowTime, y: 0}];
 						myData[value].push(itemIn);
 
 						itemOut.key = value + " (out)";
-						if(localStorage.getItem('invert') === "true") { itemOut.area = true; }
+						if (localStorage.getItem('invert') === "true") { itemOut.area = true; }
 						itemOut.first = true;
 						itemOut.values = [{x: nowTime, y: 0}];
 						myData[value].push(itemOut);
@@ -348,18 +347,18 @@ events.push(function() {
 
 					draw_graph(refreshInterval, then, backgroundupdate);
 
-					$( "#traffic-graph-message" ).removeClass("text-danger").addClass("text-success");
-					$( "#traffic-graph-message" ).text(message.success);
+					$("#traffic-graph-message").removeClass("text-danger").addClass("text-success");
+					$("#traffic-graph-message").text(message.success);
 
 					setTimeout(function() {
-						$( "#traffic-graph-message" ).empty();
-						$( "#traffic-graph-message" ).removeClass("text-success");
+						$("#traffic-graph-message").empty();
+						$("#traffic-graph-message").removeClass("text-success");
 					}, 5000);
 
 				} else {
 
-					$( "#traffic-graph-message" ).addClass("text-danger");
-					$( "#traffic-graph-message" ).text(message.error);
+					$("#traffic-graph-message").addClass("text-danger");
+					$("#traffic-graph-message").text(message.error);
 
 					console.warn(message.error);
 
@@ -368,14 +367,14 @@ events.push(function() {
 	        })
 	        .fail(function() {
 
-			    console.warn( "The Traffic Graphs widget AJAX request failed." );
+			    console.warn("The Traffic Graphs widget AJAX request failed.");
 
 			});
 
 	    } else {
 
-			$( "#traffic-graph-message" ).addClass("text-danger");
-			$( "#traffic-graph-message" ).text(error);
+			$("#traffic-graph-message").addClass("text-danger");
+			$("#traffic-graph-message").text(error);
 
 			console.warn(error);
 
@@ -404,7 +403,9 @@ events.push(function() {
 				foreach ($ifdescrs as $ifname => $ifdescr) {
 
 					$if_shown = "";
-					if (in_array($ifname, $a_config["shown"]["item"])) { $if_shown = " selected"; };
+					if (in_array($ifname, $a_config["shown"]["item"])) {
+						$if_shown = " selected";
+					};
 					echo '<option value="' . $ifname . '"' . $if_shown . '>' . $ifdescr . "</option>\n";
 
 				}
@@ -425,7 +426,7 @@ events.push(function() {
 			<div class="col-sm-9">
 				<select class="form-control" id="traffic-graph-invert" name="traffic-graph-invert">
 				<?php
-					if($a_config["invert"] === "true") {
+					if ($a_config["invert"] === "true") {
 						echo '<option value="true" selected>On</option>';
 						echo '<option value="false">Off</option>';
 					} else {
@@ -442,7 +443,7 @@ events.push(function() {
 			<div class="col-sm-9">
 				<select class="form-control" id="traffic-graph-size" name="traffic-graph-size">
 				<?php
-					if($a_config["size"] === "8") {
+					if ($a_config["size"] === "8") {
 						echo '<option value="8" selected>Bits</option>';
 						echo '<option value="1">Bytes</option>';
 					} else {
@@ -459,7 +460,7 @@ events.push(function() {
 			<div class="col-sm-9">
 				<select class="form-control" id="traffic-graph-backgroundupdate" name="traffic-graph-backgroundupdate">
 				<?php
-					if($a_config["backgroundupdate"] === "true") {
+					if ($a_config["backgroundupdate"] === "true") {
 						echo '<option value="true" selected>Keep graphs updated on inactive tab. (increases cpu usage)</option>';
 						echo '<option value="false">Clear graphs when not visible.</option>';
 					} else {

--- a/src/usr/local/www/widgets/widgets/traffic_graphs.widget.php
+++ b/src/usr/local/www/widgets/widgets/traffic_graphs.widget.php
@@ -26,16 +26,6 @@
  * limitations under the License.
  */
 
-/* TODOs */
-//re-use on Status > traffic graphs
-//figure out why there is a missing datapoint at the start
-//name things/variables better
-//apply css change to Status > Monitoring
-//show interface name and latest in/out in upper left
-//add stacked overall graph?
-    //also show pie graph of lastest percentages of total? (split 50/50 on width)
-    //make this an option?
-
 $nocsrf = true;
 
 require_once("guiconfig.inc");
@@ -49,99 +39,72 @@ if (ipsec_enabled()) {
 	$ifdescrs['enc0'] = "IPsec";
 }
 
-//there are no traffic graph widget defaults in config yet. so set them, but don't write the config
-if (!is_array($config["widgets"]["trafficgraphs"])) {
-
-	$config["widgets"]["trafficgraphs"] = array();
-	$config["widgets"]["trafficgraphs"]["refreshinterval"] = 1;
-	$config["widgets"]["trafficgraphs"]["invert"] = "true";
-	$config["widgets"]["trafficgraphs"]["size"] = 1;
-	$config["widgets"]["trafficgraphs"]["backgroundupdate"] = "false";
-	$config["widgets"]["trafficgraphs"]["shown"] = array();
-	$config["widgets"]["trafficgraphs"]["shown"]["item"] = array();
-
-	foreach ($ifdescrs as $ifname => $ifdescr) {
-
-		$ifinfo = get_interface_info($ifname);
-
-		if ($ifinfo['status'] != "down") {
-			$config["widgets"]["trafficgraphs"]["shown"]["item"][] = $ifname;
-		}
-
-	}
-
-	//TODO silently write to config? (use a config message about saving defaults)
-
-}
-
-if (!isset($config["widgets"]["trafficgraphs"]["size"])) {
-	$config["widgets"]["trafficgraphs"]["size"] = 1;
-}
-
-if (!isset($config["widgets"]["trafficgraphs"]["invert"])) {
-	$config["widgets"]["trafficgraphs"]["invert"] = "true";
-}
-
-if (!isset($config["widgets"]["trafficgraphs"]["backgroundupdate"])) {
-	$config["widgets"]["trafficgraphs"]["backgroundupdate"] = "true";
-}
-
-$a_config = &$config["widgets"]["trafficgraphs"];
-
-// save new default config options that have been submitted
 if ($_POST) {
 
-	//TODO validate data and throw error
-	$a_config["shown"]["item"] = $_POST["traffic-graph-interfaces"];
-
-	// TODO check if between 1 and 10
-	if (isset($_POST["traffic-graph-interval"]) && is_numericint($_POST["traffic-graph-interval"])) {
-		$a_config["refreshinterval"] = $_POST["traffic-graph-interval"];
-	} else {
-		die('{ "error" : "Refresh Interval is not a valid number between 1 and 10." }');
+	if (!is_array($user_settings["widgets"]["traffic_graphs"])) {
+		$user_settings["widgets"]["traffic_graphs"] = array();
 	}
 
-	if ($_POST["traffic-graph-invert"] === "true" || $_POST["traffic-graph-invert"] === "false") {
-		$a_config["invert"] = $_POST["traffic-graph-invert"];
-	} else {
-		die('{ "error" : "Invert is not a boolean of true or false." }');
+	if (isset($_POST["refreshinterval"])) {
+		$user_settings["widgets"]["traffic_graphs"]["refreshinterval"] = $_POST["refreshinterval"];
 	}
 
-	if ($_POST["traffic-graph-backgroundupdate"] === "true" || $_POST["traffic-graph-backgroundupdate"] === "false") {
-		$a_config["backgroundupdate"] = $_POST["traffic-graph-backgroundupdate"];
-	} else {
-		die('{ "error" : "Backgroundupdate is not a boolean of true or false." }');
+	if (isset($_POST["invert"])) {
+		$user_settings["widgets"]["traffic_graphs"]["invert"] = $_POST["invert"];
 	}
-	
-	//TODO validate data and throw error
-	$a_config["size"] = $_POST["traffic-graph-size"];
 
-	write_config(gettext("Updated traffic graph settings via dashboard."));
+	if (isset($_POST["backgroundupdate"])) {
+		$user_settings["widgets"]["traffic_graphs"]["backgroundupdate"] = $_POST["backgroundupdate"];
+	}
 
-	header('Content-Type: application/json');
+	if (isset($_POST["size"])) {
+		$user_settings["widgets"]["traffic_graphs"]["size"] = $_POST["size"];
+	}
 
-	die('{ "success" : "The changes have been applied successfully." }');
+	$validNames = array();
 
+	foreach ($ifdescrs as $ifdescr => $ifname) {
+		array_push($validNames, $ifdescr);
+	}
+
+	if (is_array($_POST['show'])) {
+		$user_settings["widgets"]["traffic_graphs"]["filter"] = implode(',', array_diff($validNames, $_POST['show']));
+	} else {
+		$user_settings["widgets"]["traffic_graphs"]["filter"] = "";
+	}
+
+	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Updated traffic graphs widget settings via dashboard."));
+	header("Location: /");
+	exit(0);
 }
 
-$refreshinterval = $a_config["refreshinterval"];
-
-$ifsarray = [];
-
-foreach ($a_config["shown"]["item"] as $ifname) {
-
-	$ifinfo = get_interface_info($ifname);
-
-	if ($ifinfo['status'] != "down") {
-		$ifsarray[] = $ifname;
-	} else {
-		//TODO throw error?
-	}
-
+if (isset($user_settings['widgets']['traffic_graphs']['refreshinterval'])) {
+	$tg_refreshinterval = $user_settings['widgets']['traffic_graphs']['refreshinterval'];
+} else {
+	$tg_refreshinterval = 1;
 }
 
-$allifs = implode("|", $ifsarray);
+if (isset($user_settings['widgets']['traffic_graphs']['size'])) {
+	$tg_size = $user_settings['widgets']['traffic_graphs']['size'];
+} else {
+	$tg_size = 1;
+}
 
+if (isset($user_settings['widgets']['traffic_graphs']['invert'])) {
+	$tg_invert = $user_settings['widgets']['traffic_graphs']['invert'];
+} else {
+	$tg_invert = 'true';
+}
+
+if (isset($user_settings['widgets']['traffic_graphs']['backgroundupdate'])) {
+	$tg_backgroundupdate = $user_settings['widgets']['traffic_graphs']['backgroundupdate'];
+} else {
+	$tg_backgroundupdate = 'true';
+}
+
+$skip_tg_items = explode(",", $user_settings['widgets']['traffic_graphs']['filter']);
+$tg_displayed = false;
+$tg_displayed_ifs_array = [];
 ?>
 	<script src="/vendor/d3/d3.min.js"></script>
 	<script src="/vendor/nvd3/nv.d3.js"></script>
@@ -150,17 +113,132 @@ $allifs = implode("|", $ifsarray);
 	<link href="/vendor/nvd3/nv.d3.css" media="screen, projection" rel="stylesheet" type="text/css">
 
 	<div id="traffic-chart-error" class="alert alert-danger" style="display: none;"></div>
+<?php
+	foreach ($ifdescrs as $ifdescr => $ifname) {
+		if (in_array($ifdescr, $skip_tg_items)) {
+			continue;
+		}
 
-	<?php
-	foreach ($a_config["shown"]["item"] as $ifname) {
-		echo '<div id="traffic-chart-' . $ifname . '" class="d3-chart traffic-widget-chart">';
+		$ifinfo = get_interface_info($ifdescr);
+
+		if ($ifinfo['status'] == "down") {
+			// Do not try to display the traffic graph of a down interface,
+			// even though it is selected for display.
+			continue;
+		}
+
+		$tg_displayed = true;
+		$tg_displayed_ifs_array[] = $ifdescr;
+		echo '<div id="traffic-chart-' . $ifdescr . '" class="d3-chart traffic-widget-chart">';
 		echo '	<svg></svg>';
 		echo '</div>';
 	}
-	?>
+?>
 
-	<script type="text/javascript">
+<!-- close the body we're wrapped in and add a configuration-panel -->
+</div>
+
+<div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+
+	<form action="/widgets/widgets/traffic_graphs.widget.php" method="post" class="form-horizontal">
+		<div class="form-group">
+			<label for="traffic-graph-interval" class="col-sm-3 control-label"><?=gettext('Refresh Interval')?></label>
+			<div class="col-sm-9">
+				<input type="number" id="refreshinterval" name="refreshinterval" value="<?=$tg_refreshinterval?>" min="1" max="10" class="form-control" />
+			</div>
+		</div>
+
+		<div class="form-group">
+			<label for="invert" class="col-sm-3 control-label"><?=gettext('Inverse')?></label>
+			<div class="col-sm-9">
+				<select class="form-control" id="invert" name="invert">
+				<?php
+					if ($tg_invert === "true") {
+						echo '<option value="true" selected>On</option>';
+						echo '<option value="false">Off</option>';
+					} else {
+						echo '<option value="true">On</option>';
+						echo '<option value="false" selected>Off</option>';
+					}
+				?>
+				</select>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<label for="size" class="col-sm-3 control-label"><?=gettext('Unit Size')?></label>
+			<div class="col-sm-9">
+				<select class="form-control" id="size" name="size">
+				<?php
+					if ($tg_size === "8") {
+						echo '<option value="8" selected>Bits</option>';
+						echo '<option value="1">Bytes</option>';
+					} else {
+						echo '<option value="8">Bits</option>';
+						echo '<option value="1" selected>Bytes</option>';
+					}
+				?>
+				</select>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<label for="backgroundupdate" class="col-sm-3 control-label"><?=gettext('Background updates')?></label>
+			<div class="col-sm-9">
+				<select class="form-control" id="backgroundupdate" name="backgroundupdate">
+				<?php
+					if ($tg_backgroundupdate === "true") {
+						echo '<option value="true" selected>Keep graphs updated on inactive tab. (increases cpu usage)</option>';
+						echo '<option value="false">Clear graphs when not visible.</option>';
+					} else {
+						echo '<option value="true">Keep graphs updated on inactive tab. (increases cpu usage)</option>';
+						echo '<option value="false" selected>Clear graphs when not visible.</option>';
+					}
+				?>
+				</select>
+			</div>
+		</div>
+
+		<div class="panel panel-default col-sm-10">
+			<div class="panel-body">
+				<div class="table responsive">
+					<table class="table table-striped table-hover table-condensed">
+						<thead>
+							<tr>
+								<th><?=gettext("Interface")?></th>
+								<th><?=gettext("Show")?></th>
+							</tr>
+						</thead>
+						<tbody>
+	<?php
+					$idx = 0;
+
+					foreach ($ifdescrs as $ifdescr => $ifname):
+	?>
+							<tr>
+								<td><?=$ifname?></td>
+								<td class="col-sm-2"><input id="show[]" name ="show[]" value="<?=$ifdescr?>" type="checkbox" <?=(!in_array($ifdescr, $skip_tg_items) ? 'checked':'')?>></td>
+							</tr>
+	<?php
+					endforeach;
+	?>
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<div class="col-sm-offset-3 col-sm-6">
+				<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
+				<button id="showalltgitems" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			</div>
+		</div>
+	</form>
+
+<script type="text/javascript">
 //<![CDATA[
+// Used by /js/traffic-graphs.js to display description from name
 var graph_interfacenames = <?php
 	foreach ($ifdescrs as $ifname => $ifdescr) {
 		$iflist[$ifname] = $ifdescr;
@@ -170,14 +248,14 @@ var graph_interfacenames = <?php
 
 events.push(function() {
 
-	var InterfaceString = "<?=$allifs?>";
+	var InterfaceString = "<?=implode("|", $tg_displayed_ifs_array)?>";
 
 	//store saved settings in a fresh localstorage
 	localStorage.clear();
-	localStorage.setItem('interval', <?=$refreshinterval?>);
-	localStorage.setItem('invert', <?=$a_config["invert"]?>);
-	localStorage.setItem('size', <?=$a_config["size"]?>);
-	localStorage.setItem('backgroundupdate', <?=$a_config["backgroundupdate"]?>);
+	localStorage.setItem('interval', <?=$tg_refreshinterval?>);
+	localStorage.setItem('invert', <?=$tg_invert?>);
+	localStorage.setItem('size', <?=$tg_size?>);
+	localStorage.setItem('backgroundupdate', <?=$tg_backgroundupdate?>);
 
 	window.interfaces = InterfaceString.split("|");
 	window.charts = {};
@@ -221,7 +299,7 @@ events.push(function() {
 
 	//re-draw graph when the page goes from inactive (in it's window) to active
 	Visibility.change(function (e, state) {
-		if ($('#traffic-graph-backgroundupdate').val() === "true"){
+		if (backgroundupdate) {
 			return;
 		}
 		if (state === "visible") {
@@ -259,224 +337,13 @@ events.push(function() {
 		}
 	});
 
-	// save new config defaults
-    $('#traffic-graph-form').submit(function(event) {
-
-		var error = false;
-		$("#traffic-chart-error").hide();
-
-		var interfaces = $("#traffic-graph-interfaces").val();
-		refreshInterval = parseInt($("#traffic-graph-interval").val());
-		var invert = $("#traffic-graph-invert").val();
-		var size = $("#traffic-graph-size").val();
-		var backgroundupdate = $("#traffic-graph-backgroundupdate").val();
-
-		//TODO validate interfaces data and throw error
-
-		if (!Number.isInteger(refreshInterval) || refreshInterval < 1 || refreshInterval > 10) {
-			error = 'Refresh Interval is not a valid number between 1 and 10.';
-		}
-
-		if (invert != "true" && invert != "false") {
-			error = 'Invert is not a boolean of true or false.';
-		}
-
-		if (!error) {
-
-			var formData = {
-				'traffic-graph-interfaces'       : interfaces,
-				'traffic-graph-interval'         : refreshInterval,
-				'traffic-graph-invert'           : invert,
-				'traffic-graph-size'             : size,
-				'traffic-graph-backgroundupdate' : backgroundupdate
-			};
-
-			$.ajax({
-				type        : 'POST',
-				url         : '/widgets/widgets/traffic_graphs.widget.php',
-				data        : formData,
-				dataType    : 'json',
-				encode      : true
-			})
-			.done(function(message) {
-
-				if (message.success) {
-
-					Visibility.stop(updateIds);
-					clearInterval(updateTimerIds);
-
-					//remove all old graphs (divs/svgs)
-					$(".traffic-widget-chart").remove();
-
-					window.interfaces = interfaces;
-					localStorage.setItem('interval', refreshInterval);
-					localStorage.setItem('invert', invert);
-					localStorage.setItem('size', size);
-					localStorage.setItem('backgroundupdate', backgroundupdate);
-
-					//redraw graph with new settings
-					now = then = new Date(Date.now());
-
-					var freshData = [];
-
-					var nowTime = now.getTime();
-
-					$.each( interfaces, function( key, value ) {
-
-						//create new graphs (divs/svgs)
-						$("#widget-traffic_graphs_panel-body").append('<div id="traffic-chart-' + value + '" class="d3-chart traffic-widget-chart"><svg></svg></div>');
-
-						myData[value] = [];
-
-						var itemIn = new Object();
-						var itemOut = new Object();
-
-						itemIn.key = value + " (in)";
-						if (localStorage.getItem('invert') === "true") { itemIn.area = true; }
-						itemIn.first = true;
-						itemIn.values = [{x: nowTime, y: 0}];
-						myData[value].push(itemIn);
-
-						itemOut.key = value + " (out)";
-						if (localStorage.getItem('invert') === "true") { itemOut.area = true; }
-						itemOut.first = true;
-						itemOut.values = [{x: nowTime, y: 0}];
-						myData[value].push(itemOut);
-
-					});
-
-					draw_graph(refreshInterval, then, backgroundupdate);
-
-					$("#traffic-graph-message").removeClass("text-danger").addClass("text-success");
-					$("#traffic-graph-message").text(message.success);
-
-					setTimeout(function() {
-						$("#traffic-graph-message").empty();
-						$("#traffic-graph-message").removeClass("text-success");
-					}, 5000);
-
-				} else {
-
-					$("#traffic-graph-message").addClass("text-danger");
-					$("#traffic-graph-message").text(message.error);
-
-					console.warn(message.error);
-
-				}
-
-	        })
-	        .fail(function() {
-
-			    console.warn("The Traffic Graphs widget AJAX request failed.");
-
-			});
-
-	    } else {
-
-			$("#traffic-graph-message").addClass("text-danger");
-			$("#traffic-graph-message").text(error);
-
-			console.warn(error);
-
-	    }
-
-        event.preventDefault();
-    });
-
+	$("#showalltgitems").click(function() {
+		$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
+			$(this).prop("checked", true);
+		});
+	});
 });
 //]]>
 </script>
 
 <script src="/js/traffic-graphs.js"></script>
-
-<!-- close the body we're wrapped in and add a configuration-panel -->
-</div>
-
-<div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
-
-	<form id="traffic-graph-form" action="/widgets/widgets/traffic_graphs.widget.php" method="post" class="form-horizontal">
-		<div class="form-group">
-			<label for="traffic-graph-interfaces" class="col-sm-3 control-label"><?=gettext('Show graphs')?></label>
-			<div class="col-sm-9">
-				<select name="traffic-graph-interfaces[]" id="traffic-graph-interfaces" multiple>
-				<?php
-				foreach ($ifdescrs as $ifname => $ifdescr) {
-
-					$if_shown = "";
-					if (in_array($ifname, $a_config["shown"]["item"])) {
-						$if_shown = " selected";
-					};
-					echo '<option value="' . $ifname . '"' . $if_shown . '>' . $ifdescr . "</option>\n";
-
-				}
-				?>
-				</select>
-			</div>
-		</div>
-
-		<div class="form-group">
-			<label for="traffic-graph-interval" class="col-sm-3 control-label"><?=gettext('Refresh Interval')?></label>
-			<div class="col-sm-9">
-				<input type="number" id="traffic-graph-interval" name="traffic-graph-interval" value="<?=$refreshinterval?>" min="1" max="10" class="form-control" />
-			</div>
-		</div>
-
-		<div class="form-group">
-			<label for="traffic-graph-invert" class="col-sm-3 control-label"><?=gettext('Inverse')?></label>
-			<div class="col-sm-9">
-				<select class="form-control" id="traffic-graph-invert" name="traffic-graph-invert">
-				<?php
-					if ($a_config["invert"] === "true") {
-						echo '<option value="true" selected>On</option>';
-						echo '<option value="false">Off</option>';
-					} else {
-						echo '<option value="true">On</option>';
-						echo '<option value="false" selected>Off</option>';
-					}
-				?>
-				</select>
-			</div>
-		</div>
-
-		<div class="form-group">
-			<label for="traffic-graph-size" class="col-sm-3 control-label"><?=gettext('Unit Size')?></label>
-			<div class="col-sm-9">
-				<select class="form-control" id="traffic-graph-size" name="traffic-graph-size">
-				<?php
-					if ($a_config["size"] === "8") {
-						echo '<option value="8" selected>Bits</option>';
-						echo '<option value="1">Bytes</option>';
-					} else {
-						echo '<option value="8">Bits</option>';
-						echo '<option value="1" selected>Bytes</option>';
-					}
-				?>
-				</select>
-			</div>
-		</div>
-
-		<div class="form-group">
-			<label for="traffic-graph-backgroundupdate" class="col-sm-3 control-label"><?=gettext('Background updates')?></label>
-			<div class="col-sm-9">
-				<select class="form-control" id="traffic-graph-backgroundupdate" name="traffic-graph-backgroundupdate">
-				<?php
-					if ($a_config["backgroundupdate"] === "true") {
-						echo '<option value="true" selected>Keep graphs updated on inactive tab. (increases cpu usage)</option>';
-						echo '<option value="false">Clear graphs when not visible.</option>';
-					} else {
-						echo '<option value="true">Keep graphs updated on inactive tab. (increases cpu usage)</option>';
-						echo '<option value="false" selected>Clear graphs when not visible.</option>';
-					}
-				?>
-				</select>
-			</div>
-		</div>
-		<div class="form-group">
-			<div class="col-sm-3 text-right">
-				<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			</div>
-			<div class="col-sm-9">
-				<div id="traffic-graph-message"></div>
-			</div>
-		</div>
-	</form>


### PR DESCRIPTION
This is the equivalent of #3652 (which implements this logic for the other widgets).
A separate PR is needed here, because the Traffic Graphs Widget first needs to have a code base that works in a similar way to the other widgets. That code base is provided by the following other PRs that are waiting to be reviewed/merged:
#3654 Traffic Graphs Widget whitespace
#3655 Traffic graph widget filter checkboxes

Those need to be merged first in order, then this one will show just a few lines of diff.