### PR TITLE
Fix comparisons for CDATA tags in config

### DIFF
--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -247,7 +247,7 @@ function dump_xml_config_sub($arr, $indent) {
 						    (substr($ent, 0, 9) == "ldap_attr") ||
 						    (substr($ent, 0, 9) == "ldap_bind") ||
 						    (substr($ent, 0, 11) == "ldap_basedn") ||
-						    (substr($ent, 0, 18) == "ldap_authcn") ||
+						    (substr($ent, 0, 11) == "ldap_authcn") ||
 						    (substr($ent, 0, 19) == "ldap_extended_query")) {
 							$xmlconfig .= "<$ent><![CDATA[" . htmlentities($cval) . "]]></$ent>\n";
 						} else {
@@ -278,9 +278,9 @@ function dump_xml_config_sub($arr, $indent) {
 				    (substr($ent, 0, 9) == "ldap_attr") ||
 				    (substr($ent, 0, 9) == "ldap_bind") ||
 				    (substr($ent, 0, 11) == "ldap_basedn") ||
-				    (substr($ent, 0, 18) == "ldap_authcn") ||
+				    (substr($ent, 0, 11) == "ldap_authcn") ||
 				    (substr($ent, 0, 19) == "ldap_extended_query") ||
-				    (substr($ent, 0, 5) == "text")) {
+				    (substr($ent, 0, 4) == "text")) {
 					$xmlconfig .= "<$ent><![CDATA[" . htmlentities($val) . "]]></$ent>\n";
 				} else {
 					$xmlconfig .= "<$ent>" . htmlentities($val) . "</$ent>\n";


### PR DESCRIPTION
Some length numbers here do not match the strings they are comparing with. That looks very odd.
Note that:
```
substr($ent, 0, 5) == "text"
```
will return true when $ent is "text". So actually this "works". But it returns false if $ent is "text1" "texta" etc.
So it depends what the intention was.

If it was intended to match just "text" then I could be just:
```
$ent == "text"
```
If it was intended to match "text" "text1" "texta" etc, then it needs to be fixed like I suggest here.