### PR TITLE
Diag DNS fix update alias button text after add alias

### DIFF
--- a/src/usr/local/www/diag_dns.php
+++ b/src/usr/local/www/diag_dns.php
@@ -212,6 +212,8 @@ if ($createdalias) {
 	} else {
 		print_info_box(gettext("Alias was created successfully."), 'success');
 	}
+
+	$alias_exists = true;
 }
 
 $form = new Form(false);


### PR DESCRIPTION
1) Lookup a name with Diag DNS
2) Press "Add Alias"
The alias is added, but the button still says "Add Alias".

Actually the alias exists by now. The button should say "Update Alias".

Fix: once we have emitted the alias create/update success message, we can set $alias_exists true so that the rest of the code is based on the (possibly new) state.