### PR TITLE
Provide backend functions to get safe versions of release info, and HTML from a pfsense doc page (redmine feature 5074)

### DIFF
--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -85,7 +85,8 @@ $g = array(
 	"pkg_prefix" => "pfSense-pkg-",
 	"default_timezone" => "Etc/UTC",
 	"language" => "en_US",
-	"default_config_backup_count" => 30
+	"default_config_backup_count" => 30,
+	'doc_root_url' => 'doc.pfsense.org/index.php/'
 );
 
 /* IP TOS flags */

--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -86,7 +86,8 @@ $g = array(
 	"default_timezone" => "Etc/UTC",
 	"language" => "en_US",
 	"default_config_backup_count" => 30,
-	'doc_root_url' => 'doc.pfsense.org/index.php/'
+	'doc_root_url' => 'doc.pfsense.org/index.php/',
+	'doc_api_url' => 'doc.pfsense.org/api.php?'
 );
 
 /* IP TOS flags */

--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -87,7 +87,8 @@ $g = array(
 	"language" => "en_US",
 	"default_config_backup_count" => 30,
 	'doc_root_url' => 'doc.pfsense.org/index.php/',
-	'doc_api_url' => 'doc.pfsense.org/api.php?'
+	'doc_api_url' => 'doc.pfsense.org/api.php?',
+	'doc_pages_cache' => '/tmp/doc_pages_cache/';
 );
 
 /* IP TOS flags */

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3292,7 +3292,8 @@ function compare_by_name($a, $b) {
 }
 
 /* Get list of releases and relevant data for each, from doc pages
- * NOTE: RETURN STRINGS NOT SANITISED (ALTHOUGH FROM OUR OWN WEBSITE), other than a crude replacing of "<" ">" "&" by html entities
+ * NOTE: RETURN STRINGS NOT SANITISED (ALTHOUGH FROM OUR OWN WEBSITE), 
+ * other than a crude replacing of "<" ">" "&" and <0x20 by html entities using filter_var().
  * (These chars are rare and not much expected anyway, and probably not an issue if replaced)
  * CALLING CODE MUST SANITISE AS NEEDED
 */
@@ -3309,7 +3310,7 @@ if ($h === false) {
 // get bare table lines for the first table on the page
 $null_strings = array("|-\n", "|}\n");
 $h = str_replace($null_strings, "", strstr(strstr($h, "\n|-\n"), "\n|}\n", true));
-$h = str_replace(['<', '&', '>'], ['&lt;', '&amp;', '&gt;'], $h);
+$h = filter_var(FILTER_SANITIZE_SPECIAL_CHARS, $h);
 $patterns = array(
 	'/^\|\s+/m',					// remove initial "|" (and any spaces following it) on each line
 	'/(?<=^|\|\|)[^|]+\|(?!\|)/m',			// remove any cell-formatting sections such as align="center"

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3291,7 +3291,11 @@ function compare_by_name($a, $b) {
 	return strcasecmp($a['name'], $b['name']);
 }
 
-// Get list of releases and relevant data for each, from doc pages
+/* Get list of releases and relevant data for each, from doc pages
+ * NOTE: RETURN STRINGS NOT SANITISED (ALTHOUGH FROM OUR OWN WEBSITE), other than a crude replacing of "<" ">" "&" by html entities
+ * (These chars are rare and not much expected anyway, and probably not an issue if replaced)
+ * CALLING CODE MUST SANITISE AS NEEDED
+*/
 function get_release_list() {
 global $config, $g;
 
@@ -3305,14 +3309,14 @@ if ($h === false) {
 // get bare table lines for the first table on the page
 $null_strings = array("|-\n", "|}\n");
 $h = str_replace($null_strings, "", strstr(strstr($h, "\n|-\n"), "\n|}\n", true));
-
+$h = str_replace(['<', '&', '>'], ['&lt;', '&amp;', '&gt;'], $h);
 $patterns = array(
 	'/^\|\s+/m',					// remove initial "|" (and any spaces following it) on each line
 	'/(?<=^|\|\|)[^|]+\|(?!\|)/m',			// remove any cell-formatting sections such as align="center"
 	'/^.*\|\|[^[|]+$/m',				// remove future releases where final column doesn't contain [[REL_TITLE | REL_STATUS]]
 	'/\|\|\s*\[\[([^|\]]+)\|([^|\]]+)\]\]\s*$/m',	// convert [[REL_TITLE | REL_STATUS]] in final column to 2 columns
 	'/\|[^|\]]*\]\]/m',				// remove the narrative portion from any other "[[PAGE | NARRATIVE]]" page links
-	'/(^|[^[])\[https?:\/\/([^\s|[\]]+)\s+([^\s|[\]]+)\]([^]]|$)/im'       
+	'/(^|[^[])\[https?:\/\/([^\s|[\]]+)\s+([^\s|[\]]+)\]([^]]|$)/im'
 							// split narrative portion of [http(s):* NARRATIVE] external links to a separate column
 );
 

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3373,6 +3373,25 @@ global $g;
 	return $rel_list;
 }
 
+/* Update cache of known changelogs.
+ * As these doc pages are mostly static, once cached we rarely update, so it should be very fast (immediate) after the 1st run.
+ * Also as these pages are small and relatively few, and rarely added to, the cache won't grow large, nor will old pages become irrelevant easily,
+ * so no need for complex caching code. Pretty much check for updates and not much more.
+ */
+function update_all_release_details() {
+	global $g;
+
+	$rel_list = get_release_list($from);
+
+	foreach ($rel_list as $relnum => $reldata) {
+		if (!file_exists($reldata['cachefile'])) {
+			@array_map('unlink', glob($g['doc_pages_cache'] . str_replace(' ', '_', $reldata['doc_title']) . '@*.html'));
+			$html = get_sanitised_doc_page($reldata['doc_title']);
+			file_put_contents($reldata['cachefile'], $html);
+		}
+	}
+}
+
 /* Scrape a doc page in HTML format, sanitised so it can be trusted to be displayed to the user in the router GUI context.
  * (Although we control the docs website, we don't want any doc pages issue to open a vulnerability due to trusting the doc pages
  * content and displaying in-router, so treat the doc pages as *untrusted* and sanitise accordingly.)

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3301,52 +3301,102 @@ function get_release_list() {
 global $config, $g;
 
 //get raw markup for the release versions page
-$url = 'https://' . $g['doc_root_url'] . 'Versions_of_pfSense_and_FreeBSD?action=raw';
-$h = file_get_contents($url);
-if ($h === false) {
-  return array('errmsg' => 'Could not retrieve list of releases and changelog details');
+	$url = 'https://' . $g['doc_root_url'] . 'Versions_of_pfSense_and_FreeBSD?action=raw';
+	$h = file_get_contents($url);
+	if ($h === false) {
+	  return array('errmsg' => 'Could not retrieve list of releases and changelog details');
+	}
+
+	// get bare table lines for the first table on the page
+	$null_strings = array("|-\n", "|}\n");
+	$h = str_replace($null_strings, "", strstr(strstr($h, "\n|-\n"), "\n|}\n", true));
+	$h = filter_var(FILTER_SANITIZE_SPECIAL_CHARS, $h);
+	$patterns = array(
+		'/^\|\s+/m',					// remove initial "|" (and any spaces following it) on each line
+		'/(?<=^|\|\|)[^|]+\|(?!\|)/m',			// remove any cell-formatting sections such as align="center"
+		'/^.*\|\|[^[|]+$/m',				// remove future releases where final column doesn't contain [[REL_TITLE | REL_STATUS]]
+		'/\|\|\s*\[\[([^|\]]+)\|([^|\]]+)\]\]\s*$/m',	// convert [[REL_TITLE | REL_STATUS]] in final column to 2 columns
+		'/\|[^|\]]*\]\]/m',				// remove the narrative portion from any other "[[PAGE | NARRATIVE]]" page links
+		'/(^|[^[])\[https?:\/\/([^\s|[\]]+)\s+([^\s|[\]]+)\]([^]]|$)/im'
+								// split narrative portion of [http(s):* NARRATIVE] external links to a separate column
+	);
+
+	$replace = array(
+		'', 
+		'', 
+		'', 
+		'|| \1 || \2',
+		']]',
+		'\1 \2 || \3 \4'
+	);
+
+	$h = preg_replace($patterns, $replace, $h);
+
+	$rel_list = array();
+	foreach (explode("\n", $h) as $rel_line) {
+	  $r = preg_split("/\s+\|\|\s+/", $rel_line);
+	  if (strlen($r[0] > 1)) {
+	    $rel_list[] = array(
+		'release_version' => $r[0],
+		'date' => $r[7],
+		'github_branch' => $r[3],
+		'freebsd_version' => $r[5],
+		'doc_url' => $url = 'https://' . ($config2['lang'] == 'en' ? '' : $config2['lang'] . '.') . $g2['doc_url_template'] . str_replace(' ', '_', $r[8]),
+		'status' => $r[9]
+	    );
+	  }
+	}
+
+	return $rel_list;
 }
 
-// get bare table lines for the first table on the page
-$null_strings = array("|-\n", "|}\n");
-$h = str_replace($null_strings, "", strstr(strstr($h, "\n|-\n"), "\n|}\n", true));
-$h = filter_var(FILTER_SANITIZE_SPECIAL_CHARS, $h);
-$patterns = array(
-	'/^\|\s+/m',					// remove initial "|" (and any spaces following it) on each line
-	'/(?<=^|\|\|)[^|]+\|(?!\|)/m',			// remove any cell-formatting sections such as align="center"
-	'/^.*\|\|[^[|]+$/m',				// remove future releases where final column doesn't contain [[REL_TITLE | REL_STATUS]]
-	'/\|\|\s*\[\[([^|\]]+)\|([^|\]]+)\]\]\s*$/m',	// convert [[REL_TITLE | REL_STATUS]] in final column to 2 columns
-	'/\|[^|\]]*\]\]/m',				// remove the narrative portion from any other "[[PAGE | NARRATIVE]]" page links
-	'/(^|[^[])\[https?:\/\/([^\s|[\]]+)\s+([^\s|[\]]+)\]([^]]|$)/im'
-							// split narrative portion of [http(s):* NARRATIVE] external links to a separate column
-);
+/* Scrape a doc page in HTML format, sanitised so it can be trusted to be displayed to the user in the router GUI context.
+ * (Although we control the docs website, we don't want any issue of hack to create a vulnerability due to trusting the docs pages and
+ *  displaying content from them in-router, especially if we don't actually *have* to trust it.)
+ * Useful if we want to provide help pages or changelogs within the GUI at any time. 
+ *
+ * The tags allowed can be formatted with CSS or str_replace() if formatting is needed, but that's separate.
+ 
+ * Keeping this function very simple right now, as it's mainly intended for changelogs/release notes which don't use complex formatting
+ * or images. So it might need enhancing if used for other doc pages.
+ *
+ * The sanitising used is as follows:
+ * 1) use strip_tags() to remove all but a few "well known" tags likely to be used in doc pages (most aren't used right now)
+ * 2) remove any comments
+ * 3) remove any attribs or other content from all tags, after the <ALPHA or </ALPHA opening, except for "<a ..."
+ * 4) With <a>, we need to preserve HREF but handle a few possible pathological issues (e.g., hrefs in title="...", href javascript).
+ *    We do this by:
+ *    4.1) ensure the token string "valid-href" isn't being used (it shouldn't be)
+ *    4.2) detect and rename any VALID hrefs that start with ftp/http(s) or / or # values, to "valid-href"
+ *    4.3) Delete *all other content* before/after the *first* "valid-href" clause in every <a> tag, and rename back to href
+ */
+function get_sanitised_doc_page($doc_page) {
 
-$replace = array(
-	'', 
-	'', 
-	'', 
-	'|| \1 || \2',
-	']]',
-	'\1 \2 || \3 \4'
-);
+	$url = 'https://' . $g2['doc_root_url'] . str_replace(' ', '_', $doc_page);
+	$h = file_get_contents($url);
+	if ($h === false) {
+	  return array('errmsg' => 'Could not retrieve list of releases and changelog details');
+	}
 
-$h = preg_replace($patterns, $replace, $h);
+	$h = strstr(strstr($h, '<h1>'),	'<div class="printfooter">', true);
+	$h = strip_tags($h, '<h1><h2><h3><h4><ul><ol><li><p><br><a><b><u><i><sup><sub><table><th><tr><td><blockquote>');	
 
-$rel_list = array();
-foreach (explode("\n", $h) as $rel_line) {
-  $r = preg_split("/\s+\|\|\s+/", $rel_line);
-  if (strlen($r[0] > 1)) {
-    $rel_list[] = array(
-        'release_version' => $r[0],
-        'date' => $r[7],
-        'github_branch' => $r[3],
-        'freebsd_version' => $r[5],
-        'doc_url' => $url = 'https://' . ($config2['lang'] == 'en' ? '' : $config2['lang'] . '.') . $g2['doc_url_template'] . str_replace(' ', '_', $r[8]),
-        'status' => $r[9]
-    );
-  }
-}
+	$patterns = array(
+		'%<!--.*-->%',				// remove comments
+		'%<([^a>][a-z1-9]*|a[^ >]+|/[a-z1-9]+)[^a-z1-9>][^>]*>%im',	// remove all attributes from any opening tag except <a> and from any closing tag
+		'/valid-href/',				// sanitise "href" in <a>: Ensure nothing's using the fake attribute "valid-href"...
+		'/href\s*=\s*[\'"]([https?|ftp|\/|#]:[^\'">]*)[\'"]/im',		// ...retag anything that's strictly capable of being an href attribute as 'valid-href'
+		'/<a (.*? |)valid-href="([^"]*)" [^>]*>/im'	// ...then remove all text except the first valid-href tag (if any) from <a> and rename to "href" again
+	);
 
-return $rel_list;
+	$replace = array(
+		'',
+		'<\1>',
+		'',
+		' valid-href="\1" ',
+		'<a href="\2">'
+	);
+
+	return preg_replace($patterns, $replace, $h);
 }
 ?>

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3293,12 +3293,12 @@ function compare_by_name($a, $b) {
 
 /* Get list of releases and relevant data for each, from doc pages
  * NOTE: RETURN STRINGS NOT SANITISED (ALTHOUGH FROM OUR OWN WEBSITE), 
- * other than a crude replacing of "<" ">" "&" and <0x20 by html entities using filter_var().
+ * other than a crude replacing of "<" ">" "&" by html entities.
  * (These chars are rare and not much expected anyway, and probably not an issue if replaced)
- * CALLING CODE MUST SANITISE AS NEEDED
+ * CALLING CODE MUST SANITISE AS NEEDED. MIGHT NEED MORE HERE.
 */
 function get_release_list() {
-global $config, $g;
+global $g;
 
 //get raw markup for the release versions page
 	$url = 'https://' . $g['doc_root_url'] . 'Versions_of_pfSense_and_FreeBSD?action=raw';
@@ -3310,7 +3310,8 @@ global $config, $g;
 	// get bare table lines for the first table on the page
 	$null_strings = array("|-\n", "|}\n");
 	$h = str_replace($null_strings, "", strstr(strstr($h, "\n|-\n"), "\n|}\n", true));
-	$h = filter_var(FILTER_SANITIZE_SPECIAL_CHARS, $h);
+	$h = str_replace(['<', '&', '>'], ['&lt;', '&amp;', '&gt;'], $h);
+	
 	$patterns = array(
 		'/^\|\s+/m',					// remove initial "|" (and any spaces following it) on each line
 		'/(?<=^|\|\|)[^|]+\|(?!\|)/m',			// remove any cell-formatting sections such as align="center"
@@ -3332,19 +3333,38 @@ global $config, $g;
 
 	$h = preg_replace($patterns, $replace, $h);
 
-	$rel_list = array();
+	$rel_list = $pagelookup = array();
+	
+	// build table of release info
+	
 	foreach (explode("\n", $h) as $rel_line) {
-	  $r = preg_split("/\s+\|\|\s+/", $rel_line);
-	  if (strlen($r[0] > 1)) {
-	    $rel_list[] = array(
-		'release_version' => $r[0],
-		'date' => $r[7],
-		'github_branch' => $r[3],
-		'freebsd_version' => $r[5],
-		'doc_url' => $url = 'https://' . ($config2['lang'] == 'en' ? '' : $config2['lang'] . '.') . $g2['doc_url_template'] . str_replace(' ', '_', $r[8]),
-		'status' => $r[9]
-	    );
-	  }
+		$r = preg_split("/\s+\|\|\s+/", $rel_line);
+		if (strlen($r[0] > 1)) {
+			$rel_list[] = array(
+				'release_version' => $r[0],
+				'release_date' => $r[7], 		 //FIXME: NOT IN STD TIME FORMAT
+				'page_modified_date' => '',		// will fill via API if accessible
+				'github_branch' => $r[3],
+				'freebsd_version' => $r[5],
+				'doc_title' => $r[8],
+				'doc_url' => $url = 'https://' . $g['doc_root_url'] . str_replace(' ', '_', $r[8]),	// 'en' only at the moment
+				'status' => $r[9]
+			    );
+			$pagelookup[$r[8]] = count($rel_list) - 1;
+		}
+	}
+	
+	// add info only available through API. Currently only the "page last modified" timestamp. If inaccessible, ignore the extra data
+
+	$titlelist = str_replace(' ', '_', implode('|', array_keys($pagelookup)));
+	$apiurl = "https://{$g['doc_api_url']}action=query&format=json&prop=revisions&formatversion=2&titles={$titlelist}&rvprop=timestamp&redirects";
+	$h = file_get_contents($apiurl);
+	if ($h !== false) {
+		$apidata = json_decode($h, true);
+		foreach ($apidata['query']['pages'] as $p) {
+			$pageidx = $pagelookup[$p['title']];
+			$rel_list[$pageidx]['page_modified_date'] = $p['revisions'][0]['timestamp']; 	 //FIXME: NOT IN STD TIME FORMAT
+		}
 	}
 
 	return $rel_list;

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3290,4 +3290,58 @@ function addrtolower($ip) {
 function compare_by_name($a, $b) {
 	return strcasecmp($a['name'], $b['name']);
 }
+
+// Get list of releases and relevant data for each, from doc pages
+function get_release_list() {
+global $config, $g;
+
+//get raw markup for the release versions page
+$url = 'https://' . $g['doc_root_url'] . 'Versions_of_pfSense_and_FreeBSD?action=raw';
+$h = file_get_contents($url);
+if ($h === false) {
+  return array('errmsg' => 'Could not retrieve list of releases and changelog details');
+}
+
+// get bare table lines for the first table on the page
+$null_strings = array("|-\n", "|}\n");
+$h = str_replace($null_strings, "", strstr(strstr($h, "\n|-\n"), "\n|}\n", true));
+
+$patterns = array(
+	'/^\|\s+/m',					// remove initial "|" (and any spaces following it) on each line
+	'/(?<=^|\|\|)[^|]+\|(?!\|)/m',			// remove any cell-formatting sections such as align="center"
+	'/^.*\|\|[^[|]+$/m',				// remove future releases where final column doesn't contain [[REL_TITLE | REL_STATUS]]
+	'/\|\|\s*\[\[([^|\]]+)\|([^|\]]+)\]\]\s*$/m',	// convert [[REL_TITLE | REL_STATUS]] in final column to 2 columns
+	'/\|[^|\]]*\]\]/m',				// remove the narrative portion from any other "[[PAGE | NARRATIVE]]" page links
+	'/(^|[^[])\[https?:\/\/([^\s|[\]]+)\s+([^\s|[\]]+)\]([^]]|$)/im'       
+							// split narrative portion of [http(s):* NARRATIVE] external links to a separate column
+);
+
+$replace = array(
+	'', 
+	'', 
+	'', 
+	'|| \1 || \2',
+	']]',
+	'\1 \2 || \3 \4'
+);
+
+$h = preg_replace($patterns, $replace, $h);
+
+$rel_list = array();
+foreach (explode("\n", $h) as $rel_line) {
+  $r = preg_split("/\s+\|\|\s+/", $rel_line);
+  if (strlen($r[0] > 1)) {
+    $rel_list[] = array(
+        'release_version' => $r[0],
+        'date' => $r[7],
+        'github_branch' => $r[3],
+        'freebsd_version' => $r[5],
+        'doc_url' => $url = 'https://' . ($config2['lang'] == 'en' ? '' : $config2['lang'] . '.') . $g2['doc_url_template'] . str_replace(' ', '_', $r[8]),
+        'status' => $r[9]
+    );
+  }
+}
+
+return $rel_list;
+}
 ?>

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3348,7 +3348,8 @@ global $g;
 				'freebsd_version' => $r[5],
 				'doc_title' => $r[8],
 				'doc_url' => $url = 'https://' . $g['doc_root_url'] . str_replace(' ', '_', $r[8]),	// 'en' only at the moment
-				'status' => $r[9]
+				'status' => $r[9],
+				'cachefile' => 	''			// will fill via API if accessible
 			    );
 			$pagelookup[$r[8]] = count($rel_list) - 1;
 		}
@@ -3363,7 +3364,9 @@ global $g;
 		$apidata = json_decode($h, true);
 		foreach ($apidata['query']['pages'] as $p) {
 			$pageidx = $pagelookup[$p['title']];
-			$rel_list[$pageidx]['page_modified_date'] = $p['revisions'][0]['timestamp']; 	 //FIXME: NOT IN STD TIME FORMAT
+			$timestamp = $p['revisions'][0]['timestamp']; 	 //FIXME: NOT IN STD TIME FORMAT
+			$rel_list[$pageidx]['page_modified_date'] = $timestamp;
+			$rel_list[$pageidx]['cachefile'] = $g['doc_pages_cache'] . str_replace(' ', '_', $p) . '@' . $timestamp;
 		}
 	}
 

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3366,7 +3366,7 @@ global $g;
 			$pageidx = $pagelookup[$p['title']];
 			$timestamp = $p['revisions'][0]['timestamp']; 	 //FIXME: NOT IN STD TIME FORMAT
 			$rel_list[$pageidx]['page_modified_date'] = $timestamp;
-			$rel_list[$pageidx]['cachefile'] = $g['doc_pages_cache'] . str_replace(' ', '_', $p) . '@' . $timestamp;
+			$rel_list[$pageidx]['cachefile'] = $g['doc_pages_cache'] . str_replace(' ', '_', $p) . '@' . $timestamp . '.html';
 		}
 	}
 

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3372,8 +3372,9 @@ global $config, $g;
  *    4.4) Ensuring any links kept, open in a new tab.
  */
 function get_sanitised_doc_page($doc_page) {
-
-	$url = 'https://' . $g2['doc_root_url'] . str_replace(' ', '_', $doc_page);
+	global $g;
+	
+	$url = 'https://' . $g['doc_root_url'] . str_replace(' ', '_', $doc_page);
 	$h = file_get_contents($url);
 	if ($h === false) {
 	  return array('errmsg' => 'Could not retrieve list of releases and changelog details');

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3366,7 +3366,7 @@ global $g;
 			$pageidx = $pagelookup[$p['title']];
 			$timestamp = $p['revisions'][0]['timestamp']; 	 //FIXME: NOT IN STD TIME FORMAT
 			$rel_list[$pageidx]['page_modified_date'] = $timestamp;
-			$rel_list[$pageidx]['cachefile'] = $g['doc_pages_cache'] . str_replace(' ', '_', $p) . '@' . $timestamp . '.html';
+			$rel_list[$pageidx]['cachefile'] = $g['doc_pages_cache'] . str_replace(' ', '_', $p) . '@' . str_replace(':', '.', $timestamp) . '.html';
 		}
 	}
 

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3384,7 +3384,7 @@ function update_all_release_details() {
 	$rel_list = get_release_list($from);
 
 	foreach ($rel_list as $relnum => $reldata) {
-		if (!file_exists($reldata['cachefile'])) {
+		if ($reldata['cachefile'] != '' && !file_exists($reldata['cachefile'])) {
 			@array_map('unlink', glob($g['doc_pages_cache'] . str_replace(' ', '_', $reldata['doc_title']) . '@*.html'));
 			$html = get_sanitised_doc_page($reldata['doc_title']);
 			file_put_contents($reldata['cachefile'], $html);

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3351,20 +3351,20 @@ global $config, $g;
 }
 
 /* Scrape a doc page in HTML format, sanitised so it can be trusted to be displayed to the user in the router GUI context.
- * (Although we control the docs website, we don't want any issue of hack to create a vulnerability due to trusting the docs pages and
- *  displaying content from them in-router, especially if we don't actually *have* to trust it.)
+ * (Although we control the docs website, we don't want any doc pages issue to open a vulnerability due to trusting the doc pages
+ * content and displaying in-router, so treat the doc pages as *untrusted* and sanitise accordingly.)
  * Useful if we want to provide help pages or changelogs within the GUI at any time. 
  *
- * The tags allowed can be formatted with CSS or str_replace() if formatting is needed, but that's separate.
+ * The permitted tags are "bare". They can be formatted with CSS or str_replace() if formatting is needed, but that's separate.
  
  * Keeping this function very simple right now, as it's mainly intended for changelogs/release notes which don't use complex formatting
- * or images. So it might need enhancing if used for other doc pages.
+ * or images. So it might need more richness if used for other doc pages.
  *
- * The sanitising used is as follows:
- * 1) use strip_tags() to remove all but a few "well known" tags likely to be used in doc pages (most aren't used right now)
- * 2) remove any comments
- * 3) remove any attribs or other content from all tags, after the <ALPHA or </ALPHA opening, except for "<a ..."
- * 4) With <a>, we need to preserve HREF but handle a few possible pathological issues (e.g., hrefs in title="...", href javascript).
+ * The sanitising method is as follows:
+ * 1) use strip_tags() to remove all but a few "well known" tags likely to be used in doc pages (even though most aren't actually in common use)
+ * 2) remove comments
+ * 3) remove attribs or other content from all tags, after the <ALPHA or </ALPHA opening, except for "<a ..."
+ * 4) With "<a>", we need to preserve HREF but handle a few possible pathological HREF issues (e.g., hrefs in title="...", href javascript).
  *    We do this by:
  *    4.1) ensure the token string "valid-href" isn't being used (it shouldn't be)
  *    4.2) detect and rename any VALID hrefs that start with ftp/http(s) or / or # values, to "valid-href"

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3369,6 +3369,7 @@ global $config, $g;
  *    4.1) ensure the token string "valid-href" isn't being used (it shouldn't be)
  *    4.2) detect and rename any VALID hrefs that start with ftp/http(s) or / or # values, to "valid-href"
  *    4.3) Delete *all other content* before/after the *first* "valid-href" clause in every <a> tag, and rename back to href
+ *    4.4) Ensuring any links kept, open in a new tab.
  */
 function get_sanitised_doc_page($doc_page) {
 
@@ -3394,7 +3395,7 @@ function get_sanitised_doc_page($doc_page) {
 		'<\1>',
 		'',
 		' valid-href="\1" ',
-		'<a href="\2">'
+		'<a href="\2" target="_blank">'
 	);
 
 	return preg_replace($patterns, $replace, $h);

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3366,7 +3366,7 @@ global $g;
 			$pageidx = $pagelookup[$p['title']];
 			$timestamp = $p['revisions'][0]['timestamp']; 	 //FIXME: NOT IN STD TIME FORMAT
 			$rel_list[$pageidx]['page_modified_date'] = $timestamp;
-			$rel_list[$pageidx]['cachefile'] = $g['doc_pages_cache'] . str_replace(' ', '_', $p) . '@' . str_replace(':', '.', $timestamp) . '.html';
+			$rel_list[$pageidx]['cachefile'] = $g['doc_pages_cache'] . str_replace(' ', '_', $p['title']) . '@' . str_replace(':', '.', $timestamp) . '.html';
 		}
 	}
 
@@ -3382,7 +3382,8 @@ function update_all_release_details() {
 	global $g;
 
 	$rel_list = get_release_list($from);
-
+	safe_mkdir($g['doc_pages_cache']);
+	
 	foreach ($rel_list as $relnum => $reldata) {
 		if ($reldata['cachefile'] != '' && !file_exists($reldata['cachefile'])) {
 			@array_map('unlink', glob($g['doc_pages_cache'] . str_replace(' ', '_', $reldata['doc_title']) . '@*.html'));
@@ -3422,7 +3423,7 @@ function get_sanitised_doc_page($doc_page) {
 	  return array('errmsg' => 'Could not retrieve list of releases and changelog details');
 	}
 
-	$h = strstr(strstr($h, '<h1>'),	'<div class="printfooter">', true);
+	$h = strstr(strstr(strstr($h, 'id="toc"'), '<h'), '<div class="printfooter">', true);
 	$h = strip_tags($h, '<h1><h2><h3><h4><ul><ol><li><p><br><a><b><u><i><sup><sub><table><th><tr><td><blockquote>');	
 
 	$patterns = array(


### PR DESCRIPTION
Provide functions to get pfSense release info for GUI use. 
See @jim-p comment on [redmine 5074](https://redmine.pfsense.org/issues/5074)

It would be very useful when upgrading, to have easy access to the changelog from `system -> system update`.

But there's no easy way from the GUI to view the changelog for the current release, or, if a release was skipped, the skipped releases up to the current release.  We could just add a crude link, but the user might need more than one version's changes (if they skipped a release) and it's nicer anyway to present it in-GUI.

To make this possible, we first need to get the pfSense release info in usable form. This PR adds 3 underlying functions needed.  That way when there's a new version, `system -> system update` can make use of this info and provide an easy way to view relevant changelogs for the proposed update, in future. The functions added are:

1. `get_release_list()` - returns a list of releases taken directly from the doc page _"Versions of pfSense and FreeBSD"_, including all table data (dates, status, doc pages of the release notes etc)
2. `get_sanitised_doc_page()` - returns a sanitised HTML version of a single doc page, such as the release notes for an update version.  All attribs (except a single valid href) and formatting/CSS are removed to make it easy to match the GUI's existing style/theme or add needed CSS.
3. `update_all_release_details()` - maintain a tiny cache ( ~ 20 pages x 2KB) for the bare release notes of known versions. Updated when user enters `system -> system update`. Cache is kept in `/tmp/doc_pages_cache/PAGE@TIMESTAMP` (controlled by `$g['doc_pages_cache']`).   As these doc pages are mostly static and the code checks last modified time, once cached we rarely need to update, so it should be extremely fast (immediate) after the 1st run.  Also as these pages are small and relatively few, and rarely added to, the cache won't grow large, nor will old pages become irrelevant easily, so no need for complex caching code. Pretty much just check for updates and not much more.  Stops the page from taking time to grab multiple static doc pages when we've almost certainly grabbed them previously and can reuse.


These aren't used yet, but adding them so that progress can be made on redmine 5074.

**DATA SANITISING NOTE  -** There is careful attention to sanitising , so that if there were a problem at the docs website end it doesn't create a vulnerability from reusing doc content in the router context. But as sanitising is easily done wrong, extra attention to check that it really is robust (and fix if it isn't) would be good.