### PR TITLE
Fix var/empty operation not permitted

### DIFF
--- a/src/etc/pfSense-rc
+++ b/src/etc/pfSense-rc
@@ -228,7 +228,12 @@ SWAPDEVICE=`/bin/cat /etc/fstab | /usr/bin/grep swap | /usr/bin/cut -f1`
 
 # make some directories in /var
 /bin/mkdir -p $varrunpath /var/log /var/etc /var/db/entropy /var/db/rrd /var/at/jobs/ /var/empty /var/log/nginx 2>/dev/null
+
+# turn off the immutable flag, set /var/empty to read-only, make it immutable again
+chflags noschg /var/empty
 chmod 0555 /var/empty
+chflags schg /var/empty
+
 /bin/rm -rf $varrunpath/*
 
 # Cleanup configuration files from previous instance


### PR DESCRIPTION
On my 2.4-BETA VM, after "Welcome to pfSense", "No core dumps found", I get:
```
chmod: /var/empty: Operation not permitted
```
/var/empty has the immutable flag set, so the chmod fails.

This change clears the immutable flag before chmod and puts it back after. That gets rid of the annoying "error" message in the boot process.

I don;t see this in 2.3.3 or 2.3.4-dev boot, so (without digging through the code) I guess this issue only started with changes in pfSense 2.4 and/or FreeBSD 11.