### PR TITLE
Do input validation on the actual array passed in

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -258,7 +258,7 @@ function do_input_validation($postdata, $reqdfields, $reqdfieldsn, &$input_error
 	}
 
 	for ($i = 0; $i < count($reqdfields); $i++) {
-		if ($_POST[$reqdfields[$i]] == "" && $_REQUEST[$reqdfields[$i]] == "") {
+		if ($postdata[$reqdfields[$i]] == "") {
 			$input_errors[] = sprintf(gettext("The field %s is required."), $reqdfieldsn[$i]);
 		}
 	}


### PR DESCRIPTION
I was tearing my hair out for a while. If do_input_validation() is passed some array of keys/values that has been assembled elsewhere (not $_POST, $_GET or $_REQUEST superglobals) then it does not work. The code here, for at least the last 7 years, has actually been checking the array keys in the "hard-coded" superglobals. That is a bit surprising, since the array to be checked is passed in as $postdata parameter.