### PR TITLE
Redmine 7182 Allow multiple copies of widgets on dashboard

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -445,6 +445,53 @@ function updateWidgets(newWidget) {
 	$('input[name=sequence]', $('#widgetSequence_form')).val(sequence);
 }
 
+// Determine if all the checkboxes are checked
+function are_all_checked(checkbox_panel_ref) {
+	var allBoxesChecked = true;
+	$(checkbox_panel_ref).each(function() {
+		if ((this.type == 'checkbox') && !this.checked) {
+			allBoxesChecked = false;
+		}
+	});
+	return allBoxesChecked;
+}
+
+// If the checkboxes are all checked, then clear them all.
+// Otherwise set them all.
+function set_clear_checkboxes(checkbox_panel_ref) {
+	checkTheBoxes = !are_all_checked(checkbox_panel_ref);
+
+	$(checkbox_panel_ref).each(function() {
+		$(this).prop("checked", checkTheBoxes);
+	});
+}
+
+// Set the given id to All or None button depending if the checkboxes are all checked.
+function set_all_none_button(checkbox_panel_ref, all_none_button_id) {
+	if (are_all_checked(checkbox_panel_ref)) {
+		text = "<?=gettext('None')?>";
+	} else {
+		text = "<?=gettext('All')?>";
+	}
+
+	$("#" + all_none_button_id).html('<i class="fa fa-undo icon-embed-btn"></i>' + text);
+}
+
+// Setup the necessary events to manage the All/None button and included checkboxes
+// used for selecting the items to show on a widget.
+function set_widget_checkbox_events(checkbox_panel_ref, all_none_button_id) {
+		set_all_none_button(checkbox_panel_ref, all_none_button_id);
+
+		$(checkbox_panel_ref).change(function() {
+			set_all_none_button(checkbox_panel_ref, all_none_button_id);
+		});
+
+		$("#" + all_none_button_id).click(function() {
+			set_clear_checkboxes(checkbox_panel_ref);
+			set_all_none_button(checkbox_panel_ref, all_none_button_id);
+		});
+}
+
 events.push(function() {
 
 	// Make panels destroyable

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -108,16 +108,16 @@ foreach ($phpincludefiles as $includename) {
 
 ##build list of widgets
 foreach (glob("/usr/local/www/widgets/widgets/*.widget.php") as $file) {
-	$name = basename($file, '.widget.php');
+	$basename = basename($file, '.widget.php');
 	// Get the widget title that should be in a var defined in the widget's inc file.
-	$widgettitle = ${$name . '_title'};
+	$widgettitle = ${$basename . '_title'};
 
 	if (empty(trim($widgettitle))) {
 		// Fall back to constructing a title from the file name of the widget.
-		$widgettitle = ucwords(str_replace('_', ' ', $name));
+		$widgettitle = ucwords(str_replace('_', ' ', $basename));
 	}
 
-	$widgets[ $name ] = array('name' => $widgettitle, 'display' => 'none');
+	$known_widgets[$basename . '-0'] = array('basename' => $basename, 'title' => $widgettitle, 'display' => 'none');
 }
 
 ##if no config entry found, initialize config entry
@@ -133,11 +133,54 @@ if ($_POST && $_POST['sequence']) {
 	// Start with the user's widget settings.
 	$widget_settings = $user_settings['widgets'];
 
-	$widget_settings['sequence'] = rtrim($_POST['sequence'], ',');
+	$widget_sep = ',';
+	$widget_seq_array = explode($widget_sep, rtrim($_POST['sequence'], $widget_sep));
+	$widget_counter_array = array();
+	$widget_sep = '';
 
-	foreach ($widgets as $widgetname => $widgetconfig) {
-		if ($_POST[$widgetname . '-config']) {
-			$widget_settings[$widgetname . '-config'] = $_POST[$widgetname . '-config'];
+	// Make a record of the counter of each widget that is in use.
+	foreach ($widget_seq_array as $widget_seq_data) {
+		list($basename, $col, $display, $widget_counter) = explode(':', $widget_seq_data);
+
+		if ($widget_counter != 'next') {
+			$widget_counter_array[$basename][$widget_counter] = true;
+			$widget_sequence .= $widget_sep . $widget_seq_data;
+			$widget_sep = ',';
+		}
+	}
+
+	// Find any new entry (and do not assume there is only 1 new entry)
+	foreach ($widget_seq_array as $widget_seq_data) {
+		list($basename, $col, $display, $widget_counter) = explode(':', $widget_seq_data);
+
+		if ($widget_counter == 'next') {
+			// Construct the widget counter of the new widget instance by finding
+			// the first non-negative integer that is not in use.
+			// The reasoning here is that if you just deleted a widget instance,
+			// e.g. had System Information 0,1,2 and deleted 1,
+			// then when you add System Information again it will become instance 1,
+			// which will bring back whatever filter selections happened to be on
+			// the previous instance 1.
+			$instance_num = 0;
+
+			while (isset($widget_counter_array[$basename][$instance_num])) {
+				$instance_num++;
+			}
+
+			$widget_sequence .= $widget_sep . $basename . ':' . $col . ':' . $display . ':' . $instance_num;
+			$widget_counter_array[$basename][$instance_num] = true;
+			$widget_sep = ',';
+		}
+	}
+
+	$widget_settings['sequence'] = $widget_sequence;
+
+	foreach ($widget_counter_array as $basename => $instances) {
+		foreach ($instances as $instance => $value) {
+			$widgetconfigname = $basename . '-' . $instance . '-config';
+			if ($_POST[$widgetconfigname]) {
+				$widget_settings[$widgetconfigname] = $_POST[$widgetconfigname];
+			}
 		}
 	}
 
@@ -230,13 +273,20 @@ if ($user_settings['widgets']['sequence'] != "") {
 	$widgetsfromconfig = array();
 
 	foreach (explode(',', $pconfig['sequence']) as $line) {
-		list($file, $col, $display) = explode(':', $line);
+		$line_items = explode(':', $line);
+		if (count($line_items) == 3) {
+			// There can be multiple copies of a widget on the dashboard.
+			// Default the copy number if it is not present (e.g. from old configs)
+			$line_items[] = 0;
+		}
+
+		list($basename, $col, $display, $copynum) = $line_items;
 
 		// be backwards compatible
 		// If the display column information is missing, we will assign a temporary
 		// column here. Next time the user saves the dashboard it will fix itself
 		if ($col == "") {
-			if ($file == "system_information") {
+			if ($basename == "system_information") {
 				$col = "col1";
 			} else {
 				$col = "col2";
@@ -248,28 +298,32 @@ if ($user_settings['widgets']['sequence'] != "") {
 			$col = "col" . $dashboardcolumns;
 		}
 
-		$offset = strpos($file, '-container');
+		$offset = strpos($basename, '-container');
 		if (false !== $offset) {
-			$file = substr($file, 0, $offset);
+			$basename = substr($basename, 0, $offset);
 		}
 
 		// Get the widget title that should be in a var defined in the widget's inc file.
-		$widgettitle = ${$file . '_title'};
+		$widgettitle = ${$basename . '_title'};
 
 		if (empty(trim($widgettitle))) {
 			// Fall back to constructing a title from the file name of the widget.
-			$widgettitle = ucwords(str_replace('_', ' ', $file));
+			$widgettitle = ucwords(str_replace('_', ' ', $basename));
 		}
 
-		$widgetsfromconfig[ $file ] = array(
-			'name' => $widgettitle,
+		$widgetkey = $basename . '-' . $copynum;
+
+		$widgetsfromconfig[$widgetkey] = array(
+			'basename' => $basename,
+			'title' => $widgettitle,
 			'col' => $col,
 			'display' => $display,
+			'copynum' => $copynum,
 		);
 	}
 
 	// add widgets that may not be in the saved configuration, in case they are to be displayed later
-	$widgets = $widgetsfromconfig + $widgets;
+	$widgets = $widgetsfromconfig + $known_widgets;
 
 	##find custom configurations of a particular widget and load its info to $pconfig
 	foreach ($widgets as $widgetname => $widgetconfig) {
@@ -317,15 +371,13 @@ pfSense_handle_custom_code("/usr/local/pkg/dashboard/pre_dashboard");
 			<div class="row">
 <?php
 
-// Build the Available Widgets table using a sorted copy of the $widgets array
-$available = $widgets;
-uasort($available, function($a, $b){ return strcasecmp($a['name'], $b['name']); });
+// Build the Available Widgets table using a sorted copy of the $known_widgets array
+$available = $known_widgets;
+uasort($available, function($a, $b){ return strcasecmp($a['title'], $b['title']); });
 
-foreach ($available as $widgetname => $widgetconfig):
-	if ($widgetconfig['display'] == 'none'):
+foreach ($available as $widgetkey => $widgetconfig):
 ?>
-		<div class="col-sm-3"><a href="#" id="btnadd-<?=$widgetname?>"><i class="fa fa-plus"></i> <?=$widgetconfig['name']?></a></div>
-	<?php endif; ?>
+		<div class="col-sm-3"><a href="#" id="btnadd-<?=$widgetconfig['basename']?>"><i class="fa fa-plus"></i> <?=$widgetconfig['title']?></a></div>
 <?php endforeach; ?>
 			</div>
 		</div>
@@ -340,20 +392,20 @@ foreach ($available as $widgetname => $widgetconfig):
 
 <?php
 $widgetColumns = array();
-foreach ($widgets as $widgetname => $widgetconfig) {
+foreach ($widgets as $widgetkey => $widgetconfig) {
 	if ($widgetconfig['display'] == 'none') {
 		continue;
 	}
 
-	if (!file_exists('/usr/local/www/widgets/widgets/'. $widgetname.'.widget.php')) {
+	if (!file_exists('/usr/local/www/widgets/widgets/'. $widgetconfig['basename'].'.widget.php')) {
 		continue;
 	}
 
-	if (!isset($widgetColumns[ $widgetconfig['col'] ])) {
-		$widgetColumns[ $widgetconfig['col'] ] = array();
+	if (!isset($widgetColumns[$widgetconfig['col']])) {
+		$widgetColumns[$widgetconfig['col']] = array();
 	}
 
-	$widgetColumns[ $widgetconfig['col'] ][ $widgetname ] = $widgetconfig;
+	$widgetColumns[$widgetconfig['col']][$widgetkey] = $widgetconfig;
 }
 ?>
 
@@ -369,36 +421,55 @@ foreach ($widgets as $widgetname => $widgetconfig) {
 			echo '<div class="col-md-' . $columnWidth . '" id="widgets-col' . $currentColumnNumber . '">';
 			$columnWidgets = $widgetColumns['col'.$currentColumnNumber];
 
-			foreach ($columnWidgets as $widgetname => $widgetconfig) {
+			foreach ($columnWidgets as $widgetkey => $widgetconfig) {
+				// Construct some standard names for the ids this widget will use for its commonly-used elements.
+				// Included widget.php code can rely on and use these, so the format does not have to be repeated in every widget.php
+				$widget_panel_body_id = 'widget-' . $widgetkey . '_panel-body';
+				$widget_panel_footer_id = 'widget-' . $widgetkey . '_panel-footer';
+				$widget_showallnone_id = 'widget-' . $widgetkey . '_showallnone';
+
 				// Compose the widget title and include the title link if available
-				$widgetlink = ${$widgetname . '_title_link'};
+				$widgetlink = ${$widgetconfig['basename'] . '_title_link'};
 
 				if ((strlen($widgetlink) > 0)) {
-					$wtitle = '<a href="' . $widgetlink . '"> ' . $widgetconfig['name'] . '</a>';
+					$wtitle = '<a href="' . $widgetlink . '"> ' . $widgetconfig['title'] . '</a>';
 				} else {
-					$wtitle = $widgetconfig['name'];
+					$wtitle = $widgetconfig['title'];
 				}
 				?>
-					<div class="panel panel-default" id="widget-<?=$widgetname?>">
+				<div class="panel panel-default" id="widget-<?=$widgetkey?>">
 					<div class="panel-heading">
 						<h2 class="panel-title">
 							<?=$wtitle?>
 							<span class="widget-heading-icon">
-								<a data-toggle="collapse" href="#widget-<?=$widgetname?>_panel-footer" class="config hidden">
+								<a data-toggle="collapse" href="#<?=$widget_panel_footer_id?>" class="config hidden">
 									<i class="fa fa-wrench"></i>
 								</a>
-								<a data-toggle="collapse" href="#widget-<?=$widgetname?>_panel-body">
+								<a data-toggle="collapse" href="#<?=$widget_panel_body_id?>">
 									<!--  actual icon is determined in css based on state of body -->
 									<i class="fa fa-plus-circle"></i>
 								</a>
-								<a data-toggle="close" href="#widget-<?=$widgetname?>">
+								<a data-toggle="close" href="#widget-<?=$widgetkey?>">
 									<i class="fa fa-times-circle"></i>
 								</a>
 							</span>
 						</h2>
 					</div>
-					<div id="widget-<?=$widgetname?>_panel-body" class="panel-body collapse<?=($widgetconfig['display'] == 'close' ? '' : ' in')?>">
-						<?php include_once('/usr/local/www/widgets/widgets/'. $widgetname.'.widget.php'); ?>
+					<div id="<?=$widget_panel_body_id?>" class="panel-body collapse<?=($widgetconfig['display'] == 'close' ? '' : ' in')?>">
+						<?php
+							// For backward compatibility, included *.widget.php code needs the var $widgetname
+							$widgetname = $widgetkey;
+							// Determine if this is the first instance of this particular widget.
+							// Provide the $widget_first_instance var, to make it easy for the included widget code
+							// to be able to know if it is being included for the first time.
+							if ($widgets_found[$widgetconfig['basename']]) {
+								$widget_first_instance = false;
+							} else {
+								$widget_first_instance = true;
+								$widgets_found[$widgetconfig['basename']] = true;
+							}
+							include('/usr/local/www/widgets/widgets/' . $widgetconfig['basename'] . '.widget.php');
+						?>
 					</div>
 				</div>
 				<?php
@@ -428,7 +499,7 @@ function updateWidgets(newWidget) {
 			// Only save details for panels that have id's like'widget-*'
 			// Some widgets create other panels, so ignore any of those.
 			if ((widget.id.split('-')[0] == 'widget') && (typeof widget_basename !== 'undefined')) {
-				sequence += widget_basename + ':' + col.id.split('-')[1] + ':' + (isOpen ? 'open' : 'close') + ',';
+				sequence += widget_basename + ':' + col.id.split('-')[1] + ':' + (isOpen ? 'open' : 'close') + ':' + widget.id.split('-')[2] + ',';
 			}
 		});
 	});
@@ -436,9 +507,9 @@ function updateWidgets(newWidget) {
 	if (typeof newWidget !== 'undefined') {
 		// The system_information widget is always added to column one. Others go in column two
 		if (newWidget == "system_information") {
-			sequence += newWidget + ':' + 'col1:open';
+			sequence += newWidget.split('-')[0] + ':' + 'col1:open:next';
 		} else {
-		sequence += newWidget + ':' + 'col2:open';
+			sequence += newWidget.split('-')[0] + ':' + 'col2:open:next';
 		}
 	}
 

--- a/src/usr/local/www/widgets/widgets/captive_portal_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/captive_portal_status.widget.php
@@ -54,9 +54,11 @@ unset($cpzone);
 
 flush();
 
-function clientcmp($a, $b) {
-	global $order;
-	return strcmp($a[$order], $b[$order]);
+if (!function_exists('clientcmp')) {
+	function clientcmp($a, $b) {
+		global $order;
+		return strcmp($a[$order], $b[$order]);
+	}
 }
 
 $cpdb_all = array();

--- a/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
@@ -285,12 +285,7 @@ function get_dyndns_service_text($dyndns_type) {
 		setTimeout('dyndns_getstatus()', 5*60*1000);
 	}
 	events.push(function(){
-		$("#showalldyndns").click(function() {
-			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
-				$(this).prop("checked", true);
-			});
-		});
-
+		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showalldyndns");
 	});
 	// Do the first status check 2 seconds after the dashboard opens
 	setTimeout('dyndns_getstatus()', 2000);

--- a/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
@@ -125,7 +125,7 @@ if ($_REQUEST['getdyndnsstatus']) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['dyn_dns_status']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['dyn_dns_status']['filter'] = "";
+		$user_settings['widgets']['dyn_dns_status']['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Dynamic DNS Filter via Dashboard."));
@@ -204,6 +204,13 @@ function get_dyndns_service_text($dyndns_type) {
 		</td>
 	</tr>
 	<?php endforeach;?>
+	<?php if ($rowid == -1):?>
+	<tr>
+		<td colspan="4" class="text-center">
+			<?=gettext('All Dyn DNS entries are hidden.');?>
+		</td>
+	</tr>
+	<?php endif;?>
 	</tbody>
 </table>
 </div>

--- a/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
@@ -29,17 +29,21 @@ require_once("functions.inc");
 require_once("/usr/local/www/widgets/include/dyn_dns_status.inc");
 
 // Constructs a unique key that will identify a Dynamic DNS entry in the filter list.
-function get_dyndnsent_key($dyndns) {
-	return $dyndns['id'];
+if (!function_exists('get_dyndnsent_key')) {
+	function get_dyndnsent_key($dyndns) {
+		return $dyndns['id'];
+	}
 }
 
-function get_dyndns_hostname_text($dyndns) {
-	global $dyndns_split_domain_types;
-	if (in_array($dyndns['type'], $dyndns_split_domain_types)) {
-		return $dyndns['host'] . "." . $dyndns['domainname'];
-	}
+if (!function_exists('get_dyndns_hostname_text')) {
+	function get_dyndns_hostname_text($dyndns) {
+		global $dyndns_split_domain_types;
+		if (in_array($dyndns['type'], $dyndns_split_domain_types)) {
+			return $dyndns['host'] . "." . $dyndns['domainname'];
+		}
 
-	return $dyndns['host'];
+		return $dyndns['host'];
+	}
 }
 
 if (!is_array($config['dyndnses']['dyndns'])) {
@@ -64,9 +68,8 @@ array_walk($all_dyndns, function(&$dyndns) {
 	}
 });
 
-$skipdyndns = explode(",", $user_settings['widgets']['dyn_dns_status']['filter']);
-
 if ($_REQUEST['getdyndnsstatus']) {
+	$skipdyndns = explode(",", $user_settings['widgets'][$_REQUEST['getdyndnsstatus']]['filter']);
 	$first_entry = true;
 	foreach ($all_dyndns as $dyndns) {
 		if (in_array(get_dyndnsent_key($dyndns), $skipdyndns)) {
@@ -114,7 +117,7 @@ if ($_REQUEST['getdyndnsstatus']) {
 		}
 	}
 	exit;
-} else if ($_POST) {
+} else if ($_POST['widgetkey']) {
 
 	$validNames = array();
 
@@ -123,9 +126,9 @@ if ($_REQUEST['getdyndnsstatus']) {
 	}
 
 	if (is_array($_POST['show'])) {
-		$user_settings['widgets']['dyn_dns_status']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['dyn_dns_status']['filter'] = implode(',', $validNames);
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Dynamic DNS Filter via Dashboard."));
@@ -134,28 +137,34 @@ if ($_REQUEST['getdyndnsstatus']) {
 
 $iflist = get_configured_interface_with_descr();
 
-function get_dyndns_interface_text($dyndns_iface) {
-	global $iflist;
-	if (isset($iflist[$dyndns_iface])) {
-		return $iflist[$dyndns_iface];
-	}
+if (!function_exists('get_dyndns_interface_text')) {
+	function get_dyndns_interface_text($dyndns_iface) {
+		global $iflist;
+		if (isset($iflist[$dyndns_iface])) {
+			return $iflist[$dyndns_iface];
+		}
 
-	// This will be a gateway group name.
-	return $dyndns_iface;
+		// This will be a gateway group name.
+		return $dyndns_iface;
+	}
 }
 
 $dyndns_providers = array_combine(explode(" ", DYNDNS_PROVIDER_VALUES), explode(",", DYNDNS_PROVIDER_DESCRIPTIONS));
+$skipdyndns = explode(",", $user_settings['widgets'][$widgetkey]['filter']);
+$widgetkey_nodash = str_replace("-", "", $widgetkey);
 
-function get_dyndns_service_text($dyndns_type) {
-	global $dyndns_providers;
+if (!function_exists('get_dyndns_service_text')) {
+	function get_dyndns_service_text($dyndns_type) {
+		global $dyndns_providers;
 
-	if (isset($dyndns_providers[$dyndns_type])) {
-		return $dyndns_providers[$dyndns_type];
-	} else if ($dyndns_type == '_rfc2136_') {
-		return "RFC 2136";
+		if (isset($dyndns_providers[$dyndns_type])) {
+			return $dyndns_providers[$dyndns_type];
+		} else if ($dyndns_type == '_rfc2136_') {
+			return "RFC 2136";
+		}
+
+		return $dyndns_type;
 	}
-
-	return $dyndns_type;
 }
 
 ?>
@@ -215,11 +224,12 @@ function get_dyndns_service_text($dyndns_type) {
 </table>
 </div>
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/dyn_dns_status.widget.php" method="post" class="form-horizontal">
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
+			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 			<div class="table responsive">
 				<table class="table table-striped table-hover table-condensed">
 					<thead>
@@ -232,7 +242,7 @@ function get_dyndns_service_text($dyndns_type) {
 					</thead>
 					<tbody>
 <?php
-				$skipdyndns = explode(",", $user_settings['widgets']['dyn_dns_status']['filter']);
+				$skipdyndns = explode(",", $user_settings['widgets'][$widgetkey]['filter']);
 				foreach ($all_dyndns as $dyndns):
 ?>
 						<tr>
@@ -253,41 +263,41 @@ function get_dyndns_service_text($dyndns_type) {
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">
 			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			<button id="showalldyndns" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			<button id="<?=$widget_showallnone_id?>" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
 		</div>
 	</div>
 </form>
 
 <script type="text/javascript">
 //<![CDATA[
-	function dyndns_getstatus() {
+	function dyndns_getstatus_<?=$widgetkey_nodash?>() {
 		scroll(0,0);
 		var url = "/widgets/widgets/dyn_dns_status.widget.php";
-		var pars = 'getdyndnsstatus=yes';
+		var pars = 'getdyndnsstatus=<?=$widgetkey?>';
 		$.ajax(
 			url,
 			{
 				type: 'get',
 				data: pars,
-				complete: dyndnscallback
+				complete: dyndnscallback_<?=$widgetkey_nodash?>
 			});
 
 	}
-	function dyndnscallback(transport) {
+	function dyndnscallback_<?=$widgetkey_nodash?>(transport) {
 		// The server returns a string of statuses separated by vertical bars
 		var responseStrings = transport.responseText.split("|");
 		for (var count=0; count<responseStrings.length; count++) {
-			var divlabel = '#dyndnsstatus' + count;
+			var divlabel = '#widget-<?=$widgetkey?> #dyndnsstatus' + count;
 			$(divlabel).prop('innerHTML',responseStrings[count]);
 		}
 
 		// Refresh the status every 5 minutes
-		setTimeout('dyndns_getstatus()', 5*60*1000);
+		setTimeout('dyndns_getstatus_<?=$widgetkey_nodash?>()', 5*60*1000);
 	}
 	events.push(function(){
-		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showalldyndns");
+		set_widget_checkbox_events("#<?=$widget_panel_footer_id?> [id^=show]", "<?=$widget_showallnone_id?>");
 	});
 	// Do the first status check 2 seconds after the dashboard opens
-	setTimeout('dyndns_getstatus()', 2000);
+	setTimeout('dyndns_getstatus_<?=$widgetkey_nodash?>()', 2000);
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -188,11 +188,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 	}
 
 	events.push(function(){
-		$("#showallgateways").click(function() {
-			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
-				$(this).prop("checked", true);
-			});
-		});
+		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallgateways");
 
 		// Start polling for updates some small random number of seconds from now (so that all the widgets don't
 		// hit the server at exactly the same time)

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -48,17 +48,17 @@ if ($_POST) {
 		$user_settings["widgets"]["gateways_widget"]["display_type"] = $_POST["display_type"];
 	}
 
+	$validNames = array();
+	$a_gateways = return_gateways_array();
+
+	foreach ($a_gateways as $gname => $gateway) {
+		array_push($validNames, $gname);
+	}
+
 	if (is_array($_POST['show'])) {
-		$validNames = array();
-		$a_gateways = return_gateways_array();
-
-		foreach ($a_gateways as $gname => $gateway) {
-			array_push($validNames, $gname);
-		}
-
 		$user_settings["widgets"]["gateways_widget"]["gatewaysfilter"] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings["widgets"]["gateways_widget"]["gatewaysfilter"] = "";
+		$user_settings["widgets"]["gateways_widget"]["gatewaysfilter"] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Updated gateways widget settings via dashboard."));
@@ -319,7 +319,7 @@ function compose_table_body_contents() {
 
 	if (!$gw_displayed) {
 		$rtnstr .= '<tr>';
-		$rtnstr .= 	'<td colspan="5">';
+		$rtnstr .= 	'<td colspan="5" class="text-center">';
 		if (count($a_gateways)) {
 			$rtnstr .= gettext('All gateways are hidden.');
 		} else {

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -31,21 +31,151 @@ require_once("pfsense-utils.inc");
 require_once("functions.inc");
 require_once("/usr/local/www/widgets/include/gateways.inc");
 
+if (!function_exists('compose_table_body_contents')) {
+	function compose_table_body_contents($widgetkey) {
+		global $user_settings;
+
+		$rtnstr = '';
+
+		$a_gateways = return_gateways_array();
+		$gateways_status = array();
+		$gateways_status = return_gateways_status(true);
+
+		if (isset($user_settings["widgets"][$widgetkey]["display_type"])) {
+			$display_type = $user_settings["widgets"][$widgetkey]["display_type"];
+		} else {
+			$display_type = "gw_ip";
+		}
+
+		$hiddengateways = explode(",", $user_settings["widgets"][$widgetkey]["gatewaysfilter"]);
+		$gw_displayed = false;
+
+		foreach ($a_gateways as $gname => $gateway) {
+			if (in_array($gname, $hiddengateways)) {
+				continue;
+			}
+
+			$gw_displayed = true;
+			$rtnstr .= "<tr>\n";
+			$rtnstr .= 	"<td>\n";
+			$rtnstr .= htmlspecialchars($gateway['name']) . "<br />";
+			$rtnstr .= '<div id="gateway' . $counter . '" style="display:inline"><b>';
+
+			$monitor_address = "";
+			$monitor_address_disp = "";
+			if ($display_type == "monitor_ip" || $display_type == "both_ip") {
+				$monitor_address = $gateway['monitor'];
+				if ($monitor_address != "" && $display_type == "both_ip") {
+					$monitor_address_disp = " (" . $monitor_address . ")";
+				} else {
+					$monitor_address_disp = $monitor_address;
+				}
+			}
+
+			$if_gw = '';
+			// If the user asked to display Gateway IP or both IPs, or asked for just monitor IP but the monitor IP is blank
+			// then find the gateway IP (which is also the monitor IP if the monitor IP was not explicitly set).
+			if ($display_type == "gw_ip" || $display_type == "both_ip" || ($display_type == "monitor_ip" && $monitor_address == "")) {
+				if (is_ipaddr($gateway['gateway'])) {
+					$if_gw = htmlspecialchars($gateway['gateway']);
+				} else {
+					if ($gateway['ipprotocol'] == "inet") {
+						$if_gw = htmlspecialchars(get_interface_gateway($gateway['friendlyiface']));
+					}
+					if ($gateway['ipprotocol'] == "inet6") {
+						$if_gw = htmlspecialchars(get_interface_gateway_v6($gateway['friendlyiface']));
+					}
+				}
+				if ($if_gw == "") {
+					$if_gw = "~";
+				}
+			}
+
+			if ($monitor_address == $if_gw) {
+				$monitor_address_disp = "";
+			}
+
+			$rtnstr .= $if_gw . $monitor_address_disp;
+			unset ($if_gw);
+			unset ($monitor_address);
+			unset ($monitor_address_disp);
+			$counter++;
+
+			$rtnstr .= 		"</b>";
+			$rtnstr .= 		"</div>\n";
+			$rtnstr .= 	"</td>\n";
+
+			if ($gateways_status[$gname]) {
+				if (stristr($gateways_status[$gname]['status'], "force_down")) {
+					$online = gettext("Offline (forced)");
+					$bgcolor = "danger";  // lightcoral
+				} elseif (stristr($gateways_status[$gname]['status'], "down")) {
+					$online = gettext("Offline");
+					$bgcolor = "danger";  // lightcoral
+				} elseif (stristr($gateways_status[$gname]['status'], "highloss")) {
+					$online = gettext("Packetloss");
+					$bgcolor = "danger";  // lightcoral
+				} elseif (stristr($gateways_status[$gname]['status'], "loss")) {
+					$online = gettext("Packetloss");
+					$bgcolor = "warning";  // khaki
+				} elseif (stristr($gateways_status[$gname]['status'], "highdelay")) {
+					$online = gettext("Latency");
+					$bgcolor = "danger";  // lightcoral
+				} elseif (stristr($gateways_status[$gname]['status'], "delay")) {
+					$online = gettext("Latency");
+					$bgcolor = "warning";  // khaki
+				} elseif ($gateways_status[$gname]['status'] == "none") {
+					if ($gateways_status[$gname]['monitor_disable'] || ($gateways_status[$gname]['monitorip'] == "none")) {
+						$online = gettext("Online <br/>(unmonitored)");
+					} else {
+						$online = gettext("Online");
+					}
+					$bgcolor = "success";  // lightgreen
+				} elseif ($gateways_status[$gname]['status'] == "") {
+					$online = gettext("Pending");
+					$bgcolor = "info";  // lightgray
+				}
+			} else {
+				$online = gettext("Unknown");
+				$bgcolor = "info";  // lightblue
+			}
+
+			$rtnstr .= 	"<td>" . ($gateways_status[$gname] ? htmlspecialchars($gateways_status[$gname]['delay']) : gettext("Pending")) . "</td>\n";
+			$rtnstr .= 	"<td>" . ($gateways_status[$gname] ? htmlspecialchars($gateways_status[$gname]['stddev']) : gettext("Pending")) . "</td>\n";
+			$rtnstr .= 	"<td>" . ($gateways_status[$gname] ? htmlspecialchars($gateways_status[$gname]['loss']) : gettext("Pending")) . "</td>\n";
+			$rtnstr .= '<td class="bg-' . $bgcolor . '">' . $online . "</td>\n";
+			$rtnstr .= "</tr>\n";
+		}
+
+		if (!$gw_displayed) {
+			$rtnstr .= '<tr>';
+			$rtnstr .= 	'<td colspan="5" class="text-center">';
+			if (count($a_gateways)) {
+				$rtnstr .= gettext('All gateways are hidden.');
+			} else {
+				$rtnstr .= gettext('No gateways found.');
+			}
+			$rtnstr .= '</td>';
+			$rtnstr .= '</tr>';
+		}
+		return($rtnstr);
+	}
+}
+
 // Compose the table contents and pass it back to the ajax caller
 if ($_REQUEST && $_REQUEST['ajax']) {
-	print(compose_table_body_contents());
+	print(compose_table_body_contents($_REQUEST['widgetkey']));
 	exit;
 }
 
-if ($_POST) {
+if ($_POST['widgetkey']) {
 
-
-	if (!is_array($user_settings["widgets"]["gateways_widget"])) {
-		$user_settings["widgets"]["gateways_widget"] = array();
+	if (!is_array($user_settings["widgets"][$_POST['widgetkey']])) {
+		$user_settings["widgets"][$_POST['widgetkey']] = array();
 	}
 
 	if (isset($_POST["display_type"])) {
-		$user_settings["widgets"]["gateways_widget"]["display_type"] = $_POST["display_type"];
+		$user_settings["widgets"][$_POST['widgetkey']]["display_type"] = $_POST["display_type"];
 	}
 
 	$validNames = array();
@@ -56,9 +186,9 @@ if ($_POST) {
 	}
 
 	if (is_array($_POST['show'])) {
-		$user_settings["widgets"]["gateways_widget"]["gatewaysfilter"] = implode(',', array_diff($validNames, $_POST['show']));
+		$user_settings["widgets"][$_POST['widgetkey']]["gatewaysfilter"] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings["widgets"]["gateways_widget"]["gatewaysfilter"] = implode(',', $validNames);
+		$user_settings["widgets"][$_POST['widgetkey']]["gatewaysfilter"] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Updated gateways widget settings via dashboard."));
@@ -67,6 +197,8 @@ if ($_POST) {
 }
 
 $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period'] * 1000 : 10000;
+$widgetkey_nodash = str_replace("-", "", $widgetkey);
+
 ?>
 
 <div class="table-responsive">
@@ -80,15 +212,15 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 				<th><?=gettext("Status")?></th>
 			</tr>
 		</thead>
-		<tbody id="gwtblbody">
+		<tbody id="<?=$widgetkey?>-gwtblbody">
 <?php
-		print(compose_table_body_contents());
+		print(compose_table_body_contents($widgetkey));
 ?>
 		</tbody>
 	</table>
 </div>
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 <form action="/widgets/widgets/gateways.widget.php" method="post" class="form-horizontal">
 	<div class="form-group">
 		<label class="col-sm-3 control-label"><?=gettext('Display')?></label>
@@ -96,8 +228,8 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 			$display_type_gw_ip = "checked";
 			$display_type_monitor_ip = "";
 			$display_type_both_ip = "";
-			if (isset($user_settings["widgets"]["gateways_widget"]["display_type"])) {
-				$selected_radio = $user_settings["widgets"]["gateways_widget"]["display_type"];
+			if (isset($user_settings["widgets"][$widgetkey]["display_type"])) {
+				$selected_radio = $user_settings["widgets"][$widgetkey]["display_type"];
 				if ($selected_radio == "gw_ip") {
 					$display_type_gw_ip = "checked";
 					$display_type_monitor_ip = "";
@@ -130,6 +262,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
+			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 			<div class="table responsive">
 				<table class="table table-striped table-hover table-condensed">
 					<thead>
@@ -141,7 +274,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 					<tbody>
 <?php
 				$a_gateways = return_gateways_array();
-				$hiddengateways = explode(",", $user_settings["widgets"]["gateways_widget"]["gatewaysfilter"]);
+				$hiddengateways = explode(",", $user_settings["widgets"][$widgetkey]["gatewaysfilter"]);
 				$idx = 0;
 
 				foreach ($a_gateways as $gname => $gateway):
@@ -162,7 +295,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">
 			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			<button id="showallgateways" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			<button id="<?=$widget_showallnone_id?>" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
 		</div>
 	</div>
 </form>
@@ -170,160 +303,29 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 <script>
 //<![CDATA[
 
-	function get_gw_stats() {
+	function get_gw_stats_<?=$widgetkey_nodash?>() {
 		var ajaxRequest;
 
 		ajaxRequest = $.ajax({
 				url: "/widgets/widgets/gateways.widget.php",
 				type: "post",
-				data: { ajax: "ajax"}
+				data: { ajax: "ajax", widgetkey: "<?=$widgetkey?>"}
 			});
 
 		// Deal with the results of the above ajax call
 		ajaxRequest.done(function (response, textStatus, jqXHR) {
-			$('#gwtblbody').html(response);
+			$('#<?=$widgetkey?>-gwtblbody').html(response);
 			// and do it again
-			setTimeout(get_gw_stats, "<?=$widgetperiod?>");
+			setTimeout(get_gw_stats_<?=$widgetkey_nodash?>, "<?=$widgetperiod?>");
 		});
 	}
 
 	events.push(function(){
-		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallgateways");
+		set_widget_checkbox_events("#<?=$widget_panel_footer_id?> [id^=show]", "<?=$widget_showallnone_id?>");
 
 		// Start polling for updates some small random number of seconds from now (so that all the widgets don't
 		// hit the server at exactly the same time)
-		setTimeout(get_gw_stats, Math.floor((Math.random() * 10000) + 1000));
+		setTimeout(get_gw_stats_<?=$widgetkey_nodash?>, Math.floor((Math.random() * 10000) + 1000));
 	});
 //]]>
 </script>
-
-<?php
-function compose_table_body_contents() {
-	global $user_settings;
-
-	$rtnstr = '';
-
-	$a_gateways = return_gateways_array();
-	$gateways_status = array();
-	$gateways_status = return_gateways_status(true);
-
-	if (isset($user_settings["widgets"]["gateways_widget"]["display_type"])) {
-		$display_type = $user_settings["widgets"]["gateways_widget"]["display_type"];
-	} else {
-		$display_type = "gw_ip";
-	}
-
-	$hiddengateways = explode(",", $user_settings["widgets"]["gateways_widget"]["gatewaysfilter"]);
-	$gw_displayed = false;
-
-	foreach ($a_gateways as $gname => $gateway) {
-		if (in_array($gname, $hiddengateways)) {
-			continue;
-		}
-
-		$gw_displayed = true;
-		$rtnstr .= "<tr>\n";
-		$rtnstr .= 	"<td>\n";
-		$rtnstr .= htmlspecialchars($gateway['name']) . "<br />";
-		$rtnstr .= '<div id="gateway' . $counter . '" style="display:inline"><b>';
-
-		$monitor_address = "";
-		$monitor_address_disp = "";
-		if ($display_type == "monitor_ip" || $display_type == "both_ip") {
-			$monitor_address = $gateway['monitor'];
-			if ($monitor_address != "" && $display_type == "both_ip") {
-				$monitor_address_disp = " (" . $monitor_address . ")";
-			} else {
-				$monitor_address_disp = $monitor_address;
-			}
-		}
-
-		$if_gw = '';
-		// If the user asked to display Gateway IP or both IPs, or asked for just monitor IP but the monitor IP is blank
-		// then find the gateway IP (which is also the monitor IP if the monitor IP was not explicitly set).
-		if ($display_type == "gw_ip" || $display_type == "both_ip" || ($display_type == "monitor_ip" && $monitor_address == "")) {
-			if (is_ipaddr($gateway['gateway'])) {
-				$if_gw = htmlspecialchars($gateway['gateway']);
-			} else {
-				if ($gateway['ipprotocol'] == "inet") {
-					$if_gw = htmlspecialchars(get_interface_gateway($gateway['friendlyiface']));
-				}
-				if ($gateway['ipprotocol'] == "inet6") {
-					$if_gw = htmlspecialchars(get_interface_gateway_v6($gateway['friendlyiface']));
-				}
-			}
-			if ($if_gw == "") {
-				$if_gw = "~";
-			}
-		}
-
-		if ($monitor_address == $if_gw) {
-			$monitor_address_disp = "";
-		}
-
-		$rtnstr .= $if_gw . $monitor_address_disp;
-		unset ($if_gw);
-		unset ($monitor_address);
-		unset ($monitor_address_disp);
-		$counter++;
-
-		$rtnstr .= 		"</b>";
-		$rtnstr .= 		"</div>\n";
-		$rtnstr .= 	"</td>\n";
-
-		if ($gateways_status[$gname]) {
-			if (stristr($gateways_status[$gname]['status'], "force_down")) {
-				$online = gettext("Offline (forced)");
-				$bgcolor = "danger";  // lightcoral
-			} elseif (stristr($gateways_status[$gname]['status'], "down")) {
-				$online = gettext("Offline");
-				$bgcolor = "danger";  // lightcoral
-			} elseif (stristr($gateways_status[$gname]['status'], "highloss")) {
-				$online = gettext("Packetloss");
-				$bgcolor = "danger";  // lightcoral
-			} elseif (stristr($gateways_status[$gname]['status'], "loss")) {
-				$online = gettext("Packetloss");
-				$bgcolor = "warning";  // khaki
-			} elseif (stristr($gateways_status[$gname]['status'], "highdelay")) {
-				$online = gettext("Latency");
-				$bgcolor = "danger";  // lightcoral
-			} elseif (stristr($gateways_status[$gname]['status'], "delay")) {
-				$online = gettext("Latency");
-				$bgcolor = "warning";  // khaki
-			} elseif ($gateways_status[$gname]['status'] == "none") {
-				if ($gateways_status[$gname]['monitor_disable'] || ($gateways_status[$gname]['monitorip'] == "none")) {
-					$online = gettext("Online <br/>(unmonitored)");
-				} else {
-					$online = gettext("Online");
-				}
-				$bgcolor = "success";  // lightgreen
-			} elseif ($gateways_status[$gname]['status'] == "") {
-				$online = gettext("Pending");
-				$bgcolor = "info";  // lightgray
-			}
-		} else {
-			$online = gettext("Unknown");
-			$bgcolor = "info";  // lightblue
-		}
-
-		$rtnstr .= 	"<td>" . ($gateways_status[$gname] ? htmlspecialchars($gateways_status[$gname]['delay']) : gettext("Pending")) . "</td>\n";
-		$rtnstr .= 	"<td>" . ($gateways_status[$gname] ? htmlspecialchars($gateways_status[$gname]['stddev']) : gettext("Pending")) . "</td>\n";
-		$rtnstr .= 	"<td>" . ($gateways_status[$gname] ? htmlspecialchars($gateways_status[$gname]['loss']) : gettext("Pending")) . "</td>\n";
-		$rtnstr .= '<td class="bg-' . $bgcolor . '">' . $online . "</td>\n";
-		$rtnstr .= "</tr>\n";
-	}
-
-	if (!$gw_displayed) {
-		$rtnstr .= '<tr>';
-		$rtnstr .= 	'<td colspan="5" class="text-center">';
-		if (count($a_gateways)) {
-			$rtnstr .= gettext('All gateways are hidden.');
-		} else {
-			$rtnstr .= gettext('No gateways found.');
-		}
-		$rtnstr .= '</td>';
-		$rtnstr .= '</tr>';
-	}
-	return($rtnstr);
-}
-?>

--- a/src/usr/local/www/widgets/widgets/gmirror_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/gmirror_status.widget.php
@@ -33,6 +33,7 @@ require_once("gmirror.inc");
 	<?=gmirror_html_status()?>
 </div>
 
+<?php if ($widget_first_instance): ?>
 <script type="text/javascript">
 //<![CDATA[
 function gmirrorStatusUpdateFromServer() {
@@ -45,7 +46,7 @@ function gmirrorStatusUpdateFromServer() {
 			return raw.replace(/<script>([\s\S]*)<\/script>/gi, '');
 		},
 		success: function(data){
-			$('#gmirror_status').html(data);
+			$('[id="gmirror_status"]').html(data);
 		}
 	});
 }
@@ -55,3 +56,4 @@ events.push(function(){
 });
 //]]>
 </script>
+<?php endif; ?>

--- a/src/usr/local/www/widgets/widgets/installed_packages.widget.php
+++ b/src/usr/local/www/widgets/widgets/installed_packages.widget.php
@@ -146,6 +146,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	<?=gettext("Packages may be added/managed here: ")?> <a href="pkg_mgr_installed.php"><?=gettext("System")?> -&gt; <?=gettext("Packages")?></a>
 </p>
 
+<?php if ($widget_first_instance): ?>
 <script type="text/javascript">
 //<![CDATA[
 
@@ -160,7 +161,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 
 		// Deal with the results of the above ajax call
 		ajaxRequest.done(function (response, textStatus, jqXHR) {
-			$('#pkgtbl').html(response);
+			$('[id="pkgtbl"]').html(response);
 
 			// and do it again
 			// NOT! There is no need to refresh this widget
@@ -173,3 +174,4 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	});
 //]]>
 </script>
+<?php endif; ?>

--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -185,11 +185,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 	}
 
 	events.push(function(){
-		$("#showallinterfacesforstats").click(function() {
-			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
-				$(this).prop("checked", true);
-			});
-		});
+		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallinterfacesforstats");
 
 		// Start polling for updates some small random number of seconds from now (so that all the widgets don't
 		// hit the server at exactly the same time)

--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -49,6 +49,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	);
 
 	$skipinterfaces = explode(",", $user_settings['widgets']['interface_statistics']['iffilter']);
+	$interface_is_displayed = false;
 
 	print("<thead>");
 	print(	"<tr>");
@@ -57,7 +58,12 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	foreach ($ifdescrs as $ifdescr => $ifname) {
 		if (!in_array($ifdescr, $skipinterfaces)) {
 			print(		"<th>" . $ifname . "</th>");
+			$interface_is_displayed = true;
 		}
+	}
+
+	if (!$interface_is_displayed) {
+		print("<th>" . gettext('All interfaces are hidden.') . "</th>");
 	}
 
 	print(		"</tr>");
@@ -101,7 +107,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['interface_statistics']['iffilter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['interface_statistics']['iffilter'] = "";
+		$user_settings['widgets']['interface_statistics']['iffilter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Interface Statistics Filter via Dashboard."));

--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -48,7 +48,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 		'collisions' => gettext('Collisions'),
 	);
 
-	$skipinterfaces = explode(",", $user_settings['widgets']['interface_statistics']['iffilter']);
+	$skipinterfaces = explode(",", $user_settings['widgets'][$_REQUEST['widgetkey']]['iffilter']);
 	$interface_is_displayed = false;
 
 	print("<thead>");
@@ -96,7 +96,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	}
 	print(	"</tbody>");
 	exit;
-} else if ($_POST) {
+} else if ($_POST['widgetkey']) {
 
 	$validNames = array();
 
@@ -105,9 +105,9 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	}
 
 	if (is_array($_POST['show'])) {
-		$user_settings['widgets']['interface_statistics']['iffilter'] = implode(',', array_diff($validNames, $_POST['show']));
+		$user_settings['widgets'][$_POST['widgetkey']]['iffilter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['interface_statistics']['iffilter'] = implode(',', $validNames);
+		$user_settings['widgets'][$_POST['widgetkey']]['iffilter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Interface Statistics Filter via Dashboard."));
@@ -115,18 +115,20 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 }
 
 $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period'] * 1000 : 10000;
+$widgetkey_nodash = str_replace("-", "", $widgetkey);
 
 ?>
-<table id="iftbl" class="table table-striped table-hover">
+<table id="<?=$widgetkey?>-iftbl" class="table table-striped table-hover">
 	<tr><td><?=gettext("Retrieving interface data")?></td></tr>
 </table>
 
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/interface_statistics.widget.php" method="post" class="form-horizontal">
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
+			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 			<div class="table responsive">
 				<table class="table table-striped table-hover table-condensed">
 					<thead>
@@ -137,7 +139,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 					</thead>
 					<tbody>
 <?php
-				$skipinterfaces = explode(",", $user_settings['widgets']['interface_statistics']['iffilter']);
+				$skipinterfaces = explode(",", $user_settings['widgets'][$widgetkey]['iffilter']);
 				$idx = 0;
 
 				foreach ($ifdescrs as $ifdescr => $ifname):
@@ -158,7 +160,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">
 			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			<button id="showallinterfacesforstats" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			<button id="<?=$widget_showallnone_id?>" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
 		</div>
 	</div>
 </form>
@@ -166,30 +168,30 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 <script type="text/javascript">
 //<![CDATA[
 
-	function get_if_stats() {
+	function get_if_stats_<?=$widgetkey_nodash?>() {
 		var ajaxRequest;
 
 		ajaxRequest = $.ajax({
 				url: "/widgets/widgets/interface_statistics.widget.php",
 				type: "post",
-				data: { ajax: "ajax"}
+				data: { ajax: "ajax", widgetkey: "<?=$widgetkey?>"}
 			});
 
 		// Deal with the results of the above ajax call
 		ajaxRequest.done(function (response, textStatus, jqXHR) {
-			$('#iftbl').html(response);
+			$('#<?=$widgetkey?>-iftbl').html(response);
 
 			// and do it again
-			setTimeout(get_if_stats, "<?=$widgetperiod?>");
+			setTimeout(get_if_stats_<?=$widgetkey_nodash?>, "<?=$widgetperiod?>");
 		});
 	}
 
 	events.push(function(){
-		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallinterfacesforstats");
+		set_widget_checkbox_events("#<?=$widget_panel_footer_id?> [id^=show]", "<?=$widget_showallnone_id?>");
 
 		// Start polling for updates some small random number of seconds from now (so that all the widgets don't
 		// hit the server at exactly the same time)
-		setTimeout(get_if_stats, Math.floor((Math.random() * 10000) + 1000));
+		setTimeout(get_if_stats_<?=$widgetkey_nodash?>, Math.floor((Math.random() * 10000) + 1000));
 	});
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -188,12 +188,7 @@ endif;
 <script>
 //<![CDATA[
 	events.push(function(){
-		$("#showallinterfaces").click(function() {
-			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
-				$(this).prop("checked", true);
-			});
-		});
-
+		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallinterfaces");
 	});
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -29,7 +29,7 @@ require_once("/usr/local/www/widgets/include/interfaces.inc");
 
 $ifdescrs = get_configured_interface_with_descr();
 
-if ($_POST) {
+if ($_POST['widgetkey']) {
 
 	$validNames = array();
 
@@ -38,9 +38,9 @@ if ($_POST) {
 	}
 
 	if (is_array($_POST['show'])) {
-		$user_settings['widgets']['interfaces']['iffilter'] = implode(',', array_diff($validNames, $_POST['show']));
+		$user_settings['widgets'][$_POST['widgetkey']]['iffilter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['interfaces']['iffilter'] = implode(',', $validNames);
+		$user_settings['widgets'][$_POST['widgetkey']]['iffilter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Interfaces Filter via Dashboard."));
@@ -53,7 +53,7 @@ if ($_POST) {
 	<table class="table table-striped table-hover table-condensed">
 		<tbody>
 <?php
-$skipinterfaces = explode(",", $user_settings['widgets']['interfaces']['iffilter']);
+$skipinterfaces = explode(",", $user_settings['widgets'][$widgetkey]['iffilter']);
 $interface_is_displayed = false;
 
 foreach ($ifdescrs as $ifdescr => $ifname):
@@ -144,11 +144,12 @@ endif;
 	</table>
 </div>
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/interfaces.widget.php" method="post" class="form-horizontal">
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
+			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 			<div class="table responsive">
 				<table class="table table-striped table-hover table-condensed">
 					<thead>
@@ -159,7 +160,7 @@ endif;
 					</thead>
 					<tbody>
 <?php
-				$skipinterfaces = explode(",", $user_settings['widgets']['interfaces']['iffilter']);
+				$skipinterfaces = explode(",", $user_settings['widgets'][$widgetkey]['iffilter']);
 				$idx = 0;
 
 				foreach ($ifdescrs as $ifdescr => $ifname):
@@ -180,7 +181,7 @@ endif;
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">
 			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			<button id="showallinterfaces" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			<button id="<?=$widget_showallnone_id?>" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
 		</div>
 	</div>
 </form>
@@ -188,7 +189,7 @@ endif;
 <script>
 //<![CDATA[
 	events.push(function(){
-		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallinterfaces");
+		set_widget_checkbox_events("#<?=$widget_panel_footer_id?> [id^=show]", "<?=$widget_showallnone_id?>");
 	});
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -40,7 +40,7 @@ if ($_POST) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['interfaces']['iffilter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['interfaces']['iffilter'] = "";
+		$user_settings['widgets']['interfaces']['iffilter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Interfaces Filter via Dashboard."));
@@ -54,12 +54,14 @@ if ($_POST) {
 		<tbody>
 <?php
 $skipinterfaces = explode(",", $user_settings['widgets']['interfaces']['iffilter']);
+$interface_is_displayed = false;
 
 foreach ($ifdescrs as $ifdescr => $ifname):
 	if (in_array($ifdescr, $skipinterfaces)) {
 		continue;
 	}
 
+	$interface_is_displayed = true;
 	$ifinfo = get_interface_info($ifdescr);
 	if ($ifinfo['pppoelink'] || $ifinfo['pptplink'] || $ifinfo['l2tplink']) {
 		/* PPP link (non-cell) - looks like a modem */
@@ -127,6 +129,16 @@ foreach ($ifdescrs as $ifdescr => $ifname):
 	</tr>
 <?php
 endforeach;
+if (!$interface_is_displayed):
+?>
+	<tr>
+		<td class="text-center">
+			<?=gettext('All interfaces are hidden.');?>
+		</td>
+	</tr>
+
+<?php
+endif;
 ?>
 		</tbody>
 	</table>

--- a/src/usr/local/www/widgets/widgets/ipsec.widget.php
+++ b/src/usr/local/www/widgets/widgets/ipsec.widget.php
@@ -170,11 +170,13 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	exit;
 }
 
+$widgetkey_nodash = str_replace("-", "", $widgetkey);
+
 if (isset($config['ipsec']['phase1'])) {
 	$tab_array = array();
-	$tab_array[] = array(gettext("Overview"), true, "ipsec-Overview");
-	$tab_array[] = array(gettext("Tunnels"), false, "ipsec-tunnel");
-	$tab_array[] = array(gettext("Mobile"), false, "ipsec-mobile");
+	$tab_array[] = array(gettext("Overview"), true, $widgetkey_nodash . "-Overview");
+	$tab_array[] = array(gettext("Tunnels"), false, $widgetkey_nodash . "-tunnel");
+	$tab_array[] = array(gettext("Mobile"), false, $widgetkey_nodash . "-mobile");
 
 	display_widget_tabs($tab_array);
 }
@@ -183,7 +185,7 @@ $mobile = ipsec_dump_mobile();
 $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period'] * 1000 : 10000;
 
 if (isset($config['ipsec']['phase2'])): ?>
-<div id="ipsec-Overview" style="display:block;"  class="table-responsive">
+<div id="<?=$widgetkey_nodash?>-Overview" style="display:block;"  class="table-responsive">
 	<table class="table table-striped table-hover">
 		<thead>
 		<tr>
@@ -197,7 +199,7 @@ if (isset($config['ipsec']['phase2'])): ?>
 		</tbody>
 	</table>
 </div>
-<div class="table-responsive" id="ipsec-tunnel" style="display:none;">
+<div class="table-responsive" id="<?=$widgetkey_nodash?>-tunnel" style="display:none;">
 	<table class="table table-striped table-hover">
 	<thead>
 	<tr>
@@ -214,7 +216,7 @@ if (isset($config['ipsec']['phase2'])): ?>
 </div>
 
 	<?php if (is_array($mobile['pool'])): ?>
-<div id="ipsec-mobile" style="display:none;" class="table-responsive">
+<div id="<?=$widgetkey_nodash?>-mobile" style="display:none;" class="table-responsive">
 		<table class="table table-striped table-hover">
 		<thead>
 		<tr>
@@ -288,7 +290,7 @@ function changeTabDIV(selectedDiv) {
 	}
 }
 
-function get_ipsec_stats() {
+function get_ipsec_stats_<?=$widgetkey_nodash?>() {
 	var ajaxRequest;
 
 	ajaxRequest = $.ajax({
@@ -303,17 +305,17 @@ function get_ipsec_stats() {
 	// Deal with the results of the above ajax call
 	ajaxRequest.done(function (response, textStatus, jqXHR) {
 
-		$('tbody', '#ipsec-' + curtab).html(response);
+		$('tbody', '#<?=$widgetkey_nodash?>-' + curtab).html(response);
 
 		// and do it again
-		setTimeout(get_ipsec_stats, "<?=$widgetperiod?>");
+		setTimeout(get_ipsec_stats_<?=$widgetkey_nodash?>, "<?=$widgetperiod?>");
 	});
 }
 
 events.push(function(){
 	// Start polling for updates some small random number of seconds from now (so that all the widgets don't
 	// hit the server at exactly the same time)
-	setTimeout(get_ipsec_stats, Math.floor((Math.random() * 10000) + 1000));
+	setTimeout(get_ipsec_stats_<?=$widgetkey_nodash?>, Math.floor((Math.random() * 10000) + 1000));
 });
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -29,11 +29,11 @@ require_once("functions.inc");
 /* In an effort to reduce duplicate code, many shared functions have been moved here. */
 require_once("filter_log.inc");
 
-if ($_POST) {
+if ($_POST['widgetkey']) {
 	if (is_numeric($_POST['filterlogentries'])) {
-		$user_settings['widgets']['filterlogentries'] = $_POST['filterlogentries'];
+		$user_settings['widgets'][$_POST['widgetkey']]['filterlogentries'] = $_POST['filterlogentries'];
 	} else {
-		unset($user_settings['widgets']['filterlogentries']);
+		unset($user_settings['widgets'][$_POST['widgetkey']]['filterlogentries']);
 	}
 
 	$acts = array();
@@ -48,22 +48,22 @@ if ($_POST) {
 	}
 
 	if (!empty($acts)) {
-		$user_settings['widgets']['filterlogentriesacts'] = implode(" ", $acts);
+		$user_settings['widgets'][$_POST['widgetkey']]['filterlogentriesacts'] = implode(" ", $acts);
 	} else {
-		unset($user_settings['widgets']['filterlogentriesacts']);
+		unset($user_settings['widgets'][$_POST['widgetkey']]['filterlogentriesacts']);
 	}
 	unset($acts);
 
 	if (($_POST['filterlogentriesinterfaces']) and ($_POST['filterlogentriesinterfaces'] != "All")) {
-		$user_settings['widgets']['filterlogentriesinterfaces'] = trim($_POST['filterlogentriesinterfaces']);
+		$user_settings['widgets'][$_POST['widgetkey']]['filterlogentriesinterfaces'] = trim($_POST['filterlogentriesinterfaces']);
 	} else {
-		unset($user_settings['widgets']['filterlogentriesinterfaces']);
+		unset($user_settings['widgets'][$_POST['widgetkey']]['filterlogentriesinterfaces']);
 	}
 
 	if (is_numeric($_POST['filterlogentriesinterval'])) {
-		$user_settings['widgets']['filterlogentriesinterval'] = $_POST['filterlogentriesinterval'];
+		$user_settings['widgets'][$_POST['widgetkey']]['filterlogentriesinterval'] = $_POST['filterlogentriesinterval'];
 	} else {
-		unset($user_settings['widgets']['filterlogentriesinterval']);
+		unset($user_settings['widgets'][$_POST['widgetkey']]['filterlogentriesinterval']);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Filter Log Entries via Dashboard."));
@@ -71,31 +71,38 @@ if ($_POST) {
 	exit(0);
 }
 
+// When this widget is included in the dashboard, $widgetkey is already defined before the widget is included.
+// When the ajax call is made to refresh the firewall log table, 'widgetkey' comes in $_REQUEST.
+if ($_REQUEST['widgetkey']) {
+	$widgetkey = $_REQUEST['widgetkey'];
+}
+
 $iface_descr_arr = get_configured_interface_with_descr();
 
-$nentries = isset($user_settings['widgets']['filterlogentries']) ? $user_settings['widgets']['filterlogentries'] : 5;
+$nentries = isset($user_settings['widgets'][$widgetkey]['filterlogentries']) ? $user_settings['widgets'][$widgetkey]['filterlogentries'] : 5;
 
 //set variables for log
-$nentriesacts		= isset($user_settings['widgets']['filterlogentriesacts'])		? $user_settings['widgets']['filterlogentriesacts']		: 'All';
-$nentriesinterfaces = isset($user_settings['widgets']['filterlogentriesinterfaces']) ? $user_settings['widgets']['filterlogentriesinterfaces'] : 'All';
+$nentriesacts		= isset($user_settings['widgets'][$widgetkey]['filterlogentriesacts']) ? $user_settings['widgets'][$widgetkey]['filterlogentriesacts'] : 'All';
+$nentriesinterfaces = isset($user_settings['widgets'][$widgetkey]['filterlogentriesinterfaces']) ? $user_settings['widgets'][$widgetkey]['filterlogentriesinterfaces'] : 'All';
 
 $filterfieldsarray = array(
 	"act" => $nentriesacts,
 	"interface" => isset($iface_descr_arr[$nentriesinterfaces]) ? $iface_descr_arr[$nentriesinterfaces] : $nentriesinterfaces
 );
 
-$nentriesinterval = isset($user_settings['widgets']['filterlogentriesinterval']) ? $user_settings['widgets']['filterlogentriesinterval'] : 60;
+$nentriesinterval = isset($user_settings['widgets'][$widgetkey]['filterlogentriesinterval']) ? $user_settings['widgets'][$widgetkey]['filterlogentriesinterval'] : 60;
 
 $filter_logfile = "{$g['varlog_path']}/filter.log";
 
 $filterlog = conv_log_filter($filter_logfile, $nentries, 50, $filterfieldsarray);
+
+$widgetkey_nodash = str_replace("-", "", $widgetkey);
 ?>
 <script type="text/javascript">
 //<![CDATA[
-	var logWidgetLastRefresh = <?=time()?>;
+	var logWidgetLastRefresh<?=$widgetkey_nodash?> = <?=time()?>;
 //]]>
 </script>
-
 
 <table class="table table-striped table-hover">
 	<thead>
@@ -177,38 +184,39 @@ if (isset($_GET['lastsawtime'])) {
 
 <script type="text/javascript">
 //<![CDATA[
-function logWidgetUpdateFromServer() {
+function logWidgetUpdateFromServer<?=$widgetkey_nodash?>() {
 	$.ajax({
 		type: 'get',
 		url: '/widgets/widgets/log.widget.php',
-		data: 'lastsawtime='+logWidgetLastRefresh,
+		data: { lastsawtime: logWidgetLastRefresh<?=$widgetkey_nodash?>, widgetkey: "<?=$widgetkey?>"},
 		dataFilter: function(raw){
 			// We reload the entire widget, strip this block of javascript from it
 			return raw.replace(/<script>([\s\S]*)<\/script>/gi, '');
 		},
 		dataType: 'html',
 		success: function(data){
-			$('#widget-log .panel-body').html(data);
+			$('#widget-<?=$widgetkey?> .panel-body').html(data);
 		}
 	});
 }
 
 events.push(function(){
-	setInterval('logWidgetUpdateFromServer()', <?=$nentriesinterval?>*1000);
+	setInterval('logWidgetUpdateFromServer<?=$widgetkey_nodash?>()', <?=$nentriesinterval?>*1000);
 });
 //]]>
 </script>
 
 <!-- close the body we're wrapped in and add a configuration-panel -->
 </div>
-<div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+<div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <?php
-$pconfig['nentries'] = isset($user_settings['widgets']['filterlogentries']) ? $user_settings['widgets']['filterlogentries'] : '';
-$pconfig['nentriesinterval'] = isset($user_settings['widgets']['filterlogentriesinterval']) ? $user_settings['widgets']['filterlogentriesinterval'] : '';
+$pconfig['nentries'] = isset($user_settings['widgets'][$widgetkey]['filterlogentries']) ? $user_settings['widgets'][$widgetkey]['filterlogentries'] : '';
+$pconfig['nentriesinterval'] = isset($user_settings['widgets'][$widgetkey]['filterlogentriesinterval']) ? $user_settings['widgets'][$widgetkey]['filterlogentriesinterval'] : '';
 ?>
 	<form action="/widgets/widgets/log.widget.php" method="post"
 		class="form-horizontal">
+		<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 		<div class="form-group">
 			<label for="filterlogentries" class="col-sm-4 control-label"><?=gettext('Number of entries')?></label>
 			<div class="col-sm-6">

--- a/src/usr/local/www/widgets/widgets/ntp_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/ntp_status.widget.php
@@ -194,7 +194,7 @@ if ($_REQUEST['updateme']) {
 	exit;
 }
 ?>
-
+<?php if ($widget_first_instance): ?>
 <script type="text/javascript">
 //<![CDATA[
 var d = new Date('<?=date_format(date_create(), 'c')?>');
@@ -210,11 +210,11 @@ setInterval(function() {
 	thisMinute = thisMinute < 10 ? "0" + thisMinute : thisMinute;
 	thisSecond = thisSecond < 10 ? "0" + thisSecond : thisSecond;
 
-	$('#ntpStatusClock').html(thisHour +':' + thisMinute + ':' + thisSecond + ' ' + tz);
+	$('[id="ntpStatusClock"]').html(thisHour +':' + thisMinute + ':' + thisSecond + ' ' + tz);
 }, 1000);
 //]]>
 </script>
-
+<?php endif; ?>
 <table id="ntpstatus" class="table table-striped table-hover">
 	<tbody>
 		<tr>
@@ -224,7 +224,7 @@ setInterval(function() {
 		</tr>
 	</tbody>
 </table>
-
+<?php if ($widget_first_instance): ?>
 <script type="text/javascript">
 //<![CDATA[
 	function ntp_getstatus() {
@@ -242,7 +242,7 @@ setInterval(function() {
 	function ntpstatuscallback(transport) {
 		// The server returns formatted html code
 		var responseStringNtp = transport.responseText
-		$('#ntpstatus').prop('innerHTML',responseStringNtp);
+		$('[id="ntpstatus"]').prop('innerHTML',responseStringNtp);
 
 		// Refresh the status at the configured interval
 		setTimeout('ntp_getstatus()', "<?=$widgetperiod?>");
@@ -254,3 +254,4 @@ setInterval(function() {
 
 //]]>
 </script>
+<?php endif; ?>

--- a/src/usr/local/www/widgets/widgets/openvpn.widget.php
+++ b/src/usr/local/www/widgets/widgets/openvpn.widget.php
@@ -24,6 +24,253 @@ $nocsrf = true;
 require_once("guiconfig.inc");
 require_once("openvpn.inc");
 
+// Output the widget panel from this function so that it can be called from the AJAX handler as well as
+// when first rendering the page
+if (!function_exists('printPanel')) {
+	function printPanel($widgetkey) {
+		global $user_settings;
+
+		$servers = openvpn_get_active_servers();
+		$sk_servers = openvpn_get_active_servers("p2p");
+		$clients = openvpn_get_active_clients();
+		$skipovpns = explode(",", $user_settings['widgets'][$widgetkey]['filter']);
+
+		$opstring = "";
+		$got_ovpn_server = false;
+
+		foreach ($servers as $server):
+			if (in_array($server['vpnid'], $skipovpns)) {
+				continue;
+			}
+
+			$got_ovpn_server = true;
+
+		$opstring .= "<div class=\"widget panel panel-default\">";
+		$opstring .=	"<div class=\"panel-heading\"><h2 class=\"panel-title\">" . htmlspecialchars($server['name']) . "</h2></div>";
+		$opstring .=	"<div class=\"table-responsive\">";
+		$opstring .=		"<table class=\"table table-striped table-hover table-condensed sortable-theme-bootstrap\" data-sortable>";
+		$opstring .=			"<thead>";
+		$opstring .=				"<tr>";
+		$opstring .=					"<th>" . gettext('Name/Time') . "</th>";
+		$opstring .=					"<th>" . gettext('Real/Virtual IP') . "</th>";
+		$opstring .=					"<th></th>";
+		$opstring .=				"</tr>";
+		$opstring .=			"</thead>";
+		$opstring .=			"<tbody>";
+
+					$rowIndex = 0;
+					foreach ($server['conns'] as $conn):
+						$evenRowClass = $rowIndex % 2 ? " listMReven" : " listMRodd";
+						$rowIndex++;
+
+		$opstring .=				"<tr name=\"" . "r:" . $server['mgmt'] . ":" . $conn['remote_host'] . "\" class=\"" . $evenRowClass . "\">";
+		$opstring .=					"<td>";
+		$opstring .=						$conn['common_name'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td>";
+		$opstring .=						$conn['remote_host'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td>";
+		$opstring .=						"<i class=\"fa fa-times-circle\" ";
+		$opstring .=							"onclick=\"killClient('" . $server['mgmt'] . "', '" . $conn['remote_host'] . "');\" ";
+		$opstring .=							"style=\"cursor:pointer;\" ";
+		$opstring .=							"name=\"" . "i:" . $server['mgmt'] . ":" . $conn['remote_host'] . "\" ";
+		$opstring .=							"title=\"" . sprintf(gettext('Kill client connection from %s'), $conn['remote_host']) . "\">";
+		$opstring .=						"</i>";
+		$opstring .=					"</td>";
+		$opstring .=				"</tr>";
+		$opstring .=				"<tr name=\"" . "r:" . $server['mgmt'] . ":" . $conn['remote_host'] . "\" class=\"" . $evenRowClass . "\">";
+		$opstring .=					"<td>";
+		$opstring .=						$conn['connect_time'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td>";
+		$opstring .=						$conn['virtual_addr'];
+		if (!empty($conn['virtual_addr']) && !empty($conn['virtual_addr6'])) {
+			$opstring .=						"<br />";
+		}
+		$opstring .=						$conn['virtual_addr6'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td></td>";
+		$opstring .=				"</tr>";
+
+					endforeach;
+
+		$opstring .=			"</tbody>";
+		$opstring .=		"</table>";
+		$opstring .=	"</div>";
+		$opstring .= "</div>";
+
+		endforeach;
+
+		print($opstring);
+
+		$got_sk_server = false;
+
+		if (!empty($sk_servers)):
+			foreach ($sk_servers as $sk_server):
+				if (!in_array($sk_server['vpnid'], $skipovpns)) {
+					$got_sk_server = true;
+					break;
+				}
+			endforeach;
+		endif;
+
+		if ($got_sk_server):
+
+		$opstring = "";
+		$opstring .= "<div class=\"widget panel panel-default\">";
+		$opstring .=	"<div class=\"panel-heading\"><h2 class=\"panel-title\">" . gettext("Peer to Peer Server Instance Statistics") . "</h2></div>";
+		$opstring .=	"<div class=\"table-responsive\">";
+		$opstring .=		"<table class=\"table table-striped table-hover table-condensed sortable-theme-bootstrap\" data-sortable>";
+		$opstring .=			"<thead>";
+		$opstring .=				"<tr>";
+		$opstring .=					"<th>" . gettext('Name/Time') . "</th>";
+		$opstring .=					"<th>" . gettext('Remote/Virtual IP') . "</th>";
+		$opstring .=					"<th></th>";
+		$opstring .=				"</tr>";
+		$opstring .=			"</thead>";
+		$opstring .=			"<tbody>";
+
+					foreach ($sk_servers as $sk_server):
+						if (in_array($sk_server['vpnid'], $skipovpns)) {
+							continue;
+						}
+
+		$opstring .=				"<tr name=\"r:" . $sk_server['port'] . ":" . $sk_server['remote_host'] . "\">";
+		$opstring .=					"<td>";
+		$opstring .=						$sk_server['name'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td>";
+		$opstring .=						$sk_server['remote_host'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td>";
+
+						if ($sk_server['status'] == "up") {
+							/* tunnel is up */
+		$opstring .=						"<i class=\"fa fa-arrow-up text-success\"></i>";
+						} else {
+							/* tunnel is down */
+		$opstring .=						"<i class=\"fa fa-arrow-down text-danger\"></i>";
+						}
+
+		$opstring .=					"</td>";
+		$opstring .=				"</tr>";
+		$opstring .=				"<tr name=\"r:" . $sk_server['port'] . ":" . $sk_server['remote_host'] . "\">";
+		$opstring .=					"<td>";
+		$opstring .=						$sk_server['connect_time'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td>";
+		$opstring .=						$sk_server['virtual_addr'];
+		if (!empty($sk_server['virtual_addr']) && !empty($sk_server['virtual_addr6'])) {
+			$opstring .=						"<br />";
+		}
+		$opstring .=						$sk_server['virtual_addr6'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td></td>";
+		$opstring .=				"</tr>";
+
+					endforeach;
+
+		$opstring .=			"</tbody>";
+		$opstring .=		"</table>";
+		$opstring .=	"</div>";
+		$opstring .= "</div>";
+
+		print($opstring);
+
+		endif;
+
+		$got_ovpn_client = false;
+
+		if (!empty($clients)):
+			foreach ($clients as $client):
+				if (!in_array($client['vpnid'], $skipovpns)) {
+					$got_ovpn_client = true;
+					break;
+				}
+			endforeach;
+		endif;
+
+		if ($got_ovpn_client):
+
+		$opstring = "";
+
+		$opstring .= "<div class=\"widget panel panel-default\">";
+		$opstring .=	"<div class=\"panel-heading\"><h2 class=\"panel-title\">" . gettext("Client Instance Statistics") . "</h2></div>";
+		$opstring .=	"<div class=\"table-responsive\">";
+		$opstring .=		"<table class=\"table table-striped table-hover table-condensed sortable-theme-bootstrap\" data-sortable>";
+		$opstring .=			"<thead>";
+		$opstring .=				"<tr>";
+		$opstring .=					"<th>" . gettext('Name/Time') . "</th>";
+		$opstring .=					"<th>" . gettext('Remote/Virtual IP') . "</th>";
+		$opstring .=					"<th></th>";
+		$opstring .=				"</tr>";
+		$opstring .=			"</thead>";
+		$opstring .=			"<tbody>";
+
+					foreach ($clients as $client):
+						if (in_array($client['vpnid'], $skipovpns)) {
+							continue;
+						}
+
+		$opstring .=				"<tr name=\"r:" . $client['port'] . ":" . $client['remote_host'] . "\">";
+		$opstring .=					"<td>";
+		$opstring .=						$client['name'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td>";
+		$opstring .=						$client['remote_host'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td>";
+
+						if ($client['status'] == "up") {
+							/* tunnel is up */
+		$opstring .=						"<i class=\"fa fa-arrow-up text-success\"></i>";
+						} else {
+							/* tunnel is down */
+		$opstring .=						"<i class=\"fa fa-arrow-down text-danger\"></i>";
+						}
+
+		$opstring .=					"</td>";
+		$opstring .=				"</tr>";
+		$opstring .=				"<tr name=\"r:" . $client['port'] . ":" . $client['remote_host'] . "\">";
+		$opstring .=					"<td>";
+		$opstring .=						$client['connect_time'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td>";
+		$opstring .=						$client['virtual_addr'];
+		if (!empty($client['virtual_addr']) && !empty($client['virtual_addr6'])) {
+			$opstring .=						"<br />";
+		}
+		$opstring .=						$client['virtual_addr6'];
+		$opstring .=					"</td>";
+		$opstring .=					"<td></td>";
+		$opstring .=				"</tr>";
+
+					endforeach;
+
+		$opstring .=			"</tbody>";
+		$opstring .=		"</table>";
+		$opstring .=	"</div>";
+		$opstring .= "</div>";
+
+		print($opstring);
+
+		endif;
+
+		if ((empty($clients)) && (empty($servers)) && (empty($sk_servers))) {
+			$none_to_display_text = gettext("No OpenVPN instances defined");
+		} else if (!$got_ovpn_server && !$got_sk_server && !$got_ovpn_client) {
+			$none_to_display_text = gettext("All OpenVPN instances are hidden");
+		} else {
+			$none_to_display_text = "";
+		}
+		
+		if (strlen($none_to_display_text) > 0) {
+			print('<table class="table"><tbody><td class="text-center">' . $none_to_display_text . '</td></tbody></table>');
+		}
+	}
+}
+
 /* Handle AJAX */
 if ($_GET['action']) {
 	if ($_GET['action'] == "kill") {
@@ -41,9 +288,9 @@ if ($_GET['action']) {
 
 // Compose the table contents and pass it back to the ajax caller
 if ($_REQUEST && $_REQUEST['ajax']) {
-	printPanel();
+	printPanel($_REQUEST['widgetkey']);
 	exit;
-} else if ($_POST) {
+} else if ($_POST['widgetkey']) {
 
 	$validNames = array();
 	$servers = openvpn_get_active_servers();
@@ -63,327 +310,33 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	}
 
 	if (is_array($_POST['show'])) {
-		$user_settings['widgets']['openvpn']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['openvpn']['filter'] = implode(',', $validNames);
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved OpenVPN Filter via Dashboard."));
 	header("Location: /index.php");
 }
 
-// Output the widget panel from this function so that it can be called from the AJAX handler as well as
-// when first rendering the page
-function printPanel() {
-	global $user_settings;
-
-	$servers = openvpn_get_active_servers();
-	$sk_servers = openvpn_get_active_servers("p2p");
-	$clients = openvpn_get_active_clients();
-	$skipovpns = explode(",", $user_settings['widgets']['openvpn']['filter']);
-
-	$opstring = "";
-	$got_ovpn_server = false;
-
-	foreach ($servers as $server):
-		if (in_array($server['vpnid'], $skipovpns)) {
-			continue;
-		}
-
-		$got_ovpn_server = true;
-
-	$opstring .= "<div class=\"widget panel panel-default\">";
-	$opstring .=	"<div class=\"panel-heading\"><h2 class=\"panel-title\">" . htmlspecialchars($server['name']) . "</h2></div>";
-	$opstring .=	"<div class=\"table-responsive\">";
-	$opstring .=		"<table class=\"table table-striped table-hover table-condensed sortable-theme-bootstrap\" data-sortable>";
-	$opstring .=			"<thead>";
-	$opstring .=				"<tr>";
-	$opstring .=					"<th>" . gettext('Name/Time') . "</th>";
-	$opstring .=					"<th>" . gettext('Real/Virtual IP') . "</th>";
-	$opstring .=					"<th></th>";
-	$opstring .=				"</tr>";
-	$opstring .=			"</thead>";
-	$opstring .=			"<tbody>";
-
-				$rowIndex = 0;
-				foreach ($server['conns'] as $conn):
-					$evenRowClass = $rowIndex % 2 ? " listMReven" : " listMRodd";
-					$rowIndex++;
-
-	$opstring .=				"<tr name=\"" . "r:" . $server['mgmt'] . ":" . $conn['remote_host'] . "\" class=\"" . $evenRowClass . "\">";
-	$opstring .=					"<td>";
-	$opstring .=						$conn['common_name'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td>";
-	$opstring .=						$conn['remote_host'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td>";
-	$opstring .=						"<i class=\"fa fa-times-circle\" ";
-	$opstring .=							"onclick=\"killClient('" . $server['mgmt'] . "', '" . $conn['remote_host'] . "');\" ";
-	$opstring .=							"style=\"cursor:pointer;\" ";
-	$opstring .=							"name=\"" . "i:" . $server['mgmt'] . ":" . $conn['remote_host'] . "\" ";
-	$opstring .=							"title=\"" . sprintf(gettext('Kill client connection from %s'), $conn['remote_host']) . "\">";
-	$opstring .=						"</i>";
-	$opstring .=					"</td>";
-	$opstring .=				"</tr>";
-	$opstring .=				"<tr name=\"" . "r:" . $server['mgmt'] . ":" . $conn['remote_host'] . "\" class=\"" . $evenRowClass . "\">";
-	$opstring .=					"<td>";
-	$opstring .=						$conn['connect_time'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td>";
-	$opstring .=						$conn['virtual_addr'];
-	if (!empty($conn['virtual_addr']) && !empty($conn['virtual_addr6'])) {
-		$opstring .=						"<br />";
-	}
-	$opstring .=						$conn['virtual_addr6'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td></td>";
-	$opstring .=				"</tr>";
-
-				endforeach;
-
-	$opstring .=			"</tbody>";
-	$opstring .=		"</table>";
-	$opstring .=	"</div>";
-	$opstring .= "</div>";
-
-	endforeach;
-
-	print($opstring);
-
-	$got_sk_server = false;
-
-	if (!empty($sk_servers)):
-		foreach ($sk_servers as $sk_server):
-			if (!in_array($sk_server['vpnid'], $skipovpns)) {
-				$got_sk_server = true;
-				break;
-			}
-		endforeach;
-	endif;
-
-	if ($got_sk_server):
-
-	$opstring = "";
-	$opstring .= "<div class=\"widget panel panel-default\">";
-	$opstring .=	"<div class=\"panel-heading\"><h2 class=\"panel-title\">" . gettext("Peer to Peer Server Instance Statistics") . "</h2></div>";
-	$opstring .=	"<div class=\"table-responsive\">";
-	$opstring .=		"<table class=\"table table-striped table-hover table-condensed sortable-theme-bootstrap\" data-sortable>";
-	$opstring .=			"<thead>";
-	$opstring .=				"<tr>";
-	$opstring .=					"<th>" . gettext('Name/Time') . "</th>";
-	$opstring .=					"<th>" . gettext('Remote/Virtual IP') . "</th>";
-	$opstring .=					"<th></th>";
-	$opstring .=				"</tr>";
-	$opstring .=			"</thead>";
-	$opstring .=			"<tbody>";
-
-				foreach ($sk_servers as $sk_server):
-					if (in_array($sk_server['vpnid'], $skipovpns)) {
-						continue;
-					}
-
-	$opstring .=				"<tr name=\"r:" . $sk_server['port'] . ":" . $sk_server['remote_host'] . "\">";
-	$opstring .=					"<td>";
-	$opstring .=						$sk_server['name'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td>";
-	$opstring .=						$sk_server['remote_host'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td>";
-
-					if ($sk_server['status'] == "up") {
-						/* tunnel is up */
-	$opstring .=						"<i class=\"fa fa-arrow-up text-success\"></i>";
-					} else {
-						/* tunnel is down */
-	$opstring .=						"<i class=\"fa fa-arrow-down text-danger\"></i>";
-					}
-
-	$opstring .=					"</td>";
-	$opstring .=				"</tr>";
-	$opstring .=				"<tr name=\"r:" . $sk_server['port'] . ":" . $sk_server['remote_host'] . "\">";
-	$opstring .=					"<td>";
-	$opstring .=						$sk_server['connect_time'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td>";
-	$opstring .=						$sk_server['virtual_addr'];
-	if (!empty($sk_server['virtual_addr']) && !empty($sk_server['virtual_addr6'])) {
-		$opstring .=						"<br />";
-	}
-	$opstring .=						$sk_server['virtual_addr6'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td></td>";
-	$opstring .=				"</tr>";
-
-				endforeach;
-
-	$opstring .=			"</tbody>";
-	$opstring .=		"</table>";
-	$opstring .=	"</div>";
-	$opstring .= "</div>";
-
-	print($opstring);
-
-	endif;
-
-	$got_ovpn_client = false;
-
-	if (!empty($clients)):
-		foreach ($clients as $client):
-			if (!in_array($client['vpnid'], $skipovpns)) {
-				$got_ovpn_client = true;
-				break;
-			}
-		endforeach;
-	endif;
-
-	if ($got_ovpn_client):
-
-	$opstring = "";
-
-	$opstring .= "<div class=\"widget panel panel-default\">";
-	$opstring .=	"<div class=\"panel-heading\"><h2 class=\"panel-title\">" . gettext("Client Instance Statistics") . "</h2></div>";
-	$opstring .=	"<div class=\"table-responsive\">";
-	$opstring .=		"<table class=\"table table-striped table-hover table-condensed sortable-theme-bootstrap\" data-sortable>";
-	$opstring .=			"<thead>";
-	$opstring .=				"<tr>";
-	$opstring .=					"<th>" . gettext('Name/Time') . "</th>";
-	$opstring .=					"<th>" . gettext('Remote/Virtual IP') . "</th>";
-	$opstring .=					"<th></th>";
-	$opstring .=				"</tr>";
-	$opstring .=			"</thead>";
-	$opstring .=			"<tbody>";
-
-				foreach ($clients as $client):
-					if (in_array($client['vpnid'], $skipovpns)) {
-						continue;
-					}
-
-	$opstring .=				"<tr name=\"r:" . $client['port'] . ":" . $client['remote_host'] . "\">";
-	$opstring .=					"<td>";
-	$opstring .=						$client['name'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td>";
-	$opstring .=						$client['remote_host'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td>";
-
-					if ($client['status'] == "up") {
-						/* tunnel is up */
-	$opstring .=						"<i class=\"fa fa-arrow-up text-success\"></i>";
-					} else {
-						/* tunnel is down */
-	$opstring .=						"<i class=\"fa fa-arrow-down text-danger\"></i>";
-					}
-
-	$opstring .=					"</td>";
-	$opstring .=				"</tr>";
-	$opstring .=				"<tr name=\"r:" . $client['port'] . ":" . $client['remote_host'] . "\">";
-	$opstring .=					"<td>";
-	$opstring .=						$client['connect_time'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td>";
-	$opstring .=						$client['virtual_addr'];
-	if (!empty($client['virtual_addr']) && !empty($client['virtual_addr6'])) {
-		$opstring .=						"<br />";
-	}
-	$opstring .=						$client['virtual_addr6'];
-	$opstring .=					"</td>";
-	$opstring .=					"<td></td>";
-	$opstring .=				"</tr>";
-
-				endforeach;
-
-	$opstring .=			"</tbody>";
-	$opstring .=		"</table>";
-	$opstring .=	"</div>";
-	$opstring .= "</div>";
-
-	print($opstring);
-
-	endif;
-
-	if ((empty($clients)) && (empty($servers)) && (empty($sk_servers))) {
-		$none_to_display_text = gettext("No OpenVPN instances defined");
-	} else if (!$got_ovpn_server && !$got_sk_server && !$got_ovpn_client) {
-		$none_to_display_text = gettext("All OpenVPN instances are hidden");
-	} else {
-		$none_to_display_text = "";
-	}
-	
-	if (strlen($none_to_display_text) > 0) {
-		print('<table class="table"><tbody><td class="text-center">' . $none_to_display_text . '</td></tbody></table>');
-	}
-}
-
 $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period'] * 1000 : 10000;
+$widgetkey_nodash = str_replace("-", "", $widgetkey);
 
 ?>
 
-<script type="text/javascript">
-//<![CDATA[
-	function killClient(mport, remipp) {
-
-		$.ajax(
-			"widgets/widgets/openvpn.widget.php" +
-				"?action=kill&port=" + mport + "&remipp=" + remipp,
-			{ type: "get", complete: killComplete }
-		);
-	}
-
-	function killComplete(req) {
-		var values = req.responseText.split("|");
-		if (values[3] != "0") {
-			alert('<?=gettext("An error occurred.");?>' + ' (' + values[3] + ')');
-			return;
-		}
-
-		$('tr[name="r:' + values[1] + ":" + values[2] + '"]').each(
-			function(index,row) { $(row).fadeOut(1000); }
-		);
-	}
-
-	// Refresh the panel
-	function get_update() {
-		var ajaxRequest;
-
-		ajaxRequest = $.ajax({
-				url: "/widgets/widgets/openvpn.widget.php",
-				type: "post",
-				data: { ajax: "ajax"}
-			});
-
-		// Deal with the results of the above ajax call
-		ajaxRequest.done(function (response, textStatus, jqXHR) {
-			$('#mainpanel').html(response);
-
-			// and do it again
-			setTimeout(get_update, "<?=$widgetperiod?>");
-		});
-	}
-
-	events.push(function(){
-		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallovpns");
-
-		// Start polling for updates some small random number of seconds from now (so that all the widgets don't
-		// hit the server at exactly the same time)
-		setTimeout(get_update, Math.floor((Math.random() * 10000) + 1000));
-	});
-//]]>
-</script>
-<div id="mainpanel" class="content">
+<div id="<?=$widgetkey?>-openvpn-mainpanel" class="content">
 
 <?php
-	printPanel();
+	printPanel($widgetkey);
 ?>
 </div>
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/openvpn.widget.php" method="post" class="form-horizontal">
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
+			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 			<div class="table responsive">
 				<table class="table table-striped table-hover table-condensed">
 					<thead>
@@ -397,7 +350,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 				$servers = openvpn_get_active_servers();
 				$sk_servers = openvpn_get_active_servers("p2p");
 				$clients = openvpn_get_active_clients();
-				$skipovpns = explode(",", $user_settings['widgets']['openvpn']['filter']);
+				$skipovpns = explode(",", $user_settings['widgets'][$widgetkey]['filter']);
 				foreach ($servers as $server):
 ?>
 						<tr>
@@ -432,7 +385,59 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">
 			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			<button id="showallovpns" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			<button id="<?=$widget_showallnone_id?>" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
 		</div>
 	</div>
 </form>
+
+<script type="text/javascript">
+//<![CDATA[
+	function killClient(mport, remipp) {
+
+		$.ajax(
+			"widgets/widgets/openvpn.widget.php" +
+				"?action=kill&port=" + mport + "&remipp=" + remipp,
+			{ type: "get", complete: killComplete }
+		);
+	}
+
+	function killComplete(req) {
+		var values = req.responseText.split("|");
+		if (values[3] != "0") {
+			alert('<?=gettext("An error occurred.");?>' + ' (' + values[3] + ')');
+			return;
+		}
+
+		$('tr[name="r:' + values[1] + ":" + values[2] + '"]').each(
+			function(index,row) { $(row).fadeOut(1000); }
+		);
+	}
+
+	// Refresh the panel
+	function get_openvpn_update_<?=$widgetkey_nodash?>() {
+		var ajaxRequest;
+
+		ajaxRequest = $.ajax({
+				url: "/widgets/widgets/openvpn.widget.php",
+				type: "post",
+				data: { ajax: "ajax", widgetkey: "<?=$widgetkey?>"}
+			});
+
+		// Deal with the results of the above ajax call
+		ajaxRequest.done(function (response, textStatus, jqXHR) {
+			$('#<?=$widgetkey?>-openvpn-mainpanel').html(response);
+
+			// and do it again
+			setTimeout(get_openvpn_update_<?=$widgetkey_nodash?>, "<?=$widgetperiod?>");
+		});
+	}
+
+	events.push(function(){
+		set_widget_checkbox_events("#<?=$widget_panel_footer_id?> [id^=show]", "<?=$widget_showallnone_id?>");
+
+		// Start polling for updates some small random number of seconds from now (so that all the widgets don't
+		// hit the server at exactly the same time)
+		setTimeout(get_openvpn_update_<?=$widgetkey_nodash?>, Math.floor((Math.random() * 10000) + 1000));
+	});
+//]]>
+</script>

--- a/src/usr/local/www/widgets/widgets/openvpn.widget.php
+++ b/src/usr/local/www/widgets/widgets/openvpn.widget.php
@@ -364,11 +364,7 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 	}
 
 	events.push(function(){
-		$("#showallovpns").click(function() {
-			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
-				$(this).prop("checked", true);
-			});
-		});
+		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallovpns");
 
 		// Start polling for updates some small random number of seconds from now (so that all the widgets don't
 		// hit the server at exactly the same time)

--- a/src/usr/local/www/widgets/widgets/openvpn.widget.php
+++ b/src/usr/local/www/widgets/widgets/openvpn.widget.php
@@ -65,7 +65,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['openvpn']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['openvpn']['filter'] = "";
+		$user_settings['widgets']['openvpn']['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved OpenVPN Filter via Dashboard."));
@@ -83,11 +83,14 @@ function printPanel() {
 	$skipovpns = explode(",", $user_settings['widgets']['openvpn']['filter']);
 
 	$opstring = "";
+	$got_ovpn_server = false;
 
 	foreach ($servers as $server):
 		if (in_array($server['vpnid'], $skipovpns)) {
 			continue;
 		}
+
+		$got_ovpn_server = true;
 
 	$opstring .= "<div class=\"widget panel panel-default\">";
 	$opstring .=	"<div class=\"panel-heading\"><h2 class=\"panel-title\">" . htmlspecialchars($server['name']) . "</h2></div>";
@@ -302,7 +305,15 @@ function printPanel() {
 	endif;
 
 	if ((empty($clients)) && (empty($servers)) && (empty($sk_servers))) {
-		print(gettext("No OpenVPN instances defined"));
+		$none_to_display_text = gettext("No OpenVPN instances defined");
+	} else if (!$got_ovpn_server && !$got_sk_server && !$got_ovpn_client) {
+		$none_to_display_text = gettext("All OpenVPN instances are hidden");
+	} else {
+		$none_to_display_text = "";
+	}
+	
+	if (strlen($none_to_display_text) > 0) {
+		print('<table class="table"><tbody><td class="text-center">' . $none_to_display_text . '</td></tbody></table>');
 	}
 }
 

--- a/src/usr/local/www/widgets/widgets/picture.widget.php
+++ b/src/usr/local/www/widgets/widgets/picture.widget.php
@@ -26,19 +26,19 @@ require_once("pfsense-utils.inc");
 require_once("functions.inc");
 
 if ($_GET['getpic']=="true") {
-	$pic_type_s = explode(".", $user_settings['widgets']['picturewidget_filename']);
+	$pic_type_s = explode(".", $user_settings['widgets'][$_GET['widgetkey']]['picturewidget_filename']);
 	$pic_type = $pic_type_s[1];
-	if ($user_settings['widgets']['picturewidget']) {
-		$data = base64_decode($user_settings['widgets']['picturewidget']);
+	if ($user_settings['widgets'][$_GET['widgetkey']]['picturewidget']) {
+		$data = base64_decode($user_settings['widgets'][$_GET['widgetkey']]['picturewidget']);
 	}
-	header("Content-Disposition: inline; filename=\"{$user_settings['widgets']['picturewidget_filename']}\"");
+	header("Content-Disposition: inline; filename=\"{$user_settings['widgets'][$_GET['widgetkey']]['picturewidget_filename']}\"");
 	header("Content-Type: image/{$pic_type}");
 	header("Content-Length: " . strlen($data));
 	echo $data;
 	exit;
 }
 
-if ($_POST) {
+if ($_POST['widgetkey']) {
 	if (is_uploaded_file($_FILES['pictfile']['tmp_name'])) {
 		/* read the file contents */
 		$fd_pic = fopen($_FILES['pictfile']['tmp_name'], "rb");
@@ -52,8 +52,8 @@ if ($_POST) {
 			die("Could not read temporary file");
 		} else {
 			$picname = basename($_FILES['uploadedfile']['name']);
-			$user_settings['widgets']['picturewidget'] = base64_encode($data);
-			$user_settings['widgets']['picturewidget_filename'] = $_FILES['pictfile']['name'];
+			$user_settings['widgets'][$_POST['widgetkey']]['picturewidget'] = base64_encode($data);
+			$user_settings['widgets'][$_POST['widgetkey']]['picturewidget_filename'] = $_FILES['pictfile']['name'];
 			save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Picture widget saved via Dashboard."));
 			header("Location: /index.php");
 			exit;
@@ -62,14 +62,15 @@ if ($_POST) {
 }
 
 ?>
-<a href="/widgets/widgets/picture.widget.php?getpic=true" target="_blank">
-	<img style="width:100%; height:100%" src="/widgets/widgets/picture.widget.php?getpic=true" alt="picture" />
+<a href="/widgets/widgets/picture.widget.php?getpic=true&widgetkey=<?=$widgetkey?>" target="_blank">
+	<img style="width:100%; height:100%" src="/widgets/widgets/picture.widget.php?getpic=true&widgetkey=<?=$widgetkey?>" alt="picture" />
 </a>
 
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/picture.widget.php" method="post" enctype="multipart/form-data" class="form-inline">
+	<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 	<label for="pictfile"><?=gettext('New picture:')?> </label>
 	<input id="pictfile" name="pictfile" type="file" class="form-control" />
 	<button type="submit" class="btn btn-primary btn-xs">

--- a/src/usr/local/www/widgets/widgets/rss.widget.php
+++ b/src/usr/local/www/widgets/widgets/rss.widget.php
@@ -25,36 +25,38 @@ require_once("guiconfig.inc");
 require_once("pfsense-utils.inc");
 require_once("functions.inc");
 
-if ($_POST['rssfeed']) {
-	$user_settings['widgets']['rssfeed'] = str_replace("\n", ",", htmlspecialchars($_POST['rssfeed'], ENT_QUOTES | ENT_HTML401));
-	$user_settings['widgets']['rssmaxitems'] = str_replace("\n", ",", htmlspecialchars($_POST['rssmaxitems'], ENT_QUOTES | ENT_HTML401));
-	$user_settings['widgets']['rsswidgetheight'] = htmlspecialchars($_POST['rsswidgetheight'], ENT_QUOTES | ENT_HTML401);
-	$user_settings['widgets']['rsswidgettextlength'] = htmlspecialchars($_POST['rsswidgettextlength'], ENT_QUOTES | ENT_HTML401);
+if ($_POST['widgetkey']) {
+	$user_settings['widgets'][$_POST['widgetkey']]['rssfeed'] = str_replace("\n", ",", htmlspecialchars($_POST['rssfeed'], ENT_QUOTES | ENT_HTML401));
+	$user_settings['widgets'][$_POST['widgetkey']]['rssmaxitems'] = str_replace("\n", ",", htmlspecialchars($_POST['rssmaxitems'], ENT_QUOTES | ENT_HTML401));
+	$user_settings['widgets'][$_POST['widgetkey']]['rsswidgetheight'] = htmlspecialchars($_POST['rsswidgetheight'], ENT_QUOTES | ENT_HTML401);
+	$user_settings['widgets'][$_POST['widgetkey']]['rsswidgettextlength'] = htmlspecialchars($_POST['rsswidgettextlength'], ENT_QUOTES | ENT_HTML401);
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved RSS Widget feed via Dashboard."));
 	header("Location: /");
 }
 
 // Use saved feed and max items
-if ($user_settings['widgets']['rssfeed']) {
-	$rss_feed_s = explode(",", $user_settings['widgets']['rssfeed']);
+if ($user_settings['widgets'][$widgetkey]['rssfeed']) {
+	$rss_feed_s = explode(",", $user_settings['widgets'][$widgetkey]['rssfeed']);
 }
 
-if ($user_settings['widgets']['rssmaxitems']) {
-	$max_items =  $user_settings['widgets']['rssmaxitems'];
+if ($user_settings['widgets'][$widgetkey]['rssmaxitems']) {
+	$max_items =  $user_settings['widgets'][$widgetkey]['rssmaxitems'];
 }
 
-if (is_numeric($user_settings['widgets']['rsswidgetheight'])) {
-	$rsswidgetheight =	$user_settings['widgets']['rsswidgetheight'];
+if (is_numeric($user_settings['widgets'][$widgetkey]['rsswidgetheight'])) {
+	$rsswidgetheight =	$user_settings['widgets'][$widgetkey]['rsswidgetheight'];
 }
 
-if (is_numeric($user_settings['widgets']['rsswidgettextlength'])) {
-	$rsswidgettextlength =	$user_settings['widgets']['rsswidgettextlength'];
+if (is_numeric($user_settings['widgets'][$widgetkey]['rsswidgettextlength'])) {
+	$rsswidgettextlength =	$user_settings['widgets'][$widgetkey]['rsswidgettextlength'];
 }
 
 // Set a default feed if none exists
 if (!$rss_feed_s) {
 	$rss_feed_s = "https://www.netgate.com/blog/";
-	$user_settings['widgets']['rssfeed'] = "https://www.netgate.com/blog/";
+	if ($widgetkey != "") {
+		$user_settings['widgets'][$widgetkey]['rssfeed'] = $rss_feed_s;
+	}
 }
 
 if (!$max_items || !is_numeric($max_items)) {
@@ -69,8 +71,8 @@ if (!$rsswidgettextlength || !is_numeric($rsswidgettextlength)) {
 	$rsswidgettextlength = 140; // oh twitter, how do we love thee?
 }
 
-if ($user_settings['widgets']['rssfeed']) {
-	$textarea_txt =	 str_replace(",", "\n", $user_settings['widgets']['rssfeed']);
+if ($user_settings['widgets'][$widgetkey]['rssfeed']) {
+	$textarea_txt =	 str_replace(",", "\n", $user_settings['widgets'][$widgetkey]['rssfeed']);
 } else {
 	$textarea_txt = "";
 }
@@ -85,11 +87,13 @@ if ($user_settings['widgets']['rssfeed']) {
 	exec("chmod a+rw /tmp/simplepie/.");
 	exec("chmod a+rw /tmp/simplepie/cache/.");
 	require_once("simplepie/simplepie.inc");
-	function textLimit($string, $length, $replacer = '...') {
-		if (strlen($string) > $length) {
-			return (preg_match('/^(.*)\W.*$/', substr($string, 0, $length+1), $matches) ? $matches[1] : substr($string, 0, $length)) . $replacer;
+	if (!function_exists('textLimit')) {
+		function textLimit($string, $length, $replacer = '...') {
+			if (strlen($string) > $length) {
+				return (preg_match('/^(.*)\W.*$/', substr($string, 0, $length+1), $matches) ? $matches[1] : substr($string, 0, $length)) . $replacer;
+			}
+			return $string;
 		}
-		return $string;
 	}
 	$feed = new SimplePie();
 	$feed->set_cache_location("/tmp/simplepie/");
@@ -120,9 +124,10 @@ if ($user_settings['widgets']['rssfeed']) {
 </div>
 
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/rss.widget.php" method="post" class="form-horizontal">
+	<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 	<div class="form-group">
 		<label for="rssfeed" class="col-sm-3 control-label"><?=gettext('Feeds')?></label>
 		<div class="col-sm-6">

--- a/src/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/services_status.widget.php
@@ -59,7 +59,7 @@ if ($_POST) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['servicestatusfilter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['servicestatusfilter'] = "";
+		$user_settings['widgets']['servicestatusfilter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Service Status Filter via Dashboard."));
@@ -83,11 +83,14 @@ $skipservices = explode(",", $user_settings['widgets']['servicestatusfilter']);
 
 if (count($services) > 0) {
 	uasort($services, "service_dispname_compare");
+	$service_is_displayed = false;
 
 	foreach ($services as $service) {
 		if ((!$service['dispname']) || (in_array($service['dispname'], $skipservices)) || (!is_service_enabled($service['dispname']))) {
 			continue;
 		}
+
+		$service_is_displayed = true;
 
 		if (empty($service['description'])) {
 			$service['description'] = get_pkg_descr($service['name']);
@@ -103,8 +106,12 @@ if (count($services) > 0) {
 			</tr>
 <?php
 	}
+
+	if (!$service_is_displayed) {
+		echo "<tr><td colspan=\"4\" class=\"text-center\">" . gettext("All services are hidden") . ". </td></tr>\n";
+	}
 } else {
-	echo "<tr><td colspan=\"3\" class=\"text-center\">" . gettext("No services found") . ". </td></tr>\n";
+	echo "<tr><td colspan=\"4\" class=\"text-center\">" . gettext("No services found") . ". </td></tr>\n";
 }
 ?>
 		</tbody>

--- a/src/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/services_status.widget.php
@@ -48,7 +48,7 @@ for ($idx=1; $idx < $numsvcs; $idx++) {
 	}
 }
 
-if ($_POST) {
+if ($_POST['widgetkey']) {
 
 	$validNames = array();
 
@@ -57,9 +57,9 @@ if ($_POST) {
 	}
 
 	if (is_array($_POST['show'])) {
-		$user_settings['widgets']['servicestatusfilter'] = implode(',', array_diff($validNames, $_POST['show']));
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['servicestatusfilter'] = implode(',', $validNames);
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Service Status Filter via Dashboard."));
@@ -79,7 +79,7 @@ if ($_POST) {
 		</thead>
 		<tbody>
 <?php
-$skipservices = explode(",", $user_settings['widgets']['servicestatusfilter']);
+$skipservices = explode(",", $user_settings['widgets'][$widgetkey]['filter']);
 
 if (count($services) > 0) {
 	uasort($services, "service_dispname_compare");
@@ -118,11 +118,12 @@ if (count($services) > 0) {
 	</table>
 </div>
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/services_status.widget.php" method="post" class="form-horizontal">
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
+			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 			<div class="table responsive">
 				<table class="table table-striped table-hover table-condensed">
 					<thead>
@@ -133,7 +134,7 @@ if (count($services) > 0) {
 					</thead>
 					<tbody>
 <?php
-				$skipservices = explode(",", $user_settings['widgets']['servicestatusfilter']);
+				$skipservices = explode(",", $user_settings['widgets'][$widgetkey]['filter']);
 				$idx = 0;
 
 				foreach ($services as $service):
@@ -156,7 +157,7 @@ if (count($services) > 0) {
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">
 			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			<button id="showallservices" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			<button id="<?=$widget_showallnone_id?>" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
 		</div>
 	</div>
 </form>
@@ -164,7 +165,7 @@ if (count($services) > 0) {
 <script type="text/javascript">
 //<![CDATA[
 	events.push(function(){
-		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallservices");
+		set_widget_checkbox_events("#<?=$widget_panel_footer_id?> [id^=show]", "<?=$widget_showallnone_id?>");
 	});
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/services_status.widget.php
@@ -164,12 +164,7 @@ if (count($services) > 0) {
 <script type="text/javascript">
 //<![CDATA[
 	events.push(function(){
-		$("#showallservices").click(function() {
-			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
-				$(this).prop("checked", true);
-			});
-		});
-
+		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallservices");
 	});
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/smart_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/smart_status.widget.php
@@ -162,12 +162,7 @@ if (count($devs) > 0)  {
 <script type="text/javascript">
 //<![CDATA[
 	events.push(function(){
-		$("#showallsmartdrives").click(function() {
-			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
-				$(this).prop("checked", true);
-			});
-		});
-
+		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallsmartdrives");
 	});
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/smart_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/smart_status.widget.php
@@ -47,7 +47,7 @@ if ($_POST) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['smart_status']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['smart_status']['filter'] = "";
+		$user_settings['widgets']['smart_status']['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved SMART Status Filter via Dashboard."));
@@ -69,6 +69,7 @@ if ($_POST) {
 	<tbody>
 <?php
 $skipsmart = explode(",", $user_settings['widgets']['smart_status']['filter']);
+$smartdrive_is_displayed = false;
 
 if (count($devs) > 0)  {
 	foreach ($devs as $dev)  { ## for each found drive do
@@ -76,6 +77,7 @@ if (count($devs) > 0)  {
 			continue;
 		}
 
+		$smartdrive_is_displayed = true;
 		$dev_ident = exec("diskinfo -v /dev/$dev | grep ident   | awk '{print $1}'"); ## get identifier from drive
 		$dev_state = trim(exec("smartctl -H /dev/$dev | awk -F: '/^SMART overall-health self-assessment test result/ {print $2;exit}
 /^SMART Health Status/ {print $2;exit}'")); ## get SMART state from drive
@@ -101,6 +103,16 @@ if (count($devs) > 0)  {
 			<td><?=$dev?></td>
 			<td><?=$dev_ident?></td>
 			<td><?=ucfirst($dev_state)?></td>
+		</tr>
+<?php
+	}
+
+	if (!$smartdrive_is_displayed) {
+?>
+		<tr>
+			<td colspan="4" class="text-center">
+				<?=gettext('All SMART drives are hidden.');?>
+			</td>
 		</tr>
 <?php
 	}

--- a/src/usr/local/www/widgets/widgets/smart_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/smart_status.widget.php
@@ -36,7 +36,7 @@ if ($specplatform['name'] != "Hyper-V") {
 	$devs = get_smart_drive_list();
 }
 
-if ($_POST) {
+if ($_POST['widgetkey']) {
 
 	$validNames = array();
 
@@ -45,9 +45,9 @@ if ($_POST) {
 	}
 
 	if (is_array($_POST['show'])) {
-		$user_settings['widgets']['smart_status']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['smart_status']['filter'] = implode(',', $validNames);
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved SMART Status Filter via Dashboard."));
@@ -68,7 +68,7 @@ if ($_POST) {
 	</thead>
 	<tbody>
 <?php
-$skipsmart = explode(",", $user_settings['widgets']['smart_status']['filter']);
+$skipsmart = explode(",", $user_settings['widgets'][$widgetkey]['filter']);
 $smartdrive_is_displayed = false;
 
 if (count($devs) > 0)  {
@@ -122,11 +122,12 @@ if (count($devs) > 0)  {
 </table>
 </div>
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/smart_status.widget.php" method="post" class="form-horizontal">
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
+			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 			<div class="table responsive">
 				<table class="table table-striped table-hover table-condensed">
 					<thead>
@@ -155,14 +156,14 @@ if (count($devs) > 0)  {
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">
 			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			<button id="showallsmartdrives" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			<button id="<?=$widget_showallnone_id?>" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
 		</div>
 	</div>
 </form>
 <script type="text/javascript">
 //<![CDATA[
 	events.push(function(){
-		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallsmartdrives");
+		set_widget_checkbox_events("#<?=$widget_panel_footer_id?> [id^=show]", "<?=$widget_showallnone_id?>");
 	});
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -487,11 +487,7 @@ function updateMeters() {
 }
 
 events.push(function(){
-	$("#showallsysinfoitems").click(function() {
-		$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
-			$(this).prop("checked", true);
-		});
-	});
+	set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallsysinfoitems");
 });
 
 var update_interval = "<?=$widgetperiod?>";

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -96,7 +96,7 @@ if ($_REQUEST['getupdatestatus']) {
 	}
 
 	exit;
-} elseif ($_POST) {
+} elseif ($_POST['widgetkey']) {
 
 	$validNames = array();
 
@@ -105,9 +105,9 @@ if ($_REQUEST['getupdatestatus']) {
 	}
 
 	if (is_array($_POST['show'])) {
-		$user_settings['widgets']['system_information']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['system_information']['filter'] = implode(',', $validNames);
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved System Information Widget Filter via Dashboard."));
@@ -122,7 +122,7 @@ $widgetperiod += 1000;
 
 $filesystems = get_mounted_filesystems();
 
-$skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']['filter']);
+$skipsysinfoitems = explode(",", $user_settings['widgets'][$widgetkey]['filter']);
 $rows_displayed = false;
 ?>
 
@@ -410,11 +410,12 @@ $rows_displayed = false;
 </table>
 </div>
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/system_information.widget.php" method="post" class="form-horizontal">
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
+			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 			<div class="table responsive">
 				<table class="table table-striped table-hover table-condensed">
 					<thead>
@@ -443,13 +444,14 @@ $rows_displayed = false;
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">
 			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			<button id="showallsysinfoitems" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			<button id="<?=$widget_showallnone_id?>" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
 		</div>
 	</div>
 </form>
 
 <script type="text/javascript">
 //<![CDATA[
+<?php if ($widget_first_instance): ?>
 <?php if (!isset($config['system']['firmware']['disablecheck'])): ?>
 function systemStatusGetUpdateStatus() {
 	$.ajax({
@@ -462,7 +464,7 @@ function systemStatusGetUpdateStatus() {
 		},
 		dataType: 'html',
 		success: function(data){
-			$('#widget-system_information #updatestatus').html(data);
+			$('[id^=widget-system_information] #updatestatus').html(data);
 		}
 	});
 }
@@ -486,14 +488,10 @@ function updateMeters() {
 
 }
 
-events.push(function(){
-	set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallsysinfoitems");
-});
-
 var update_interval = "<?=$widgetperiod?>";
 
 function setProgress(barName, percent) {
-	$('#' + barName).css('width', percent + '%').attr('aria-valuenow', percent);
+	$('[id="' + barName + '"]').css('width', percent + '%').attr('aria-valuenow', percent);
 }
 
 function setTimer() {
@@ -526,7 +524,7 @@ function stats(x) {
 
 function updateMemory(x) {
 	if ($('#memusagemeter')) {
-		$("#memusagemeter").html(x);
+		$('[id="memusagemeter"]').html(x);
 	}
 	if ($('#memUsagePB')) {
 		setProgress('memUsagePB', parseInt(x));
@@ -535,13 +533,13 @@ function updateMemory(x) {
 
 function updateMbuf(x) {
 	if ($('#mbuf')) {
-		$("#mbuf").html('(' + x + ')');
+		$('[id="mbuf"]').html('(' + x + ')');
 	}
 }
 
 function updateMbufMeter(x) {
 	if ($('#mbufusagemeter')) {
-		$("#mbufusagemeter").html(x + '%');
+		$('[id="mbufusagemeter"]').html(x + '%');
 	}
 	if ($('#mbufPB')) {
 		setProgress('mbufPB', parseInt(x));
@@ -551,7 +549,7 @@ function updateMbufMeter(x) {
 function updateCPU(x) {
 
 	if ($('#cpumeter')) {
-		$("#cpumeter").html(x + '%');
+		$('[id="cpumeter"]').html(x + '%');
 	}
 	if ($('#cpuPB')) {
 		setProgress('cpuPB', parseInt(x));
@@ -565,7 +563,7 @@ function updateCPU(x) {
 
 function updateTemp(x) {
 	if ($("#tempmeter")) {
-		$("#tempmeter").html(x + '&deg;' + 'C');
+		$('[id="tempmeter"]').html(x + '&deg;' + 'C');
 	}
 	if ($('#tempPB')) {
 		setProgress('tempPB', parseInt(x));
@@ -574,25 +572,25 @@ function updateTemp(x) {
 
 function updateDateTime(x) {
 	if ($('#datetime')) {
-		$("#datetime").html(x);
+		$('[id="datetime"]').html(x);
 	}
 }
 
 function updateUptime(x) {
 	if ($('#uptime')) {
-		$("#uptime").html(x);
+		$('[id="uptime"]').html(x);
 	}
 }
 
 function updateState(x) {
 	if ($('#pfstate')) {
-		$("#pfstate").html('(' + x + ')');
+		$('[id="pfstate"]').html('(' + x + ')');
 	}
 }
 
 function updateStateMeter(x) {
 	if ($('#pfstateusagemeter')) {
-		$("#pfstateusagemeter").html(x + '%');
+		$('[id="pfstateusagemeter"]').html(x + '%');
 	}
 	if ($('#statePB')) {
 		setProgress('statePB', parseInt(x));
@@ -601,13 +599,13 @@ function updateStateMeter(x) {
 
 function updateCpuFreq(x) {
 	if ($('#cpufreq')) {
-		$("#cpufreq").html(x);
+		$('[id="cpufreq"]').html(x);
 	}
 }
 
 function updateLoadAverage(x) {
 	if ($('#load_average')) {
-		$("#load_average").html(x);
+		$('[id="load_average"]').html(x);
 	}
 }
 
@@ -617,7 +615,7 @@ function updateInterfaceStats(x) {
 		var counter = 1;
 		for (var y=0; y<statistics_split.length-1; y++) {
 			if ($('#stat' + counter)) {
-				$('#stat' + counter).html(statistics_split[y]);
+				$('[id="stat' + counter + '"]').html(statistics_split[y]);
 				counter++;
 			}
 		}
@@ -636,25 +634,25 @@ function updateInterfaces(x) {
 			}
 			switch (details[1]) {
 				case "up":
-					$('#' + details[0] + '-up').css("display","inline");
-					$('#' + details[0] + '-down').css("display","none");
-					$('#' + details[0] + '-block').css("display","none");
-					$('#' + details[0] + '-ip').html(ipv4_details);
-					$('#' + details[0] + '-ipv6').html(details[3]);
-					$('#' + details[0] + '-media').html(details[4]);
+					$('[id="' + details[0] + '-up"]').css("display","inline");
+					$('[id="' + details[0] + '-down"]').css("display","none");
+					$('[id="' + details[0] + '-block"]').css("display","none");
+					$('[id="' + details[0] + '-ip"]').html(ipv4_details);
+					$('[id="' + details[0] + '-ipv6"]').html(details[3]);
+					$('[id="' + details[0] + '-media"]').html(details[4]);
 					break;
 				case "down":
-					$('#' + details[0] + '-down').css("display","inline");
-					$('#' + details[0] + '-up').css("display","none");
-					$('#' + details[0] + '-block').css("display","none");
-					$('#' + details[0] + '-ip').html(ipv4_details);
-					$('#' + details[0] + '-ipv6').html(details[3]);
-					$('#' + details[0] + '-media').html(details[4]);
+					$('[id="' + details[0] + '-down"]').css("display","inline");
+					$('[id="' + details[0] + '-up"]').css("display","none");
+					$('[id="' + details[0] + '-block"]').css("display","none");
+					$('[id="' + details[0] + '-ip"]').html(ipv4_details);
+					$('[id="' + details[0] + '-ipv6"]').html(details[3]);
+					$('[id="' + details[0] + '-media"]').html(details[4]);
 					break;
 				case "block":
-					$('#' + details[0] + '-block').css("display","inline");
-					$('#' + details[0] + '-down').css("display","none");
-					$('#' + details[0] + '-up').css("display","none");
+					$('[id="' + details[0] + '-block"]').css("display","inline");
+					$('[id="' + details[0] + '-down"]').css("display","none");
+					$('[id="' + details[0] + '-up"]').css("display","none");
 					break;
 			}
 		});
@@ -673,6 +671,10 @@ function widgetActive(x) {
 /* start updater */
 events.push(function(){
 	setTimer();
+});
+<?php endif; // $widget_first_instance ?>
+events.push(function(){
+	set_widget_checkbox_events("#<?=$widget_panel_footer_id?> [id^=show]", "<?=$widget_showallnone_id?>");
 });
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -107,7 +107,7 @@ if ($_REQUEST['getupdatestatus']) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['system_information']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['system_information']['filter'] = "";
+		$user_settings['widgets']['system_information']['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved System Information Widget Filter via Dashboard."));
@@ -123,6 +123,7 @@ $widgetperiod += 1000;
 $filesystems = get_mounted_filesystems();
 
 $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']['filter']);
+$rows_displayed = false;
 ?>
 
 <div class="table-responsive">
@@ -130,6 +131,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 	<tbody>
 <?php
 	if (!in_array('name', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Name");?></th>
@@ -138,6 +140,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('system', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("System");?></th>
@@ -157,6 +160,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('version', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Version");?></th>
@@ -178,6 +182,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('cpu_type', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("CPU Type");?></th>
@@ -195,6 +200,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('hwcrypto', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<?php if ($hwcrypto): ?>
 		<tr>
@@ -205,6 +211,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('uptime', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Uptime");?></th>
@@ -213,6 +220,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('current_datetime', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Current date/time");?></th>
@@ -221,6 +229,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('dns_servers', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("DNS server(s)");?></th>
@@ -238,6 +247,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('last_config_change', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<?php if ($config['revision']): ?>
 		<tr>
@@ -248,6 +258,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('state_table_size', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("State table size");?></th>
@@ -266,6 +277,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('mbuf_usage', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("MBUF Usage");?></th>
@@ -284,6 +296,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('temperature', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<?php if (get_temp() != ""): ?>
 		<tr>
@@ -301,6 +314,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('load_average', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Load average");?></th>
@@ -311,6 +325,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('cpu_usage', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("CPU usage");?></th>
@@ -326,6 +341,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('memory_usage', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<tr>
 			<th><?=gettext("Memory usage");?></th>
@@ -342,6 +358,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('swap_usage', $skipsysinfoitems)):
+		$rows_displayed = true;
 ?>
 		<?php if ($showswap == true): ?>
 		<tr>
@@ -360,6 +377,7 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 	endif;
 	if (!in_array('disk_usage', $skipsysinfoitems)):
+		$rows_displayed = true;
 		$diskidx = 0;
 		foreach ($filesystems as $fs):
 ?>
@@ -376,6 +394,15 @@ $skipsysinfoitems = explode(",", $user_settings['widgets']['system_information']
 <?php
 			$diskidx++;
 		endforeach;
+	endif;
+	if (!$rows_displayed):
+?>
+		<tr>
+			<td class="text-center">
+				<?=gettext('All System Information items are hidden.');?>
+			</td>
+		</tr>
+<?php
 	endif;
 ?>
 

--- a/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
+++ b/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
@@ -183,12 +183,7 @@ if (is_array($config['dhcpd'])) {
 <script>
 //<![CDATA[
 	events.push(function(){
-		$("#showallwols").click(function() {
-			$("#widget-<?=$widgetname?>_panel-footer [id^=show]").each(function() {
-				$(this).prop("checked", true);
-			});
-		});
-
+		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallwols");
 	});
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
+++ b/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
@@ -32,11 +32,13 @@ if (is_array($config['wol']['wolentry'])) {
 }
 
 // Constructs a unique key that will identify a WoL entry in the filter list.
-function get_wolent_key($wolent) {
-	return ($wolent['interface'] . "|" . $wolent['mac']);
+if (!function_exists('get_wolent_key')) {
+	function get_wolent_key($wolent) {
+		return ($wolent['interface'] . "|" . $wolent['mac']);
+	}
 }
 
-if ($_POST) {
+if ($_POST['widgetkey']) {
 
 	$validNames = array();
 
@@ -45,9 +47,9 @@ if ($_POST) {
 	}
 
 	if (is_array($_POST['show'])) {
-		$user_settings['widgets']['wol']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['wol']['filter'] = implode(',', $validNames);
+		$user_settings['widgets'][$_POST['widgetkey']]['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Wake on LAN Filter via Dashboard."));
@@ -67,7 +69,7 @@ if ($_POST) {
 	</thead>
 	<tbody>
 <?php
-$skipwols = explode(",", $user_settings['widgets']['wol']['filter']);
+$skipwols = explode(",", $user_settings['widgets'][$widgetkey]['filter']);
 
 if (count($wolcomputers) > 0):
 	$wol_entry_is_displayed = false;
@@ -135,11 +137,12 @@ if (is_array($config['dhcpd'])) {
 <?php endif; ?>
 </div>
 <!-- close the body we're wrapped in and add a configuration-panel -->
-</div><div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
+</div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/wake_on_lan.widget.php" method="post" class="form-horizontal">
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
+			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
 			<div class="table responsive">
 				<table class="table table-striped table-hover table-condensed">
 					<thead>
@@ -152,7 +155,7 @@ if (is_array($config['dhcpd'])) {
 					</thead>
 					<tbody>
 <?php
-				$skipwols = explode(",", $user_settings['widgets']['wol']['filter']);
+				$skipwols = explode(",", $user_settings['widgets'][$widgetkey]['filter']);
 				$idx = 0;
 
 				foreach ($wolcomputers as $wolent):
@@ -175,7 +178,7 @@ if (is_array($config['dhcpd'])) {
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">
 			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			<button id="showallwols" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			<button id="<?=$widget_showallnone_id?>" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
 		</div>
 	</div>
 </form>
@@ -183,7 +186,7 @@ if (is_array($config['dhcpd'])) {
 <script>
 //<![CDATA[
 	events.push(function(){
-		set_widget_checkbox_events("#widget-<?=$widgetname?>_panel-footer [id^=show]", "showallwols");
+		set_widget_checkbox_events("#<?=$widget_panel_footer_id?> [id^=show]", "<?=$widget_showallnone_id?>");
 	});
 //]]>
 </script>

--- a/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
+++ b/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
@@ -47,7 +47,7 @@ if ($_POST) {
 	if (is_array($_POST['show'])) {
 		$user_settings['widgets']['wol']['filter'] = implode(',', array_diff($validNames, $_POST['show']));
 	} else {
-		$user_settings['widgets']['wol']['filter'] = "";
+		$user_settings['widgets']['wol']['filter'] = implode(',', $validNames);
 	}
 
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Wake on LAN Filter via Dashboard."));
@@ -70,11 +70,14 @@ if ($_POST) {
 $skipwols = explode(",", $user_settings['widgets']['wol']['filter']);
 
 if (count($wolcomputers) > 0):
+	$wol_entry_is_displayed = false;
+
 	foreach ($wolcomputers as $wolent):
 		if (in_array(get_wolent_key($wolent), $skipwols)) {
 			continue;
 		}
 
+		$wol_entry_is_displayed = true;
 		$is_active = exec("/usr/sbin/arp -an |/usr/bin/grep {$wolent['mac']}| /usr/bin/wc -l|/usr/bin/awk '{print $1;}'");
 		$status = exec("/usr/sbin/arp -an | /usr/bin/awk '$4 == \"{$wolent['mac']}\" { print $7 }'");
 		?>
@@ -101,8 +104,15 @@ if (count($wolcomputers) > 0):
 				</a>
 			</td>
 		</tr>
-<?php	endforeach;
-else: ?>
+<?php
+	endforeach;
+	if (!$wol_entry_is_displayed):
+?>
+		<tr><td colspan="4" class="text-center"><?=gettext("All WoL entries are hidden.")?></td></tr>
+<?php
+	endif;
+else:
+?>
 	<tr><td colspan="4" class="text-center"><?= gettext("No saved WoL addresses") ?></td></tr>
 <?php
 endif;


### PR DESCRIPTION
Redmine 7182 is about breaking up the System Information widget into smaller pieces on the dashboard. This PR implements the capability by giving the ability to put any widget(s) onto the dashboard multiple times. The user can then move the widgets into whichever columns they like, and filter what rows are displayed in the widget (for those widgets like System Information, Interfaces, Gateways... that have the row-filtering tool). Thus for a widget that has a long list of stuff, the user can break it into 2 copies, put them in different columns, and choose different filtering of the content.

This still needs the following:

1) Implement functionality for Traffic Graphs widget. That is waiting on other PRs being merged that make the Traffic Graphs widget code work similar to the other widgets.
2) Make conversion code for existing widget settings. (This change standardizes the way the widget preference settings are stored in the config, so some widgets will have slightly different settings keys. To be nice to users, the old settings should be migrated.)
