### PR TITLE
Set default language in General Setup to en_US

### DIFF
--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -47,6 +47,11 @@ if (!isset($config['system']['webgui']['dashboardcolumns'])) {
 	$config['system']['webgui']['dashboardcolumns'] = 2;
 }
 
+// set default language if unset
+if (!isset($config['system']['language'])) {
+	$config['system']['language'] = 'en_US';
+}
+
 $dnsgw_counter = 1;
 
 while (isset($config["system"]["dns{$dnsgw_counter}gw"])) {


### PR DESCRIPTION
Since https://github.com/pfsense/pfsense/commit/fdcde31b4a910c4e058513c1e3f68a62e722da6b added German to the top of the get_locale_list() array, if you start with a default system and go to System->General Setup (make some changes to other fields if you like) and press Save, you end up in German because that is what gets selected in the dropdown when the config does not yet have a language in it.
The code assumed that the language of the default system is the language at the top of the list, which is no longer true.