### PR TITLE
phpsessionmanager, csrf should use phpsession_end before exit to avoid syslog warning about a open session

### DIFF
--- a/src/usr/local/www/csrf/csrf-magic.php
+++ b/src/usr/local/www/csrf/csrf-magic.php
@@ -201,6 +201,7 @@ function csrf_check($fatal = true) {
         $callback = $GLOBALS['csrf']['callback'];
         if (trim($tokens, 'A..Za..z0..9:;,') !== '') $tokens = 'hidden';
         $callback($tokens);
+		phpsession_end();
         exit;
     }
     return $ok;


### PR DESCRIPTION
phpsessionmanager, csrf should use phpsession_end before exit to avoid syslog warning about a open session