### PR TITLE
Fix #7394 rename alias correctly on edit

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2078,6 +2078,37 @@ function update_progress_bar($percent, $first_time) {
 	}
 }
 
+function update_alias_name($new_alias_name, $orig_alias_name) {
+	if (!$orig_alias_name) {
+		return;
+	}
+
+	// Firewall rules
+	update_alias_names_upon_change(array('filter', 'rule'), array('source', 'address'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('filter', 'rule'), array('destination', 'address'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('filter', 'rule'), array('source', 'port'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('filter', 'rule'), array('destination', 'port'), $new_alias_name, $orig_alias_name);
+	// NAT Rules
+	update_alias_names_upon_change(array('nat', 'rule'), array('source', 'address'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('nat', 'rule'), array('source', 'port'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('nat', 'rule'), array('destination', 'address'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('nat', 'rule'), array('destination', 'port'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('nat', 'rule'), array('target'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('nat', 'rule'), array('local-port'), $new_alias_name, $orig_alias_name);
+	// NAT 1:1 Rules
+	//update_alias_names_upon_change(array('nat', 'onetoone'), array('external'), $new_alias_name, $orig_alias_name);
+	//update_alias_names_upon_change(array('nat', 'onetoone'), array('source', 'address'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('nat', 'onetoone'), array('destination', 'address'), $new_alias_name, $orig_alias_name);
+	// NAT Outbound Rules
+	update_alias_names_upon_change(array('nat', 'outbound', 'rule'), array('source', 'network'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('nat', 'outbound', 'rule'), array('sourceport'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('nat', 'outbound', 'rule'), array('destination', 'address'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('nat', 'outbound', 'rule'), array('dstport'), $new_alias_name, $orig_alias_name);
+	update_alias_names_upon_change(array('nat', 'outbound', 'rule'), array('target'), $new_alias_name, $orig_alias_name);
+	// Alias in an alias
+	update_alias_names_upon_change(array('aliases', 'alias'), array('address'), $new_alias_name, $orig_alias_name);
+}
+
 function update_alias_names_upon_change($section, $field, $new_alias_name, $origname) {
 	global $g, $config, $pconfig, $debug;
 	if (!$origname) {

--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -328,17 +328,8 @@ if ($_POST) {
 									if (is_array($ifdescrs)) {
 										foreach ($ifdescrs as $iface) {
 											if (is_alias($config['interfaces'][$iface]['descr'])) {
-												// Firewall rules
 												$origname = $config['interfaces'][$iface]['descr'];
-												$newname = $config['interfaces'][$iface]['descr'] . "Alias";
-												update_alias_names_upon_change(array('filter', 'rule'), array('source', 'address'), $newname, $origname);
-												update_alias_names_upon_change(array('filter', 'rule'), array('destination', 'address'), $newname, $origname);
-												// NAT Rules
-												update_alias_names_upon_change(array('nat', 'rule'), array('source', 'address'), $newname, $origname);
-												update_alias_names_upon_change(array('nat', 'rule'), array('destination', 'address'), $newname, $origname);
-												update_alias_names_upon_change(array('nat', 'rule'), array('target'), $newname, $origname);
-												// Alias in an alias
-												update_alias_names_upon_change(array('aliases', 'alias'), array('address'), $newname, $origname);
+												update_alias_name($origname . "Alias", $origname);
 											}
 										}
 									}

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -469,30 +469,7 @@ if ($_POST['save']) {
 		 *	 renamed on referenced rules and such
 		 */
 		if ($_POST['name'] <> $_POST['origname']) {
-			// Firewall rules
-			update_alias_names_upon_change(array('filter', 'rule'), array('source', 'address'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('filter', 'rule'), array('destination', 'address'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('filter', 'rule'), array('source', 'port'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('filter', 'rule'), array('destination', 'port'), $_POST['name'], $origname);
-			// NAT Rules
-			update_alias_names_upon_change(array('nat', 'rule'), array('source', 'address'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('nat', 'rule'), array('source', 'port'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('nat', 'rule'), array('destination', 'address'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('nat', 'rule'), array('destination', 'port'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('nat', 'rule'), array('target'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('nat', 'rule'), array('local-port'), $_POST['name'], $origname);
-			// NAT 1:1 Rules
-			//update_alias_names_upon_change(array('nat', 'onetoone'), array('external'), $_POST['name'], $origname);
-			//update_alias_names_upon_change(array('nat', 'onetoone'), array('source', 'address'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('nat', 'onetoone'), array('destination', 'address'), $_POST['name'], $origname);
-			// NAT Outbound Rules
-			update_alias_names_upon_change(array('nat', 'outbound', 'rule'), array('source', 'network'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('nat', 'outbound', 'rule'), array('sourceport'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('nat', 'outbound', 'rule'), array('destination', 'address'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('nat', 'outbound', 'rule'), array('dstport'), $_POST['name'], $origname);
-			update_alias_names_upon_change(array('nat', 'outbound', 'rule'), array('target'), $_POST['name'], $origname);
-			// Alias in an alias
-			update_alias_names_upon_change(array('aliases', 'alias'), array('address'), $_POST['name'], $origname);
+			update_alias_name($_POST['name'], $origname);
 		}
 
 		pfSense_handle_custom_code("/usr/local/pkg/firewall_aliases_edit/pre_write_config");

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -60,10 +60,6 @@ if (!is_array($config['aliases']['alias'])) {
 }
 $a_aliases = &$config['aliases']['alias'];
 
-if ($_POST['save']) {
-	$origname = $_POST['origname'];
-}
-
 // Debugging
 if ($debug) {
 	unlink_if_exists("{$g['tmp_path']}/alias_rename_log.txt");
@@ -122,6 +118,14 @@ if (isset($id) && $a_aliases[$id]) {
 			$pconfig['address'] = $a_aliases[$id]['aliasurl'];
 		}
 	}
+}
+
+if ($_POST['save']) {
+	// Remember the original name on an attempt to save
+	$origname = $_POST['origname'];
+} else {
+	// Set the original name on edit (or add, when this will be blank)
+	$origname = $pconfig['name'];
 }
 
 $tab = $_REQUEST['tab'];
@@ -468,7 +472,7 @@ if ($_POST['save']) {
 		/*	 Check to see if alias name needs to be
 		 *	 renamed on referenced rules and such
 		 */
-		if ($_POST['name'] <> $_POST['origname']) {
+		if ($_POST['name'] <> $origname) {
 			update_alias_name($_POST['name'], $origname);
 		}
 
@@ -635,7 +639,7 @@ $form->addGlobal(new Form_Input(
 	'origname',
 	null,
 	'hidden',
-	$pconfig['name']
+	$origname
 ));
 
 if (isset($id) && $a_aliases[$id]) {


### PR DESCRIPTION
If you change an alias name, but have other input errors on the initial attempt to save, then fix the input errors and save again, the alias name did not get updated in Rules/NAT/etc where it was used.

Refactor update_alias_names_upon_change also (which I was looking at before seeing this bug), to get rid of all that repeated code. Where it is used in diag_backup when restoring a m0n0wall config, it does not hurt to try to rename any port aliases etc also, in case somehow there were port aliases in an old m0n0wall config.