### PR TITLE
Improve flexibility of DHCPD config

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -688,6 +688,18 @@ EOPP;
 		$subnet = gen_subnet($ifcfgip, $ifcfgsn);
 		$subnetmask = gen_subnet_mask($ifcfgsn);
 
+		$vipaliases = Array();
+		if (is_array($config['virtualip']['vip'])) {
+			foreach ($config['virtualip']['vip'] as $vipent) {
+				if ($vipent['mode'] != 'ipalias') continue;
+				if ($vipent['interface'] != $dhcpif) continue;
+				$vipalias = Array();
+				$vipalias['subnet'] = $vipent['subnet'];
+				$vipalias['subnet_bits'] = $vipent['subnet_bits'];
+				array_push($vipaliases, $vipalias);
+			}
+		}
+
 		if (!is_ipaddr($subnet)) {
 			continue;
 		}
@@ -798,6 +810,16 @@ EOPP;
 				// Skip the first octet of the MAC address - for media type, typically Ethernet ("01") and match the rest.
 				$dhcpdconf .= '	match if substring (hardware, 1, ' . (substr_count($mac, ':') + 1) . ') = ' . $mac . ';' . "\n";
 				$dhcpdconf .= '}' . "\n";
+			}
+		}
+        $vipaliases = Array();
+		if (isset($config['dhcpd'][$dhcpif]['enable_aliases'])) {
+			$dhcpdconf .= "shared-network {$dhcpif} {\n";
+			foreach ($vipaliases as $vipalias) {
+				$vipsubnet = gen_subnet($vipalias['subnet'], $vipalias['subnet_bits']);
+				$vipsubnetbits = $vipalias['subnet_bits'];
+				$vipsubnetmask = gen_subnet_mask($vipalias['subnet_bits']);
+				$dhcpdconf .= "subnet {$vipsubnet} netmask {$vipsubnetmask} {}\n";
 			}
 		}
 
@@ -1066,6 +1088,9 @@ EOD;
 }
 
 EOD;
+		if (isset($config['dhcpd'][$dhcpif]['enable_aliases'])) {
+			$dhcpdconf .= "}\n";
+		}
 
 		/* add static mappings */
 		if (is_array($dhcpifconf['staticmap'])) {

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -180,6 +180,7 @@ if (is_array($dhcpdconf)) {
 	// Global Options
 	if (!is_numeric($pool) && !($act == "newpool")) {
 		$pconfig['enable'] = isset($dhcpdconf['enable']);
+		$pconfig['enable_aliases'] = isset($dhcpdconf['enable_aliases']);
 		$pconfig['staticarp'] = isset($dhcpdconf['staticarp']);
 		// No reason to specify this per-pool, per the dhcpd.conf man page it needs to be in every
 		//	 pool and should be specified in every pool both nodes share, so we'll treat it as global
@@ -561,6 +562,7 @@ if (isset($_POST['save'])) {
 			}
 
 			$dhcpdconf['enable'] = $new_dhcpd_enable;
+			$dhcpdconf['enable_aliases'] = ($_POST['enable_aliases']) ? true : false;
 			$dhcpdconf['staticarp'] = ($_POST['staticarp']) ? true : false;
 			$previous = $dhcpdconf['failover_peerip'];
 			if ($previous != $_POST['failover_peerip']) {
@@ -854,6 +856,12 @@ if (!is_numeric($pool) && !($act == "newpool")) {
 			'Enable',
 			sprintf(gettext("Enable DHCP server on %s interface"), htmlspecialchars($iflist[$if])),
 			$pconfig['enable']
+		));
+		$section->addInput(new Form_Checkbox(
+			'enable_aliases',
+			'Virtual IPs',
+			sprintf(gettext("Allow DHCP static mappings on virtual IP subnets bound to %s interface"), htmlspecialchars($iflist[$if])),
+			$pconfig['enable_aliases']
 		));
 	}
 } else {

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -107,6 +107,7 @@ if (!is_array($config['dhcpd'][$if]['pool'])) {
 }
 $a_pools = &$config['dhcpd'][$if]['pool'];
 
+$aliases_enabled=isset($config['dhcpd'][$if]['enable_aliases']);
 $static_arp_enabled=isset($config['dhcpd'][$if]['staticarp']);
 $netboot_enabled=isset($config['dhcpd'][$if]['netboot']);
 $a_maps = &$config['dhcpd'][$if]['staticmap'];
@@ -252,7 +253,7 @@ if ($_POST) {
 
 		$lansubnet_start = gen_subnetv4($ifcfgip, $ifcfgsn);
 		$lansubnet_end = gen_subnetv4_max($ifcfgip, $ifcfgsn);
-		if (!is_inrange_v4($_POST['ipaddr'], $lansubnet_start, $lansubnet_end)) {
+		if ((!$aliases_enabled || !ip_in_interface_alias_subnet($if, $_POST['ipaddr'])) && (!is_inrange_v4($_POST['ipaddr'], $lansubnet_start, $lansubnet_end))) {
 			$input_errors[] = sprintf(gettext("The IP address must lie in the %s subnet."), $ifcfgdescr);
 		}
 


### PR DESCRIPTION
- New checkbox "Virtual IPs" to allow dhcpd to use ipalias subnets
- Allow creation of static mappings on ipalias subnets

I've minimally tested this. It's mostly for comment at this point. 

This is a very minimal effort to allow creation of dhcpd static host configurations on ipalias subnets. It is enabled by checking the "Virtual IPs" checkbox on the DHCPD service configuration view. Once enabled, the user will be able to create static mappings with addresses that match any subnet bound to the interface, including ipalias address subnets.

In order to facilitate this change, once enabled, the dhcpd.conf is modified to include all subnets of a given interface within a "shared-network" block named for the interface the subnets live on. No options are allowed within ipalias subnets.

This is as far as I'd like to go with this feature, but it could be expanded to allow for "Additional Pools" to be created within the ipalias subnets. I did some work towards this, but have stopped as it becomes very difficult to validate the new pools and all of their options without a major refactor if services_dhcp.php.

Know issues:
- Once "Virtual IPs" is disabled, the out of subnet static mappings remain
- dhcpd.conf indentation is inconsistent
