### PR TITLE
VirtualIP, FIX, VIPs should have a <uniqueid> property inside the config.xml

### DIFF
--- a/src/usr/local/www/firewall_virtual_ip_edit.php
+++ b/src/usr/local/www/firewall_virtual_ip_edit.php
@@ -214,7 +214,6 @@ if ($_POST['save']) {
 		/* CARP specific fields */
 		if ($_POST['mode'] === "carp") {
 			$vipent['vhid'] = $_POST['vhid'];
-			$vipent['uniqid'] = $_POST['uniqid'];
 			$vipent['advskew'] = $_POST['advskew'];
 			$vipent['advbase'] = $_POST['advbase'];
 
@@ -225,9 +224,14 @@ if ($_POST['save']) {
 			}
 		}
 
-		/* IPalias specific fields */
-		if ($_POST['mode'] === "ipalias") {
-			$vipent['uniqid'] = $_POST['uniqid'];
+		/* IPalias and CARP should have a uniqid */
+		if ($_POST['mode'] === "carp" || $_POST['mode'] === "ipalias") {
+			if (empty($_POST['uniqid'])) {
+				// if we changed a 'parp' or 'other' alias to 'carp'/'ipalias' it needs a uniqid
+				$vipent['uniqid'] = uniqid();
+			} else {
+				$vipent['uniqid'] = $_POST['uniqid'];
+			}
 		}
 
 		/* Common fields */


### PR DESCRIPTION
VirtualIP, FIX, VIPs should have a <uniqueid> property inside the config.xml, however if they are added as 'proxy-arp' or 'other' and then modified to ipalias or carp, the uniqueid stays empty.