### PR TITLE
Update nsswitch when 'Disable DNS Forwarder'

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -135,6 +135,18 @@ function system_resolvconf_generate($dynupdate = false) {
 		$resolvconf .= "nameserver 127.0.0.1\n";
 	}
 
+	if (isset($config['system']['dnslocalhost'])) {
+		file_put_contents('/etc/nsswitch.conf', str_replace(
+			'hosts: file dns', 'hosts: dns files',
+			file_get_contents('/etc/nsswitch.conf')
+		));
+	} else {
+		file_put_contents('/etc/nsswitch.conf', str_replace(
+			'hosts: dns files', 'hosts: files dns',
+			file_get_contents('/etc/nsswitch.conf')
+		));
+	}
+
 	if (isset($syscfg['dnsallowoverride'])) {
 		/* get dynamically assigned DNS servers (if any) */
 		$ns = array_unique(get_searchdomains());

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -137,7 +137,7 @@ function system_resolvconf_generate($dynupdate = false) {
 
 	if (isset($config['system']['dnslocalhost'])) {
 		file_put_contents('/etc/nsswitch.conf', str_replace(
-			'hosts: file dns', 'hosts: dns files',
+			'hosts: files dns', 'hosts: dns files',
 			file_get_contents('/etc/nsswitch.conf')
 		));
 	} else {


### PR DESCRIPTION
tl;dr firewall services use /etc/hosts when it shouldn't

[Edit: fixed the paragraph width and added replication example]

Services on the firewall continue to use unbound for lookups when /etc/resolv.conf is configured for the forward resolvers.

This affected my OpenVPN client running on the firewall where my LAN has public hosts being overridden to the VPN IP addresses (including the VPN server). The OpenVPN client does a DNS lookup via /etc/hosts because of the /etc/nsswitch.conf config and tries to connect to the internal IP I configured in unbound for the LAN hosts, rather than public IP returned by the configured resolvers. This caused the VPN to fail to connect because it was trying to connect to the wrong IP. This also affected ntpd and likely every service as nsswitch was working as configured.

Replication steps:

Variables:

Public VPN Server IP: `123.45.67.89`
Public VPN Server hostname: `vpn.domain.tld`
Internal VPN Server IP: `10.3.2.1/24`
Internal VPN Serer hostname: `vpn.domain.tld`

pfSense configurations:

Services / DNS Resolver / General Settings / Host Overrides
`vpn.domain.tld`: `10.3.2.1`

On disk configuration:

`/etc/resolv.conf`:
```
search domain.tld
nameserver 8.8.8.8
nameserver 8.8.4.4
```

`/etc/hosts`
```
10.3.2.1 vpn.domain.tld
```

`/etc/nsswitch.conf`
```
...
hosts: files dns
...
```

When OpenVPN attempts to connect to `"vpn.domain.tld"` it resolves this host to `"10.3.2.1"` and fails to connect because there it no route to host.

This is happening because `/etc/nsswitch` resolves `"vpn.domain.tld"` to the definition in `/etc/hosts` rather than doing a lookup against `8.8.8.8` (or `8.8.4.4`) as configured by the checkbox option.

The change swaps the `/etc/nsswitch.conf` host lookup order to use `/etc/resolv.conf` before checking `/etc/hosts` to resolve the hostname which is what I assumed the UI option would have done.