### PR TITLE
Fix display of BIOS only on Sytem Info widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -161,6 +161,7 @@ $rows_displayed = false;
 <?php
 	endif;
 	if (!in_array('bios', $skipsysinfoitems)):
+		$rows_displayed = true;
 		unset($biosvendor);
 		unset($biosversion);
 		unset($biosdate);


### PR DESCRIPTION
If I filter the System Info Widget to display only the BIOS item, it thinks that no rows are displayed and show the message "All System Information items are hidden." - see attached screen shot.

Make it know that an item has been selected for display.
![bios-info-only](https://cloud.githubusercontent.com/assets/1535615/24257765/cb9076da-1013-11e7-949c-12af5d538535.png)
