### PR TITLE
Interfaces is the same word on english and spanish.

### DIFF
--- a/src/usr/local/share/locale/es/LC_MESSAGES/pfSense.po
+++ b/src/usr/local/share/locale/es/LC_MESSAGES/pfSense.po
@@ -991,7 +991,7 @@ msgstr "No información de estado IPsec disponible."
 #: src/usr/local/www/interfaces_vlan.php:76
 #: src/usr/local/www/interfaces_lagg.php:76
 msgid "Interfaces"
-msgstr "Interfases"
+msgstr "Interfaces"
 
 #: src/usr/local/www/interfaces_assign.php:34
 #: src/usr/local/www/interfaces_assign.php:494


### PR DESCRIPTION
"Interfases" is not correctly on spanish