### PR TITLE
Improve system information widget

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1442,8 +1442,11 @@ function is_pppoe_server_enabled() {
 	return $pppoeenable;
 }
 
-/* Optional arg forces hh:mm:ss without days */
-function convert_seconds_to_dhms($sec, $showhoursonly = false) {
+/* Optional args:
+ * $showhoursonly forces hh:mm:ss without days
+ * $showHMS outputs 30h 20m 15s rather than the default 30:20:15
+*/
+function convert_seconds_to_dhms($sec, $showhoursonly = false, $showHMS = false) {
 	if (!is_numericint($sec)) {
 		return '-';
 	}
@@ -1453,7 +1456,7 @@ function convert_seconds_to_dhms($sec, $showhoursonly = false) {
 					(int)(($sec % 3600)/60),
 					$sec % 60
 				);
-	return ($d > 0 ? $d . 'd ' : '') . sprintf('%02d:%02d:%02d', $h, $m, $s);
+	return ($d > 0 ? $d . 'd ' : '') . sprintf(($showHMS ? '%02dh %02dm %02ds' : '%02d:%02d:%02d'), $h, $m, $s);
 }
 
 /* Compute the total uptime from the ppp uptime log file in the conf directory */

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2470,7 +2470,7 @@ function system_identify_specific_platform() {
 		// if $g['platform'] contains the software/firmware name rather than a hardware name, don't use it.
 		return array('name' => $g['platform'], 'descr' => $g['platform']);
 	} else {
-		return array('name' => 'Generic/unknown', 'descr' => 'Generic/unknown');
+		return array('name' => 'Non-specific hardware', 'descr' => 'Non-specific hardware');
 	}
 }
 

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2346,10 +2346,12 @@ function system_get_serial() {
 }
 
 /*
- * attempt to identify the specific platform (for embedded systems)
+ * attempt to identify the specific physical/virtual platform (for embedded systems)
  * Returns an array with two elements:
- * name => platform string (e.g. 'wrap', 'alix' etc.)
- * descr => human-readable description (e.g. "PC Engines WRAP")
+ *   name => platform string (e.g. 'wrap', 'alix', 'vmware', etc.)
+ *   descr => human-readable description (e.g. "PC Engines WRAP")
+ * If no specific platform is identified, it returns the strings in $g['platform'] as 
+ * a fallback, and if that's empty then returns 'Unknown platform'.
  */
 function system_identify_specific_platform() {
 	global $g;
@@ -2464,7 +2466,12 @@ function system_identify_specific_platform() {
 	}
 	unset($dmesg_boot);
 
-	return array('name' => $g['platform'], 'descr' => $g['platform']);
+	if (strlen($g['platform']) > 0 && $g['platform'] != $g['product_name']) {
+		// if $g['platform'] contains the software/firmware name rather than a hardware name, don't use it.
+		return array('name' => $g['platform'], 'descr' => $g['platform']);
+	} else {
+		return array('name' => 'Generic/unknown', 'descr' => 'Generic/unknown');
+	}
 }
 
 function system_get_dmesg_boot() {

--- a/src/usr/local/www/includes/functions.inc.php
+++ b/src/usr/local/www/includes/functions.inc.php
@@ -42,41 +42,14 @@ function get_stats() {
 }
 
 function get_uptime() {
-	$uptime = get_uptime_sec();
+	$uptime_sec = get_uptime_sec();
 
-	if (intval($uptime) == 0) {
+	if (intval($uptime_sec) > 0) {
+		return convert_seconds_to_dhms($uptime_sec, false, true);
+	} else {
 		return;
 	}
 
-	$updays = (int)($uptime / 86400);
-	$uptime %= 86400;
-	$uphours = (int)($uptime / 3600);
-	$uptime %= 3600;
-	$upmins = (int)($uptime / 60);
-	$uptime %= 60;
-	$upsecs = (int)($uptime);
-
-	$uptimestr = "";
-	if ($updays > 1) {
-		$uptimestr .= "$updays Days ";
-	} else if ($updays > 0) {
-		$uptimestr .= "1 Day ";
-	}
-
-	if ($uphours > 1) {
-		$hours = "s";
-	}
-
-	if ($upmins > 1) {
-		$minutes = "s";
-	}
-
-	if ($upmins > 1) {
-		$seconds = "s";
-	}
-
-	$uptimestr .= sprintf("%02d Hour$hours %02d Minute$minutes %02d Second$seconds", $uphours, $upmins, $upsecs);
-	return $uptimestr;
 }
 
 /* Calculates non-idle CPU time and returns as a percentage */

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -531,7 +531,7 @@ function systemStatusGetUpdateStatus() {
 		},
 		dataType: 'html',
 		success: function(data){
-			$('[id^=widget-system_information] #updatestatus').html(data);
+			$('#system-information-widget-updatestatus').html(data);
 		}
 	});
 }

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -511,7 +511,7 @@ if (count($data) == 0) {
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">
 			<button type="submit" class="btn btn-primary"><i class="fa fa-save icon-embed-btn"></i><?=gettext('Save')?></button>
-			<button id="showallsysinfoitems" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
+			<button id="<?=$widget_showallnone_id?>" type="button" class="btn btn-info"><i class="fa fa-undo icon-embed-btn"></i><?=gettext('All')?></button>
 		</div>
 	</div>
 </form>

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -332,14 +332,12 @@ END;
 
 	// merge data into html template, indent HTML, and return
 
-	if (strlen($data_template) > 0) {
-		$data = vsprintf($data_template, $args);
+	$data = vsprintf($data_template, $args);  // no need to test zero length template, it'll be detected since $data will be zero length
 
-		if (strlen($data) > 0) {
-			$html = "<th><span style='font-weight:normal; margin-left:20px'>{$title_content}</span></th>\n" .
-				"<td>\n{$data}\n</td>\n";
-			return str_replace("\n", "\n\t\t\t", $html);
-		}
+	if (strlen($data) > 0) {
+		$html = "<th><span style='font-weight:normal; margin-left:20px'>{$title_content}</span></th>\n" .
+			"<td>\n{$data}\n</td>\n";
+		return str_replace("\n", "\n\t\t\t", $html);
 	}
 
 	return '';

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -325,6 +325,7 @@ END;
 
 
 		case 'ALL_HIDDEN':
+			$title_content = gettext('Empty');
 			$data_template = "<div class='text-center'>\n%s</div>";
 			$args[] = gettext('All System Information items are hidden or can not be shown.');
 			break;
@@ -438,10 +439,9 @@ foreach ($itemsshown as $itemkey) {
 }
 if (count($data) == 0) {
 	// adds a single item containing the special key for the "no sysinfo selected" item if nothing else will display
-	$data[0] = array(
-		'cattitle' => '',
-		'itemstoshow' => array('itemsort' => '', 'item_html' => '<tr>' . get_sysinfo_item_html('ALL_HIDDEN') . '<tr>')
-		);
+	$data[0]['cattitle'] = '';
+	$data[0]['itemstoshow'][0]['itemtitle'] = '';
+	$data[0]['itemstoshow'][0]['item_html'] = '<tr>' . get_sysinfo_item_html('ALL_HIDDEN') . '</tr>';
 }
 
 // Now we have the HTML for each category and items within categories, or a "nothing to show" section if none
@@ -457,8 +457,10 @@ if (count($data) == 0) {
 	//sort categories
 	ksort($data);
 	foreach ($data as $cat => $cat_data) {
-		// display title for this category
-		echo "<tr><th><strong>{$cat_data['cattitle']}</strong></th>\n<td>&nbsp;</td></tr>";
+		if (strlen($cat_data['cattitle']) > 0) {
+			// display title for this category
+			echo "<tr><th><strong>{$cat_data['cattitle']}</strong></th>\n<td>&nbsp;</td></tr>";
+		}
 		// sort and output items within category
 		ksort($cat_data);
 		foreach($cat_data['itemstoshow'] as $itemsort => $itemdata) {
@@ -475,7 +477,7 @@ if (count($data) == 0) {
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 
 <form action="/widgets/widgets/system_information.widget.php" method="post" class="form-horizontal">
-	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
+    <?=gen_customwidgettitle_div($widgetconfig['title']); ?>
     <div class="panel panel-default col-sm-10">
 		<div class="panel-body">
 			<input type="hidden" name="widgetkey" value="<?=$widgetkey; ?>">

--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -128,21 +128,9 @@ function get_sysinfo_item_html($itemkey) {
 
 		case 'platform':
 			if (!$g['hideplatform']) {
-				$is_nano = ($g['platform'] == "nanobsd");
-				// there's extra info (boot slice) if it's nanobsd
-				$data_template = "%s" . ($is_nano ? "\n<br/>nanobsd: <strong>%s</strong>:<br/>\n%s\n%s" : '');
+				$data_template = "%s";
 				$platform = system_identify_specific_platform();
-				$args[] = htmlspecialchars($platform['descr']) . (($g['platform'] == "nanobsd" && file_exists("/etc/nanosize.txt")) ? " (" . htmlspecialchars(trim(file_get_contents("/etc/nanosize.txt"))) . ")" : "");
-				if ($is_nano) {
-					global $SLICE, $OLDSLICE, $TOFLASH, $COMPLETE_PATH, $COMPLETE_BOOT_PATH;
-					global $GLABEL_SLICE, $UFS_ID, $OLD_UFS_ID, $BOOTFLASH;
-					global $BOOT_DEVICE, $REAL_BOOT_DEVICE, $BOOT_DRIVE, $ACTIVE_SLICE;
-					nanobsd_detect_slice_info();
-					$rw = is_writable("/") ? "(rw)" : "(ro)";
-					$args[] = gettext("NanoBSD Boot Slice");
-					$args[] = htmlspecialchars(nanobsd_friendly_slice_name($BOOT_DEVICE)) . ' / ' . htmlspecialchars($BOOTFLASH) . $rw;
-					$args[] = ($BOOTFLASH != $ACTIVE_SLICE ? "<br /><br />" . gettext('Next Boot') . ":<br />" . htmlspecialchars(nanobsd_friendly_slice_name($GLABEL_SLICE)) . ' / ' . htmlspecialchars($ACTIVE_SLICE) : "");
-				}
+				$args[] = htmlspecialchars($platform['descr']);
 			}
 			break;
 


### PR DESCRIPTION
The systinfo widget has a lot of rows, which makes it useful but hard for the eye to quickly find specific info. Also a few places the info isn't great, and the code itself is made less easy to maintain and ensure consistency, because each item is generated inline rather than separating the data for each item, from the collation and output.  What this PR does:

1. Sysinfo widget items have been grouped _(router, hardware platform, system status, resource usage)_ and the grouping method makes maintaining it, trivial.

2. The code generating data for each item shown, has been moved. It was inline with the table generation; now it's in a function of its own. This helps to simplify things a lot, because there's a single function returning the item _data_ and the main code generates the widget output in far fewer lines.

3. The platform is a bit confused, as to whether it's returning the platform (HW) or firmware/system running on it (pfSense). This is compounded by system_identify_specific_platform() falling back on returning the product name instead of a hardware platform, which isn't desireable in any call to that function in the codebase (I checked!). I've cleaned it up, so the router firmware shows the product name, and the physical platform shows the hardware/virtual platform if known, making this good.

4. Quite a few minor improvements and anomalies fixed. For example, "platform" didn't always return the actual platform as is expected everywhere in the codebase, because it falls back on $g['platform'] which by default contains the product name not the platform name. The BIOS is given but not the motherboard model (without which a bios vendor/revision is useless). The table is generated in a tight loop with handling of empty items and the case of no viewable items are cleaned up a lot; this gets rid of the constant `"if (!in_array('ITEM', $skipsysinfoitems)):"` and `"$rows_displayed = true;"` which simplifies it a lot.

5. The code relies for "niceness" on a couple of minor changes to the conversion of seconds to HMS (for uptime), and the derivation of the physical/virtual platform name..  These two changes to other files are transparent and "standalone", and useful in their own right,  so they're submitted in separate PRs, but I've included them in this one as well, because it relies on them.

Screenshot in comment below.

**Caveat -** The code works fine for me and looks good. However there's been a lot of recent work to the widgets and dashboard by @phil-davis recently. I've tried to merge what I've done into the most recent version, but it's hard to be sure.