### PR TITLE
ipsec, prevent simultaneous/repeated calling of vpn_ipsec_configure() by /etc/rc.newipsecdns

### DIFF
--- a/src/etc/rc.newipsecdns
+++ b/src/etc/rc.newipsecdns
@@ -25,8 +25,21 @@
  * limitations under the License.
  */
 
-/* parse the configuration and include all functions used below */
 require_once("util.inc");
+require_once("globals.inc");
+
+/* make sure to wait until the boot scripts have finished */
+if (file_exists("{$g['varrun_path']}/booting")) {
+	return;
+}
+
+$ipseclck_pending = try_lock('ipsecdns_pending', 0);
+if (!$ipseclck_pending) {
+	/* if a vpn_ipsec_configure() is still pending no need to stack up another one */
+	return;
+}
+
+/* parse the configuration and include all functions used below */
 require_once("config.inc");
 require_once("gwlb.inc");
 require_once("functions.inc");
@@ -36,21 +49,20 @@ require_once("auth.inc");
 require_once("ipsec.inc");
 require_once("vpn.inc");
 
-/* make sure to wait until the boot scripts have finished */
-if (file_exists("{$g['varrun_path']}/booting")) {
-	return;
-}
-
-if (ipsec_enabled()) {
-	sleep(15);
-	log_error("IPSEC: One or more IPsec tunnel endpoints has changed its IP. Refreshing.");
-} else {
+if (!ipsec_enabled()) {
+	unlock($ipseclck_pending);
 	return;
 }
 
 $ipseclck = lock('ipsecdns', LOCK_EX);
+sleep(12);
+unlock($ipseclck_pending);
+sleep(3);
+log_error("IPSEC: One or more IPsec tunnel endpoints has changed its IP. Refreshing.");
+
+/* make sure we have the latest configuration changes loaded. */
+$config = parse_config();
 
 vpn_ipsec_configure();
 
 unlock($ipseclck);
-?>


### PR DESCRIPTION
ipsec, prevent simultaneous/repeated calling of vpn_ipsec_configure() by /etc/rc.newipsecdns
also exit the script without parsing a config if not needed.

p.s.
I think this would decrease the amount of ipsec restarts when events needing such restarts occur.. One might however argue that the vpn_ipsec_configure() itself also performs locking which would make all sleeping and locking in the rc.newipsecdns unneeded.?