### PR TITLE
Unbound start hold off on system boot  - Wait for dhcp6

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3515,6 +3515,9 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 			// N.B. PPP connections using PPP as the IPv6 parent interface are excluded because the ppp-ipv6 script
 			// calls interface_dhcpv6_configure() for these connections after IPv6CP is up, whilst rc.newwanip
 			// handles all non-PPP connections with 'dhcp6usev4iface' set
+			/* Remove the check file. Should not be there but just in case */
+			unlink_if_exists("/tmp/{$wanif}_dhcp6_complete");
+			log_error(gettext("calling interface_dhcpv6_configure."));																																		  
 			if (!(isset($wancfg['dhcp6usev4iface']) || $wancfg['ipaddr']==='ppp')) {
 				interface_dhcpv6_configure($interface, $wancfg);
 			}

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2261,8 +2261,26 @@ function services_unbound_configure($restart_dhcp = true) {
 			$return = 1;
 		}
 
+		/* Check here for dhcp6 complete - wait upto 10 seconds */
+		if($config['interfaces']["wan"]['ipaddrv6'] == 'dhcp6') {
+			$wanif = get_real_interface("wan", "inet6");
+			if (platform_booting()) {
+				for ($i=1; $i <= 10; $i++) {
+					if (!file_exists("/tmp/{$wanif}_dhcp6_complete")) { 
+						log_error(gettext("Unbound start waiting on dhcp6c."));
+						sleep(1);
+					} else {
+						unlink_if_exists("/tmp/{$wanif}_dhcp6_complete");
+						log_error(gettext("dhcp6 init complete. Continuing"));
+						break;
+					}						
+				}
+			}
+		}
+		
 		sync_unbound_service();
 		if (platform_booting()) {
+			log_error(gettext("sync unbound done."));
 			echo gettext("done.") . "\n";
 		}
 

--- a/src/etc/rc.newwanipv6
+++ b/src/etc/rc.newwanipv6
@@ -140,6 +140,7 @@ setup_gateways_monitor();
 
 if (platform_booting()) {
 	// avoid race conditions in many of the below functions that occur during boot
+	touch("/tmp/{$interface_real}_dhcp6_complete");
 	exit;
 }
 


### PR DESCRIPTION

Some users are complaining that unbound is having problems with ipv6 queries after a boot, restarting unbound alone fixes the problem.

Further examination did indeed show that the problem is caused by unbound starting before dhcp6c - RTSOLD - rc.newwanipv6 sequence have completed, making sure that these have all run before unbound is allowed to start corrects the problem.

In order to fix this I have added a file creation of a file in tmp.  In rc.newwanipv6, this is the final function when the system is  booting and ONLY when the system is booting.

In  interfaces.inc I have added an unlink_if_exists () of this file, this is a "just in case" catch, should the file have been left behind due to some unforeseen event.

The real work is done in services.inc, a section of code has been added that can cause up-to a ten second delay before allowing unbound to start. This is achieved by waiting for the file created by rc.newwanipv6 to exist, once it does exist then the file is deleted, the sleep loop breaks and unbound is allowed to start. If the file does not exist after 10 seconds then the sleep loop exits and unbound can start.

Checks are made for the fact that WAN is using Ipv6 and dhcp6,