### PR TITLE
show disabled status on status-interfaces

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1484,6 +1484,7 @@ function get_interface_info($ifdescr) {
 		return;
 	}
 	$ifinfo['hwif'] = $config['interfaces'][$ifdescr]['if'];
+	$ifinfo['enable'] = isset($config['interfaces'][$ifdescr]['enable']);
 	$ifinfo['if'] = get_real_interface($ifdescr);
 
 	$chkif = $ifinfo['if'];

--- a/src/usr/local/www/status_interfaces.php
+++ b/src/usr/local/www/status_interfaces.php
@@ -113,7 +113,7 @@ foreach ($ifdescrs as $ifdescr => $ifname):
 	<div class="panel-body">
 		<dl class="dl-horizontal">
 <?php
-		showDef(true, gettext("Status"), $ifinfo['status']);
+		showDef(true, gettext("Status"), $ifinfo['enable'] ? $ifinfo['status'] : gettext('disabled'));
 		showDefBtn($ifinfo['dhcplink'], 'DHCP', $ifinfo['dhcplink'], $ifdescr, $ifinfo['dhcplink'] == "up" ? gettext("Release") : gettext("Renew"), $ifinfo['dhcplink'] == "up" ? $chkbox_relinquish_lease_v4 : '');
 		showDefBtn($ifinfo['dhcp6link'], 'DHCP6', $ifinfo['dhcp6link'], $ifdescr, $ifinfo['dhcp6link'] == "up" ? gettext("Release") : gettext("Renew"), $ifinfo['dhcp6link'] == "up" ? $chkbox_relinquish_lease_v6 : '');
 		showDefBtn($ifinfo['pppoelink'], 'PPPoE', $ifinfo['pppoelink'], $ifdescr, $ifinfo['pppoelink'] == "up" ? gettext("Disconnect") : gettext("Connect"), '');


### PR DESCRIPTION
from a forum comment https://forum.pfsense.org/index.php?topic=136279.0

It can be misleading to report "down" when it is just that the interface is disabled in pfSense. e.g. when I disable LAN then it shows "down".

However, I tried also in a VM with LAN as "em1" and then OPT1 as a VLAN on "em1". With both interfaces disabled, Status->Interfaces shows LAN as down and OPT1 as up. So something happens differently for detecting/reporting the status of VLANs.

This is the quick-and-easy way to just override the "up/down" status if the interface is disabled. But perhaps things can be done better in ``pfSense_get_interface_addresses`` so that it returns a more accurate up/down state even when the interface is disabled at the pfSense software level.