### PR TITLE
Allow specific gateways to be excluded from default gateway switching

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -927,9 +927,13 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 		if (empty($upgw) && ($gwsttng['ipprotocol'] == $ipprotocol) && (isset($gwsttng['monitor_disable']) || isset($gwsttng['action_disable']) || $gateways_status[$gwname]['status'] == "none") && $gwsttng[$gwname]['friendlyiface'] != "lan") {
 			if ($gwsttng['no_defgw_switch']) {
 				// do not elect this gateway if the `skip` option is set
-				log_error(sprintf(gettext('Found UP gateway %1$s but it was administratively skipped due to gateway settings'), $gwname));
+				if ($g['debug']) {
+					log_error(sprintf(gettext('Found UP gateway %1$s but it was administratively skipped due to gateway settings'), $gwname));
+				}
 			} else {
-				// log_error(sprintf(gettext('Found UP gateway %1$s'), $gwname));
+				if ($g['debug']) {
+					log_error(sprintf(gettext('Found UP gateway %1$s'), $gwname));
+				}
 				$upgw = $gwname;
 			}
 		}

--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -643,6 +643,11 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 					$found_defaultv6 = 1;
 				}
 			}
+
+			if (isset($gateway['no_defgw_switch'])) {
+				$gateway['no_defgw_switch'] = true;
+			}
+
 			/* include the gateway index as the attribute */
 			$gateway['attribute'] = $i;
 
@@ -920,7 +925,13 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 		/* Keep a record of the last up gateway */
 		/* XXX: Blacklist lan for now since it might cause issues to those who have a gateway set for it */
 		if (empty($upgw) && ($gwsttng['ipprotocol'] == $ipprotocol) && (isset($gwsttng['monitor_disable']) || isset($gwsttng['action_disable']) || $gateways_status[$gwname]['status'] == "none") && $gwsttng[$gwname]['friendlyiface'] != "lan") {
-			$upgw = $gwname;
+			if ($gwsttng['no_defgw_switch']) {
+				// do not elect this gateway if the `skip` option is set
+				log_error(sprintf(gettext('Found UP gateway %1$s but it was administratively skipped due to gateway settings'), $gwname));
+			} else {
+				// log_error(sprintf(gettext('Found UP gateway %1$s'), $gwname));
+				$upgw = $gwname;
+			}
 		}
 		if ($dfltgwdown == true && !empty($upgw)) {
 			break;
@@ -1518,6 +1529,11 @@ function validate_gateway($gateway_settings, $id = "", $parent_ip = "", $parent_
 		}
 	}
 
+	if (($gateway_settings['no_defgw_switch'] == "yes") && ($gateway_settings['defaultgw'] == "yes")) {
+		/* marking a gateway as the default is mutually exclusive with this option */
+		$input_errors[] = gettext("Gateway cannot be both the default and also excluded from gateway switching. Choose one or the other.");
+	}
+
 	if (isset($gateway_settings['name'])) {
 		/* check for overlaps */
 		foreach ($a_gateways as $gateway) {
@@ -1753,6 +1769,10 @@ function save_gateway($gateway_settings, $realid = "") {
 		} else {
 			mwexec("/sbin/route delete -inet6 " . escapeshellarg($a_gateway_item[$realid]['monitor']));
 		}
+	}
+
+	if ($gateway_settings['no_defgw_switch'] == "yes" || $gateway_settings['no_defgw_switch'] == "on") {
+		$gateway['no_defgw_switch'] = true;
 	}
 
 	if ($gateway_settings['defaultgw'] == "yes" || $gateway_settings['defaultgw'] == "on") {

--- a/src/usr/local/www/system_advanced_misc.php
+++ b/src/usr/local/www/system_advanced_misc.php
@@ -384,8 +384,11 @@ $section->addInput(new Form_Checkbox(
 	'Enable default gateway switching',
 	$pconfig['gw_switch_default']
 ))->setHelp('If the default gateway goes down, switch the default gateway to '.
-	'another available one. This is not enabled by default, as it\'s unnecessary in '.
-	'most all scenarios, which instead use gateway groups.');
+	'another available one. If you do not enable this option, traffic originating '.
+	'from the firewall itself (e.g. SMTP notifications) may fail if the default '.
+	'gateway is down, even if other gateways are still up. Individual gateways '.
+	'can be omitted from being marked as default by enabling the "Skip Default" '.
+	'checkbox on their respective %1$sGateway Settings%2$s page.','<a href="system_gateways.php">','</a>');
 
 $form->add($section);
 $section = new Form_Section('Power Savings');

--- a/src/usr/local/www/system_gateways.php
+++ b/src/usr/local/www/system_gateways.php
@@ -248,6 +248,7 @@ display_top_tabs($tab_array);
 					<tr>
 						<th></th>
 						<th><?=gettext("Name")?></th>
+						<th><?=gettext("Skip Def.")?></th>
 						<th><?=gettext("Interface")?></th>
 						<th><?=gettext("Gateway")?></th>
 						<th><?=gettext("Monitor IP")?></th>
@@ -281,6 +282,14 @@ foreach ($a_gateways as $i => $gateway):
 				echo " <strong>(default)</strong>";
 			}
 ?>
+						</td>
+						<td>
+							<?php
+								if (isset($gateway['no_defgw_switch'])) {
+									echo '<i class="fa fa-arrow-circle-o-down" title="This gateway will be skipped during default gateway switching"></i>';
+								}
+							?>
+							&nbsp;
 						</td>
 						<td>
 							<?=htmlspecialchars(convert_friendly_interface_to_friendly_descr($gateway['friendlyiface']))?>

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -81,6 +81,7 @@ if (isset($id) && $a_gateways[$id]) {
 	$pconfig['descr'] = $a_gateways[$id]['descr'];
 	$pconfig['attribute'] = $a_gateways[$id]['attribute'];
 	$pconfig['disabled'] = isset($a_gateways[$id]['disabled']);
+	$pconfig['no_defgw_switch'] = isset($a_gateways[$id]['no_defgw_switch']);
 }
 
 if (isset($_REQUEST['dup']) && is_numericint($_REQUEST['dup'])) {
@@ -199,7 +200,22 @@ $section->addInput(new Form_Checkbox(
 	'Default Gateway',
 	'This will select the above gateway as the default gateway.',
 	$pconfig['defaultgw']
-));
+))->toggles('.toggle-nodefgwswitch');
+
+$group = new Form_Group('Skip Default');
+$group->addClass('toggle-nodefgwswitch', 'collapse');
+
+if ($pconfig['defaultgw'] == false)
+	$group->addClass('in');
+
+$group->add(new Form_Checkbox(
+	'no_defgw_switch',
+	null,
+	'Not eligible to become the default gateway',
+	$pconfig['no_defgw_switch']
+))->setHelp('If checked, this gateway will not be chosen during default gateway switching (see %1$sSystem &gt; Advanced%2$s).','<a href="system_advanced_misc.php">','</a>');
+
+$section->add($group);
 
 $section->addInput(new Form_Checkbox(
 	'monitor_disable',


### PR DESCRIPTION
_Rebase/update of my old PR #3609 -- trying again!_

This commit adds a feature to allow you to optionally prevent gateways from being elected as default during Gateway Switching operations in a multi-WAN environment when the "Enable default gateway switching" option is enabled. Some possible use cases:

- non-internet-facing gateways
- metered connections
- VPN gateways

This only controls the default gateway of the firewall itself; it does not change the behavior of Policy Based Routing.

**Changes/new features**

-adds a `no_defgw_switch` flag to gateway config that will cause it to be excluded from the default gateway selection process
-indicate this setting (as an icon) in System > Routing > Gateways
-updated help text for Default gateway switching in System > Advanced > Misc to better describe the usage of that feature
-adds some debug logging for gw change events
-setting a gateway as default on the edit page automatically toggles/hides this option, as having both enabled would not be sane

_Files changed:_
/etc/inc/gwlb.inc
/usr/local/www/system_advanced_misc.php
/usr/local/www/system_gateways.php
/usr/local/www/system_gateways_edit.php
