### PR TITLE
Allow customize of dashboard widget names

### DIFF
--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -248,7 +248,8 @@ function dump_xml_config_sub($arr, $indent) {
 						    (substr($ent, 0, 9) == "ldap_bind") ||
 						    (substr($ent, 0, 11) == "ldap_basedn") ||
 						    (substr($ent, 0, 18) == "ldap_authcn") ||
-						    (substr($ent, 0, 19) == "ldap_extended_query")) {
+						    (substr($ent, 0, 19) == "ldap_extended_query") ||
+							($ent == "customwidgettitle")) {
 							$xmlconfig .= "<$ent><![CDATA[" . htmlentities($cval) . "]]></$ent>\n";
 						} else {
 							$xmlconfig .= "<$ent>" . htmlentities($cval) . "</$ent>\n";
@@ -280,6 +281,7 @@ function dump_xml_config_sub($arr, $indent) {
 				    (substr($ent, 0, 11) == "ldap_basedn") ||
 				    (substr($ent, 0, 18) == "ldap_authcn") ||
 				    (substr($ent, 0, 19) == "ldap_extended_query") ||
+				    ($ent == "customwidgettitle") ||
 				    (substr($ent, 0, 5) == "text")) {
 					$xmlconfig .= "<$ent><![CDATA[" . htmlentities($val) . "]]></$ent>\n";
 				} else {

--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -248,8 +248,7 @@ function dump_xml_config_sub($arr, $indent) {
 						    (substr($ent, 0, 9) == "ldap_bind") ||
 						    (substr($ent, 0, 11) == "ldap_basedn") ||
 						    (substr($ent, 0, 18) == "ldap_authcn") ||
-						    (substr($ent, 0, 19) == "ldap_extended_query") ||
-							($ent == "customwidgettitle")) {
+						    (substr($ent, 0, 19) == "ldap_extended_query")) {
 							$xmlconfig .= "<$ent><![CDATA[" . htmlentities($cval) . "]]></$ent>\n";
 						} else {
 							$xmlconfig .= "<$ent>" . htmlentities($cval) . "</$ent>\n";
@@ -281,7 +280,6 @@ function dump_xml_config_sub($arr, $indent) {
 				    (substr($ent, 0, 11) == "ldap_basedn") ||
 				    (substr($ent, 0, 18) == "ldap_authcn") ||
 				    (substr($ent, 0, 19) == "ldap_extended_query") ||
-				    ($ent == "customwidgettitle") ||
 				    (substr($ent, 0, 5) == "text")) {
 					$xmlconfig .= "<$ent><![CDATA[" . htmlentities($val) . "]]></$ent>\n";
 				} else {

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -577,6 +577,25 @@ function genhtmltitle($title, $links=true) {
 	return $bc;
 }
 
+function gen_customwidgettitle_div($widgettitle) {
+	$divstr = '<div class="form-group">';
+	$divstr .= '  <label for="customwidgettitle" class="col-sm-4 control-label">' . gettext('Widget titley'). '</label>';
+	$divstr .= '  <div class="col-sm-4">';
+	$divstr .= '    <input type="text" name="customwidgettitle" id="customwidgettitle" value="'. $widgettitle . '" class="form-control" />';
+	$divstr .= '  </div>';
+	$divstr .= '</div>';
+
+	return $divstr;
+}
+
+function set_customwidgettitle(& $user_settings) {
+	if ($_POST['customwidgettitle']) {
+		$user_settings['widgets'][$_POST['widgetkey']]['customwidgettitle'] = trim($_POST['customwidgettitle']);
+	} else {
+		unset($user_settings['widgets'][$_POST['widgetkey']]['customwidgettitle']);
+	}
+}
+
 /* update the changedesc and changecount(er) variables */
 function update_changedesc($update) {
 	global $changedesc;

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -579,9 +579,9 @@ function genhtmltitle($title, $links=true) {
 
 function gen_customwidgettitle_div($widgettitle) {
 	$divstr = '<div class="form-group">';
-	$divstr .= '  <label for="customwidgettitle" class="col-sm-4 control-label">' . gettext('Widget title'). '</label>';
+	$divstr .= '  <label for="descr" class="col-sm-4 control-label">' . gettext('Widget title'). '</label>';
 	$divstr .= '  <div class="col-sm-4">';
-	$divstr .= '    <input type="text" name="customwidgettitle" id="customwidgettitle" value="'. $widgettitle . '" class="form-control" />';
+	$divstr .= '    <input type="text" name="descr" id="descr" value="'. $widgettitle . '" class="form-control" />';
 	$divstr .= '  </div>';
 	$divstr .= '</div>';
 
@@ -589,10 +589,10 @@ function gen_customwidgettitle_div($widgettitle) {
 }
 
 function set_customwidgettitle(& $user_settings) {
-	if ($_POST['customwidgettitle']) {
-		$user_settings['widgets'][$_POST['widgetkey']]['customwidgettitle'] = trim($_POST['customwidgettitle']);
+	if ($_POST['descr']) {
+		$user_settings['widgets'][$_POST['widgetkey']]['descr'] = trim($_POST['descr']);
 	} else {
-		unset($user_settings['widgets'][$_POST['widgetkey']]['customwidgettitle']);
+		unset($user_settings['widgets'][$_POST['widgetkey']]['descr']);
 	}
 }
 

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -579,7 +579,7 @@ function genhtmltitle($title, $links=true) {
 
 function gen_customwidgettitle_div($widgettitle) {
 	$divstr = '<div class="form-group">';
-	$divstr .= '  <label for="customwidgettitle" class="col-sm-4 control-label">' . gettext('Widget titley'). '</label>';
+	$divstr .= '  <label for="customwidgettitle" class="col-sm-4 control-label">' . gettext('Widget title'). '</label>';
 	$divstr .= '  <div class="col-sm-4">';
 	$divstr .= '    <input type="text" name="customwidgettitle" id="customwidgettitle" value="'. $widgettitle . '" class="form-control" />';
 	$divstr .= '  </div>';

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -302,16 +302,19 @@ if ($user_settings['widgets']['sequence'] != "") {
 		if (false !== $offset) {
 			$basename = substr($basename, 0, $offset);
 		}
-
-		// Get the widget title that should be in a var defined in the widget's inc file.
-		$widgettitle = ${$basename . '_title'};
-
-		if (empty(trim($widgettitle))) {
-			// Fall back to constructing a title from the file name of the widget.
-			$widgettitle = ucwords(str_replace('_', ' ', $basename));
-		}
-
 		$widgetkey = $basename . '-' . $copynum;
+
+		if (isset($user_settings['widgets'][$widgetkey]['customwidgettitle'])) {
+			$widgettitle = htmlentities($user_settings['widgets'][$widgetkey]['customwidgettitle']);
+		} else {
+			// Get the widget title that should be in a var defined in the widget's inc file.
+			$widgettitle = ${$basename . '_title'};
+
+			if (empty(trim($widgettitle))) {
+				// Fall back to constructing a title from the file name of the widget.
+				$widgettitle = ucwords(str_replace('_', ' ', $basename));
+			}
+		}
 
 		$widgetsfromconfig[$widgetkey] = array(
 			'basename' => $basename,

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -304,8 +304,8 @@ if ($user_settings['widgets']['sequence'] != "") {
 		}
 		$widgetkey = $basename . '-' . $copynum;
 
-		if (isset($user_settings['widgets'][$widgetkey]['customwidgettitle'])) {
-			$widgettitle = htmlentities($user_settings['widgets'][$widgetkey]['customwidgettitle']);
+		if (isset($user_settings['widgets'][$widgetkey]['descr'])) {
+			$widgettitle = htmlentities($user_settings['widgets'][$widgetkey]['descr']);
 		} else {
 			// Get the widget title that should be in a var defined in the widget's inc file.
 			$widgettitle = ${$basename . '_title'};

--- a/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/dyn_dns_status.widget.php
@@ -118,6 +118,7 @@ if ($_REQUEST['getdyndnsstatus']) {
 	}
 	exit;
 } else if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 
 	$validNames = array();
 
@@ -227,6 +228,7 @@ if (!function_exists('get_dyndns_service_text')) {
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/dyn_dns_status.widget.php" method="post" class="form-horizontal">
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
 			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -169,6 +169,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 }
 
 if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 
 	if (!is_array($user_settings["widgets"][$_POST['widgetkey']])) {
 		$user_settings["widgets"][$_POST['widgetkey']] = array();
@@ -222,8 +223,9 @@ $widgetkey_nodash = str_replace("-", "", $widgetkey);
 <!-- close the body we're wrapped in and add a configuration-panel -->
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 <form action="/widgets/widgets/gateways.widget.php" method="post" class="form-horizontal">
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
 	<div class="form-group">
-		<label class="col-sm-3 control-label"><?=gettext('Display')?></label>
+		<label class="col-sm-4 control-label"><?=gettext('Display')?></label>
 		<?php
 			$display_type_gw_ip = "checked";
 			$display_type_monitor_ip = "";

--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -97,6 +97,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	print(	"</tbody>");
 	exit;
 } else if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 
 	$validNames = array();
 
@@ -126,6 +127,7 @@ $widgetkey_nodash = str_replace("-", "", $widgetkey);
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/interface_statistics.widget.php" method="post" class="form-horizontal">
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
 			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -32,6 +32,7 @@ $ifdescrs = get_configured_interface_with_descr();
 $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period'] * 1000 * 6 : 60000;
 
 if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 
 	$validNames = array();
 
@@ -157,6 +158,7 @@ endif;
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/interfaces.widget.php" method="post" class="form-horizontal">
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
 	<div class="panel panel-default col-sm-10">
 		<div class="panel-body">
 			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">

--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -30,6 +30,8 @@ require_once("functions.inc");
 require_once("filter_log.inc");
 
 if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
+
 	if (is_numeric($_POST['filterlogentries'])) {
 		$user_settings['widgets'][$_POST['widgetkey']]['filterlogentries'] = $_POST['filterlogentries'];
 	} else {
@@ -217,6 +219,8 @@ $pconfig['nentriesinterval'] = isset($user_settings['widgets'][$widgetkey]['filt
 	<form action="/widgets/widgets/log.widget.php" method="post"
 		class="form-horizontal">
 		<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
+		<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
+
 		<div class="form-group">
 			<label for="filterlogentries" class="col-sm-4 control-label"><?=gettext('Number of entries')?></label>
 			<div class="col-sm-6">

--- a/src/usr/local/www/widgets/widgets/openvpn.widget.php
+++ b/src/usr/local/www/widgets/widgets/openvpn.widget.php
@@ -291,6 +291,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	printPanel($_REQUEST['widgetkey']);
 	exit;
 } else if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 
 	$validNames = array();
 	$servers = openvpn_get_active_servers();
@@ -334,6 +335,7 @@ $widgetkey_nodash = str_replace("-", "", $widgetkey);
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/openvpn.widget.php" method="post" class="form-horizontal">
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
 			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">

--- a/src/usr/local/www/widgets/widgets/picture.widget.php
+++ b/src/usr/local/www/widgets/widgets/picture.widget.php
@@ -39,6 +39,8 @@ if ($_GET['getpic']=="true") {
 }
 
 if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
+
 	if (is_uploaded_file($_FILES['pictfile']['tmp_name'])) {
 		/* read the file contents */
 		$fd_pic = fopen($_FILES['pictfile']['tmp_name'], "rb");
@@ -59,6 +61,9 @@ if ($_POST['widgetkey']) {
 			exit;
 		}
 	}
+
+	header("Location: /index.php");
+	exit;
 }
 
 ?>
@@ -69,12 +74,18 @@ if ($_POST['widgetkey']) {
 <!-- close the body we're wrapped in and add a configuration-panel -->
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
-<form action="/widgets/widgets/picture.widget.php" method="post" enctype="multipart/form-data" class="form-inline">
+<form action="/widgets/widgets/picture.widget.php" method="post" enctype="multipart/form-data" class="form-horizontal">
 	<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
-	<label for="pictfile"><?=gettext('New picture:')?> </label>
-	<input id="pictfile" name="pictfile" type="file" class="form-control" />
-	<button type="submit" class="btn btn-primary btn-xs">
-		<i class="fa fa-upload icon-embed-btn"></i>
-		<?=gettext('Upload')?>
-	</button>
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
+	<div class="form-group">
+		<label for="pictfile" class="col-sm-4 control-label"><?=gettext('New picture:')?> </label>
+		<div class="col-sm-6">
+			<input id="pictfile" name="pictfile" type="file" class="form-control" />
+		</div>
+	</div>
+	<div class="form-group">
+		<div class="col-sm-offset-3 col-sm-6">
+			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
+		</div>
+	</div>
 </form>

--- a/src/usr/local/www/widgets/widgets/picture.widget.php
+++ b/src/usr/local/www/widgets/widgets/picture.widget.php
@@ -56,12 +56,10 @@ if ($_POST['widgetkey']) {
 			$picname = basename($_FILES['uploadedfile']['name']);
 			$user_settings['widgets'][$_POST['widgetkey']]['picturewidget'] = base64_encode($data);
 			$user_settings['widgets'][$_POST['widgetkey']]['picturewidget_filename'] = $_FILES['pictfile']['name'];
-			save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Picture widget saved via Dashboard."));
-			header("Location: /index.php");
-			exit;
 		}
 	}
 
+	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Picture widget saved via Dashboard."));
 	header("Location: /index.php");
 	exit;
 }

--- a/src/usr/local/www/widgets/widgets/rss.widget.php
+++ b/src/usr/local/www/widgets/widgets/rss.widget.php
@@ -26,6 +26,7 @@ require_once("pfsense-utils.inc");
 require_once("functions.inc");
 
 if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 	$user_settings['widgets'][$_POST['widgetkey']]['rssfeed'] = str_replace("\n", ",", htmlspecialchars($_POST['rssfeed'], ENT_QUOTES | ENT_HTML401));
 	$user_settings['widgets'][$_POST['widgetkey']]['rssmaxitems'] = str_replace("\n", ",", htmlspecialchars($_POST['rssmaxitems'], ENT_QUOTES | ENT_HTML401));
 	$user_settings['widgets'][$_POST['widgetkey']]['rsswidgetheight'] = htmlspecialchars($_POST['rsswidgetheight'], ENT_QUOTES | ENT_HTML401);
@@ -128,29 +129,30 @@ if ($user_settings['widgets'][$widgetkey]['rssfeed']) {
 
 <form action="/widgets/widgets/rss.widget.php" method="post" class="form-horizontal">
 	<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
 	<div class="form-group">
-		<label for="rssfeed" class="col-sm-3 control-label"><?=gettext('Feeds')?></label>
+		<label for="rssfeed" class="col-sm-4 control-label"><?=gettext('Feeds')?></label>
 		<div class="col-sm-6">
 			<textarea id="rssfeed" name="rssfeed" class="form-control"><?=$textarea_txt;?></textarea>
 		</div>
 	</div>
 
 	<div class="form-group">
-		<label for="rssmaxitems" class="col-sm-3 control-label"><?=gettext('# Stories')?></label>
+		<label for="rssmaxitems" class="col-sm-4 control-label"><?=gettext('# Stories')?></label>
 		<div class="col-sm-6">
 			<input type="number" id="rssmaxitems" name="rssmaxitems" value="<?=$max_items?>" min="1" max="100" class="form-control" />
 		</div>
 	</div>
 
 	<div class="form-group">
-		<label for="rsswidgetheight" class="col-sm-3 control-label"><?=gettext('Widget height')?></label>
+		<label for="rsswidgetheight" class="col-sm-4 control-label"><?=gettext('Widget height')?></label>
 		<div class="col-sm-6">
 			<input type="number" id="rsswidgetheight" name="rsswidgetheight" value="<?=$rsswidgetheight?>" min="100" max="2500" step="100" class="form-control" />
 		</div>
 	</div>
 
 	<div class="form-group">
-		<label for="rsswidgettextlength" class="col-sm-3 control-label"><?=gettext('Content limit')?></label>
+		<label for="rsswidgettextlength" class="col-sm-4 control-label"><?=gettext('Content limit')?></label>
 		<div class="col-sm-6">
 			<input type="number" id="rsswidgettextlength" name="rsswidgettextlength" value="<?=$rsswidgettextlength?>" min="100" max="5000" step="10" class="form-control" />
 		</div>

--- a/src/usr/local/www/widgets/widgets/services_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/services_status.widget.php
@@ -49,6 +49,7 @@ for ($idx=1; $idx < $numsvcs; $idx++) {
 }
 
 if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 
 	$validNames = array();
 
@@ -121,6 +122,7 @@ if (count($services) > 0) {
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/services_status.widget.php" method="post" class="form-horizontal">
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
 			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">

--- a/src/usr/local/www/widgets/widgets/smart_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/smart_status.widget.php
@@ -37,6 +37,7 @@ if ($specplatform['name'] != "Hyper-V") {
 }
 
 if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 
 	$validNames = array();
 
@@ -125,6 +126,7 @@ if (count($devs) > 0)  {
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/smart_status.widget.php" method="post" class="form-horizontal">
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
 			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -98,6 +98,7 @@ if ($_REQUEST['getupdatestatus']) {
 
 	exit;
 } elseif ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 
 	$validNames = array();
 
@@ -441,6 +442,7 @@ $rows_displayed = false;
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/system_information.widget.php" method="post" class="form-horizontal">
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
 			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">

--- a/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
+++ b/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
@@ -105,6 +105,7 @@ if (!function_exists('getBoolValueFromConfig')) {
 //=========================================================================
 //save widget config settings on POST
 if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 	saveThresholdSettings($user_settings, $_POST, "thermal_sensors_widget_zone_warning_threshold", "thermal_sensors_widget_zone_critical_threshold");
 	saveThresholdSettings($user_settings, $_POST, "thermal_sensors_widget_core_warning_threshold", "thermal_sensors_widget_core_critical_threshold");
 
@@ -166,95 +167,72 @@ $thermal_sensors_widget_pulsateCritical = getBoolValueFromConfig($user_settings,
 <input type="hidden" id="thermal_sensors-config" name="thermal_sensors-config" value="" />
 
 <div id="<?=$widget_panel_footer_id?>" class="widgetconfigdiv panel-footer collapse" >
-	<form action="/widgets/widgets/thermal_sensors.widget.php" method="post" id="iform_thermal_sensors_settings" name="iform_thermal_sensors_settings">
-	<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
-	<table>
-		<tr>
-			<td class="text-left" colspan="2">
-				<strong><?=gettext('Thresholds in')?> &deg;C <?=gettext('(1 to 100):')?></strong>
-			</td>
-			<td class="text-right" colspan="1">
-				<strong><?=gettext('Display settings:')?></strong>
-			</td>
-		</tr>
-		<tr>
-			<td class="text-right">
-				<?=gettext('Zone Warning:')?>
-			</td>
-			<td>
-				<input type="text" maxlength="3" size="3" class="formfld unknown"
-					name="thermal_sensors_widget_zone_warning_threshold"
-					id="thermal_sensors_widget_zone_warning_threshold"
-					value="<?= $thermal_sensors_widget_zoneWarningTempThreshold; ?>" />
-			</td>
-			<td class="text-right">
-				<label for="thermal_sensors_widget_show_raw_output"><?=gettext('Show raw output (no graph):')?> </label>
-				<input type="checkbox"
-					id="thermal_sensors_widget_show_raw_output"
-					name="thermal_sensors_widget_show_raw_output"
-					value="<?= $thermal_sensors_widget_showRawOutput; ?>" <?= ($thermal_sensors_widget_showRawOutput) ? " checked" : ""; ?> />
-			</td>
-		</tr>
-		<tr>
-			<td class="text-right">
-				<?=gettext('Zone Critical:')?>
-			</td>
-			<td>
-				<input type="text" maxlength="3" size="3" class="formfld unknown"
-					name="thermal_sensors_widget_zone_critical_threshold"
-					id="thermal_sensors_widget_zone_critical_threshold"
-					value="<?= $thermal_sensors_widget_zoneCriticalTempThreshold; ?>" />
-			</td>
-			<td class="text-right">
-				<label for="thermal_sensors_widget_show_full_sensor_name"><?=gettext('Show full sensor name:')?> </label>
-				<input type="checkbox"
-					id="thermal_sensors_widget_show_full_sensor_name"
-					name="thermal_sensors_widget_show_full_sensor_name"
-					value="<?= $thermal_sensors_widget_showFullSensorName; ?>" <?= ($thermal_sensors_widget_showFullSensorName) ? " checked" : ""; ?> />
-			</td>
-		</tr>
-		<tr>
-			<td class="text-right">
-				<?=gettext('Core Warning:')?>
-			</td>
-			<td>
-				<input type="text" maxlength="3" size="3" class="formfld unknown"
-					name="thermal_sensors_widget_core_warning_threshold"
-					id="thermal_sensors_widget_core_warning_threshold"
-					value="<?= $thermal_sensors_widget_coreWarningTempThreshold ?>" />
-			</td>
-			<td class="text-right">
+	<form action="/widgets/widgets/thermal_sensors.widget.php" method="post" class="form-horizontal">
+		<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">
+		<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
+		<div class="form-group">
+			<label class="col-sm-6 control-label"><?=gettext('Thresholds in')?> &deg;C <?=gettext('(1 to 100):')?></label>
+		</div>
 
-			</td>
-		</tr>
-		<tr>
-			<td class="text-right">
-				<?=gettext('Core Critical:')?>
-			</td>
-			<td>
-				<input type="text" maxlength="3" size="3" class="formfld unknown"
-					name="thermal_sensors_widget_core_critical_threshold"
-					id="thermal_sensors_widget_core_critical_threshold"
-					value="<?= $thermal_sensors_widget_coreCriticalTempThreshold ?>" />
-			</td>
-			<td class="text-right">
+		<div class="form-group">
+			<label class="col-sm-4 control-label"><?=gettext('Zone Warning')?></label>
+			<div class="col-sm-2">
+				<input type="text" name="thermal_sensors_widget_zone_warning_threshold" id="thermal_sensors_widget_zone_warning_threshold" value="<?= $thermal_sensors_widget_zoneWarningTempThreshold; ?>" class="form-control" />
+			</div>
+		</div>
 
-			</td>
-		</tr>
-		<tr>
-			<td class="text-right" colspan="3">
-				<button type="submit" id="thermal_sensors_widget_submit" name="thermal_sensors_widget_submit" class="btn btn-primary btn-sm" value="Save">
-					<i class="fa fa-save icon-embed-btn"></i>
-					<?=gettext("Save")?>
-				</button>
-			</td>
-		</tr>
-		<tr>
-			<td class="text-left" colspan="3">
-				<span><?=gettext('* A proper Thermal Sensor / Module can be configured under')?> <br />
-				&nbsp;&nbsp;&nbsp;<a href="system_advanced_misc.php"><?=gettext('System')?> &gt; <?=gettext('Advanced')?> &gt; <?=gettext('Miscellaneous')?> : <?=gettext('Thermal Sensors')?> <?=gettext('section')?></a>.</span>
-			</td>
-		</tr>
-	</table>
-</form>
+		<div class="form-group">
+			<label class="col-sm-4 control-label"><?=gettext('Zone Critical')?></label>
+			<div class="col-sm-2">
+				<input type="text" name="thermal_sensors_widget_zone_critical_threshold" id="thermal_sensors_widget_zone_critical_threshold" value="<?= $thermal_sensors_widget_zoneCriticalTempThreshold; ?>" class="form-control" />
+			</div>
+		</div>
 
+		<div class="form-group">
+			<label class="col-sm-4 control-label"><?=gettext('Core Warning')?></label>
+			<div class="col-sm-2">
+				<input type="text" name="thermal_sensors_widget_core_warning_threshold" id="thermal_sensors_widget_core_warning_threshold" value="<?= $thermal_sensors_widget_coreWarningTempThreshold; ?>" class="form-control" />
+			</div>
+		</div>
+
+		<div class="form-group">
+			<label class="col-sm-4 control-label"><?=gettext('Core Critical')?></label>
+			<div class="col-sm-2">
+				<input type="text" name="thermal_sensors_widget_core_critical_threshold" id="thermal_sensors_widget_core_critical_threshold" value="<?= $thermal_sensors_widget_coreCriticalTempThreshold; ?>" class="form-control" />
+			</div>
+		</div>
+
+		<div class="form-group">
+			<label class="col-sm-6 control-label"><?=gettext('Display settings:')?></label>
+		</div>
+
+		<div class="form-group">
+			<label for="thermal_sensors_widget_show_raw_output" class="col-sm-4 control-label"><?=gettext('Show raw output')?></label>
+			<div class="col-sm-6 checkbox">
+				<label>
+					<input type="checkbox" name="thermal_sensors_widget_show_raw_output" id="thermal_sensors_widget_show_raw_output" value="<?= $thermal_sensors_widget_showRawOutput; ?>" <?= ($thermal_sensors_widget_showRawOutput) ? " checked" : ""; ?>/>
+					<?=gettext('(no graph)')?>
+				</label>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<label for="thermal_sensors_widget_show_full_sensor_name" class="col-sm-4 control-label"><?=gettext('Show full sensor name')?></label>
+			<div class="col-sm-6 checkbox">
+				<label>
+					<input type="checkbox" name="thermal_sensors_widget_show_full_sensor_name" id="thermal_sensors_widget_show_full_sensor_name" value="<?= $thermal_sensors_widget_showFullSensorName; ?>" <?= ($thermal_sensors_widget_showFullSensorName) ? " checked" : ""; ?>/>
+				</label>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<div class="col-sm-offset-4 col-sm-6">
+				<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<span><?=gettext('* A proper Thermal Sensor / Module can be configured under')?> <br />
+			&nbsp;&nbsp;&nbsp;<a href="system_advanced_misc.php"><?=gettext('System')?> &gt; <?=gettext('Advanced')?> &gt; <?=gettext('Miscellaneous')?> : <?=gettext('Thermal Sensors')?> <?=gettext('section')?></a>.</span>
+		</div>
+	</form>

--- a/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
+++ b/src/usr/local/www/widgets/widgets/wake_on_lan.widget.php
@@ -39,6 +39,7 @@ if (!function_exists('get_wolent_key')) {
 }
 
 if ($_POST['widgetkey']) {
+	set_customwidgettitle($user_settings);
 
 	$validNames = array();
 
@@ -140,6 +141,7 @@ if (is_array($config['dhcpd'])) {
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/wake_on_lan.widget.php" method="post" class="form-horizontal">
+	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
 			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">


### PR DESCRIPTION
Forum: https://forum.pfsense.org/index.php?topic=129040.msg713499#msg713499

For all widgets that already have a "wrench tool" (i.e. they already have some custom settings or filter), this adds a setting to specify the widget title. So if you have a widget on the dashboard twice (presumably with different settings/filter selections), you will have the ability to give each widget a custom title.