### PR TITLE
gateway monitoring, give apinger some time to properly 'initialize' before using its results

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -323,26 +323,44 @@ function get_dpinger_status($gwname, $detailed = false) {
 		log_error("dpinger: status socket {$proc['socket']} not found");
 		return false;
 	}
+	$timeoutcounter = 0;
+	while (true) {
+		$fp = stream_socket_client("unix://{$proc['socket']}", $errno, $errstr, 10);
+		if (!$fp) {
+			log_error(sprintf(gettext('dpinger: cannot connect to status socket %1$s - %2$s (%3$s)'), $proc['socket'], $errstr, $errno));
+			return false;
+		}
 
-	$fp = stream_socket_client("unix://{$proc['socket']}", $errno, $errstr, 10);
-	if (!$fp) {
-		log_error(sprintf(gettext('dpinger: cannot connect to status socket %1$s - %2$s (%3$s)'), $proc['socket'], $errstr, $errno));
-		return false;
+		$status = '';
+		while (!feof($fp)) {
+			$status .= fgets($fp, 1024);
+		}
+		fclose($fp);
+
+		$r = array();
+		list(
+			$r['gwname'],
+			$r['latency_avg'],
+			$r['latency_stddev'],
+			$r['loss']
+		) = explode(' ', preg_replace('/\n/', '', $status));
+
+		// dpinger returns '<gwname> 0 0 0' when queried directly after it starts.
+		// while a latency of 0 and a loss of 0 would be perfect, in a real world it doesnt happen.
+		// or does it, anyone? if so we must 'detect' the initialization period differently..
+		$ready = $r['latency_stddev'] != '0' || $r['loss'] != '0';
+		
+		if ($ready) {
+			break;
+		} else {
+			$timeoutcounter++;
+			if ($timeoutcounter > 300) {
+				log_error(sprintf(gettext('dpinger: timeout while retrieving status for gateway %s'), $gwname));
+				return false;
+			}
+			usleep(10000);
+		}
 	}
-
-	$status = '';
-	while (!feof($fp)) {
-		$status .= fgets($fp, 1024);
-	}
-	fclose($fp);
-
-	$r = array();
-	list(
-	    $r['gwname'],
-	    $r['latency_avg'],
-	    $r['latency_stddev'],
-	    $r['loss']
-	) = explode(' ', preg_replace('/\n/', '', $status));
 
 	$r['srcip'] = $proc['srcip'];
 	$r['targetip'] = $proc['targetip'];


### PR DESCRIPTION
gateway monitoring, give apinger some time to properly 'initialize' before using its results

this avoids needles "gateway added/removed from routing group" emails, and possible other events that might trigger when a gateway fails or comes back online

(This sometimes happens when actually nothing changed regarding the status gateways themselves..)