### PR TITLE
Handle empty port alias refactor

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2710,18 +2710,36 @@ function filter_generate_user_rule($rule) {
 		return "# {$error_text}";
 	}
 	if ($rule['source']['port']
-	    && !(is_portrange(str_replace("-", ":", $rule['source']['port']))
-	    || alias_expand($rule['source']['port']))) {
-		$error_text = sprintf(gettext("Unresolvable source port alias '%1\$s' for rule '%2\$s'"), $rule['source']['port'], $rule['descr']);
-		file_notice("Filter_Reload", $error_text);
-		return "# {$error_text}";
+	    && !is_portorrange(str_replace("-", ":", $rule['source']['port']))) {
+		$error_text = "";
+
+		// It is not a literal port or port range, so alias should exist, and expand to something non-empty
+		if (!alias_expand($rule['source']['port'])) {
+			$error_text = sprintf(gettext("Unresolvable source port alias '%1\$s' for rule '%2\$s'"), $rule['source']['port'], $rule['descr']);
+		} else if (trim(filter_generate_nested_alias($rule['source']['port'])) == "") {
+			$error_text = sprintf(gettext("Empty source port alias '%1\$s' for rule '%2\$s'"), $rule['source']['port'], $rule['descr']);
+		}
+
+		if ($error_text) {
+			file_notice("Filter_Reload", $error_text);
+			return "# {$error_text}";
+		}
 	}
 	if ($rule['destination']['port']
-	    && !(is_portrange(str_replace("-", ":", $rule['destination']['port']))
-	    || alias_expand($rule['destination']['port']))) {
-		$error_text = sprintf(gettext("Unresolvable destination port alias '%1\$s' for rule '%2\$s'"), $rule['destination']['port'], $rule['descr']);
-		file_notice("Filter_Reload", $error_text);
-		return "# {$error_text}";
+	    && !is_portorrange(str_replace("-", ":", $rule['destination']['port']))) {
+		$error_text = "";
+
+		// It is not a literal port or port range, so alias should exist, and expand to something non-empty
+		if (!alias_expand($rule['destination']['port'])) {
+			$error_text = sprintf(gettext("Unresolvable destination port alias '%1\$s' for rule '%2\$s'"), $rule['destination']['port'], $rule['descr']);
+		} else if (trim(filter_generate_nested_alias($rule['destination']['port'])) == "") {
+			$error_text = sprintf(gettext("Empty destination port alias '%1\$s' for rule '%2\$s'"), $rule['destination']['port'], $rule['descr']);
+		}
+
+		if ($error_text) {
+			file_notice("Filter_Reload", $error_text);
+			return "# {$error_text}";
+		}
 	}
 	update_filter_reload_status(gettext("Setting up pass/block rules"));
 	$type = $rule['type'];

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -623,7 +623,7 @@ function filter_generate_nested_alias($name, $alias, &$aliasnesting, &$aliasaddr
 				$tmpline = filter_generate_nested_alias($name, $aliastable[$address], $aliasnesting, $aliasaddrnesting, $use_filterdns);
 			}
 		} else if (!isset($aliasaddrnesting[$address])) {
-			if (!is_ipaddr($address) && !is_subnet($address) && !((($alias_type == 'port') || ($alias_type == 'url_ports')) && (is_port($address) || is_portrange($address))) && is_hostname($address)) {
+			if (!is_ipaddr($address) && !is_subnet($address) && !((($alias_type == 'port') || ($alias_type == 'url_ports')) && is_portorrange($address)) && is_hostname($address)) {
 				if (!isset($filterdns["{$address}{$name}"])) {
 					$use_filterdns = true;
 					$filterdns["{$address}{$name}"] = "pf {$address} {$name}\n";

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -636,7 +636,7 @@ function filter_generate_nested_alias_recurse($name, $alias, &$aliasnesting, &$a
 				$tmpline = filter_generate_nested_alias_recurse($name, $aliastable[$address], $aliasnesting, $aliasaddrnesting, $use_filterdns);
 			}
 		} else if (!isset($aliasaddrnesting[$address])) {
-			if (!is_ipaddr($address) && !is_subnet($address) && !((($alias_type == 'port') || ($alias_type == 'url_ports')) && is_portorrange($address)) && is_hostname($address)) {
+			if (!is_ipaddr($address) && !is_subnet($address) && !((($alias_type == 'port') || ($alias_type == 'url_ports')) && is_port_or_range($address)) && is_hostname($address)) {
 				if (!isset($filterdns["{$address}{$name}"])) {
 					$use_filterdns = true;
 					$filterdns["{$address}{$name}"] = "pf {$address} {$name}\n";
@@ -2710,7 +2710,7 @@ function filter_generate_user_rule($rule) {
 		return "# {$error_text}";
 	}
 	if ($rule['source']['port']
-	    && !is_portorrange(str_replace("-", ":", $rule['source']['port']))) {
+	    && !is_port_or_range(str_replace("-", ":", $rule['source']['port']))) {
 		$error_text = "";
 
 		// It is not a literal port or port range, so alias should exist, and expand to something non-empty
@@ -2726,7 +2726,7 @@ function filter_generate_user_rule($rule) {
 		}
 	}
 	if ($rule['destination']['port']
-	    && !is_portorrange(str_replace("-", ":", $rule['destination']['port']))) {
+	    && !is_port_or_range(str_replace("-", ":", $rule['destination']['port']))) {
 		$error_text = "";
 
 		// It is not a literal port or port range, so alias should exist, and expand to something non-empty

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -587,7 +587,20 @@ function filter_generate_scrubing() {
 	return $scrubrules;
 }
 
-function filter_generate_nested_alias($name, $alias, &$aliasnesting, &$aliasaddrnesting, &$use_filterdns = false) {
+function filter_generate_nested_alias($name) {
+	global $aliastable;
+
+	$aliasnesting = array();
+	$aliasaddrnesting = array();
+
+	if (($name == "") || !isset($aliastable[$name])) {
+		return "";
+	}
+
+	return filter_generate_nested_alias_recurse($name, $aliastable[$name], $aliasnesting, $aliasaddrnesting);
+}
+
+function filter_generate_nested_alias_recurse($name, $alias, &$aliasnesting, &$aliasaddrnesting, &$use_filterdns = false) {
 	global $aliastable, $filterdns;
 
 	$addresses = explode(" ", $alias);
@@ -604,7 +617,7 @@ function filter_generate_nested_alias($name, $alias, &$aliasnesting, &$aliasaddr
 		$tmpline = "";
 		if (is_alias($address)) {
 			if (alias_get_type($address) == 'urltable') {
-				// Feature#1603. For this type of alias we do not need to recursively call filter_generate_nested_alias. Just load IPs from the file.
+				// Feature#1603. For this type of alias we do not need to recursively call filter_generate_nested_alias_recurse. Just load IPs from the file.
 				$urltable_nesting = alias_expand_urltable($address);
 				if (!empty($urltable_nesting)) {
 					$urlfile_as_arr = file($urltable_nesting);
@@ -620,7 +633,7 @@ function filter_generate_nested_alias($name, $alias, &$aliasnesting, &$aliasaddr
 			}
 			/* We already expanded this alias so there is no necessity to do it again. */
 			else if (!isset($aliasnesting[$address])) {
-				$tmpline = filter_generate_nested_alias($name, $aliastable[$address], $aliasnesting, $aliasaddrnesting, $use_filterdns);
+				$tmpline = filter_generate_nested_alias_recurse($name, $aliastable[$address], $aliasnesting, $aliasaddrnesting, $use_filterdns);
 			}
 		} else if (!isset($aliasaddrnesting[$address])) {
 			if (!is_ipaddr($address) && !is_subnet($address) && !((($alias_type == 'port') || ($alias_type == 'url_ports')) && is_portorrange($address)) && is_hostname($address)) {
@@ -664,9 +677,7 @@ function filter_expand_alias($alias_name) {
 	if (isset($config['aliases']['alias'])) {
 		foreach ($config['aliases']['alias'] as $aliased) {
 			if ($aliased['name'] == $alias_name) {
-				$aliasnesting = array();
-				$aliasaddrnesting = array();
-				return filter_generate_nested_alias($aliased['name'], $aliased['address'], $aliasnesting, $aliasaddrnesting);
+				return filter_generate_nested_alias($aliased['name']);
 			}
 		}
 	}
@@ -750,14 +761,12 @@ function filter_generate_aliases() {
 	/* Setup pf groups */
 	if (isset($config['aliases']['alias'])) {
 		foreach ($config['aliases']['alias'] as $aliased) {
-			$aliasnesting = array();
-			$aliasaddrnesting = array();
 			if (is_numericint($aliased['name'])) {
 				// skip aliases with numeric-only names. redmine #4289
 				file_notice("Filter_Reload", sprintf(gettext("Aliases with numeric-only names are not valid. Skipping alias %s"), $aliased['name']));
 				continue;
 			}
-			$addrlist = filter_generate_nested_alias($aliased['name'], $aliased['address'], $aliasnesting, $aliasaddrnesting);
+			$addrlist = filter_generate_nested_alias($aliased['name']);
 			switch ($aliased['type']) {
 			case "host":
 			case "network":

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2153,7 +2153,7 @@ function parse_aliases_file($filename, $type = "url", $max_items = -1, $kflc = f
 				$tmp = $tmp_str;
 			}
 			$valid = (($type == "url" || $type == "urltable") && (is_ipaddr($tmp) || is_subnet($tmp))) ||
-				(($type == "url_ports" || $type == "urltable_ports") && (is_port($tmp) || is_portrange($tmp)));
+				(($type == "url_ports" || $type == "urltable_ports") && is_portorrange($tmp));
 			if ($valid) {
 				$items[] = $tmp;
 				if (count($items) == $max_items) {

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2153,7 +2153,7 @@ function parse_aliases_file($filename, $type = "url", $max_items = -1, $kflc = f
 				$tmp = $tmp_str;
 			}
 			$valid = (($type == "url" || $type == "urltable") && (is_ipaddr($tmp) || is_subnet($tmp))) ||
-				(($type == "url_ports" || $type == "urltable_ports") && is_portorrange($tmp));
+				(($type == "url_ports" || $type == "urltable_ports") && is_port_or_range($tmp));
 			if ($valid) {
 				$items[] = $tmp;
 				if (count($items) == $max_items) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1125,12 +1125,12 @@ function is_portrange($portrange) {
 }
 
 /* returns true if $port is a valid TCP/UDP port number or range ("<port>:<port>") */
-function is_portorrange($port) {
+function is_port_or_range($port) {
 	return (is_port($port) || is_portrange($port));
 }
 
 /* returns true if $port is a valid port number or an alias thereof */
-function is_portoralias($port) {
+function is_port_or_alias($port) {
 	global $config;
 
 	if (is_alias($port)) {
@@ -1148,8 +1148,8 @@ function is_portoralias($port) {
 }
 
 /* returns true if $port is a valid TCP/UDP port number or range ("<port>:<port>") or an alias thereof */
-function is_portorrangeoralias($port) {
-	return (is_portoralias($port) || is_portrange($port));
+function is_port_or_range_or_alias($port) {
+	return (is_port_or_alias($port) || is_portrange($port));
 }
 
 /* create ranges of sequential port numbers (200:215) and remove duplicates */
@@ -1791,7 +1791,7 @@ function alias_expand($name) {
 			}
 		}
 		return "\${$name}";
-	} else if (is_ipaddr($name) || is_subnet($name) || is_portorrange($name)) {
+	} else if (is_ipaddr($name) || is_subnet($name) || is_port_or_range($name)) {
 		return "{$name}";
 	} else {
 		return null;

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1124,6 +1124,11 @@ function is_portrange($portrange) {
 	return (count($ports) == 2 && is_port($ports[0]) && is_port($ports[1]));
 }
 
+/* returns true if $port is a valid TCP/UDP port number or range ("<port>:<port>") */
+function is_portorrange($port) {
+	return (is_port($port) || is_portrange($port));
+}
+
 /* returns true if $port is a valid port number or an alias thereof */
 function is_portoralias($port) {
 	global $config;
@@ -1140,6 +1145,11 @@ function is_portoralias($port) {
 	} else {
 		return is_port($port);
 	}
+}
+
+/* returns true if $port is a valid TCP/UDP port number or range ("<port>:<port>") or an alias thereof */
+function is_portorrangeoralias($port) {
+	return (is_portoralias($port) || is_portrange($port));
 }
 
 /* create ranges of sequential port numbers (200:215) and remove duplicates */
@@ -1781,7 +1791,7 @@ function alias_expand($name) {
 			}
 		}
 		return "\${$name}";
-	} else if (is_ipaddr($name) || is_subnet($name) || is_port($name) || is_portrange($name)) {
+	} else if (is_ipaddr($name) || is_subnet($name) || is_portorrange($name)) {
 		return "{$name}";
 	} else {
 		return null;

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1129,8 +1129,8 @@ function is_port_or_range($port) {
 	return (is_port($port) || is_portrange($port));
 }
 
-/* returns true if $port is a valid port number or an alias thereof */
-function is_port_or_alias($port) {
+/* returns true if $port is an alias that is a port type */
+function is_portalias($port) {
 	global $config;
 
 	if (is_alias($port)) {
@@ -1141,15 +1141,18 @@ function is_port_or_alias($port) {
 				}
 			}
 		}
-		return false;
-	} else {
-		return is_port($port);
 	}
+	return false;
+}
+
+/* returns true if $port is a valid port number or an alias thereof */
+function is_port_or_alias($port) {
+	return (is_port($port) || is_portalias($port));
 }
 
 /* returns true if $port is a valid TCP/UDP port number or range ("<port>:<port>") or an alias thereof */
 function is_port_or_range_or_alias($port) {
-	return (is_port_or_alias($port) || is_portrange($port));
+	return (is_port($port) || is_portrange($port) || is_portalias($port));
 }
 
 /* create ranges of sequential port numbers (200:215) and remove duplicates */

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -429,7 +429,7 @@ if ($_POST['save']) {
 					}
 				}
 			} else if ($_POST['type'] == "port") {
-				if (!is_port($input_address) && !is_portrange($input_address)) {
+				if (!is_portorrange($input_address)) {
 					$input_errors[] = sprintf(gettext("%s is not a valid port or alias."), $input_address);
 				}
 			} else if ($_POST['type'] == "host" || $_POST['type'] == "network") {

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -429,7 +429,7 @@ if ($_POST['save']) {
 					}
 				}
 			} else if ($_POST['type'] == "port") {
-				if (!is_portorrange($input_address)) {
+				if (!is_port_or_range($input_address)) {
 					$input_errors[] = sprintf(gettext("%s is not a valid port or alias."), $input_address);
 				}
 			} else if ($_POST['type'] == "host" || $_POST['type'] == "network") {

--- a/src/usr/local/www/firewall_aliases_import.php
+++ b/src/usr/local/www/firewall_aliases_import.php
@@ -121,7 +121,7 @@ if ($_POST) {
 					if ($tab == "port") {
 						// Port alias
 						if (!empty($impip)) {
-							if (is_portorrange($impip)) {
+							if (is_port_or_range($impip)) {
 								$imported_ips[] = $impip;
 								$imported_descs[] = $impdesc;
 							} else {

--- a/src/usr/local/www/firewall_aliases_import.php
+++ b/src/usr/local/www/firewall_aliases_import.php
@@ -121,7 +121,7 @@ if ($_POST) {
 					if ($tab == "port") {
 						// Port alias
 						if (!empty($impip)) {
-							if (is_port($impip) || is_portrange($impip)) {
+							if (is_portorrange($impip)) {
 								$imported_ips[] = $impip;
 								$imported_descs[] = $impdesc;
 							} else {

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -259,20 +259,20 @@ if ($_POST['save']) {
 		$input_errors[] = sprintf(gettext("Redirect target IP must be IPv4."));
 	}
 
-	if ($_POST['srcbeginport'] && !is_portoralias($_POST['srcbeginport'])) {
+	if ($_POST['srcbeginport'] && !is_port_or_alias($_POST['srcbeginport'])) {
 		$input_errors[] = sprintf(gettext("%s is not a valid start source port. It must be a port alias or integer between 1 and 65535."), $_POST['srcbeginport']);
 	}
-	if ($_POST['srcendport'] && !is_portoralias($_POST['srcendport'])) {
+	if ($_POST['srcendport'] && !is_port_or_alias($_POST['srcendport'])) {
 		$input_errors[] = sprintf(gettext("%s is not a valid end source port. It must be a port alias or integer between 1 and 65535."), $_POST['srcendport']);
 	}
-	if ($_POST['dstbeginport'] && !is_portoralias($_POST['dstbeginport'])) {
+	if ($_POST['dstbeginport'] && !is_port_or_alias($_POST['dstbeginport'])) {
 		$input_errors[] = sprintf(gettext("%s is not a valid start destination port. It must be a port alias or integer between 1 and 65535."), $_POST['dstbeginport']);
 	}
-	if ($_POST['dstendport'] && !is_portoralias($_POST['dstendport'])) {
+	if ($_POST['dstendport'] && !is_port_or_alias($_POST['dstendport'])) {
 		$input_errors[] = sprintf(gettext("%s is not a valid end destination port. It must be a port alias or integer between 1 and 65535."), $_POST['dstendport']);
 	}
 
-	if ((strtoupper($_POST['proto']) == "TCP" || strtoupper($_POST['proto']) == "UDP" || strtoupper($_POST['proto']) == "TCP/UDP") && (!isset($_POST['nordr']) && !is_portoralias($_POST['localbeginport']))) {
+	if ((strtoupper($_POST['proto']) == "TCP" || strtoupper($_POST['proto']) == "UDP" || strtoupper($_POST['proto']) == "TCP/UDP") && (!isset($_POST['nordr']) && !is_port_or_alias($_POST['localbeginport']))) {
 		$input_errors[] = sprintf(gettext("%s is not a valid redirect target port. It must be a port alias or integer between 1 and 65535."), $_POST['localbeginport']);
 	}
 

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -189,15 +189,15 @@ if ($_POST['save']) {
 		$_POST['target'] = substr($_POST['target'], 1);
 	}
 
-	if ($protocol_uses_ports && $_POST['sourceport'] <> "" && !is_portorrangeoralias($_POST['sourceport'])) {
+	if ($protocol_uses_ports && $_POST['sourceport'] <> "" && !is_port_or_range_or_alias($_POST['sourceport'])) {
 		$input_errors[] = gettext("A valid port or port alias must be supplied for the source port entry.");
 	}
 
-	if ($protocol_uses_ports && $_POST['dstport'] <> "" && !is_portorrangeoralias($_POST['dstport'])) {
+	if ($protocol_uses_ports && $_POST['dstport'] <> "" && !is_port_or_range_or_alias($_POST['dstport'])) {
 		$input_errors[] = gettext("A valid port or port alias must be supplied for the destination port entry.");
 	}
 
-	if ($protocol_uses_ports && $_POST['natport'] <> "" && !is_portorrangeoralias($_POST['natport']) && !isset($_POST['nonat'])) {
+	if ($protocol_uses_ports && $_POST['natport'] <> "" && !is_port_or_range_or_alias($_POST['natport']) && !isset($_POST['nonat'])) {
 		$input_errors[] = gettext("A valid port must be supplied for the NAT port entry.");
 	}
 

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -189,15 +189,15 @@ if ($_POST['save']) {
 		$_POST['target'] = substr($_POST['target'], 1);
 	}
 
-	if ($protocol_uses_ports && $_POST['sourceport'] <> "" && !(is_portoralias($_POST['sourceport']) || is_portrange($_POST['sourceport']))) {
+	if ($protocol_uses_ports && $_POST['sourceport'] <> "" && !is_portorrangeoralias($_POST['sourceport'])) {
 		$input_errors[] = gettext("A valid port or port alias must be supplied for the source port entry.");
 	}
 
-	if ($protocol_uses_ports && $_POST['dstport'] <> "" && !(is_portoralias($_POST['dstport']) || is_portrange($_POST['dstport']))) {
+	if ($protocol_uses_ports && $_POST['dstport'] <> "" && !is_portorrangeoralias($_POST['dstport'])) {
 		$input_errors[] = gettext("A valid port or port alias must be supplied for the destination port entry.");
 	}
 
-	if ($protocol_uses_ports && $_POST['natport'] <> "" && !(is_portoralias($_POST['natport']) || is_portrange($_POST['natport'])) && !isset($_POST['nonat'])) {
+	if ($protocol_uses_ports && $_POST['natport'] <> "" && !is_portorrangeoralias($_POST['natport']) && !isset($_POST['nonat'])) {
 		$input_errors[] = gettext("A valid port must be supplied for the NAT port entry.");
 	}
 

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -491,16 +491,16 @@ if ($_POST['save']) {
 		$_POST['dstendport'] = 0;
 	}
 
-	if ($_POST['srcbeginport'] && !is_portoralias($_POST['srcbeginport'])) {
+	if ($_POST['srcbeginport'] && !is_port_or_alias($_POST['srcbeginport'])) {
 		$input_errors[] = sprintf(gettext("%s is not a valid start source port. It must be a port alias or integer between 1 and 65535."), $_POST['srcbeginport']);
 	}
-	if ($_POST['srcendport'] && !is_portoralias($_POST['srcendport'])) {
+	if ($_POST['srcendport'] && !is_port_or_alias($_POST['srcendport'])) {
 			$input_errors[] = sprintf(gettext("%s is not a valid end source port. It must be a port alias or integer between 1 and 65535."), $_POST['srcendport']);
 	}
-	if ($_POST['dstbeginport'] && !is_portoralias($_POST['dstbeginport'])) {
+	if ($_POST['dstbeginport'] && !is_port_or_alias($_POST['dstbeginport'])) {
 			$input_errors[] = sprintf(gettext("%s is not a valid start destination port. It must be a port alias or integer between 1 and 65535."), $_POST['dstbeginport']);
 	}
-	if ($_POST['dstendport'] && !is_portoralias($_POST['dstendport'])) {
+	if ($_POST['dstendport'] && !is_port_or_alias($_POST['dstendport'])) {
 			$input_errors[] = sprintf(gettext("%s is not a valid end destination port. It must be a port alias or integer between 1 and 65535."), $_POST['dstendport']);
 	}
 	if (!$_POST['srcbeginport_cust'] && $_POST['srcendport_cust']) {

--- a/src/usr/local/www/load_balancer_pool_edit.php
+++ b/src/usr/local/www/load_balancer_pool_edit.php
@@ -93,7 +93,7 @@ if ($_POST['save']) {
 		$input_errors[] = sprintf(gettext("Sorry, an alias is already named %s."), $_POST['name']);
 	}
 
-	if (!is_portoralias($_POST['port'])) {
+	if (!is_port_or_alias($_POST['port'])) {
 		$input_errors[] = gettext("The port must be an integer between 1 and 65535, or a port alias.");
 	}
 

--- a/src/usr/local/www/load_balancer_virtual_server_edit.php
+++ b/src/usr/local/www/load_balancer_virtual_server_edit.php
@@ -88,7 +88,7 @@ if ($_POST['save']) {
 		$input_errors[] = gettext("The 'name' field must be 32 characters or less.");
 	}
 
-	if ($_POST['port'] != "" && !is_portoralias($_POST['port'])) {
+	if ($_POST['port'] != "" && !is_port_or_alias($_POST['port'])) {
 		$input_errors[] = gettext("The port must be an integer between 1 and 65535, a port alias, or left blank.");
 	}
 


### PR DESCRIPTION
This sits on top of #3670 and refactors to:
1) Add "_" characters to various is_port_or* functions.
2) Adds an is_portalias function, refactors is_port_or_alias to use it, refactors is_port_or_range_or_alias to call each of its 3 "parts" to get the answer.