### PR TITLE
Redmine #7422 remove bogus z at end of words

### DIFF
--- a/src/usr/local/www/interfaces_bridge_edit.php
+++ b/src/usr/local/www/interfaces_bridge_edit.php
@@ -186,7 +186,7 @@ if ($_POST['save']) {
 	if (is_array($_POST['static'])) {
 		foreach ($_POST['static'] as $ifstatic) {
 			if (is_array($_POST['members']) && !in_array($ifstatic, $_POST['members'])) {
-				$input_errors[] = sprintf(gettext('Sticky interface (%s) is not part of the bridge. Remove the sticky interface to continuez.'), $ifacelist[$ifstatic]);
+				$input_errors[] = sprintf(gettext('Sticky interface (%s) is not part of the bridge. Remove the sticky interface to continue.'), $ifacelist[$ifstatic]);
 			}
 		}
 		$pconfig['static'] = implode(',', $_POST['static']);
@@ -450,7 +450,7 @@ $section->addInput(new Form_Select(
 	$spanlist['list'],
 	true
 ))->setHelp('Add the interface named by interface as a span port on the bridge. Span ports transmit a copy of every frame received by the bridge. ' .
-			'This is most useful for snooping a bridged network passively on another host connected to one of the span ports of the bridgez. %1$s' .
+			'This is most useful for snooping a bridged network passively on another host connected to one of the span ports of the bridge. %1$s' .
 			'%2$sThe span interface cannot be part of the bridge member interfaces.%3$s', '<br />', '<strong>', '</strong>');
 
 $edgelist = build_port_list($pconfig['edge']);

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -717,7 +717,7 @@ if ($act=="new" || $act=="edit"):
 				'%1$s%2$s%3$s',
 				'<div class="infoblock">',
 				sprint_info_box(gettext('When both peers support NCP and have it enabled, NCP overrides the Encryption Algorithm above.') . '<br />' .
-					gettext('When disabled, only the selected Encryption Algorithm is allowedz.'), 'info', false),
+					gettext('When disabled, only the selected Encryption Algorithm is allowed.'), 'info', false),
 				'</div>');
 
 	foreach (explode(",", $pconfig['ncp-ciphers']) as $cipher) {


### PR DESCRIPTION
These were my bad - was testing some translation stuff, putting an extra 'z' in places so the translation would fail. But I accidentally left it in the commits/PRs.
bridge edit: https://github.com/pfsense/pfsense/commit/398821c4aa05e3ae88731b8d9ce26e8d889d9fb8
openvpn client: https://github.com/pfsense/pfsense/commit/3e142087ca38917200fd01e2d8b604c7a5135b2b

Found them by a bit of regex
```
find /usr/local/www -type f -exec grep -H '\wz\W' {} \; > /tmp/zwww.txt
```
which finds words ending in "z". There are lots of OK ones (Hz, tgz and so on), but these couple are dodgy.