### PR TITLE
get_pkg_info improve installed_pkgs_only case

### DIFF
--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -354,6 +354,12 @@ function get_pkg_info($pkgs = 'all', $remote_repo_usage_disabled = false,
 	}
 
 	
+	if ($installed_pkgs_only && !is_pkg_installed($pkgs)) {
+		// Return early if the caller wants just installed packages and there are none.
+		// Saves doing any calls that might access a remote package repo.
+		return array();
+	}
+
 	if (!function_exists('is_subsystem_dirty')) {
 		require_once("util.inc");
 	}
@@ -374,13 +380,18 @@ function get_pkg_info($pkgs = 'all', $remote_repo_usage_disabled = false,
 		$extra_param = "-U ";
 	}
 
-	if (!$installed_pkgs_only) {
+	// If we want more than just the currently installed packages or
+	//    we want up-to-date remote repo info
+	// then do a full pkg search
+	if (!$installed_pkgs_only || !$remote_repo_usage_disabled) {
 		$rc = pkg_exec(
 		    "search {$extra_param}-R --raw-format json-compact " .
 		    $pkgs, $out, $err);
 	}
-	if (($installed_pkgs_only || ($rc != 0 && $remote_repo_usage_disabled))
-	    && is_pkg_installed($pkgs)) {
+
+	if (($installed_pkgs_only || $rc != 0) &&
+	    $remote_repo_usage_disabled &&
+	    is_pkg_installed($pkgs)) {
 		/*
 		 * Fall back on pkg info to return locally installed matching
 		 * pkgs instead, if:
@@ -391,7 +402,9 @@ function get_pkg_info($pkgs = 'all', $remote_repo_usage_disabled = false,
 		 *       but it didn't have any contents, or for other reasons
 		 *       returned an error.
 		 *   AND
-		 *   (2) at least some pkgs matching <pattern> are installed
+		 *   (2) remote repo data is not required
+		 *   AND
+		 *   (3) at least some pkgs matching <pattern> are installed
 		 *
 		 * Following an unsuccessful attempt to access a remote repo
 		 * catalog, the local copy is wiped clear. Thereafter any
@@ -455,8 +468,11 @@ function get_pkg_info($pkgs = 'all', $remote_repo_usage_disabled = false,
 		    "https://github.com/pfsense/FreeBSD-ports/commits/devel/" .
 		    $pkg_info['categories'][0] . '/' . $pkg_info['name'];
 
+		$pkg_is_installed = false;
+
 		if (is_pkg_installed($pkg_info['name'])) {
 			$pkg_info['installed'] = true;
+			$pkg_is_installed = true;
 
 			$rc = pkg_exec("query %v {$pkg_info['name']}", $out,
 			    $err);
@@ -477,12 +493,15 @@ function get_pkg_info($pkgs = 'all', $remote_repo_usage_disabled = false,
 			    $out);
 		} else if (is_package_installed($pkg_info['shortname'])) {
 			$pkg_info['broken'] = true;
+			$pkg_is_installed = true;
 		}
 
 		$pkg_info['desc'] = preg_replace('/\n+WWW:.*$/', '',
 		    $pkg_info['desc']);
 
-		$result[] = $pkg_info;
+		if (!$installed_pkgs_only || $pkg_is_installed) {
+			$result[] = $pkg_info;
+		}
 		unset($pkg_info);
 	}
 

--- a/src/usr/local/www/pkg_mgr_installed.php
+++ b/src/usr/local/www/pkg_mgr_installed.php
@@ -46,28 +46,19 @@ if (($_REQUEST) && ($_REQUEST['ajax'])) {
 }
 
 function get_pkg_table() {
-	$installed_packages = array();
-	$package_list = get_pkg_info();
+	$installed_packages = get_pkg_info('all', false, true);
 
-	if (!$package_list) {
+	if (is_array($input_errors)) {
 		print("error");
 		exit;
 	}
-
-	foreach ($package_list as $pkg) {
-		if (!isset($pkg['installed']) && !isset($pkg['broken'])) {
-			continue;
-		}
-		$installed_packages[] = $pkg;
-	}
-
-	$pkgtbl = "";
 
 	if (empty($installed_packages)) {
 		print ("nopkg");
 		exit;
 	}
 
+	$pkgtbl = "";
 	$pkgtbl .='		<div class="table-responsive">';
 	$pkgtbl .='		<table class="table table-striped table-hover table-condensed">';
 	$pkgtbl .='			<thead>';


### PR DESCRIPTION
1) If the caller asks for installed_pkgs_only and actually there are no locally installed packages, then return early with an empty array. That saves bothering to wait for remote repo operations when on a "new" system that does not have any packages installed - the "Installed Packages" GUI display can return quickly.

2) If the caller asks for installed_pkgs_only then previously it would only return the local information, regardless of the setting of remote_repo_usage_disabled. Now if installed_pkgs_only is true but remote_repo_usage_disabled is false, it will go out and update the local data from remote, then build a return array of just the installed packages. This allows a caller to do:
```
$installed_packages = get_pkg_info('all', false, true);
```
to get just an array of installed packages, but using the latest remote repo data (if the remote repo is reachable). That will ensure the caller can find out if there is a new version of a package available.
Previously that parameter combination to get_pkg_info() did not do what the caller might reasonably expect.

3) Use the above in pkg_mgr_installed.php to get just the installed packages, and get "them" quickly if there are no installed packages.
Tricky bit: the only way to really know if get_pkg_info() had real errors to tell you about is to look at the $input_errors[] array, which get_pkg_info() adds to as a global. It is perfectly OK for get_pkg_info() to return an empty array when there are no matching packages - e.g. the case of no installed packages.