### PR TITLE
Add Option to use static IPV6 over v4 parent ( PPPoE )

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -5132,7 +5132,8 @@ function get_real_interface($interface = "wan", $family = "all", $realv6iface = 
 							case 'ppp':
 							case 'l2tp':
 							case 'pptp':
-								if (isset($cfg['dhcp6usev4iface']) && $realv6iface === false) {
+								// Added catch for static v6 but using v4 link. Sets things to use pppoe link
+								if ((isset($cfg['dhcp6usev4iface']) && $realv6iface === false) || isset($cfg['ipv6usev4iface'])) {
 									$wanif = $cfg['if'];
 								} else {
 									$parents = get_parent_interface($interface);

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -1903,7 +1903,7 @@ $section->addInput(new Form_IpAddress(
 $section->addInput(new Form_Checkbox(
 	'ipv6usev4iface',
 	'Use IPv4 connectivity as parent interface',
-	'IPV6 will use  the IPv4 connectivity link (PPPoE)',
+	'IPv6 will use the IPv4 connectivity link (PPPoE)',
 	$pconfig['ipv6usev4iface']
 ));
 

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -313,6 +313,7 @@ switch ($wancfg['ipaddrv6']) {
 	default:
 		if (is_ipaddrv6($wancfg['ipaddrv6'])) {
 			$pconfig['type6'] = "staticv6";
+			$pconfig['ipv6usev4iface'] = isset($wancfg['ipv6usev4iface']);
 			$pconfig['ipaddrv6'] = $wancfg['ipaddrv6'];
 			$pconfig['subnetv6'] = $wancfg['subnetv6'];
 			$pconfig['gatewayv6'] = $wancfg['gatewayv6'];
@@ -1047,6 +1048,7 @@ if ($_POST['apply']) {
 		unset($wancfg['dhcp6-ia-pd-send-hint']);
 		unset($wancfg['dhcp6prefixonly']);
 		unset($wancfg['dhcp6usev4iface']);
+		unset($wancfg['ipv6usev4iface']);
 		unset($wancfg['dhcp6debug']);
 		unset($wancfg['track6-interface']);
 		unset($wancfg['track6-prefix-id']);
@@ -1275,6 +1277,9 @@ if ($_POST['apply']) {
 			case "staticv6":
 				$wancfg['ipaddrv6'] = $_POST['ipaddrv6'];
 				$wancfg['subnetv6'] = $_POST['subnetv6'];
+				if ($_POST['ipv6usev4iface'] == "yes") {
+					$wancfg['ipv6usev4iface'] = true;
+				}
 				if ($_POST['gatewayv6'] != "none") {
 					$wancfg['gatewayv6'] = $_POST['gatewayv6'];
 				}
@@ -1894,6 +1899,13 @@ $section->addInput(new Form_IpAddress(
 	$pconfig['ipaddrv6'],
 	'V6'
 ))->addMask('subnetv6', $pconfig['subnetv6'], 128);
+
+$section->addInput(new Form_Checkbox(
+	'ipv6usev4iface',
+	'Use IPv4 connectivity as parent interface',
+	'IPV6 will use  the IPv4 connectivity link (PPPoE)',
+	$pconfig['ipv6usev4iface']
+));
 
 $group = new Form_Group('IPv6 Upstream gateway');
 


### PR DESCRIPTION
A new option when setting a v6 static on the WAN to allow the connection to use the parent V4 interfaces i.e. PPPoE.

Some ISP's allow the use of static V6 addresses and PD over a PPPoE link. This patch adds a new option under WAN settings for IPv6 static address, the option to use the parent v4 ( pppoe) interface.  The change was needed as although it is possible to set up the static and it works just using the given address, the gateway and monitoring did not work. it is essential to know what the gateway address is when using this option, as you'll need to manually add the gateway. In my case this is found by using dhcp in the first instance to get that information, and then adding a new gateway etc.