### PR TITLE
Refactor if list functions

### DIFF
--- a/src/etc/inc/easyrule.inc
+++ b/src/etc/inc/easyrule.inc
@@ -30,7 +30,7 @@ require_once("config.inc");
 function easyrule_find_rule_interface($int) {
 	global $config;
 	/* Borrowed from firewall_rules.php */
-	$iflist = get_configured_interface_with_descr(false, true);
+	$iflist = get_configured_interface_with_descr(true);
 
 	if ($config['pppoe']['mode'] == "server") {
 		$iflist['pppoe'] = "PPPoE Server";

--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -638,7 +638,7 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 	if ($disabled == false) {
 		$iflist = get_configured_interface_with_descr();
 	} else {
-		$iflist = get_configured_interface_with_descr(false, true);
+		$iflist = get_configured_interface_with_descr(true);
 	}
 
 	/* Process/add dynamic v4 gateways. */

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2519,7 +2519,7 @@ function interface_sync_wireless_clones(&$ifcfg, $sync_changes = false) {
 	$baseif = interface_get_wireless_base($ifcfg['if']);
 
 	// Sync shared settings for assigned clones
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	foreach ($iflist as $if) {
 		if ($baseif == interface_get_wireless_base($config['interfaces'][$if]['if']) && $ifcfg['if'] != $config['interfaces'][$if]['if']) {
 			if (isset($config['interfaces'][$if]['wireless']['standard']) || $sync_changes) {
@@ -4802,7 +4802,7 @@ function convert_real_interface_to_friendly_interface_name($interface = "wan", $
 
 	/* XXX: For speed reasons reference directly the interface array */
 	$ifdescrs = &$config['interfaces'];
-	//$ifdescrs = get_configured_interface_list(false, true);
+	//$ifdescrs = get_configured_interface_list(true);
 
 	foreach ($ifdescrs as $if => $ifname) {
 		if ($if == $interface || $ifname['if'] == $interface) {

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4879,7 +4879,7 @@ function convert_friendly_interface_to_friendly_descr($interface) {
 				return get_interface_linklocal($interface);
 			} else {
 				/* if list */
-				$ifdescrs = get_configured_interface_with_descr(false, true);
+				$ifdescrs = get_configured_interface_with_descr(true);
 				foreach ($ifdescrs as $if => $ifname) {
 					if ($if == $interface || $ifname == $interface) {
 						return $ifname;

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -605,7 +605,7 @@ function is_schedule_inuse($schedule) {
 function setup_microcode() {
 
 	/* if list */
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	foreach ($iflist as $if => $ifdescr) {
 		enable_hardware_offloading($if);
 	}

--- a/src/etc/inc/upgrade_config.inc
+++ b/src/etc/inc/upgrade_config.inc
@@ -742,7 +742,7 @@ function upgrade_041_to_042() {
 function upgrade_042_to_043() {
 	global $config;
 	/* migrate old interface gateway to the new gateways config */
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	$gateways = array();
 	$i = 0;
 	foreach ($iflist as $ifname => $interface) {
@@ -837,7 +837,7 @@ function upgrade_043_to_044() {
 
 function upgrade_044_to_045() {
 	global $config;
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	if (is_array($config['vlans']['vlan']) && count($config['vlans']['vlan'])) {
 		$i = 0;
 		foreach ($config['vlans']['vlan'] as $id => $vlan) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1408,16 +1408,13 @@ function get_configured_interface_list_by_realif($only_opt = false, $withdisable
 }
 
 /* return the configured interfaces list with their description. */
-function get_configured_interface_with_descr($only_opt = false, $withdisabled = false) {
+function get_configured_interface_with_descr($withdisabled = false) {
 	global $config, $user_settings;
 
 	$iflist = array();
 
 	/* if list */
 	foreach ($config['interfaces'] as $if => $ifdetail) {
-		if ($only_opt && ($if == "wan" || $if == "lan")) {
-			continue;
-		}
 		if (isset($ifdetail['enable']) || $withdisabled == true) {
 			if (empty($ifdetail['descr'])) {
 				$iflist[$if] = strtoupper($if);

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1386,16 +1386,13 @@ function get_configured_interface_list($only_opt = false, $withdisabled = false)
 }
 
 /* return the configured interfaces list. */
-function get_configured_interface_list_by_realif($only_opt = false, $withdisabled = false) {
+function get_configured_interface_list_by_realif($withdisabled = false) {
 	global $config;
 
 	$iflist = array();
 
 	/* if list */
 	foreach ($config['interfaces'] as $if => $ifdetail) {
-		if ($only_opt && ($if == "wan" || $if == "lan")) {
-			continue;
-		}
 		if (isset($ifdetail['enable']) || $withdisabled == true) {
 			$tmpif = get_real_interface($if);
 			if (!empty($tmpif)) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1367,16 +1367,13 @@ function compare_interface_friendly_names($a, $b) {
 }
 
 /* return the configured interfaces list. */
-function get_configured_interface_list($only_opt = false, $withdisabled = false) {
+function get_configured_interface_list($withdisabled = false) {
 	global $config;
 
 	$iflist = array();
 
 	/* if list */
 	foreach ($config['interfaces'] as $if => $ifdetail) {
-		if ($only_opt && ($if == "wan" || $if == "lan")) {
-			continue;
-		}
 		if (isset($ifdetail['enable']) || $withdisabled == true) {
 			$iflist[$if] = $if;
 		}

--- a/src/etc/rc.banner
+++ b/src/etc/rc.banner
@@ -32,7 +32,7 @@ $machine = trim(`uname -m`);
 
 print "*** Welcome to {$product} {$g['product_version_string']} ({$machine}) on {$hostname} ***\n";
 
-$iflist = get_configured_interface_with_descr(false, true);
+$iflist = get_configured_interface_with_descr(true);
 foreach ($iflist as $ifname => $friendly) {
 	/* point to this interface's config */
 	$ifconf = $config['interfaces'][$ifname];

--- a/src/etc/rc.initial.setlanip
+++ b/src/etc/rc.initial.setlanip
@@ -134,7 +134,7 @@ function get_interface_config_description($iface) {
 $fp = fopen('php://stdin', 'r');
 
 /* build an interface collection */
-$ifdescrs = get_configured_interface_with_descr(false, true);
+$ifdescrs = get_configured_interface_with_descr(true);
 $count = count($ifdescrs);
 
 /* grab interface that we will operate on, unless there is only one interface */

--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -317,7 +317,7 @@ if ($_POST) {
 									}
 									unset($config['shaper']);
 									/* optional if list */
-									$ifdescrs = get_configured_interface_list(true, true);
+									$ifdescrs = get_configured_interface_list(true);
 									/* remove special characters from interface descriptions */
 									if (is_array($ifdescrs)) {
 										foreach ($ifdescrs as $iface) {

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -51,7 +51,7 @@ if (is_array($config['load_balancer']['lbpool'])) {
 	}
 }
 
-$reserved_ifs = get_configured_interface_list(false, true);
+$reserved_ifs = get_configured_interface_list(true);
 $reserved_keywords = array_merge($reserved_keywords, $reserved_ifs, $reserved_table_names);
 $max_alias_addresses = 5000;
 

--- a/src/usr/local/www/firewall_aliases_import.php
+++ b/src/usr/local/www/firewall_aliases_import.php
@@ -44,7 +44,7 @@ if (is_array($config['load_balancer']['lbpool'])) {
 	}
 }
 
-$reserved_ifs = get_configured_interface_list(false, true);
+$reserved_ifs = get_configured_interface_list(true);
 $reserved_keywords = array_merge($reserved_keywords, $reserved_ifs, $reserved_table_names);
 
 $tab = $_REQUEST['tab'];

--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -429,7 +429,7 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['nobinat']
 ))->setHelp('Excludes the address from a later, more general, rule.');
 
-$iflist = get_configured_interface_with_descr(false, true);
+$iflist = get_configured_interface_with_descr(true);
 
 foreach ($iflist as $if => $ifdesc) {
 	if (have_ruleint_access($if)) {

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -667,7 +667,7 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['nordr']
 ))->setHelp('This option is rarely needed. Don\'t use this without thorough knowledge of the implications.');
 
-$iflist = get_configured_interface_with_descr(false, true);
+$iflist = get_configured_interface_with_descr(true);
 
 foreach ($iflist as $if => $ifdesc) {
 	if (have_ruleint_access($if)) {

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -472,7 +472,7 @@ $section->addInput(new Form_Checkbox(
 	isset($pconfig['nonat'])
 ))->setHelp('In most cases this option is not required.');
 
-$iflist = get_configured_interface_with_descr(false, true);
+$iflist = get_configured_interface_with_descr(true);
 
 foreach ($iflist as $if => $ifdesc) {
 	if (have_ruleint_access($if)) {

--- a/src/usr/local/www/firewall_virtual_ip.php
+++ b/src/usr/local/www/firewall_virtual_ip.php
@@ -262,7 +262,7 @@ display_top_tabs($tab_array);
 			</thead>
 			<tbody>
 <?php
-$interfaces = get_configured_interface_with_descr(false, true);
+$interfaces = get_configured_interface_with_descr(true);
 $viplist = get_configured_vip_list();
 
 foreach ($viplist as $vipname => $address) {

--- a/src/usr/local/www/firewall_virtual_ip_edit.php
+++ b/src/usr/local/www/firewall_virtual_ip_edit.php
@@ -290,7 +290,7 @@ include("head.inc");
 function build_if_list() {
 	$list = array();
 
-	$interfaces = get_configured_interface_with_descr(false, true);
+	$interfaces = get_configured_interface_with_descr(true);
 	$carplist = get_configured_vip_list('all', VIP_CARP);
 
 	foreach ($carplist as $vipname => $address) {

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -230,7 +230,7 @@ $specialnets = array(
 	"pppoe" => gettext("PPPoE clients"),
 	"l2tp" => gettext("L2TP clients"));
 
-$spiflist = get_configured_interface_with_descr(false, true);
+$spiflist = get_configured_interface_with_descr(true);
 foreach ($spiflist as $ifgui => $ifdesc) {
 	$specialnets[$ifgui] = $ifdesc . " net";
 	$specialnets[$ifgui . 'ip'] = $ifdesc . " address";

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -267,7 +267,7 @@ if ($platform['name'] == "uFW") {
 	$interfaces_top[] = array(gettext("Switches"), "/switch_system.php");
 }
 
-$opts = get_configured_interface_with_descr(false, true);
+$opts = get_configured_interface_with_descr(true);
 
 foreach ($opts as $oif => $odescr) {
 	if (!isset($config['interfaces'][$oif]['ovpn'])) {

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -50,7 +50,7 @@ if (isset($_POST['referer'])) {
 }
 
 // Get configured interface list
-$ifdescrs = get_configured_interface_with_descr(false, true);
+$ifdescrs = get_configured_interface_with_descr(true);
 
 $if = "wan";
 
@@ -2441,7 +2441,7 @@ function build_ipv6interface_list() {
 
 	$list = array('' => '');
 
-	$interfaces = get_configured_interface_with_descr(false, true);
+	$interfaces = get_configured_interface_with_descr(true);
 	$dynv6ifs = array();
 
 	foreach ($interfaces as $iface => $ifacename) {

--- a/src/usr/local/www/interfaces_bridge.php
+++ b/src/usr/local/www/interfaces_bridge.php
@@ -37,7 +37,7 @@ $a_bridges = &$config['bridges']['bridged'] ;
 function bridge_inuse($num) {
 	global $config, $a_bridges;
 
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 
 	foreach ($iflist as $if) {
 		if ($config['interfaces'][$if]['if'] == $a_bridges[$num]['bridgeif']) {

--- a/src/usr/local/www/interfaces_gif.php
+++ b/src/usr/local/www/interfaces_gif.php
@@ -37,7 +37,7 @@ $a_gifs = &$config['gifs']['gif'] ;
 function gif_inuse($num) {
 	global $config, $a_gifs;
 
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	foreach ($iflist as $if) {
 		if ($config['interfaces'][$if]['if'] == $a_gifs[$num]['gifif']) {
 			return true;

--- a/src/usr/local/www/interfaces_gre.php
+++ b/src/usr/local/www/interfaces_gre.php
@@ -38,7 +38,7 @@ $a_gres = &$config['gres']['gre'] ;
 function gre_inuse($num) {
 	global $config, $a_gres;
 
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	foreach ($iflist as $if) {
 		if ($config['interfaces'][$if]['if'] == $a_gres[$num]['greif']) {
 			return true;

--- a/src/usr/local/www/interfaces_groups.php
+++ b/src/usr/local/www/interfaces_groups.php
@@ -91,7 +91,7 @@ display_top_tabs($tab_array);
 						<td>
 <?php
 		$members_arr = explode(" ", $ifgroupentry['members']);
-		$iflist = get_configured_interface_with_descr(false, true);
+		$iflist = get_configured_interface_with_descr(true);
 		$memberses_arr = array();
 		foreach ($members_arr as $memb) {
 			$memberses_arr[] = $iflist[$memb] ? $iflist[$memb] : $memb;

--- a/src/usr/local/www/interfaces_groups_edit.php
+++ b/src/usr/local/www/interfaces_groups_edit.php
@@ -48,7 +48,7 @@ if (isset($id) && $a_ifgroups[$id]) {
 }
 
 $interface_list = get_configured_interface_with_descr();
-$interface_list_disabled = get_configured_interface_with_descr(false, true);
+$interface_list_disabled = get_configured_interface_with_descr(true);
 $ifname_allowed_chars_text = gettext("Only letters (A-Z), digits (0-9) and '_' are allowed.");
 $ifname_no_digit_text = gettext("The group name cannot end with a digit.");
 

--- a/src/usr/local/www/interfaces_lagg.php
+++ b/src/usr/local/www/interfaces_lagg.php
@@ -37,7 +37,7 @@ $a_laggs = &$config['laggs']['lagg'] ;
 function lagg_inuse($num) {
 	global $config, $a_laggs;
 
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	foreach ($iflist as $if) {
 		if ($config['interfaces'][$if]['if'] == $a_laggs[$num]['laggif']) {
 			return true;

--- a/src/usr/local/www/interfaces_lagg_edit.php
+++ b/src/usr/local/www/interfaces_lagg_edit.php
@@ -101,7 +101,7 @@ if (is_array($config['laggs']['lagg']) && count($config['laggs']['lagg'])) {
 	}
 }
 
-$checklist = get_configured_interface_list(false, true);
+$checklist = get_configured_interface_list(true);
 
 foreach ($checklist as $tmpif) {
 	$realifchecklist[get_real_interface($tmpif)] = $tmpif;

--- a/src/usr/local/www/interfaces_ppps.php
+++ b/src/usr/local/www/interfaces_ppps.php
@@ -36,7 +36,7 @@ require_once("functions.inc");
 function ppp_inuse($num) {
 	global $config, $g;
 
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	if (!is_array($config['ppps']['ppp'])) {
 		return false;
 	}

--- a/src/usr/local/www/interfaces_qinq.php
+++ b/src/usr/local/www/interfaces_qinq.php
@@ -38,7 +38,7 @@ $a_qinqs = &$config['qinqs']['qinqentry'];
 function qinq_inuse($num) {
 	global $config, $a_qinqs;
 
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	foreach ($iflist as $if) {
 		if ($config['interfaces'][$if]['if'] == $a_qinqs[$num]['qinqif']) {
 			return true;

--- a/src/usr/local/www/interfaces_vlan.php
+++ b/src/usr/local/www/interfaces_vlan.php
@@ -41,7 +41,7 @@ $a_vlans = &$config['vlans']['vlan'] ;
 function vlan_inuse($num) {
 	global $config, $a_vlans;
 
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	foreach ($iflist as $if) {
 		if ($config['interfaces'][$if]['if'] == $a_vlans[$num]['vlanif']) {
 			return true;

--- a/src/usr/local/www/interfaces_wireless.php
+++ b/src/usr/local/www/interfaces_wireless.php
@@ -41,7 +41,7 @@ $a_clones = &$config['wireless']['clone'];
 function clone_inuse($num) {
 	global $config, $a_clones;
 
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 
 	foreach ($iflist as $if) {
 		if ($config['interfaces'][$if]['if'] == $a_clones[$num]['cloneif']) {

--- a/src/usr/local/www/interfaces_wireless_edit.php
+++ b/src/usr/local/www/interfaces_wireless_edit.php
@@ -42,7 +42,7 @@ $a_clones = &$config['wireless']['clone'];
 function clone_inuse($num) {
 	global $config, $a_clones;
 
-	$iflist = get_configured_interface_list(false, true);
+	$iflist = get_configured_interface_list(true);
 	foreach ($iflist as $if) {
 		if ($config['interfaces'][$if]['if'] == $a_clones[$num]['cloneif']) {
 			return true;

--- a/src/usr/local/www/pkg.php
+++ b/src/usr/local/www/pkg.php
@@ -143,7 +143,7 @@ if ($_REQUEST['act'] == "del") {
 
 ob_start();
 
-$iflist = get_configured_interface_with_descr(false, true);
+$iflist = get_configured_interface_with_descr(true);
 $evaledvar = $config['installedpackages'][xml_safe_fieldname($pkg['name'])]['config'];
 
 if ($pkg['custom_php_global_functions'] != "") {

--- a/src/usr/local/www/status_interfaces.php
+++ b/src/usr/local/www/status_interfaces.php
@@ -94,7 +94,7 @@ $pgtitle = array(gettext("Status"), gettext("Interfaces"));
 $shortcut_section = "interfaces";
 include("head.inc");
 
-$ifdescrs = get_configured_interface_with_descr(false, true);
+$ifdescrs = get_configured_interface_with_descr(true);
 
 foreach ($ifdescrs as $ifdescr => $ifname):
 	$ifinfo = get_interface_info($ifdescr);

--- a/src/usr/local/www/status_logs_common.inc
+++ b/src/usr/local/www/status_logs_common.inc
@@ -546,7 +546,7 @@ function filter_form_firewall() {
 
 
 function status_logs_build_if_list() {
-	$iflist = get_configured_interface_with_descr(false, true);
+	$iflist = get_configured_interface_with_descr(true);
 	//$iflist = get_interface_list();
 	// Allow extending of the firewall edit interfaces
 	pfSense_handle_custom_code("/usr/local/pkg/firewall_nat/pre_interfaces_edit");

--- a/src/usr/local/www/status_logs_filter.php
+++ b/src/usr/local/www/status_logs_filter.php
@@ -124,7 +124,7 @@ filter_form_firewall();
 
 // Now the forms are complete we can draw the log table and its controls
 if (!$rawfilter) {
-	$iflist = get_configured_interface_with_descr(false, true);
+	$iflist = get_configured_interface_with_descr(true);
 
 	if ($iflist[$interfacefilter]) {
 		$interfacefilter = $iflist[$interfacefilter];

--- a/src/usr/local/www/status_queues.php
+++ b/src/usr/local/www/status_queues.php
@@ -173,7 +173,7 @@ else: ?>
 				</thead>
 				<tbody>
 <?php
-	$if_queue_list = get_configured_interface_list_by_realif(false, true);
+	$if_queue_list = get_configured_interface_list_by_realif(true);
 	processQueues($altqstats, 0, "");
 ?>
 <?php endif; ?>

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -596,7 +596,7 @@ $section->addInput(new Form_Select(
 	'interface',
 	'*Interface',
 	$pconfig['friendlyiface'],
-	get_configured_interface_with_descr(false, true)
+	get_configured_interface_with_descr(true)
 ))->setHelp('Choose which interface this gateway applies to.');
 
 $section->addInput(new Form_Select(


### PR DESCRIPTION
Get rid of the "only_opt" parameter from:
get_configured_interface_list()
get_configured_interface_list_by_realif()
get_configured_interface_with_descr()

The parameter is not used in any package code.
The only place that used it was in diag_backup when restoring a m0n0wall config. The code checks each interface in the config to see if its description happens to match an alias, and fixes that. It was only checking interfaces other than [wan|lan]. Now it will check wan and lan also, which does not hurt anything.

I noticed this while looking through code related to adding a gateway when setting up an interface. Thought that I might as well cleanup the unused (and likely never to be used) parameter.