### PR TITLE
Add hint to web interface that DynDNS will automatically try to fetch…

### DIFF
--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -270,7 +270,7 @@ $section->addInput(new Form_Select(
 	'*Interface to monitor',
 	$pconfig['interface'],
 	$interfacelist
-));
+))->setHelp('If the interface IP is private the public IP will be fetched and used instead.');
 
 $section->addInput(new Form_Select(
 	'requestif',


### PR DESCRIPTION
… the public IP in case the selected interface's IP is private.

See https://github.com/pfsense/pfsense/blob/master/src/etc/inc/dyndns.class#L1684.
This doesn't seem to be documented?