### PR TITLE
Another wat to match tags for CDATA

### DIFF
--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -243,12 +243,12 @@ function dump_xml_config_sub($arr, $indent) {
 							$xmlconfig .= "<$ent></$ent>\n";
 						} else if ((substr($ent, 0, 5) == "descr") ||
 						    (substr($ent, 0, 6) == "detail") ||
-						    (substr($ent, 0, 12) == "login_banner") ||
-						    (substr($ent, 0, 9) == "ldap_attr") ||
-						    (substr($ent, 0, 9) == "ldap_bind") ||
-						    (substr($ent, 0, 11) == "ldap_basedn") ||
-						    (substr($ent, 0, 18) == "ldap_authcn") ||
-						    (substr($ent, 0, 19) == "ldap_extended_query")) {
+						    ($ent == "login_banner") ||
+						    ($ent == "ldap_attr") ||
+						    ($ent == "ldap_bind") ||
+						    ($ent == "ldap_basedn") ||
+						    ($ent == "ldap_authcn") ||
+						    ($ent == "ldap_extended_query")) {
 							$xmlconfig .= "<$ent><![CDATA[" . htmlentities($cval) . "]]></$ent>\n";
 						} else {
 							$xmlconfig .= "<$ent>" . htmlentities($cval) . "</$ent>\n";
@@ -274,13 +274,13 @@ function dump_xml_config_sub($arr, $indent) {
 				$xmlconfig .= str_repeat("\t", $indent);
 				if ((substr($ent, 0, 5) == "descr") ||
 				    (substr($ent, 0, 6) == "detail") ||
-				    (substr($ent, 0, 12) == "login_banner") ||
-				    (substr($ent, 0, 9) == "ldap_attr") ||
-				    (substr($ent, 0, 9) == "ldap_bind") ||
-				    (substr($ent, 0, 11) == "ldap_basedn") ||
-				    (substr($ent, 0, 18) == "ldap_authcn") ||
-				    (substr($ent, 0, 19) == "ldap_extended_query") ||
-				    (substr($ent, 0, 5) == "text")) {
+				    ($ent == "login_banner") ||
+				    ($ent == "ldap_attr") ||
+				    ($ent == "ldap_bind") ||
+				    ($ent == "ldap_basedn") ||
+				    ($ent == "ldap_authcn") ||
+				    ($ent == "ldap_extended_query") ||
+				    ($ent == "text")) {
 					$xmlconfig .= "<$ent><![CDATA[" . htmlentities($val) . "]]></$ent>\n";
 				} else {
 					$xmlconfig .= "<$ent>" . htmlentities($val) . "</$ent>\n";


### PR DESCRIPTION
I suspect that we only want to match exact field names like "ldap_authcn" and so on anyway, so this code could remove the substr() stuff.
I left the "descr" and "detail" clauses, because maybe it is intended to match "descr1" "detail01" and stuff like that also.