### PR TITLE
Unbound: Added ability to disable automatically added host entries

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -489,7 +489,10 @@ function system_hosts_dhcpd_entries() {
 
 /* Concatenate local, dnsmasq/unbound and dhcpd/dhcpdv6 hosts entries */
 function system_hosts_entries($dnscfg) {
-	$local = system_hosts_local_entries();
+	$local = array();
+	if (!isset($dnscfg['disable_auto_added_host_entries'])) {
+		$local = system_hosts_local_entries();
+	}
 
 	$dns = array();
 	$dhcpd = array();
@@ -1192,7 +1195,7 @@ EOD;
 			}
 		}
 	}
-	
+
 	$syslogd_sockets = "";
 	foreach ($log_sockets as $log_socket) {
 		// Ensure that the log directory exists
@@ -2155,7 +2158,7 @@ function system_dmesg_save() {
 
 	fclose($fd);
 	unset($dmesg);
-	
+
 	// vm-bhyve expects dmesg.boot at the standard location
 	@symlink("{$g['varlog_path']}/dmesg.boot", "{$g['varrun_path']}/dmesg.boot");
 

--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -549,29 +549,24 @@ function unbound_add_host_entries($cfgsubdir = "") {
 		}
 
 		$unbound_entries = "local-zone: \"{$config['system']['domain']}\" {$system_domain_local_zone_type}\n";
-
-		$hosts = system_hosts_entries($config['unbound']);
-		$added_ptr = array();
-		foreach ($hosts as $host) {
-			if (is_ipaddrv4($host['ipaddr'])) {
-				$type = 'A';
-			} else if (is_ipaddrv6($host['ipaddr'])) {
-				$type = 'AAAA';
-			} else {
-				continue;
-			}
-
-			if (!$added_ptr[$host['ipaddr']]) {
-				$unbound_entries .= "local-data-ptr: \"{$host['ipaddr']} {$host['fqdn']}\"\n";
-				$added_ptr[$host['ipaddr']] = true;
-			}
-			$unbound_entries .= "local-data: \"{$host['fqdn']} {$type} {$host['ipaddr']}\"\n";
-		}
 	}
-	else {
-		// Adds a comment to the file to make it clear it's there for a reason and to clear the file
-		// when the user enables this option.
-		$unbound_entries = "# Empty since file generation has been disabled in the options.";
+
+	$hosts = system_hosts_entries($config['unbound']);
+	$added_ptr = array();
+	foreach ($hosts as $host) {
+		if (is_ipaddrv4($host['ipaddr'])) {
+			$type = 'A';
+		} else if (is_ipaddrv6($host['ipaddr'])) {
+			$type = 'AAAA';
+		} else {
+			continue;
+		}
+
+		if (!$added_ptr[$host['ipaddr']]) {
+			$unbound_entries .= "local-data-ptr: \"{$host['ipaddr']} {$host['fqdn']}\"\n";
+			$added_ptr[$host['ipaddr']] = true;
+		}
+		$unbound_entries .= "local-data: \"{$host['fqdn']} {$type} {$host['ipaddr']}\"\n";
 	}
 
 	// Write out entries

--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -539,31 +539,39 @@ function unbound_add_domain_overrides($pvt_rev="", $cfgsubdir = "") {
 function unbound_add_host_entries($cfgsubdir = "") {
 	global $config, $g;
 
-	// Make sure the config setting is a valid unbound local zone type.  If not use "transparent".
-	if (array_key_exists($config['unbound']['system_domain_local_zone_type'], unbound_local_zone_types())) {
-		$system_domain_local_zone_type = $config['unbound']['system_domain_local_zone_type'];
-	} else {
-		$system_domain_local_zone_type = "transparent";
-	}
-
-	$unbound_entries = "local-zone: \"{$config['system']['domain']}\" {$system_domain_local_zone_type}\n";
-
-	$hosts = system_hosts_entries($config['unbound']);
-	$added_ptr = array();
-	foreach ($hosts as $host) {
-		if (is_ipaddrv4($host['ipaddr'])) {
-			$type = 'A';
-		} else if (is_ipaddrv6($host['ipaddr'])) {
-			$type = 'AAAA';
+	// Check if auto add host entries is not set
+	if (!isset($config['unbound']['disable_auto_added_host_entries'])) {
+		// Make sure the config setting is a valid unbound local zone type.  If not use "transparent".
+		if (array_key_exists($config['unbound']['system_domain_local_zone_type'], unbound_local_zone_types())) {
+			$system_domain_local_zone_type = $config['unbound']['system_domain_local_zone_type'];
 		} else {
-			continue;
+			$system_domain_local_zone_type = "transparent";
 		}
 
-		if (!$added_ptr[$host['ipaddr']]) {
-			$unbound_entries .= "local-data-ptr: \"{$host['ipaddr']} {$host['fqdn']}\"\n";
-			$added_ptr[$host['ipaddr']] = true;
+		$unbound_entries = "local-zone: \"{$config['system']['domain']}\" {$system_domain_local_zone_type}\n";
+
+		$hosts = system_hosts_entries($config['unbound']);
+		$added_ptr = array();
+		foreach ($hosts as $host) {
+			if (is_ipaddrv4($host['ipaddr'])) {
+				$type = 'A';
+			} else if (is_ipaddrv6($host['ipaddr'])) {
+				$type = 'AAAA';
+			} else {
+				continue;
+			}
+
+			if (!$added_ptr[$host['ipaddr']]) {
+				$unbound_entries .= "local-data-ptr: \"{$host['ipaddr']} {$host['fqdn']}\"\n";
+				$added_ptr[$host['ipaddr']] = true;
+			}
+			$unbound_entries .= "local-data: \"{$host['fqdn']} {$type} {$host['ipaddr']}\"\n";
 		}
-		$unbound_entries .= "local-data: \"{$host['fqdn']} {$type} {$host['ipaddr']}\"\n";
+	}
+	else {
+		// Adds a comment to the file to make it clear it's there for a reason and to clear the file
+		// when the user enables this option.
+		$unbound_entries = "# Empty since file generation has been disabled in the options.";
 	}
 
 	// Write out entries

--- a/src/usr/local/www/services_unbound_advanced.php
+++ b/src/usr/local/www/services_unbound_advanced.php
@@ -364,7 +364,7 @@ $section->addInput(new Form_Checkbox(
 	'Disable Auto-added Host Entries',
 	'Disable the automatically-added host entries',
 	$pconfig['disable_auto_added_host_entries']
-))->setHelp('By default, the primary IPv4 and IPv6 addresses of of this firewall are added as records for the system domain of this firewall as configured in %1$sSystem: General Setup%2$s. This disables the auto generation of these entries.', '<a href="system.php">', '</a>');
+))->setHelp('By default, the primary IPv4 and IPv6 addresses of this firewall are added as records for the system domain of this firewall as configured in %1$sSystem: General Setup%2$s. This disables the auto generation of these entries.', '<a href="system.php">', '</a>');
 
 $section->addInput(new Form_Checkbox(
 	'use_caps',

--- a/src/usr/local/www/services_unbound_advanced.php
+++ b/src/usr/local/www/services_unbound_advanced.php
@@ -71,6 +71,10 @@ if (isset($config['unbound']['disable_auto_added_access_control'])) {
 	$pconfig['disable_auto_added_access_control'] = true;
 }
 
+if (isset($config['unbound']['disable_auto_host_entries'])) {
+	$pconfig['disable_auto_added_host_entries'] = true;
+}
+
 if (isset($config['unbound']['use_caps'])) {
 	$pconfig['use_caps'] = true;
 }
@@ -169,6 +173,12 @@ if ($_POST) {
 				$config['unbound']['disable_auto_added_access_control'] = true;
 			} else {
 				unset($config['unbound']['disable_auto_added_access_control']);
+			}
+
+			if (isset($_POST['disable_auto_added_host_entries'])) {
+				$config['unbound']['disable_auto_added_host_entries'] = true;
+			} else {
+				unset($config['unbound']['disable_auto_added_host_entries']);
 			}
 
 			if (isset($_POST['use_caps'])) {
@@ -348,6 +358,14 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['disable_auto_added_access_control']
 ))->setHelp('By default, IPv4 and IPv6 networks residing on internal interfaces of this system are permitted. ' .
 			'Allowed networks must be manually configured on the Access Lists tab if the auto-added entries are disabled.');
+
+$section->addInput(new Form_Checkbox(
+	'disable_auto_added_host_entries',
+	'Disable Auto-added Host Entries',
+	'Disable the automatically-added host entries',
+	$pconfig['disable_auto_added_host_entries']
+))->setHelp('By default, the primary IPv4 and IPv6 addresses of the pfsense machine are added as records for the pfSense system domain (System | General Setup | Domain). ' .
+			'This disables the auto generation of these entries.');
 
 $section->addInput(new Form_Checkbox(
 	'use_caps',

--- a/src/usr/local/www/services_unbound_advanced.php
+++ b/src/usr/local/www/services_unbound_advanced.php
@@ -71,7 +71,7 @@ if (isset($config['unbound']['disable_auto_added_access_control'])) {
 	$pconfig['disable_auto_added_access_control'] = true;
 }
 
-if (isset($config['unbound']['disable_auto_host_entries'])) {
+if (isset($config['unbound']['disable_auto_added_host_entries'])) {
 	$pconfig['disable_auto_added_host_entries'] = true;
 }
 
@@ -364,8 +364,7 @@ $section->addInput(new Form_Checkbox(
 	'Disable Auto-added Host Entries',
 	'Disable the automatically-added host entries',
 	$pconfig['disable_auto_added_host_entries']
-))->setHelp('By default, the primary IPv4 and IPv6 addresses of the pfsense machine are added as records for the pfSense system domain (System | General Setup | Domain). ' .
-			'This disables the auto generation of these entries.');
+))->setHelp('By default, the primary IPv4 and IPv6 addresses of of this firewall are added as records for the system domain of this firewall as configured in %1$sSystem: General Setup%2$s. This disables the auto generation of these entries.', '<a href="system.php">', '</a>');
 
 $section->addInput(new Form_Checkbox(
 	'use_caps',


### PR DESCRIPTION
I needed to disable the host entries automatically enabled by pfSense since my zone is DNSSEC signed and this record would not be returned with DNSSEC, the clients that validated DNSSEC would not be able to resolve the DNS entry.

Found that there was another ask on the forum for this:

https://forum.pfsense.org/index.php?topic=110970.0

Since this is my first pull request let me know if it is not done correctly.

Thank you,

Robbert