### PR TITLE
Fix #7452 save new gateway

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -3377,7 +3377,7 @@ events.push(function() {
 		}
 
 		var url = "system_gateways_edit.php";
-		var pars = 'isAjax=true&ipprotocol=inet' + defaultgw + '&interface=' + escape(iface) + '&name=' + escape(name) + '&descr=' + escape(descr) + '&gateway=' + escape(gatewayip);
+		var pars = 'isAjax=true&save=true&ipprotocol=inet' + defaultgw + '&interface=' + escape(iface) + '&name=' + escape(name) + '&descr=' + escape(descr) + '&gateway=' + escape(gatewayip);
 		$.ajax(
 			url,
 			{


### PR DESCRIPTION
The code in system_gateways_edit nowadays expects $_POST['save'] to be set in order to actually save a gateway.