### PR TITLE
syslogd, list it as a service

### DIFF
--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -261,6 +261,11 @@ function get_services() {
 	$pconfig['description'] = gettext("NTP clock sync");
 	$services[] = $pconfig;
 
+	$pconfig = array();
+	$pconfig['name'] = "syslogd";
+	$pconfig['description'] = gettext("Syslog logging");
+	$services[] = $pconfig;
+	
 	if (is_array($config['captiveportal'])) {
 		foreach ($config['captiveportal'] as $zone => $setting) {
 			if (isset($setting['enable'])) {
@@ -605,6 +610,9 @@ function service_control_start($name, $extras) {
 			break;
 		case 'sshd':
 			send_event("service restart sshd");
+			break;
+		case 'syslogd':
+			system_syslogd_start();
 			break;
 		case 'openvpn':
 			$vpnmode = isset($extras['vpnmode']) ? htmlspecialchars($extras['vpnmode']) : htmlspecialchars($extras['mode']);


### PR DESCRIPTION
syslogd, list it as a service, sometimes it stops/crashes having it listed makes it easy to spot this and start it, also the Service Watchdog package can then start it when configured & needed.