### PR TITLE
PPP down script change

### DIFF
--- a/src/usr/local/sbin/ppp-linkdown
+++ b/src/usr/local/sbin/ppp-linkdown
@@ -27,7 +27,7 @@ if [ -f /tmp/${IF}up ] && [ -f /conf/${IF}.log ]; then
 	/usr/local/sbin/ppp-log-uptime.sh $seconds ${IF} &
 fi
 
-if [$IF !=~ "ppp[0-9]*"]
+if [${IF} !=~ "ppp[0-9]*"]
 then
 	/etc/rc.kill_states ${IF} ${LOCAL_IP}
 fi

--- a/src/usr/local/sbin/ppp-linkdown
+++ b/src/usr/local/sbin/ppp-linkdown
@@ -27,7 +27,7 @@ if [ -f /tmp/${IF}up ] && [ -f /conf/${IF}.log ]; then
 	/usr/local/sbin/ppp-log-uptime.sh $seconds ${IF} &
 fi
 
-if [ ${IF} !=~ "ppp[0-9]*" ]; then
+if echo "${IF}" | egrep -qv "ppp[0-9]+"; then
 	/etc/rc.kill_states ${IF} ${LOCAL_IP}
 fi
 

--- a/src/usr/local/sbin/ppp-linkdown
+++ b/src/usr/local/sbin/ppp-linkdown
@@ -27,8 +27,7 @@ if [ -f /tmp/${IF}up ] && [ -f /conf/${IF}.log ]; then
 	/usr/local/sbin/ppp-log-uptime.sh $seconds ${IF} &
 fi
 
-if [${IF} !=~ "ppp[0-9]*"]
-then
+if [ ${IF} !=~ "ppp[0-9]*" ]; then
 	/etc/rc.kill_states ${IF} ${LOCAL_IP}
 fi
 

--- a/src/usr/local/sbin/ppp-linkdown
+++ b/src/usr/local/sbin/ppp-linkdown
@@ -27,7 +27,7 @@ if [ -f /tmp/${IF}up ] && [ -f /conf/${IF}.log ]; then
 	/usr/local/sbin/ppp-log-uptime.sh $seconds ${IF} &
 fi
 
-if echo "${IF}" | egrep -qv "ppp[0-9]+"; then
+if echo "${IF}" | /usr/bin/egrep -qv "ppp[0-9]+"; then
 	/etc/rc.kill_states ${IF} ${LOCAL_IP}
 fi
 

--- a/src/usr/local/sbin/ppp-linkdown
+++ b/src/usr/local/sbin/ppp-linkdown
@@ -27,7 +27,10 @@ if [ -f /tmp/${IF}up ] && [ -f /conf/${IF}.log ]; then
 	/usr/local/sbin/ppp-log-uptime.sh $seconds ${IF} &
 fi
 
-/etc/rc.kill_states ${IF} ${LOCAL_IP}
+if [$IF !=~ "ppp[0-9]*"]
+then
+	/etc/rc.kill_states ${IF} ${LOCAL_IP}
+fi
 
 if [ "${PROTOCOL}" == "inet" && -s "/tmp/${IF}_defaultgw" ]; then
 	GW=`head -n 1 /tmp/${IF}_defaultgw`


### PR DESCRIPTION
Hi,

in the PPP down script the line

/etc/rc.kill_states ${IF} ${LOCAL_IP}

is killing cellular modems when the script is executed.
The cuaXX port is blocked after this command and the mpd deamon can not talk to the modem anymore.
Only a complete modem reset (power down/power up) brings it back up.

Therefore I added an if statement to stop the command on PPP modems.

Please let me know if you can merge that in.

Best and thanks
Sven

Voleatech