### PR TITLE
Update Zabbix options

### DIFF
--- a/tools/conf/pfPorts/make.conf
+++ b/tools/conf/pfPorts/make.conf
@@ -139,15 +139,25 @@ www_squid_UNSET_FORCE=AUTH_SMB AUTH_SQL DEBUG DNS_HELPER ECAP ESI FS_ROCK GSSAPI
 security_suricata_SET_FORCE=GEOIP HTP_PORT IPFW JSON LUAJIT NSS PORTS_PCAP NETMAP HYPERSCAN REDIS
 security_suricata_UNSET_FORCE=LUA PRELUDE SC TESTS
 
-net-mgmt_zabbix22-agent_SET_FORCE=IPV6 SQLITE
+net-mgmt_zabbix22-agent_SET_FORCE=IPV6
 
-net-mgmt_zabbix22-proxy_SET_FORCE=IPV6 SQLITE
-net-mgmt_zabbix22-proxy_UNSET_FORCE=GSSAPI JABBER MYSQL
+net-mgmt_zabbix22-proxy_SET_FORCE=IPMI IPV6 LIBXML2 SQLITE SSH
+net-mgmt_zabbix22-proxy_UNSET_FORCE=JABBER MYSQL
 
-net-mgmt_zabbix3-agent_SET_FORCE=IPV6 SQLITE
+net-mgmt_zabbix3-agent_SET_FORCE=IPV6
 
-net-mgmt_zabbix3-proxy_SET_FORCE=IPV6 SQLITE
-net-mgmt_zabbix3-proxy_UNSET_FORCE=GSSAPI JABBER MYSQL
+net-mgmt_zabbix3-proxy_SET_FORCE=IPMI IPV6 LIBXML2 SQLITE SSH
+net-mgmt_zabbix3-proxy_UNSET_FORCE=MYSQL
+
+net-mgmt_zabbix32-agent_SET_FORCE=IPV6
+
+net-mgmt_zabbix32-proxy_SET_FORCE=IPMI IPV6 LIBXML2 SQLITE SSH
+net-mgmt_zabbix32-proxy_UNSET_FORCE=MYSQL
+
+net-mgmt_zabbix34-agent_SET_FORCE=IPV6
+
+net-mgmt_zabbix34-proxy_SET_FORCE=IPMI IPV6 LIBXML2 SQLITE SSH
+net-mgmt_zabbix34-proxy_UNSET_FORCE=MYSQL
 
 mail_postfix_SET_FORCE=PCRE SASL2 SPF TLS PERL
 


### PR DESCRIPTION
- Bring versions 3.2 and 3.4
- Enable IPMI, VMware and SSH monitoring for Zabbix Proxy
- Remove unnecessary items