### PR TITLE
load package add-on tabs into config to avoid parsing all installed package xml's, fix tabgroup filter

### DIFF
--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -812,6 +812,9 @@ function install_package_xml($package_name) {
 			}
 			update_status(gettext("done.") . "\n");
 		}
+ 		if (is_array($pkg_config['tabs'])) {
+ 			$config['installedpackages']['package'][$pkgid]['tabs'] = $pkg_config['tabs'];			
+ 		}
 	} else {
 		pkg_debug("Unable to find config file\n");
 		update_status(gettext("Loading package configuration... failed!") . "\n\n" . gettext("Installation aborted."));

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -1091,13 +1091,14 @@ function add_package_tabs($tabgroup, &$tab_array) {
 	}
 
 	foreach ($config['installedpackages']['package'] as $pkg) {
-		$pkg_config = read_package_configurationfile($pkg['name']);
-
-		if (!isset($pkg_config['tabs']['tab'])) {
+		if (!is_array($pkg['tabs']['tab'])) {
 			continue;
 		}
 
-		foreach ($pkg_config['tabs']['tab'] as $tab) {
+		foreach ($pkg['tabs']['tab'] as $tab) {
+			if ($tab['tabgroup'] != $tabgroup) {
+				continue;
+			}
 			$tab_entry = array();
 			if ($tab['name']) {
 				$tab_entry[] = $tab['name'];


### PR DESCRIPTION
load package add-on tabs into config to avoid parsing all installed package xml's, fix tabgroup filter