### PR TITLE
Unbound - add a checkbox to optionally serve expired responses (Feature #7814)

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -265,6 +265,7 @@ EOF;
 	$msg_cache_size = (!empty($unboundcfg['msgcachesize'])) ? $unboundcfg['msgcachesize'] : "4";
 	$verbosity = isset($unboundcfg['log_verbosity']) ? $unboundcfg['log_verbosity'] : 1;
 	$use_caps = isset($unboundcfg['use_caps']) ? "yes" : "no";
+	$serve_expired = isset($unboundcfg['serve_expired']) ? "yes" : "no";
 
 	// Set up forwarding if it is configured
 	if (isset($unboundcfg['forwarding'])) {
@@ -357,6 +358,7 @@ outgoing-range: 4096
 prefetch: {$prefetch}
 prefetch-key: {$prefetch_key}
 use-caps-for-id: {$use_caps}
+serve-expired: {$serve_expired}
 # Statistics
 {$statistics}
 # Interface IP(s) to bind to

--- a/src/usr/local/www/services_unbound_advanced.php
+++ b/src/usr/local/www/services_unbound_advanced.php
@@ -191,6 +191,12 @@ if ($_POST) {
 				unset($config['unbound']['use_caps']);
 			}
 
+			if (isset($_POST['serve_expired'])) {
+				$config['unbound']['serve_expired'] = true;
+			} else {
+				unset($config['unbound']['serve_expired']);
+			}
+			
 			write_config(gettext("DNS Resolver configured."));
 
 			mark_subsystem_dirty('unbound');

--- a/src/usr/local/www/services_unbound_advanced.php
+++ b/src/usr/local/www/services_unbound_advanced.php
@@ -79,6 +79,10 @@ if (isset($config['unbound']['use_caps'])) {
 	$pconfig['use_caps'] = true;
 }
 
+if (isset($config['unbound']['serve_expired'])) {
+	$pconfig['serve_expired'] = true;
+}
+
 if ($_POST) {
 	if ($_POST['apply']) {
 		$retval = 0;
@@ -372,6 +376,14 @@ $section->addInput(new Form_Checkbox(
 	'Use 0x-20 encoded random bits in the DNS query to foil spoofing attempts.',
 	$pconfig['use_caps']
 ))->setHelp('See the implementation %1$sdraft dns-0x20%2$s for more information.', '<a href="https://tools.ietf.org/html/draft-vixie-dnsext-dns0x20-00">', '</a>');
+
+$section->addInput(new Form_Checkbox(
+	'serve_expired',
+	'Serve Expired',
+	'Serve old responses from cache with a TTL of 0.',
+	$pconfig['serve_expired']
+))->setHelp('If enabled, attempts to serve old responses from cache with a TTL of 0 in the response without waiting for the actual resolution to finish. ' .
+			'The actual resolution answer ends up in the cache later on.');
 
 $form->add($section);
 print($form);


### PR DESCRIPTION
See https://redmine.pfsense.org/issues/7814