### PR TITLE
Fix interface down in interface statistics widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -56,9 +56,16 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	print(		"<th></th>");
 
 	foreach ($ifdescrs as $ifdescr => $ifname) {
-		if (!in_array($ifdescr, $skipinterfaces)) {
-			print(		"<th>" . $ifname . "</th>");
-			$interface_is_displayed = true;
+		if (in_array($ifdescr, $skipinterfaces)) {
+			continue;
+		}
+
+		$interface_is_displayed = true;
+		$ifinfo_arr[$ifdescr] = get_interface_info($ifdescr);
+		$ifinfo_arr[$ifdescr]['inbytes'] = format_bytes($ifinfo_arr[$ifdescr]['inbytes']);
+		$ifinfo_arr[$ifdescr]['outbytes'] = format_bytes($ifinfo_arr[$ifdescr]['outbytes']);
+		if ($ifinfo_arr[$ifdescr]['status'] != "down") {
+			print("<th>q" . $ifname . "</th>");
 		}
 	}
 
@@ -79,16 +86,10 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 				continue;
 			}
 
-			$ifinfo = get_interface_info($ifdescr);
-
-			if ($ifinfo['status'] == "down") {
-				continue;
+			if ($ifinfo_arr[$ifdescr]['status'] != "down") {
+				print("<td>" . (isset($ifinfo_arr[$ifdescr][$key]) ? htmlspecialchars($ifinfo_arr[$ifdescr][$key]) : 'n/a') . "</td>");
 			}
 
-			$ifinfo['inbytes'] = format_bytes($ifinfo['inbytes']);
-			$ifinfo['outbytes'] = format_bytes($ifinfo['outbytes']);
-
-			print("<td>" . (isset($ifinfo[$key]) ? htmlspecialchars($ifinfo[$key]) : 'n/a') . "</td>");
 		}
 
 		print(		"</td>");


### PR DESCRIPTION
If an interface is down, the widget would write the interface description in a column heading but then omit the stats items. So later columns (to the right) would have the headings and stats items out of line.
This also fixes the performance problem that get_interface_info($ifdescr) was being called for every row of stats data for every interface. i.e. it was called 7 times for each interface when 1 time is enough.