### PR TITLE
changed how openvpn calls php for authentication

### DIFF
--- a/src/etc/inc/openvpn.auth-user.php
+++ b/src/etc/inc/openvpn.auth-user.php
@@ -32,6 +32,8 @@ require_once("radius.inc");
 require_once("auth.inc");
 require_once("interfaces.inc");
 
+parse_str(implode('&', array_slice($argv, 1)), $_GET);
+
 /**
  * Get the NAS-Identifier
  *

--- a/src/etc/inc/openvpn.tls-verify.php
+++ b/src/etc/inc/openvpn.tls-verify.php
@@ -34,6 +34,8 @@ require_once("interfaces.inc");
 
 openlog("openvpn", LOG_ODELAY, LOG_AUTH);
 
+parse_str(implode('&', array_slice($argv, 1)), $_GET);
+
 /* read data from command line */
 if (isset($_GET['certdepth'])) {
 	$cert_depth = $_GET['certdepth'];

--- a/src/usr/local/sbin/ovpn_auth_verify
+++ b/src/usr/local/sbin/ovpn_auth_verify
@@ -20,13 +20,13 @@
 
 
 if [ "$1" = "tls" ]; then
-	RESULT=$(/usr/local/sbin/fcgicli -f /etc/inc/openvpn.tls-verify.php -d "servercn=$2&depth=$3&certdepth=$4&certsubject=$5")
+	RESULT=$(/usr/local/bin/php-cgi /etc/inc/openvpn.tls-verify.php servercn=$2 depth=$3 certdepth=$4 certsubject=$5)
 else
 	# Single quoting $password breaks getting the value from the variable.
 	# Base64 and urlEncode usernames and passwords
 	password=$(echo -n "${password}" | openssl enc -base64 | sed -e 's_=_%3D_g;s_+_%2B_g;s_/_%2F_g')
 	username=$(echo -n "${username}" | openssl enc -base64 | sed -e 's_=_%3D_g;s_+_%2B_g;s_/_%2F_g')
-	RESULT=$(/usr/local/sbin/fcgicli -f /etc/inc/openvpn.auth-user.php -d "username=$username&password=$password&cn=$common_name&strictcn=$3&authcfg=$2&modeid=$4&nas_port=$5")
+	RESULT=$(/usr/local/bin/php-cgi /etc/inc/openvpn.auth-user.php username=$username password=$password cn=$common_name strictcn=$3 authcfg=$2 modeid=$4 nas_port=$5)
 fi
 
 if [ "${RESULT}" = "OK" ]; then


### PR DESCRIPTION
Currently openvpn is using the executable fcgicli to do authentication, which, from what I can tell uses php-fpm via socket connection. I've changed this to use system php instead of the service ph p-fpm. 

This will prevent individuals from being locked of a vpn connection if php-fpm would crash.  

