### PR TITLE
Remove duplicate code in get_uptime()

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1442,8 +1442,11 @@ function is_pppoe_server_enabled() {
 	return $pppoeenable;
 }
 
-/* Optional arg forces hh:mm:ss without days */
-function convert_seconds_to_dhms($sec, $showhoursonly = false) {
+/* Optional args:
+ * $showhoursonly forces hh:mm:ss without days
+ * $showHMS outputs 30h 20m 15s rather than the default 30:20:15
+*/
+function convert_seconds_to_dhms($sec, $showhoursonly = false, $showHMS = false) {
 	if (!is_numericint($sec)) {
 		return '-';
 	}
@@ -1453,7 +1456,7 @@ function convert_seconds_to_dhms($sec, $showhoursonly = false) {
 					(int)(($sec % 3600)/60),
 					$sec % 60
 				);
-	return ($d > 0 ? $d . 'd ' : '') . sprintf('%02d:%02d:%02d', $h, $m, $s);
+	return ($d > 0 ? $d . 'd ' : '') . sprintf(($showHMS ? '%02dh %02dm %02ds' : '%02d:%02d:%02d'), $h, $m, $s);
 }
 
 /* Compute the total uptime from the ppp uptime log file in the conf directory */

--- a/src/usr/local/www/includes/functions.inc.php
+++ b/src/usr/local/www/includes/functions.inc.php
@@ -42,41 +42,14 @@ function get_stats() {
 }
 
 function get_uptime() {
-	$uptime = get_uptime_sec();
+	$uptime_sec = get_uptime_sec();
 
-	if (intval($uptime) == 0) {
+	if (intval($uptime) > 0) {
+		return convert_seconds_to_dhms($uptime_sec);
+	} else {
 		return;
 	}
 
-	$updays = (int)($uptime / 86400);
-	$uptime %= 86400;
-	$uphours = (int)($uptime / 3600);
-	$uptime %= 3600;
-	$upmins = (int)($uptime / 60);
-	$uptime %= 60;
-	$upsecs = (int)($uptime);
-
-	$uptimestr = "";
-	if ($updays > 1) {
-		$uptimestr .= "$updays Days ";
-	} else if ($updays > 0) {
-		$uptimestr .= "1 Day ";
-	}
-
-	if ($uphours > 1) {
-		$hours = "s";
-	}
-
-	if ($upmins > 1) {
-		$minutes = "s";
-	}
-
-	if ($upmins > 1) {
-		$seconds = "s";
-	}
-
-	$uptimestr .= sprintf("%02d Hour$hours %02d Minute$minutes %02d Second$seconds", $uphours, $upmins, $upsecs);
-	return $uptimestr;
 }
 
 /* Calculates non-idle CPU time and returns as a percentage */

--- a/src/usr/local/www/includes/functions.inc.php
+++ b/src/usr/local/www/includes/functions.inc.php
@@ -44,7 +44,7 @@ function get_stats() {
 function get_uptime() {
 	$uptime_sec = get_uptime_sec();
 
-	if (intval($uptime) > 0) {
+	if (intval($uptime_sec) > 0) {
 		return convert_seconds_to_dhms($uptime_sec);
 	} else {
 		return;

--- a/src/usr/local/www/includes/functions.inc.php
+++ b/src/usr/local/www/includes/functions.inc.php
@@ -45,7 +45,7 @@ function get_uptime() {
 	$uptime_sec = get_uptime_sec();
 
 	if (intval($uptime_sec) > 0) {
-		return convert_seconds_to_dhms($uptime_sec);
+		return convert_seconds_to_dhms($uptime_sec, false, true);
 	} else {
 		return;
 	}


### PR DESCRIPTION
We already have a function for seconds -> (d) hms when displaying time intervals, so use it. (Also ensures consistent presentation of time periods, and also avoids the need for gettext() on the words used.)

For niceness, minor enhancement also to pfsense-utils.inc that allows time intervals to be displayed a little nicer

