### PR TITLE
Unbound - allow snoop from localhost

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -702,8 +702,8 @@ function unbound_acls_config($cfgsubdir = "") {
 	global $g, $config;
 
 	if (!isset($config['unbound']['disable_auto_added_access_control'])) {
-		$aclcfg = "access-control: 127.0.0.1/32 allow\n";
-		$aclcfg .= "access-control: ::1 allow\n";
+		$aclcfg = "access-control: 127.0.0.1/32 allow_snoop\n";
+		$aclcfg .= "access-control: ::1 allow_snoop\n";
 		// Add our networks for active interfaces including localhost
 		if (!empty($config['unbound']['active_interface'])) {
 			$active_interfaces = array_flip(explode(",", $config['unbound']['active_interface']));


### PR DESCRIPTION
dig +trace fails without this, which is super annoying for debugging/diagnostics/benchmarking or whatever similar purposes. Allowing both recursive and non-recursive queries should be of no security concern as long as it's localhost-only.

https://redmine.pfsense.org/issues/7884