### PR TITLE
MPD Custom Modem Init

### DIFF
--- a/src/usr/local/sbin/mpd.script
+++ b/src/usr/local/sbin/mpd.script
@@ -403,6 +403,8 @@ ModemIdentGeneric:
 
 ModemIdentCustom:
 	set $ModemDescription "Custom modem"
+	if $SimPin != "" call DialPeerSetPin
+	if $APN != "" call DialPeerSetAPN
 	set $ModemSetupFunc CustomSetup
 	return
 


### PR DESCRIPTION
Hi,

in PPP for Modems if we use a custom INIT String the APN and SimPin are not set the same way as the GenericModem with no INIT String.
This can lead to timeout problems on modems with a SIM Pin as they don't utilize the SIM PIN Wait from the GUI before dialing the APN.
My patch makes the Custom Init Modem Function the same as Generic by explicitly calling APN and SetPin which will honour the SIM PIN wait.

Please let me know what you think.

Best
Sven