### PR TITLE
nat, portforwards should not make up a new destination information when unkown

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2246,10 +2246,6 @@ function filter_nat_rules_generate() {
 			$srcaddr = trim($srcaddr);
 			$dstaddr = trim($dstaddr);
 
-			if (!$dstaddr) {
-				$dstaddr = $FilterIflist[$natif]['ip'];
-			}
-
 			$dstaddr_port = explode(" ", $dstaddr);
 			if (empty($dstaddr_port[0]) || strtolower(trim($dstaddr_port[0])) == "port") {
 				continue; // Skip port forward if no destination address found


### PR DESCRIPTION
nat, portforwards should not make up a new destination information when a configured dhcp interface does not currently have an address.

fixes: https://forum.pfsense.org/index.php?topic=127585.msg733528#msg733528