### PR TITLE
pkg_call_plugins put includefile and supported plugins in the normal …

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3134,19 +3134,15 @@ function pkg_call_plugins($plugin_type, $plugin_params) {
 		return $results;
 	}
 	foreach ($config['installedpackages']['package'] as $package) {
-		if (!file_exists("/usr/local/pkg/" . $package['configurationfile'])) {
-			continue;
-		}
-		$pkg_config = parse_xml_config_pkg("/usr/local/pkg/" . $package['configurationfile'], 'packagegui');
-		$pkgname = substr(reverse_strrchr($package['configurationfile'], "."), 0, -1);
-		if (is_array($pkg_config['plugins']['item'])) {
-			foreach ($pkg_config['plugins']['item'] as $plugin) {
+		if (is_array($package['plugins']['item'])) {
+			foreach ($package['plugins']['item'] as $plugin) {
 				if ($plugin['type'] == $plugin_type) {
-					if (file_exists($pkg_config['include_file'])) {
-						require_once($pkg_config['include_file']);
+					if (file_exists($package['include_file'])) {
+						require_once($package['include_file']);
 					} else {
 						continue;
 					}
+					$pkgname = substr(reverse_strrchr($package['configurationfile'], "."), 0, -1);
 					$plugin_function = $pkgname . '_'. $plugin_type;
 					$results[$pkgname] = call_user_func($plugin_function, $plugin_params);
 				}

--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -815,6 +815,13 @@ function install_package_xml($package_name) {
  		if (is_array($pkg_config['tabs'])) {
  			$config['installedpackages']['package'][$pkgid]['tabs'] = $pkg_config['tabs'];			
  		}
+		/* plugins */
+		if (isset($pkg_config['include_file'])) {
+			$config['installedpackages']['package'][$pkgid]['include_file'] = $pkg_config['include_file'];
+		}
+		if (is_array($pkg_config['plugins']['item'])) {
+			$config['installedpackages']['package'][$pkgid]['plugins']['item'] = $pkg_config['plugins']['item'];			
+		}
 	} else {
 		pkg_debug("Unable to find config file\n");
 		update_status(gettext("Loading package configuration... failed!") . "\n\n" . gettext("Installation aborted."));


### PR DESCRIPTION
…config.xml so there is no need to parse the package xml for them. this improves performance significantly for several pages like such as 'ipsec overview' and 'openvpn server edit page' which use certificates and gatewaygroups which acquire some information from plugins.