### PR TITLE
dhcp6c Advanced Config prefix interface

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4407,10 +4407,11 @@ function DHCP6_Config_File_Advanced($interface, $wancfg, $wanif) {
 			}
 			$id_assoc_statement_prefix .= ";";
 		}
-
+		
+		$realif = get_real_interface($wancfg['adv_dhcp6_prefix_selected_interface']);
 		if (is_numeric($wancfg['adv_dhcp6_prefix_interface_statement_sla_id'])) {
 			$id_assoc_statement_prefix .= "\n\tprefix-interface";
-			$id_assoc_statement_prefix .= " {$wanif}";
+			$id_assoc_statement_prefix .= " {$realif}";
 			$id_assoc_statement_prefix .= " {\n";
 			$id_assoc_statement_prefix .= "\t\tsla-id {$wancfg['adv_dhcp6_prefix_interface_statement_sla_id']};\n";
 			if (($wancfg['adv_dhcp6_prefix_interface_statement_sla_len'] >= 0) &&

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -90,6 +90,7 @@ if (!is_array($config['gateways']['gateway_item'])) {
 
 $a_gateways = &$config['gateways']['gateway_item'];
 
+$interfaces = get_configured_interface_with_descr();
 $wancfg = &$config['interfaces'][$if];
 $old_wancfg = $wancfg;
 $old_wancfg['realif'] = get_real_interface($if);
@@ -228,6 +229,7 @@ $pconfig['adv_dhcp6_id_assoc_statement_prefix_vltime'] = $wancfg['adv_dhcp6_id_a
 
 $pconfig['adv_dhcp6_prefix_interface_statement_sla_id'] = $wancfg['adv_dhcp6_prefix_interface_statement_sla_id'];
 $pconfig['adv_dhcp6_prefix_interface_statement_sla_len'] = $wancfg['adv_dhcp6_prefix_interface_statement_sla_len'];
+$pconfig['adv_dhcp6_prefix_selected_interface'] = $wancfg['adv_dhcp6_prefix_selected_interface'];
 
 $pconfig['adv_dhcp6_authentication_statement_authname'] = $wancfg['adv_dhcp6_authentication_statement_authname'];
 $pconfig['adv_dhcp6_authentication_statement_protocol'] = $wancfg['adv_dhcp6_authentication_statement_protocol'];
@@ -1093,6 +1095,7 @@ if ($_POST['apply']) {
 
 		unset($wancfg['adv_dhcp6_prefix_interface_statement_sla_id']);
 		unset($wancfg['adv_dhcp6_prefix_interface_statement_sla_len']);
+		unset($wancfg['adv_dhcp6_prefix_selected_interface']);
 
 		unset($wancfg['adv_dhcp6_authentication_statement_authname']);
 		unset($wancfg['adv_dhcp6_authentication_statement_protocol']);
@@ -1356,7 +1359,9 @@ if ($_POST['apply']) {
 				if (is_numericint($_POST['adv_dhcp6_prefix_interface_statement_sla_len'])) {
 					$wancfg['adv_dhcp6_prefix_interface_statement_sla_len'] = $_POST['adv_dhcp6_prefix_interface_statement_sla_len'];
 				}
-
+				if (!empty($_POST['adv_dhcp6_prefix_selected_interface'])) {
+					$wancfg['adv_dhcp6_prefix_selected_interface'] = $_POST['adv_dhcp6_prefix_selected_interface'];
+				}
 				if (!empty($_POST['adv_dhcp6_authentication_statement_authname'])) {
 					$wancfg['adv_dhcp6_authentication_statement_authname'] = $_POST['adv_dhcp6_authentication_statement_authname'];
 				}
@@ -2376,6 +2381,14 @@ $group->add(new Form_Input(
 ))->sethelp('sla-len');
 
 $section->add($group);
+
+$group = new Form_Group('Select prefix interface');
+$section->addInput(new Form_Select(
+	'adv_dhcp6_prefix_selected_interface',
+	'Prefix Interface',
+	$pconfig['adv_dhcp6_prefix_selected_interface'],
+	$interfaces
+))->setHelp('Select the interface on which to apply the prefix delegation.');
 
 $group = new Form_Group('Authentication statement');
 


### PR DESCRIPTION
Currently, when using dhcp6c advanced configuration the prefix interface is WAN, this is not very useful!

The changes here allow the user to enter the interface name, that's the REAL interface name, RE1 RE0 etc.