### PR TITLE
status_queues, set update frequency / fast auth_check / dont write to /tmp

### DIFF
--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -176,20 +176,31 @@ function parse_xml_config_raw($cffile, $rootobj, $isstring = "false") {
 	xml_set_character_data_handler($xml_parser, "cdata");
 	xml_parser_set_option($xml_parser, XML_OPTION_SKIP_WHITE, 1);
 
-	if (!($fp = fopen($cffile, "r"))) {
-		log_error(gettext("Error: could not open XML input") . "\n");
-		return -1;
-	}
-
-	while ($data = fread($fp, 4096)) {
-		if (!xml_parse($xml_parser, $data, feof($fp))) {
-			log_error(sprintf(gettext('XML error: %1$s at line %2$d in %3$s') . "\n",
+	if ($isstring === true) {
+		if (!xml_parse($xml_parser, $cffile, true)) {
+			log_error(sprintf(gettext('XML error: %1$s at line %2$d in XML-string') . "\n",
 				xml_error_string(xml_get_error_code($xml_parser)),
-				xml_get_current_line_number($xml_parser),
-				$cffile));
+				xml_get_current_line_number($xml_parser)));
 			return -1;
 		}
+	} else {
+		if (!($fp = fopen($cffile, "r"))) {
+			log_error(gettext("Error: could not open XML input") . "\n");
+			return -1;
+		}
+
+		while ($data = fread($fp, 4096)) {
+			if (!xml_parse($xml_parser, $data, feof($fp))) {
+				log_error(sprintf(gettext('XML error: %1$s at line %2$d in %3$s') . "\n",
+					xml_error_string(xml_get_error_code($xml_parser)),
+					xml_get_current_line_number($xml_parser),
+					$cffile));
+				return -1;
+			}
+		}
+		fclose($fp);
 	}
+	
 	xml_parser_free($xml_parser);
 
 	if ($rootobj) {

--- a/src/etc/inc/xmlreader.inc
+++ b/src/etc/inc/xmlreader.inc
@@ -154,11 +154,19 @@ function parse_xml_config_raw($cffile, $rootobj, $isstring = "false") {
 	$parsedcfg = array();
 
 	$par = new XMLReader();
-	if ($par->open($cffile, "UTF-8", LIBXML_NOERROR | LIBXML_NOWARNING)) {
-		add_elements($parsedcfg, $par);
-		$par->close();
+	if ($isstring === true) {
+		if ($par->xml($cffile, "UTF-8", LIBXML_NOERROR | LIBXML_NOWARNING)) {
+			add_elements($parsedcfg, $par);
+		} else {
+			log_error(sprintf(gettext("Error returned while trying to parse %s"), "XML-string"));
+		}
 	} else {
-		log_error(sprintf(gettext("Error returned while trying to parse %s"), $cffile));
+		if ($par->open($cffile, "UTF-8", LIBXML_NOERROR | LIBXML_NOWARNING)) {
+			add_elements($parsedcfg, $par);
+			$par->close();
+		} else {
+			log_error(sprintf(gettext("Error returned while trying to parse %s"), $cffile));
+		}
 	}
 
 	if ($rootobj) {


### PR DESCRIPTION
status_queues, set update frequency / fast auth_check / dont write to /tmp
-allow user to select update frequency
-use auth_check to allow much faster authentication checks for the the ajax update requests
-dont write to /tmp while showing queue stats but pass them along in memory
-tweak sleep's / initialization to provide more accurate results