### PR TITLE
Diag DNS disable Add Alias button when host field is changed

### DIFF
--- a/src/usr/local/www/diag_dns.php
+++ b/src/usr/local/www/diag_dns.php
@@ -316,4 +316,21 @@ if (!$input_errors && $type) {
 </div>
 <?php
 }
+?>
+<script type="text/javascript">
+//<![CDATA[
+events.push(function() {
+	var original_host = "<?=$host;?>";
+
+	$('input[name="host"]').on('input', function() {
+		if ($('#host').val() == original_host) {
+			disableInput('create_alias', false);
+		} else {
+			disableInput('create_alias', true);
+		}
+	});
+});
+//]]>
+</script>
+<?php
 include("foot.inc");


### PR DESCRIPTION
If the user edits the host field, we do not want to let them press "Add Alias"/"Update Alias" until they have actually done a lookup for the new host string. So disable the button when they have made a change to soe different host string.