### PR TITLE
 system_identify_specific_platform() shouldn't return "pfSense" when $g['platform'] contains product name

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2466,7 +2466,8 @@ function system_identify_specific_platform() {
 	}
 	unset($dmesg_boot);
 
-	if (strlen($g['platform']) > 0) {
+	if (strlen($g['platform']) > 0 && $g['platform'] != $g['product_name']) {
+		// if $g['platform'] contains the software/firmware name rather than a hardware name, don't use it.
 		return array('name' => $g['platform'], 'descr' => $g['platform']);
 	} else {
 		return array('name' => 'Unknown platform', 'descr' => 'Unknown platform');

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2470,7 +2470,7 @@ function system_identify_specific_platform() {
 		// if $g['platform'] contains the software/firmware name rather than a hardware name, don't use it.
 		return array('name' => $g['platform'], 'descr' => $g['platform']);
 	} else {
-		return array('name' => 'Unknown platform', 'descr' => 'Unknown platform');
+		return array('name' => 'Generic/unknown', 'descr' => 'Generic/unknown');
 	}
 }
 

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2470,7 +2470,7 @@ function system_identify_specific_platform() {
 		// if $g['platform'] contains the software/firmware name rather than a hardware name, don't use it.
 		return array('name' => $g['platform'], 'descr' => $g['platform']);
 	} else {
-		return array('name' => 'Generic/unknown', 'descr' => 'Generic/unknown');
+		return array('name' => 'Non-specific hardware', 'descr' => 'Non-specific hardware');
 	}
 }
 

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2346,10 +2346,12 @@ function system_get_serial() {
 }
 
 /*
- * attempt to identify the specific platform (for embedded systems)
+ * attempt to identify the specific physical/virtual platform (for embedded systems)
  * Returns an array with two elements:
- * name => platform string (e.g. 'wrap', 'alix' etc.)
- * descr => human-readable description (e.g. "PC Engines WRAP")
+ *   name => platform string (e.g. 'wrap', 'alix', 'vmware', etc.)
+ *   descr => human-readable description (e.g. "PC Engines WRAP")
+ * If no specific platform is identified, it returns the strings in $g['platform'] as 
+ * a fallback, and if that's empty then returns 'Unknown platform'.
  */
 function system_identify_specific_platform() {
 	global $g;
@@ -2464,7 +2466,11 @@ function system_identify_specific_platform() {
 	}
 	unset($dmesg_boot);
 
-	return array('name' => $g['platform'], 'descr' => $g['platform']);
+	if (strlen($g['platform']) > 0) {
+		return array('name' => $g['platform'], 'descr' => $g['platform']);
+	} else {
+		return array('name' => 'Unknown platform', 'descr' => 'Unknown platform');
+	}
 }
 
 function system_get_dmesg_boot() {

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2346,7 +2346,7 @@ function system_get_serial() {
 }
 
 /*
- * attempt to identify the specific physical/virtual platform (for embedded systems)
+ * attempt to identify the specific physical/virtual platform (in particular for embedded systems)
  * Returns an array with two elements:
  *   name => platform string (e.g. 'wrap', 'alix', 'vmware', etc.)
  *   descr => human-readable description (e.g. "PC Engines WRAP")


### PR DESCRIPTION
I've checked all uses of this function. In every case, the calling code is looking for the hardware platform, not the firmware name. Unfortunately if it's not a specific recognised hardware, this function falls back on $g['platform'] and returns that, which by default contains the product name. 

This PR ensures that if `system_identify_specific_platform()` is going to return the product name, it doesn't, to ensure the returned string is always as expected a platform name.

It also ensures that a usable string is always returned.