### PR TITLE
Make multi-widget optional by widget

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -117,7 +117,12 @@ foreach (glob("/usr/local/www/widgets/widgets/*.widget.php") as $file) {
 		$widgettitle = ucwords(str_replace('_', ' ', $basename));
 	}
 
-	$known_widgets[$basename . '-0'] = array('basename' => $basename, 'title' => $widgettitle, 'display' => 'none');
+	$known_widgets[$basename . '-0'] = array(
+		'basename' => $basename,
+		'title' => $widgettitle,
+		'display' => 'none',
+		'multicopy' => ${$basename . '_allow_multiple_widget_copies'}
+	);
 }
 
 ##if no config entry found, initialize config entry
@@ -319,7 +324,11 @@ if ($user_settings['widgets']['sequence'] != "") {
 			'col' => $col,
 			'display' => $display,
 			'copynum' => $copynum,
+			'multicopy' => ${$basename . '_allow_multiple_widget_copies'}
 		);
+
+		// Update the known_widgets entry so we know if any copy of the widget is being displayed
+		$known_widgets[$basename . '-0']['display'] = $display;
 	}
 
 	// add widgets that may not be in the saved configuration, in case they are to be displayed later
@@ -376,8 +385,11 @@ $available = $known_widgets;
 uasort($available, function($a, $b){ return strcasecmp($a['title'], $b['title']); });
 
 foreach ($available as $widgetkey => $widgetconfig):
+	// If the widget supports multiple copies, or no copies are displayed yet, then it is available to add
+	if (($widgetconfig['multicopy']) || ($widgetconfig['display'] == 'none')):
 ?>
 		<div class="col-sm-3"><a href="#" id="btnadd-<?=$widgetconfig['basename']?>"><i class="fa fa-plus"></i> <?=$widgetconfig['title']?></a></div>
+	<?php endif; ?>
 <?php endforeach; ?>
 			</div>
 		</div>

--- a/src/usr/local/www/widgets/include/dyn_dns_status.inc
+++ b/src/usr/local/www/widgets/include/dyn_dns_status.inc
@@ -23,5 +23,6 @@
 //set variable for custom title
 $dyn_dns_status_title = gettext("Dynamic DNS Status");
 $dyn_dns_status_title_link = "services_dyndns.php";
+$dyn_dns_status_allow_multiple_widget_copies = true;
 
 ?>

--- a/src/usr/local/www/widgets/include/gateways.inc
+++ b/src/usr/local/www/widgets/include/gateways.inc
@@ -22,4 +22,5 @@
 //set variable for custom title
 $gateways_title = gettext("Gateways");
 $gateways_title_link = "status_gateways.php";
+$gateways_allow_multiple_widget_copies = true;
 ?>

--- a/src/usr/local/www/widgets/include/interface_statistics.inc
+++ b/src/usr/local/www/widgets/include/interface_statistics.inc
@@ -22,4 +22,5 @@
 //set variable for custom title
 $interface_statistics_title = gettext("Interface Statistics");
 $interface_statistics_title_link = "status_interfaces.php";
+$interface_statistics_allow_multiple_widget_copies = true;
 ?>

--- a/src/usr/local/www/widgets/include/interfaces.inc
+++ b/src/usr/local/www/widgets/include/interfaces.inc
@@ -22,5 +22,6 @@
 //set variable for custom title
 $interfaces_title = gettext("Interfaces");
 $interfaces_title_link = "status_interfaces.php";
+$interfaces_allow_multiple_widget_copies = true;
 
 ?>

--- a/src/usr/local/www/widgets/include/log.inc
+++ b/src/usr/local/www/widgets/include/log.inc
@@ -22,5 +22,6 @@
 //set variable for custom title
 $log_title = gettext("Firewall Logs");
 $log_title_link = "status_logs_filter.php";
+$log_allow_multiple_widget_copies = true;
 
 ?>

--- a/src/usr/local/www/widgets/include/openvpn.inc
+++ b/src/usr/local/www/widgets/include/openvpn.inc
@@ -21,4 +21,5 @@
 
 $openvpn_title = gettext("OpenVPN");
 $openvpn_title_link = "status_openvpn.php";
+$openvpn_allow_multiple_widget_copies = true;
 ?>

--- a/src/usr/local/www/widgets/include/picture.inc
+++ b/src/usr/local/www/widgets/include/picture.inc
@@ -1,9 +1,9 @@
 <?php
 /*
- * smart_status.inc
+ * picture.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2004-2017 Rubicon Communications, LLC (Netgate)
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +19,6 @@
  * limitations under the License.
  */
 
-//set variable for custom title
-$smart_status_title = gettext("S.M.A.R.T. Status");
-$smart_status_title_link = "diag_smart.php";
-$smart_status_allow_multiple_widget_copies = true;
+$picture_title = gettext("Picture");
+$picture_allow_multiple_widget_copies = true;
 ?>

--- a/src/usr/local/www/widgets/include/rss.inc
+++ b/src/usr/local/www/widgets/include/rss.inc
@@ -1,9 +1,9 @@
 <?php
 /*
- * smart_status.inc
+ * rss.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2004-2017 Rubicon Communications, LLC (Netgate)
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +19,6 @@
  * limitations under the License.
  */
 
-//set variable for custom title
-$smart_status_title = gettext("S.M.A.R.T. Status");
-$smart_status_title_link = "diag_smart.php";
-$smart_status_allow_multiple_widget_copies = true;
+$rss_title = gettext("RSS");
+$rss_allow_multiple_widget_copies = true;
 ?>

--- a/src/usr/local/www/widgets/include/services_status.inc
+++ b/src/usr/local/www/widgets/include/services_status.inc
@@ -23,5 +23,6 @@
 //set variable for custom title
 $services_status_title = gettext("Services Status");
 $services_status_title_link = "status_services.php";
+$services_status_allow_multiple_widget_copies = true;
 
 ?>

--- a/src/usr/local/www/widgets/include/system_information.inc
+++ b/src/usr/local/www/widgets/include/system_information.inc
@@ -1,9 +1,9 @@
 <?php
 /*
- * smart_status.inc
+ * system_information.inc
  *
  * part of pfSense (https://www.pfsense.org)
- * Copyright (c) 2004-2016 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2004-2017 Rubicon Communications, LLC (Netgate)
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +19,6 @@
  * limitations under the License.
  */
 
-//set variable for custom title
-$smart_status_title = gettext("S.M.A.R.T. Status");
-$smart_status_title_link = "diag_smart.php";
-$smart_status_allow_multiple_widget_copies = true;
+$system_information_title = gettext("System Information");
+$system_information_allow_multiple_widget_copies = true;
 ?>

--- a/src/usr/local/www/widgets/include/thermal_sensors.inc
+++ b/src/usr/local/www/widgets/include/thermal_sensors.inc
@@ -23,6 +23,7 @@
 //set variable for custom title
 $thermal_sensors_widget_title = gettext("Thermal Sensors");
 //$thermal_sensors_widget_link = "thermal_sensors.php";
+$thermal_sensors_allow_multiple_widget_copies = true;
 
 
 //returns core temp data (from coretemp.ko or amdtemp.ko driver) as "|"-delimited string.

--- a/src/usr/local/www/widgets/include/wake_on_lan.inc
+++ b/src/usr/local/www/widgets/include/wake_on_lan.inc
@@ -23,5 +23,6 @@
 //set variable for custom title
 $wake_on_lan_title = gettext("Wake-on-Lan");
 $wake_on_lan_title_link = "services_wol.php";
+$wake_on_lan_allow_multiple_widget_copies = true;
 
 ?>


### PR DESCRIPTION
1) Allow widgets to explicitly specify that they are capable of having multiple copies on the dashboard.
Done by adding a var like:
```
$picture_allow_multiple_widget_copies = true;
```
to the widget's include file in /usr/local/www/widgets/include

2) If a widget does not specify that it is capable, then only allow the user to put 1 copy of it on the dashboard.

This allows existing widgets, specially those in packages, to not break things by having users put them on the dashboard multiple times. When such widgets are ready and need to be able to support multiple copies, they can use (1) to flag the capability to the dashboard.