### PR TITLE
Don't create unwanted gateways for OpenVPN interfaces

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -699,15 +699,28 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 			default:
 				$tunnelif = substr($ifcfg['if'], 0, 3);
 				if (substr($ifcfg['if'], 0, 4) == "ovpn") {
-					// if current iface is an ovpn server endpoint then check its type, skip tap only
-					if (substr($ifcfg['if'], 4, 1) == 's') {
-						$ovpnid = substr($ifcfg['if'], 5);
-						if (is_array($config['openvpn']['openvpn-server'])) {
-							foreach ($config['openvpn']['openvpn-server'] as & $ovpnserverconf) {
-								if ($ovpnserverconf['vpnid'] == $ovpnid) {
-									if ($ovpnserverconf['dev_mode'] == "tap") {
-										continue 3;
-									}
+					switch (substr($ifcfg['if'], 4, 1)) {
+						case "c":
+							$ovpntype = "openvpn-client";
+							break;
+						case "s":
+							$ovpntype = "openvpn-server";
+							break;
+						default:
+							// unknown ovpn type
+							continue 2;
+					}
+					$ovpnid = substr($ifcfg['if'], 5);
+					if (is_array($config['openvpn'][$ovpntype])) {
+						foreach ($config['openvpn'][$ovpntype] as & $ovpnconf) {
+							if ($ovpnconf['vpnid'] == $ovpnid) {
+								// skip IPv6-only interfaces
+								if ($ovpnconf['create_gw'] == "v6only") {
+									continue 3;
+								}
+								// skip tap interfaces
+								if ($ovpnconf['dev_mode'] == "tap") {
+									continue 3;
 								}
 							}
 						}
@@ -791,15 +804,28 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 			default:
 				$tunnelif = substr($ifcfg['if'], 0, 3);
 				if (substr($ifcfg['if'], 0, 4) == "ovpn") {
-					// if current iface is an ovpn server endpoint then check its type, skip tap only
-					if (substr($ifcfg['if'], 4, 1) == 's') {
-						$ovpnid = substr($ifcfg['if'], 5);
-						if (is_array($config['openvpn']['openvpn-server'])) {
-							foreach ($config['openvpn']['openvpn-server'] as & $ovpnserverconf) {
-								if ($ovpnserverconf['vpnid'] == $ovpnid) {
-									if ($ovpnserverconf['dev_mode'] == "tap") {
-										continue 3;
-									}
+					switch (substr($ifcfg['if'], 4, 1)) {
+						case "c":
+							$ovpntype = "openvpn-client";
+							break;
+						case "s":
+							$ovpntype = "openvpn-server";
+							break;
+						default:
+							// unknown ovpn type
+							continue 2;
+					}
+					$ovpnid = substr($ifcfg['if'], 5);
+					if (is_array($config['openvpn'][$ovpntype])) {
+						foreach ($config['openvpn'][$ovpntype] as & $ovpnconf) {
+							if ($ovpnconf['vpnid'] == $ovpnid) {
+								// skip IPv4-only interfaces
+								if ($ovpnconf['create_gw'] == "v4only") {
+									continue 3;
+								}
+								// skip tap interfaces
+								if ($ovpnconf['dev_mode'] == "tap") {
+									continue 3;
 								}
 							}
 						}

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -172,6 +172,11 @@ if ($act == "edit") {
 
 		$pconfig['route_no_pull'] = $a_client[$id]['route_no_pull'];
 		$pconfig['route_no_exec'] = $a_client[$id]['route_no_exec'];
+		if (isset($a_client[$id]['create_gw'])) {
+			$pconfig['create_gw'] = $a_client[$id]['create_gw'];
+		} else {
+			$pconfig['create_gw'] = "both"; // v4only, v6only, or both (default: both)
+		}
 		if (isset($a_client[$id]['verbosity_level'])) {
 			$pconfig['verbosity_level'] = $a_client[$id]['verbosity_level'];
 		} else {
@@ -442,6 +447,7 @@ if ($_POST['save']) {
 		$client['route_no_pull'] = $pconfig['route_no_pull'];
 		$client['route_no_exec'] = $pconfig['route_no_exec'];
 		$client['verbosity_level'] = $pconfig['verbosity_level'];
+		$client['create_gw'] = $pconfig['create_gw'];
 
 		if (!empty($pconfig['ncp-ciphers'])) {
 			$client['ncp-ciphers'] = implode(",", $pconfig['ncp-ciphers']);
@@ -898,6 +904,37 @@ if ($act=="new" || $act=="edit"):
 				'The default buffer size can be too small in many cases, depending on hardware and network uplink speeds. ' .
 				'Finding the best buffer size can take some experimentation. To test the best value for a site, start at ' .
 				'512KiB and test higher and lower values.');
+
+	$group = new Form_Group('Gateway creation');
+	$group->add(new Form_Checkbox(
+		'create_gw',
+		null,
+		'Both',
+		($pconfig['create_gw'] == "both"),
+		'both'
+	))->displayAsRadio();
+
+	$group->add(new Form_Checkbox(
+		'create_gw',
+		null,
+		'IPv4 only',
+		($pconfig['create_gw'] == "v4only"),
+		'v4only'
+	))->displayAsRadio();
+
+	$group->add(new Form_Checkbox(
+		'create_gw',
+		null,
+		'IPv6 only',
+		($pconfig['create_gw'] == "v6only"),
+		'v6only'
+	))->displayAsRadio();
+
+	$group->setHelp('If you assign a virtual interface to this OpenVPN client, ' .
+		'this setting controls which gateway types will be created. The default ' .
+		'setting is \'both\'.');
+
+	$section->add($group);
 
 	$section->addInput(new Form_Select(
 		'verbosity_level',

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -106,6 +106,7 @@ if ($act == "new") {
 	$pconfig['interface'] = "wan";
 	$pconfig['local_port'] = openvpn_port_next('UDP');
 	$pconfig['cert_depth'] = 1;
+	$pconfig['create_gw'] = "both"; // v4only, v6only, or both (default: both)
 	$pconfig['verbosity_level'] = 1; // Default verbosity is 1
 	// OpenVPN Defaults to SHA1
 	$pconfig['digest'] = "SHA1";
@@ -236,6 +237,12 @@ if ($act == "edit") {
 		$pconfig['autotls_enable'] = "yes";
 
 		$pconfig['duplicate_cn'] = isset($a_server[$id]['duplicate_cn']);
+
+		if (isset($a_server[$id]['create_gw'])) {
+			$pconfig['create_gw'] = $a_server[$id]['create_gw'];
+		} else {
+			$pconfig['create_gw'] = "both"; // v4only, v6only, or both (default: both)
+		}
 
 		if (isset($a_server[$id]['verbosity_level'])) {
 			$pconfig['verbosity_level'] = $a_server[$id]['verbosity_level'];
@@ -583,6 +590,7 @@ if ($_POST['save']) {
 		$server['netbios_ntype'] = $pconfig['netbios_ntype'];
 		$server['netbios_scope'] = $pconfig['netbios_scope'];
 
+		$server['create_gw'] = $pconfig['create_gw'];
 		$server['verbosity_level'] = $pconfig['verbosity_level'];
 
 		if ($pconfig['netbios_enable']) {
@@ -1295,6 +1303,37 @@ if ($act=="new" || $act=="edit"):
 				'The default buffer size can be too small in many cases, depending on hardware and network uplink speeds. ' .
 				'Finding the best buffer size can take some experimentation. To test the best value for a site, start at ' .
 				'512KiB and test higher and lower values.');
+
+	$group = new Form_Group('Gateway creation');
+	$group->add(new Form_Checkbox(
+		'create_gw',
+		null,
+		'Both',
+		($pconfig['create_gw'] == "both"),
+		'both'
+	))->displayAsRadio();
+
+	$group->add(new Form_Checkbox(
+		'create_gw',
+		null,
+		'IPv4 only',
+		($pconfig['create_gw'] == "v4only"),
+		'v4only'
+	))->displayAsRadio();
+
+	$group->add(new Form_Checkbox(
+		'create_gw',
+		null,
+		'IPv6 only',
+		($pconfig['create_gw'] == "v6only"),
+		'v6only'
+	))->displayAsRadio();
+
+	$group->setHelp('If you assign a virtual interface to this OpenVPN server, ' .
+		'this setting controls which gateway types will be created. The default ' .
+		'setting is \'both\'.');
+
+	$section->add($group);
 
 	$section->addInput(new Form_Select(
 		'verbosity_level',


### PR DESCRIPTION
This patch adds a feature to the OpenVPN client & server config pages that allows specifying what types of gateways are automatically created for _assigned_ interfaces. This helps to keep the System>Routing page shorter and easier to read, especially when a user has many OpenVPN connections defined.

Tested on 2.4.0RC and 2.4.1 snaps.

_further discussion on forum_
https://forum.pfsense.org/index.php?topic=137317.0