### PR TITLE
Removed MSS clamping exclusions

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -559,10 +559,7 @@ function filter_generate_scrubing() {
 		}
 		/* set up MSS clamping */
 		if (($scrubcfg['mss'] <> "") &&
-		    (is_numeric($scrubcfg['mss'])) &&
-		    ($scrubcfg['if'] != "pppoe") &&
-		    ($scrubcfg['if'] != "pptp") &&
-		    ($scrubif['if'] != "l2tp")) {
+		    (is_numeric($scrubcfg['mss']))) {
 			$mssclamp = "max-mss " . (intval($scrubcfg['mss'] - 40));
 		} else {
 			$mssclamp = "";


### PR DESCRIPTION
This pull request removed has the three interface exclusions and closes bug #7675

Reference: https://forum.pfsense.org/index.php?topic=132918.0

Thanks,

Robbert