### PR TITLE
xmlrpc, webgui, prevent that a xmlrpc.lock is placed that is never unlocked

### DIFF
--- a/src/usr/local/www/xmlrpc.php
+++ b/src/usr/local/www/xmlrpc.php
@@ -536,6 +536,10 @@ class pfsense_xmlrpc_server {
 	}
 }
 
+// run script untill its done and can 'unlock' the xmlrpc.lock, this prevents hanging php-fpm / webgui 
+ignore_user_abort(true); 
+set_time_limit(0);
+
 $xmlrpclockkey = lock('xmlrpc', LOCK_EX);
 
 XML_RPC2_Backend::setBackend('php');


### PR DESCRIPTION
xmlrpc, webgui, prevent that a xmlrpc.lock is placed that is never unlocked, thus hanging php and the webgui after a few more sync request are trying to acquire the lock and all are waiting..