### PR TITLE
Fix #7493 only check interface IP if static

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -692,7 +692,7 @@ if ($_POST['apply']) {
 	/* normalize MAC addresses - lowercase and convert Windows-ized hyphenated MACs to colon delimited */
 	$staticroutes = get_staticroutes(true);
 	$_POST['spoofmac'] = strtolower(str_replace("-", ":", $_POST['spoofmac']));
-	if ($_POST['ipaddr']) {
+	if (($_POST['type'] == 'staticv4') && $_POST['ipaddr']) {
 		if (!is_ipaddrv4($_POST['ipaddr'])) {
 			$input_errors[] = gettext("A valid IPv4 address must be specified.");
 		} else {
@@ -724,7 +724,7 @@ if ($_POST['apply']) {
 			}
 		}
 	}
-	if ($_POST['ipaddrv6']) {
+	if (($_POST['type'] == 'staticv6') && $_POST['ipaddrv6']) {
 		$_POST['ipaddrv6'] = addrtolower($_POST['ipaddrv6']);
 
 		if (!is_ipaddrv6($_POST['ipaddrv6'])) {


### PR DESCRIPTION
"ipaddr" is only saved to the interface config if "staticv4" type is selected.
"ipaddrv6" is only saved to the interface config if "staticv6" type is selected.
So these fields need only be checked for validity when "staticv4"/"staticv6" type is selected.

The report in the Redmine issue has a more complex situation in which this bug is apparent, but actually you can easily see the problem:
1) Edit an interface with a static IP
2) Change the IP Address field to have an invalid IP address in that field
2) Change the "type" to "none" or "DHCP" (or any other "type")
3) Press Save

An error is given saying that the IP address must be valid.
Actually that is a "dumb" error to report, because the invalid IP address string is about to be discarded anyhow.