### PR TITLE
Added Granularity for Firewall Logging Settings

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -3129,6 +3129,12 @@ function filter_rules_generate() {
 	if (isset($config['syslog']['nologdefaultpass'])) {
 		$log['pass'] = "log";
 	}
+	if (isset($config['syslog']['logsnortblock']) || !isset($config['syslog']['nologdefaultblock'])) {
+		$log['snortblock'] = "log";
+	}
+	if (isset($config['syslog']['logvirusprotblock']) || !isset($config['syslog']['nologdefaultblock'])) {
+		$log['virusprotblock'] = "log";
+	}
 
 	$saved_tracker = $tracker;
 
@@ -3206,8 +3212,8 @@ EOD;
 	$ipfrules .= <<<EOD
 
 # Snort package
-block {$log['block']} quick from <snort2c> to any tracker {$increment_tracker($tracker)} label "Block snort2c hosts"
-block {$log['block']} quick from any to <snort2c> tracker {$increment_tracker($tracker)} label "Block snort2c hosts"
+block {$log['snortblock']} quick from <snort2c> to any tracker {$increment_tracker($tracker)} label "Block snort2c hosts"
+block {$log['snortblock']} quick from any to <snort2c> tracker {$increment_tracker($tracker)} label "Block snort2c hosts"
 
 EOD;
 
@@ -3259,7 +3265,7 @@ EOD;
 	 * Support for allow limiting of TCP connections by establishment rate
 	 * Useful for protecting against sudden outbursts, etc.
 	 */
-	$ipfrules .= "block in {$log['block']} quick from <virusprot> to any tracker 1000000400 label \"virusprot overload table\"\n";
+	$ipfrules .= "block in {$log['virusprotblock']} quick from <virusprot> to any tracker 1000000400 label \"virusprot overload table\"\n";
 
 	$saved_tracker += 100;
 	$tracker = $saved_tracker;


### PR DESCRIPTION
Allows snort and virusprot table logs to be enabled independently from "default"
If "Log Default Blocks" is enabled the functionality is unchanged. If not set, a user can log snort/virusprot table blocks without all of the default blocks.