### PR TITLE
SNMP, check for several hypervisors that cause hostres module high cpu usage

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2310,6 +2310,19 @@ function services_unbound_configure($restart_dhcp = true) {
 	return $return;
 }
 
+function platform_snmpd_hostres_supported() {
+	// does hostres have trouble with all VM's? if so then perhaps the check could be done with: isvm()
+	// hostres causes high cpu usage on at least these hypervisors when a cd drive is pressent
+	$problem_hypervisors = array('vmware', 'virtualbox', 'proxmox');
+	$specplatform = system_identify_specific_platform();
+	if (file_exists('/dev/cd0')) {
+		if (in_array(strtolower($specplatform['name']), $problem_hypervisors)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 function services_snmpd_configure() {
 	global $config, $g;
 	if (isset($config['system']['developerspew'])) {
@@ -2479,7 +2492,7 @@ EOD;
 			}
 
 			if (isset($config['snmpd']['modules']['hostres'])
-			    && !(($specplatform['name'] == 'VMware') && (file_exists('/dev/cd0')))) {
+			    && platform_snmpd_hostres_supported()) {
 				$snmpdconf .= <<<EOD
 begemotSnmpdModulePath."hostres"     = "/usr/lib/snmp_hostres.so"
 

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2311,14 +2311,10 @@ function services_unbound_configure($restart_dhcp = true) {
 }
 
 function platform_snmpd_hostres_supported() {
-	// does hostres have trouble with all VM's? if so then perhaps the check could be done with: isvm()
 	// hostres causes high cpu usage on at least these hypervisors when a cd drive is pressent
-	$problem_hypervisors = array('vmware', 'virtualbox', 'proxmox');
-	$specplatform = system_identify_specific_platform();
-	if (file_exists('/dev/cd0')) {
-		if (in_array(strtolower($specplatform['name']), $problem_hypervisors)) {
-			return false;
-		}
+	// problem is confirmed on at least these platforms: vmware/hyperv/proxmox/virtualbox/xen
+	if (file_exists('/dev/cd0') && isvm()) {
+		return false;
 	}
 	return true;
 }

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2460,6 +2460,9 @@ function system_identify_specific_platform() {
 		case 'APU2':
 			return (array('name' => 'apu2', 'descr' => 'PC Engines APU2'));
 			break;
+		case 'VirtualBox':
+			return (array('name' => 'VirtualBox', 'descr' => 'VirtualBox Virtual Machine'));
+			break;
 		case 'Virtual Machine':
 			if ($maker[0] == "Microsoft Corporation") {
 				return (array('name' => 'Hyper-V', 'descr' => 'Hyper-V Virtual Machine'));

--- a/src/usr/local/www/services_snmp.php
+++ b/src/usr/local/www/services_snmp.php
@@ -32,8 +32,7 @@
 
 require_once("guiconfig.inc");
 require_once("functions.inc");
-
-$specplatform = system_identify_specific_platform();
+require_once("services.inc");
 
 if (!is_array($config['snmpd'])) {
 	$config['snmpd'] = array();
@@ -318,7 +317,7 @@ $group->add(new Form_MultiCheckbox(
 	$pconfig['pf']
 ));
 
-if (!(($specplatform['name'] == 'VMware') && (file_exists('/dev/cd0')))) {
+if (platform_snmpd_hostres_supported()) {
 	$group->add(new Form_MultiCheckbox(
 		'hostres',
 		null,
@@ -342,11 +341,11 @@ $group->add(new Form_MultiCheckbox(
 ));
 
 $section->add($group);
-if ((($specplatform['name'] == 'VMware') && (file_exists('/dev/cd0')))) {
+if (!platform_snmpd_hostres_supported()) {
 	$section->addInput(new Form_StaticText(
 		NULL,
 		NULL
-	))->setHelp(sprint_info_box('The hostres module is not compatible with VMware virtual ' .
+	))->setHelp(sprint_info_box('The hostres module is not compatible with VMware/Proxmox/Virtualbox virtual ' .
 		    'machines configured with a virtual CD/DVD Drive.', 'warning', false));
 }
 


### PR DESCRIPTION
SNMP, check for several hypervisors that cause hostres module high cpu usage

also skip setting it in the bnsmp config when such platform is detected without needing the user to save settings again

p.s.
'Proxmox' is not yet set in the system_identify_specific_platform() .. i don't have such a system.. maybe it should be a QEMU check.?. or maybe its a problem in hostres for all isvm() machines that have a cd.?