### PR TITLE
Issue #7659 foreach warning on adding gateway

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -1736,14 +1736,16 @@ function save_gateway($gateway_settings, $realid = "") {
 	if ($gateway_settings['defaultgw'] == "yes" || $gateway_settings['defaultgw'] == "on") {
 		$i = 0;
 		/* remove the default gateway bits for all gateways with the same address family */
-		foreach ($a_gateway_item as $gw) {
-			if ($gateway['ipprotocol'] == $gw['ipprotocol']) {
-				unset($config['gateways']['gateway_item'][$i]['defaultgw']);
-				if ($gw['interface'] != $gateway_settings['interface'] && $gw['defaultgw']) {
-					$reloadif = $gw['interface'];
+		if (is_array($a_gateway_item)) {
+			foreach ($a_gateway_item as $gw) {
+				if ($gateway['ipprotocol'] == $gw['ipprotocol']) {
+					unset($config['gateways']['gateway_item'][$i]['defaultgw']);
+					if ($gw['interface'] != $gateway_settings['interface'] && $gw['defaultgw']) {
+						$reloadif = $gw['interface'];
+					}
 				}
+				$i++;
 			}
-			$i++;
 		}
 		$gateway['defaultgw'] = true;
 	}


### PR DESCRIPTION
To make this happen:
1) Start with a system with just default DHCP on WAN - the system generates gateways at run ti,e for that and ```$config['gateways']['gateway_item']``` is empty.
2) Edit some interface, set it to Static IPV4, put in some IPv4 address, click "Add Gateway" and give it some gateway IP.
3) Save and apply
4) Go to the dashboard - the "crash" message is given.

This fix adds protection around the foreach() to not bother going there if there are no existing gateway items to process.

Signed-off-by: Phil Davis <phil@jankaritech.com>