### PR TITLE
php-fpm, add status page for local usage from console/shell

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1527,6 +1527,17 @@ EOD;
 			fastcgi_read_timeout 180;
 			include        /usr/local/etc/nginx/fastcgi_params;
 		}
+		location ~ (^/status$) {
+			allow 127.0.0.1;
+			deny all;
+			fastcgi_pass   unix:{$g['varrun_path']}/php-fpm.socket;
+			fastcgi_index  index.php;
+			fastcgi_param  SCRIPT_FILENAME  \$document_root\$fastcgi_script_name;
+			# Fix httpoxy - https://httpoxy.org/#fix-now
+			fastcgi_param  HTTP_PROXY  "";
+			fastcgi_read_timeout 360;
+			include        /usr/local/etc/nginx/fastcgi_params;
+		}
 	}
 
 EOD;

--- a/src/etc/rc.php_ini_setup
+++ b/src/etc/rc.php_ini_setup
@@ -310,7 +310,6 @@ pm = ondemand
 pm.process_idle_timeout = 5
 pm.max_children = $PHPFPMMAX
 pm.max_requests = 500
-
 EOF
 
 elif [ $REALMEM -gt 1000 ]; then
@@ -323,7 +322,6 @@ pm.start_servers = 1
 pm.max_requests = 500
 pm.min_spare_servers=1
 pm.max_spare_servers=1
-
 EOF
 else
 
@@ -332,10 +330,15 @@ else
 pm = static
 pm.max_children = $PHPFPMMAX
 pm.max_requests = 500
-
 EOF
 
 fi
+
+# Add status url for php-fpm this will only be made available from localhost through nginx 'allow 127.0.0.1'
+	/bin/cat >> /usr/local/lib/php-fpm.conf <<EOF
+pm.status_path = /status
+
+EOF
 
 # Remove old log file if it exists.
 if [ -f /var/run/php_modules_load_errors.txt ]; then


### PR DESCRIPTION
php-fpm, add status page for local usage from console/shell, this provides a way to check what scripts are currently running in the php-fpm processes.

For example the following can be executed from the local shell:
` fetch --no-verify-hostname --no-verify-peer "https://localhost/status?full" -o - `