### PR TITLE
add ability to specify multiple IPs in dhcprejectfrom

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -38,6 +38,27 @@ function interfaces_bring_up($interface) {
 }
 
 /*
+ * Validate comma-separated list of IPv4 addresses
+ */
+function validate_ipv4_list($value) {
+	$value = trim($value);
+
+	if (empty($value)) {
+		return false;
+	}
+
+	$list = explode(',', $value);
+
+	foreach ($list as $ip) {
+		if (!is_ipaddrv4($ip)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/*
  * Return the interface array
  */
 function get_interface_arr($flush = false) {

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4530,7 +4530,7 @@ initial-interval 1;
 	script "/usr/local/sbin/pfSense-dhclient-script";
 EOD;
 
-	if (is_ipaddrv4($wancfg['dhcprejectfrom'])) {
+	if (validate_ipv4_list($wancfg['dhcprejectfrom'])) {
 		$dhclientconf .= <<<EOD
 
 	reject {$wancfg['dhcprejectfrom']};

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -764,8 +764,8 @@ if ($_POST['apply']) {
 	if (($_POST['alias-subnet'] && !is_numeric($_POST['alias-subnet']))) {
 		$input_errors[] = gettext("A valid alias subnet bit count must be specified.");
 	}
-	if ($_POST['dhcprejectfrom'] && !is_ipaddrv4($_POST['dhcprejectfrom'])) {
-		$input_errors[] = gettext("A valid alias IP address must be specified to reject DHCP Leases from.");
+	if ($_POST['dhcprejectfrom'] && !validate_ipv4_list($_POST['dhcprejectfrom'])) {
+		$input_errors[] = gettext("An invalid IP address was detected in the 'Reject leases from' field.");
 	}
 	if (($_POST['gateway'] != "none") || ($_POST['gatewayv6'] != "none")) {
 		$match = false;
@@ -1965,7 +1965,8 @@ $section->addInput(new Form_Input(
 	'Reject leases from',
 	'text',
 	$pconfig['dhcprejectfrom']
-))->setHelp('To make the DHCP client reject leases from an undesirable DHCP server, place the IP address of the DHCP server here. ' .
+))->setHelp('To have the DHCP client reject offers from specific DHCP servers, enter their IP addresses here ' .
+			'(separate multiple entries with a comma). ' .
 			'This is useful for rejecting leases from cable modems that offer private IP addresses when they lose upstream sync.');
 
 $group = new Form_Group('Protocol timing');


### PR DESCRIPTION
This PR adds the ability to ignore DHCP offers from multiple servers.
- Forum thread: https://forum.pfsense.org/index.php?topic=124046.msg705100#msg705100
- related dhclient source:
https://github.com/pfsense/FreeBSD-src/blob/devel/sbin/dhclient/clparse.c#L945

**changed files:**
/usr/local/www/interfaces.php
/etc/inc/interfaces.inc