### PR TITLE
Diag DNS do not create an empty alias if name does not resolve

### DIFF
--- a/src/usr/local/www/diag_dns.php
+++ b/src/usr/local/www/diag_dns.php
@@ -90,6 +90,7 @@ if (isset($_POST['create_alias']) && (is_hostname($host) || is_ipaddr($host))) {
 	if ($resolved) {
 		$resolved = resolve_host_addresses($host);
 		$isfirst = true;
+		$addresses = "";
 		foreach ($resolved as $re) {
 			if ($re['data'] != "") {
 				if (!$isfirst) {
@@ -107,18 +108,24 @@ if (isset($_POST['create_alias']) && (is_hostname($host) || is_ipaddr($host))) {
 				$isfirst = false;
 			}
 		}
-		$newalias = array();
-		$newalias['name'] = $aliasname;
-		$newalias['type'] = "network";
-		$newalias['address'] = $addresses;
-		$newalias['descr'] = gettext("Created from Diagnostics-> DNS Lookup");
-		if ($alias_exists) {
-			$a_aliases[$id] = $newalias;
+		if ($addresses == "") {
+			$couldnotcreatealias = true;
 		} else {
-			$a_aliases[] = $newalias;
+			$newalias = array();
+			$newalias['name'] = $aliasname;
+			$newalias['type'] = "network";
+			$newalias['address'] = $addresses;
+			$newalias['descr'] = gettext("Created from Diagnostics-> DNS Lookup");
+			if ($alias_exists) {
+				$a_aliases[$id] = $newalias;
+			} else {
+				$a_aliases[] = $newalias;
+			}
+			write_config(gettext("Created an alias from Diagnostics - DNS Lookup page."));
+			$createdalias = true;
 		}
-		write_config(gettext("Created an alias from Diagnostics - DNS Lookup page."));
-		$createdalias = true;
+	} else {
+		$couldnotcreatealias = true;
 	}
 }
 
@@ -211,6 +218,14 @@ if ($createdalias) {
 		print_info_box(gettext("Alias was updated successfully."), 'success');
 	} else {
 		print_info_box(gettext("Alias was created successfully."), 'success');
+	}
+}
+
+if ($couldnotcreatealias) {
+	if ($alias_exists) {
+		print_info_box(sprintf(gettext("Could not update alias for %s"), $host), 'warning', false);
+	} else {
+		print_info_box(sprintf(gettext("Could not create alias for %s"), $host), 'warning', false);
 	}
 }
 


### PR DESCRIPTION
1) In Diag DNS, lookup a valid name, e.g. pfsense.org
2) Modify the Host field to something that does not resolve - e.g. pfsensezzzaaa.org
3) Press "Add Alias"
Problem: an empty alias is created for pfsensezzzaaa.org

This can also happen if you had done a successful lookup of some name "xyz.org" but then by the time you press "Add Alias" your DNS resolution is not working any more, or that name really no longer resolves or... - but of course that is a more rare instance.

Enhance the code that actually adds the alias so that it will never add an empty alias, and will report a warning back if the problem occurs.

Note: there is another issue, a little separate. If the user changes the Host field, then it would be good to hide the "Add Alias" button on-the-fly so that they cannot add an alias until they have seen a good lookup of the current string in the Host field. I will have a look at doing that next.