### PR TITLE
Improve the HELP note about what will/won't work if TLD is set to ".local"

### DIFF
--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -460,7 +460,7 @@ $section->addInput(new Form_Input(
 	$pconfig['domain'],
 	['placeholder' => 'mycorp.com, home, office, private, etc.']
 ))->setHelp('Do not use \'.local\' as the final part of the domain (TLD), The \'.local\' domain is %1$swidely used%2$s by '.
-	'mDNS (including Avahi and Apple OS X\'s Bonjour/Rendezvous/Airprint/Airplay), and some Windows systems and network devices. ' .
+	'mDNS (including Avahi and Apple OS X\'s Bonjour/Rendezvous/Airprint/Airplay), and some Windows systems and networked devices. ' .
 	'These will not network correctly if the router uses \'.local\'. Alternatives such as \'.local.lan\' or \'.mylocal\' are safe.',
 	 '<a target="_blank" href="https://www.unbound.net/pipermail/unbound-users/2011-March/001735.html">',
 	 '</a>'

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -460,7 +460,7 @@ $section->addInput(new Form_Input(
 	$pconfig['domain'],
 	['placeholder' => 'mycorp.com, home, office, private, etc.']
 ))->setHelp('Do not use \'.local\' as the final part of the domain (TLD), The \'.local\' domain is %1$swidely used%2$s by '.
-	'mDNS (including Avahi), Apple OS X (Bonjour/Rendezvous/Airprint/Airplay), and some Windows systems and network devices. ' .
+	'mDNS (including Avahi and Apple OS X\'s Bonjour/Rendezvous/Airprint/Airplay), and some Windows systems and network devices. ' .
 	'These will not network correctly if the router uses \'.local\'. Alternatives such as \'.local.lan\' or \'.mylocal\' are safe.',
 	 '<a target="_blank" href="https://www.unbound.net/pipermail/unbound-users/2011-March/001735.html">',
 	 '</a>'

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -459,9 +459,10 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['domain'],
 	['placeholder' => 'mycorp.com, home, office, private, etc.']
-))->setHelp('Do not use \'local\' as a domain name. It will cause local '.
-	'hosts running mDNS (avahi, bonjour, etc.) to be unable to resolve '.
-	'local hosts not running mDNS.');
+))->setHelp('Do not use \'.local\' as the final part of the domain (TLD), The \'.local\' domain is <a target="_blank" ' .
+	'href="https://www.unbound.net/pipermail/unbound-users/2011-March/001735.html")widely used</a> by mDNS (including Avahi), ' .
+	'Apple OS X (Bonjour/Rendezvous/Airprint/Airplay), and some Windows systems and network devices. These will not network ' .
+	'correctly if the router uses \'.local\'. Alternatives such as \'.local.lan\' or \'.mylocal\' are safe.');
 
 $form->add($section);
 

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -459,10 +459,12 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['domain'],
 	['placeholder' => 'mycorp.com, home, office, private, etc.']
-))->setHelp('Do not use \'.local\' as the final part of the domain (TLD), The \'.local\' domain is <a target="_blank" ' .
-	'href="https://www.unbound.net/pipermail/unbound-users/2011-March/001735.html")widely used</a> by mDNS (including Avahi), ' .
-	'Apple OS X (Bonjour/Rendezvous/Airprint/Airplay), and some Windows systems and network devices. These will not network ' .
-	'correctly if the router uses \'.local\'. Alternatives such as \'.local.lan\' or \'.mylocal\' are safe.');
+))->setHelp('Do not use \'.local\' as the final part of the domain (TLD), The \'.local\' domain is %1$swidely used%2$s by '.
+	'mDNS (including Avahi), Apple OS X (Bonjour/Rendezvous/Airprint/Airplay), and some Windows systems and network devices. ' .
+	'These will not network correctly if the router uses \'.local\'. Alternatives such as \'.local.lan\' or \'.mylocal\' are safe.',
+	 '<a target="_blank" href="https://www.unbound.net/pipermail/unbound-users/2011-March/001735.html">',
+	 '</a>'
+);
 
 $form->add($section);
 


### PR DESCRIPTION
For example, some people won't use mDNS and won't know other things might break.  Many users who have only a passing familiarity with Apple products will know of Airplay/Airprint but won't recognise the names of their underlying protocol "bonjour/rendezvoius" or realise these are relied on by them. Also it's not clear that while ".local" is a problem, ".local.lan" isn't.

Only a help-text edit.