### PR TITLE
permissions, log when user tries to save the configuration but has the 'deny config write' permission

### DIFF
--- a/src/etc/inc/config.lib.inc
+++ b/src/etc/inc/config.lib.inc
@@ -447,6 +447,7 @@ function write_config($desc="Unknown", $backup = true, $write_config_only = fals
 		if (!empty($_SESSION['Username']) && ($_SESSION['Username'] != "admin")) {
 			$user = getUserEntry($_SESSION['Username']);
 			if (is_array($user) && userHasPrivilege($user, "user-config-readonly")) {
+				syslog(LOG_AUTHPRIV, sprintf(gettext("Save config permission denied by the 'User - Config: Deny Config Write' permission for user '%s'."), $_SESSION['Username']));
 				phpsession_end(true);
 				return false;
 			}


### PR DESCRIPTION
permissions, log when user tries to save the configuration but has the 'deny config write' permission