### PR TITLE
Remove siproxd from globals

### DIFF
--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -37,7 +37,6 @@ define('DMYPWD', "********");
 
 global $g;
 $g = array(
-	"base_packages" => "siproxd",
 	"event_address" => "unix:///var/run/check_reload_status",
 	"factory_shipped_username" => "admin",
 	"factory_shipped_password" => "pfsense",


### PR DESCRIPTION
It was accidentally put back by a dodgy merge that missed the commit that removed this line.