### PR TITLE
Allow IPv6 RA default router lifetime of 0

### DIFF
--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -201,7 +201,7 @@ if ($_POST['save']) {
 		}
 	}
 	if ($_POST['raadvdefaultlifetime'] && !is_numericint($_POST['raadvdefaultlifetime'])) {
-		$input_errors[] = gettext("Router lifetime must be an integer between 1 and 9000.");
+		$input_errors[] = gettext("Router lifetime must be an integer between 0 and 9000.");
 	}
 
 	if (!$input_errors) {
@@ -387,7 +387,7 @@ $section->addInput(new Form_Input(
 	'Router lifetime',
 	'number',
 	$pconfig['raadvdefaultlifetime'],
-	['min' => 1, 'max' => 9000]
+	['min' => 0, 'max' => 9000]
 ))->setHelp('The lifetime associated with the default router in seconds.');
 
 $section->addInput(new Form_StaticText(


### PR DESCRIPTION
This commit is tested on 2.3.4-RELEASE-p1.

It changes a gettext string, and will affect i18n.  The msgid changes, and there are many localized strings with "1" and "9000" in them.  I've never worked with i18n and I don't know how the pfSense project handles it-- do I need to do anything for that?
