### PR TITLE
Redmine #7435 Fix edit problems due to POST id code

### DIFF
--- a/src/usr/local/www/services_captiveportal_vouchers_edit.php
+++ b/src/usr/local/www/services_captiveportal_vouchers_edit.php
@@ -212,7 +212,7 @@ if (isset($id) && $a_roll[$id]) {
 		'id',
 		null,
 		'hidden',
-		$pconfig['id']
+		$id
 	));
 }
 

--- a/src/usr/local/www/services_dnsmasq_domainoverride_edit.php
+++ b/src/usr/local/www/services_dnsmasq_domainoverride_edit.php
@@ -163,7 +163,7 @@ if (isset($id) && $a_domainOverrides[$id]) {
 		'id',
 		null,
 		'hidden',
-		$pconfig['id']
+		$id
 	));
 }
 

--- a/src/usr/local/www/services_dnsmasq_edit.php
+++ b/src/usr/local/www/services_dnsmasq_edit.php
@@ -131,11 +131,15 @@ if ($_POST['save']) {
 		}
 
 		if (($hostent['host'] == $_POST['host']) &&
-		    ($hostent['domain'] == $_POST['domain']) &&
-		    ((is_ipaddrv4($hostent['ip']) && is_ipaddrv4($_POST['ip'])) ||
-		     (is_ipaddrv6($hostent['ip']) && is_ipaddrv6($_POST['ip'])))) {
-			$input_errors[] = gettext("This host/domain already exists.");
-			break;
+		    ($hostent['domain'] == $_POST['domain'])) {
+			if (is_ipaddrv4($hostent['ip']) && is_ipaddrv4($_POST['ip'])) {
+				$input_errors[] = gettext("This host/domain override combination already exists with an IPv4 address.");
+				break;
+			}
+			if (is_ipaddrv6($hostent['ip']) && is_ipaddrv6($_POST['ip'])) {
+				$input_errors[] = gettext("This host/domain override combination already exists with an IPv6 address.");
+				break;
+			}
 		}
 	}
 
@@ -228,7 +232,7 @@ if (isset($id) && $a_hosts[$id]) {
 		'id',
 		null,
 		'hidden',
-		$pconfig['id']
+		$id
 	));
 }
 

--- a/src/usr/local/www/services_unbound_host_edit.php
+++ b/src/usr/local/www/services_unbound_host_edit.php
@@ -142,10 +142,15 @@ if ($_POST['save']) {
 		}
 
 		if (($hostent['host'] == $_POST['host']) &&
-		    ($hostent['domain'] == $_POST['domain']) &&
-		    ((is_ipaddrv4($hostent['ip']) && is_ipaddrv4($_POST['ip'])) || (is_ipaddrv6($hostent['ip']) && is_ipaddrv6($_POST['ip'])))) {
-			$input_errors[] = gettext("This host/domain already exists.");
-			break;
+		    ($hostent['domain'] == $_POST['domain'])) {
+			if (is_ipaddrv4($hostent['ip']) && is_ipaddrv4($_POST['ip'])) {
+				$input_errors[] = gettext("This host/domain override combination already exists with an IPv4 address.");
+				break;
+			}
+			if (is_ipaddrv6($hostent['ip']) && is_ipaddrv6($_POST['ip'])) {
+				$input_errors[] = gettext("This host/domain override combination already exists with an IPv6 address.");
+				break;
+			}
 		}
 	}
 
@@ -221,7 +226,7 @@ if (isset($id) && $a_hosts[$id]) {
 		'id',
 		null,
 		'hidden',
-		$pconfig['id']
+		$id
 	));
 }
 


### PR DESCRIPTION
This code would "forget" the proper value of $id and so there were effects when editing existing entries:
1) Captive Portal Vouchers, edit a roll, press save. You get told that the roll already exists.
2) DNS Forwarder, edit a host override, press save. You get told that the host override already exists.
3) DNS Resolver, edit a host override, press save. You get told that the host override already exists.
4) DNS Forwarder, edit a domain override, press save. You get a duplicate entry.

For when the user edits the IP address in a host override, I made the input error messages a bit more informative if they change the IP address V4<->V6 and there is already an entry for the new address family.