### PR TITLE
Redmine #7435 Fix edit IP address in host override

### DIFF
--- a/src/usr/local/www/services_captiveportal_vouchers_edit.php
+++ b/src/usr/local/www/services_captiveportal_vouchers_edit.php
@@ -69,6 +69,7 @@ if (isset($id) && $a_roll[$id]) {
 	$pconfig['count'] = $a_roll[$id]['count'];
 	$pconfig['minutes'] = $a_roll[$id]['minutes'];
 	$pconfig['descr'] = $a_roll[$id]['descr'];
+	$pconfig['id'] = $id;
 }
 
 $maxnumber = (1<<$config['voucher'][$cpzone]['rollbits']) -1;	// Highest Roll#

--- a/src/usr/local/www/services_dnsmasq_domainoverride_edit.php
+++ b/src/usr/local/www/services_dnsmasq_domainoverride_edit.php
@@ -53,6 +53,7 @@ if (isset($id) && $a_domainOverrides[$id]) {
 		$pconfig['dnssrcip'] = $dnsmasqpieces[1];
 	}
 	$pconfig['descr'] = $a_domainOverrides[$id]['descr'];
+	$pconfig['id'] = $id;
 }
 
 if ($_POST['save']) {

--- a/src/usr/local/www/services_dnsmasq_edit.php
+++ b/src/usr/local/www/services_dnsmasq_edit.php
@@ -50,6 +50,7 @@ if (isset($id) && $a_hosts[$id]) {
 	$pconfig['ip'] = $a_hosts[$id]['ip'];
 	$pconfig['descr'] = $a_hosts[$id]['descr'];
 	$pconfig['aliases'] = $a_hosts[$id]['aliases'];
+	$pconfig['id'] = $id;
 }
 
 if ($_POST['save']) {
@@ -131,11 +132,15 @@ if ($_POST['save']) {
 		}
 
 		if (($hostent['host'] == $_POST['host']) &&
-		    ($hostent['domain'] == $_POST['domain']) &&
-		    ((is_ipaddrv4($hostent['ip']) && is_ipaddrv4($_POST['ip'])) ||
-		     (is_ipaddrv6($hostent['ip']) && is_ipaddrv6($_POST['ip'])))) {
-			$input_errors[] = gettext("This host/domain already exists.");
-			break;
+		    ($hostent['domain'] == $_POST['domain'])) {
+			if (is_ipaddrv4($hostent['ip']) && is_ipaddrv4($_POST['ip'])) {
+				$input_errors[] = gettext("This host/domain override combination already exists with an IPv4 address.");
+				break;
+			}
+			if (is_ipaddrv6($hostent['ip']) && is_ipaddrv6($_POST['ip'])) {
+				$input_errors[] = gettext("This host/domain override combination already exists with an IPv6 address.");
+				break;
+			}
 		}
 	}
 

--- a/src/usr/local/www/services_unbound_host_edit.php
+++ b/src/usr/local/www/services_unbound_host_edit.php
@@ -61,6 +61,7 @@ if (isset($id) && $a_hosts[$id]) {
 	$pconfig['ip'] = $a_hosts[$id]['ip'];
 	$pconfig['descr'] = $a_hosts[$id]['descr'];
 	$pconfig['aliases'] = $a_hosts[$id]['aliases'];
+	$pconfig['id'] = $id;
 }
 
 if ($_POST['save']) {
@@ -142,10 +143,15 @@ if ($_POST['save']) {
 		}
 
 		if (($hostent['host'] == $_POST['host']) &&
-		    ($hostent['domain'] == $_POST['domain']) &&
-		    ((is_ipaddrv4($hostent['ip']) && is_ipaddrv4($_POST['ip'])) || (is_ipaddrv6($hostent['ip']) && is_ipaddrv6($_POST['ip'])))) {
-			$input_errors[] = gettext("This host/domain already exists.");
-			break;
+		    ($hostent['domain'] == $_POST['domain'])) {
+			if (is_ipaddrv4($hostent['ip']) && is_ipaddrv4($_POST['ip'])) {
+				$input_errors[] = gettext("This host/domain override combination already exists with an IPv4 address.");
+				break;
+			}
+			if (is_ipaddrv6($hostent['ip']) && is_ipaddrv6($_POST['ip'])) {
+				$input_errors[] = gettext("This host/domain override combination already exists with an IPv6 address.");
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
It would "forget" $id that was passed in in the initial request. Then things would go wrong through the validation checks because $_POST if "id" would be empty (although the $_GET has the id from the URL line).

Same problem for Forwarder and Resolver (don't you love copied code - I can fix 2 bugs in only a little longer than fixing 1 - sarcasm).

I made different input error messages that will tell the user in a bit more detail what the problem is.