### PR TITLE
Avoid invalid arg error when saving WoL widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
+++ b/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
@@ -42,8 +42,10 @@ if ($_POST['widgetkey']) {
 
 	$validNames = array();
 
-	foreach ($config['wol']['wolentry'] as $wolent) {
-		array_push($validNames, get_wolent_key($wolent));
+	if (is_array($config['wol']['wolentry'])) {
+		foreach ($config['wol']['wolentry'] as $wolent) {
+			array_push($validNames, get_wolent_key($wolent));
+		}
 	}
 
 	if (is_array($_POST['show'])) {


### PR DESCRIPTION
when there are no WoL entries