### PR TITLE
dyndns: added password help text for cloudflare

### DIFF
--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -370,7 +370,8 @@ $section->addPassword(new Form_Input(
 			'Route 53: Enter the Secret Access Key.%1$s' .
 			'GleSYS: Enter the API key.%1$s' .
 			'Dreamhost: Enter the API Key.%1$s' .
-			'DNSimple: Enter the API token.', '<br />');
+			'DNSimple: Enter the API token.%1$s' .
+			'CloudFlare: Enter the Global API Key.', '<br />');
 
 $section->addInput(new Form_Input(
 	'zoneid',

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -371,7 +371,7 @@ $section->addPassword(new Form_Input(
 			'GleSYS: Enter the API key.%1$s' .
 			'Dreamhost: Enter the API Key.%1$s' .
 			'DNSimple: Enter the API token.%1$s' .
-			'CloudFlare: Enter the Global API Key.', '<br />');
+			'Cloudflare: Enter the Global API Key.', '<br />');
 
 $section->addInput(new Form_Input(
 	'zoneid',


### PR DESCRIPTION
Added help text when using CloudFlare for Dynamic DNS, since it seems to confuse a lot of members.