### PR TITLE
Diag DNS do not show Add Alias if no priv to add alais

### DIFF
--- a/src/usr/local/www/diag_dns.php
+++ b/src/usr/local/www/diag_dns.php
@@ -84,7 +84,7 @@ function resolve_host_addresses($host) {
 	return $resolved;
 }
 
-if (isset($_POST['create_alias']) && (is_hostname($host) || is_ipaddr($host))) {
+if (isAllowedPage('firewall_aliases_edit.php') && isset($_POST['create_alias']) && (is_hostname($host) || is_ipaddr($host))) {
 	$resolved = gethostbyname($host);
 	$type = "hostname";
 	if ($resolved) {
@@ -234,7 +234,7 @@ $form->addGlobal(new Form_Button(
         'fa-search'
 ))->addClass('btn-primary');
 
-if (!empty($resolved)) {
+if (!empty($resolved) && isAllowedPage('firewall_aliases_edit.php')) {
 	if ($alias_exists) {
 		$button_text = gettext("Update alias");
 	} else {


### PR DESCRIPTION
Fixes https://redmine.pfsense.org/issues/7584
Only show the "Add Alias" button and do the add if the user has the page priv to add/edit an alias.