### PR TITLE
Update misleading LDAP extended query help text

### DIFF
--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -626,7 +626,7 @@ $group->add(new Form_Input(
 	'Query',
 	'text',
 	$pconfig['ldap_extended_query']
-))->setHelp('Example: memberOf=CN=Groupname,OU=MyGroups,DC=example,DC=com;OU=OtherUsers,DC=example,DC=com');
+))->setHelp('Example: memberOf=CN=Groupname,OU=MyGroups,DC=example,DC=com');
 
 $section->add($group);
 

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -626,7 +626,7 @@ $group->add(new Form_Input(
 	'Query',
 	'text',
 	$pconfig['ldap_extended_query']
-))->setHelp('Example: &amp;(objectClass=inetOrgPerson)(mail=*@example.com)');
+))->setHelp('Example: memberOf=CN=Groupname,OU=MyGroups,DC=example,DC=com;OU=OtherUsers,DC=example,DC=com');
 
 $section->add($group);
 


### PR DESCRIPTION
Spent some time with a friend setting up a pfSense box, trying to get LDAP working for OpenVPN. He was running into an issue whereby the extended LDAP query wasn't working as expected, as we were referencing the existing help text, which showed using the full `(&(...)(...))` syntax in the field. However, taking a look at `/src/etc/inc/auth.inc`:
```
if (!$ldapextendedqueryenabled) {
			$ldapfilter = "({$ldapnameattribute}={$username})";
		} else {
			$ldapfilter = "(&({$ldapnameattribute}={$username})({$ldapextendedquery}))";
		}
```
If using the extended query, it's already setting the full LDAP filter string. The existing text is a bit misleading, since it appears it's actually looking for `memberOf=...`