### PR TITLE
Make consistent rule information section

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -457,6 +457,47 @@ function gen_requirestatefilter_field(&$section, $value) {
 		'before the states are displayed. Useful for systems with large state tables.');
 }
 
+/****f* pfsense-utils/gen_created_updated_fields
+ * NAME
+ *   gen_created_updated_fields
+ * INPUTS
+ *   Pointer to form object
+ *   Array of created time and username
+ *   Array of updated time and username
+ * RESULT
+ *   no return value, section object is added to form if needed
+ ******/
+function gen_created_updated_fields(&$form, $created, $updated) {
+	$has_created_time = (isset($created['time']) && isset($created['username']));
+	$has_updated_time = (isset($updated['time']) && isset($updated['username']));
+
+	if ($has_created_time || $has_updated_time) {
+		$section = new Form_Section('Rule Information');
+
+		if ($has_created_time) {
+			$section->addInput(new Form_StaticText(
+				'Created',
+				sprintf(
+					gettext('%1$s by %2$s'),
+					date(gettext("n/j/y H:i:s"), $created['time']),
+					$created['username'])
+			));
+		}
+
+		if ($has_updated_time) {
+			$section->addInput(new Form_StaticText(
+				'Updated',
+				sprintf(
+					gettext('%1$s by %2$s'),
+					date(gettext("n/j/y H:i:s"), $updated['time']),
+					$updated['username'])
+			));
+		}
+
+		$form->add($section);
+	}
+}
+
 function hardware_offloading_applyflags($iface) {
 	global $config;
 

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -958,34 +958,7 @@ if (isset($id) && $a_nat[$id] && (!isset($_POST['dup']) || !is_numericint($_POST
 
 $form->add($section);
 
-$has_created_time = (isset($a_nat[$id]['created']) && is_array($a_nat[$id]['created']));
-$has_updated_time = (isset($a_nat[$id]['updated']) && is_array($a_nat[$id]['updated']));
-
-if ($has_created_time || $has_updated_time) {
-	$section = new Form_Section('Rule Information');
-
-	if ($has_created_time) {
-		$section->addInput(new Form_StaticText(
-			'Created',
-			sprintf(
-				gettext('%1$s by %2$s'),
-				date(gettext("n/j/y H:i:s"), $a_nat[$id]['created']['time']),
-				$a_nat[$id]['created']['username'])
-		));
-	}
-
-	if ($has_updated_time) {
-		$section->addInput(new Form_StaticText(
-			'Updated',
-			sprintf(
-				gettext('%1$s by %2$s'),
-				date(gettext("n/j/y H:i:s"), $a_nat[$id]['updated']['time']),
-				$a_nat[$id]['updated']['username'])
-		));
-	}
-
-	$form->add($section);
-}
+gen_created_updated_fields($form, $a_nat[$id]['created'], $a_nat[$id]['updated']);
 
 if (isset($id) && $a_nat[$id]) {
 	$form->addGlobal(new Form_Input(

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -684,34 +684,7 @@ $section->addInput(new Form_Input(
 
 $form->add($section);
 
-$has_created_time = (isset($a_out[$id]['created']) && is_array($a_out[$id]['created']));
-$has_updated_time = (isset($a_out[$id]['updated']) && is_array($a_out[$id]['updated']));
-
-if ($has_created_time || $has_updated_time) {
-	$section = new Form_Section('Rule Information');
-
-	if ($has_created_time) {
-		$section->addInput(new Form_StaticText(
-			'Created',
-			sprintf(
-				gettext('%1$s by %2$s'),
-				date(gettext("n/j/y H:i:s"), $a_out[$id]['created']['time']),
-				$a_out[$id]['created']['username'])
-		));
-	}
-
-	if ($has_updated_time) {
-		$section->addInput(new Form_StaticText(
-			'Updated',
-			sprintf(
-				gettext('%1$s by %2$s'),
-				date(gettext("n/j/y H:i:s"), $a_out[$id]['updated']['time']),
-				$a_out[$id]['updated']['username'])
-		));
-	}
-
-	$form->add($section);
-}
+gen_created_updated_fields($form, $a_out[$id]['created'], $a_out[$id]['updated']);
 
 print($form);
 

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1746,36 +1746,10 @@ $section->add($group)->setHelp('Choose the Acknowledge Queue only if there is a 
 	'selected Queue.'
 );
 
-$has_created_time = (isset($a_filter[$id]['created']) && is_array($a_filter[$id]['created']));
-$has_updated_time = (isset($a_filter[$id]['updated']) && is_array($a_filter[$id]['updated']));
-
-
-if ($has_created_time || $has_updated_time) {
-	$form->add($section);
-	$section = new Form_Section('Rule Information');
-
-	if ($has_created_time) {
-		$section->addInput(new Form_StaticText(
-			'Created',
-			sprintf(
-				gettext('%1$s by %2$s'),
-				date(gettext("n/j/y H:i:s"), $a_filter[$id]['created']['time']),
-				'<b>' . $a_filter[$id]['created']['username'] . '</b>')
-		));
-	}
-
-	if ($has_updated_time) {
-		$section->addInput(new Form_StaticText(
-			'Updated',
-			sprintf(
-				gettext('%1$s by %2$s'),
-				date(gettext("n/j/y H:i:s"), $a_filter[$id]['updated']['time']),
-				'<b>' . $a_filter[$id]['updated']['username'] . '</b>')
-		));
-	}
-}
-
 $form->add($section);
+
+gen_created_updated_fields($form, $a_filter[$id]['created'], $a_filter[$id]['updated']);
+
 echo $form;
 ?>
 


### PR DESCRIPTION
I noticed that in firewall rules edit the created/updated username was in bold. For NAT port forward and nat outbound edit it was just in plain text. When I went looking, of course there was repeated code, but slightly different.

Put the code into a common function and call that.

I made the text not bold, taking the democratic position that 2 out of 3 had plain text and 1 out of 3 had bold. So now they are all consistent.