### PR TITLE
Unbound Serve expired

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -249,6 +249,7 @@ EOF;
 	$harden_dnssec_stripped = isset($unboundcfg['dnssecstripped']) ? "yes" : "no";
 	$prefetch = isset($unboundcfg['prefetch']) ? "yes" : "no";
 	$prefetch_key = isset($unboundcfg['prefetchkey']) ? "yes" : "no";
+	$dns_record_cache = isset($unboundcfg['dnsrecordcache']) ? "yes" : "no";
 	$outgoing_num_tcp = isset($unboundcfg['outgoing_num_tcp']) ? $unboundcfg['outgoing_num_tcp'] : "10";
 	$incoming_num_tcp = isset($unboundcfg['incoming_num_tcp']) ? $unboundcfg['incoming_num_tcp'] : "10";
 	$edns_buffer_size = (!empty($unboundcfg['edns_buffer_size'])) ? $unboundcfg['edns_buffer_size'] : "4096";
@@ -357,6 +358,7 @@ outgoing-range: 4096
 prefetch: {$prefetch}
 prefetch-key: {$prefetch_key}
 use-caps-for-id: {$use_caps}
+serve-expired: {$dns_record_cache}
 # Statistics
 {$statistics}
 # Interface IP(s) to bind to

--- a/src/usr/local/www/services_unbound_advanced.php
+++ b/src/usr/local/www/services_unbound_advanced.php
@@ -54,6 +54,10 @@ if (isset($config['unbound']['dnssecstripped'])) {
 	$pconfig['dnssecstripped'] = true;
 }
 
+if (isset($config['unbound']['dnsrecordcache'])) {
+	$pconfig['dnsrecordcache'] = true;
+}
+
 $pconfig['msgcachesize'] = $config['unbound']['msgcachesize'];
 $pconfig['outgoing_num_tcp'] = isset($config['unbound']['outgoing_num_tcp']) ? $config['unbound']['outgoing_num_tcp'] : '10';
 $pconfig['incoming_num_tcp'] = isset($config['unbound']['incoming_num_tcp']) ? $config['unbound']['incoming_num_tcp'] : '10';
@@ -156,6 +160,11 @@ if ($_POST) {
 			} else {
 				unset($config['unbound']['dnssecstripped']);
 			}
+			if (isset($_POST['dnsrecordcache'])) {
+				$config['unbound']['dnsrecordcache'] = true;
+			} else {
+				unset($config['unbound']['dnsrecordcache']);
+			}
 			$config['unbound']['msgcachesize'] = $_POST['msgcachesize'];
 			$config['unbound']['outgoing_num_tcp'] = $_POST['outgoing_num_tcp'];
 			$config['unbound']['incoming_num_tcp'] = $_POST['incoming_num_tcp'];
@@ -255,6 +264,13 @@ $section->addInput(new Form_Checkbox(
 	'DNSSEC data is required for trust-anchored zones.',
 	$pconfig['dnssecstripped']
 ))->setHelp('If such data is absent, the zone becomes bogus. If Disabled and no DNSSEC data is received, then the zone is made insecure. ');
+
+$section->addInput(new Form_Checkbox(
+	'dnsrecordcache',
+	'Serve Expired',
+	'Serve cache records even with TTL of 0',
+	$pconfig['dnsrecordcache']
+))->setHelp('When enabled, allows unbound to serve one query even with a TTL of 0, if TTL is 0 then new record will be requested in the background when the cache is served to ensure cache is updated without latency on service of the DNS request.');
 
 $section->addInput(new Form_Select(
 	'msgcachesize',


### PR DESCRIPTION
Serve expired – Records stay in cache after TTL expires, with a TTL value of 0, if a new lookup is requested the cached record will be served for maximum performance, but at same time the resolver will ask for a new value from upstream to refresh the value and TTL.