### PR TITLE
Captive portal: fix idle times in details popup

### DIFF
--- a/src/usr/local/www/status_captiveportal.php
+++ b/src/usr/local/www/status_captiveportal.php
@@ -65,11 +65,11 @@ function print_details($cpent) {
 		$last_act = $last_act ? $last_act : $cpent[0];
 
 		$idle_time = time() - $last_act;
-		printf(gettext("Idle time: %s") . "<br>", convert_seconds_to_dhms($idle_time));
+		printf(gettext("Idle time: %s") . "<br>", convert_seconds_to_dhms((int)$idle_time));
 
 		if (!empty($cpent[8])) {
 			$idle_time_left = $last_act + $cpent[8] - time();
-			printf(gettext("Idle time left: %s") . "<br>", convert_seconds_to_dhms($idle_time_left));
+			printf(gettext("Idle time left: %s") . "<br>", convert_seconds_to_dhms((int)$idle_time_left));
 		}
 	}
 


### PR DESCRIPTION
Explicitly cast $idle_time and $idle_time_left to integers to prevent idle times from being displayed as '-' in the details popup of the captive portal status page.