### PR TITLE
Small update to ip_change_kill_states

### DIFF
--- a/src/usr/local/www/system_advanced_firewall.php
+++ b/src/usr/local/www/system_advanced_firewall.php
@@ -72,6 +72,7 @@ $pconfig['icmperrortimeout'] = $config['system']['icmperrortimeout'];
 $pconfig['otherfirsttimeout'] = $config['system']['otherfirsttimeout'];
 $pconfig['othersingletimeout'] = $config['system']['othersingletimeout'];
 $pconfig['othermultipletimeout'] = $config['system']['othermultipletimeout'];
+$pconfig['ip_change_kill_states'] = isset($config['system']['ip_change_kill_states']);
 
 if ($_POST) {
 
@@ -165,6 +166,7 @@ if ($_POST) {
 		} else {
 			unset($config['system']['disablevpnrules']);
 		}
+
 		if ($_POST['rfc959workaround'] == "yes") {
 			$config['system']['rfc959workaround'] = "enabled";
 		} else {
@@ -183,11 +185,18 @@ if ($_POST) {
 			unset($config['system']['scrubrnid']);
 		}
 
+		if ($_POST['ip_change_kill_states'] == "yes") {
+ 			$config['system']['ip_change_kill_states'] = true;
+		} else {
+			unset($config['system']['ip_change_kill_states']);
+		}
+
 		if (is_numericint($_POST['adaptiveend'])) {
 			$config['system']['adaptiveend'] = $_POST['adaptiveend'];
 		} else {
 			unset($config['system']['adaptiveend']);
 		}
+
 		if (is_numericint($_POST['adaptivestart'])) {
 			$config['system']['adaptivestart'] = $_POST['adaptivestart'];
 		} else {
@@ -435,6 +444,14 @@ $section->addInput(new Form_Checkbox(
 	'Disables the PF scrubbing option which can sometimes interfere with NFS traffic.',
 	isset($config['system']['disablescrub'])
 ));
+
+$section->addInput(new Form_Checkbox(
+	'ip_change_kill_states',
+	'Reset All States',
+	'Reset all states if WAN IP address changes',
+	isset($config['system']['ip_change_kill_states'])
+))->setHelp('This option resets all states when %1$sany%2$s WAN IP address changes, instead of only '.
+	'states associated with the IP address that was updated.', '<em>', '</em>');
 
 $group = new Form_Group('Firewall Adaptive Timeouts');
 

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -47,7 +47,6 @@ $pconfig['sharednet'] = $config['system']['sharednet'];
 $pconfig['disablechecksumoffloading'] = isset($config['system']['disablechecksumoffloading']);
 $pconfig['disablesegmentationoffloading'] = isset($config['system']['disablesegmentationoffloading']);
 $pconfig['disablelargereceiveoffloading'] = isset($config['system']['disablelargereceiveoffloading']);
-$pconfig['ip_change_kill_states'] = $config['system']['ip_change_kill_states'];
 
 if ($_POST) {
 
@@ -130,12 +129,6 @@ if ($_POST) {
 			$config['system']['disablelargereceiveoffloading'] = true;
 		} else {
 			unset($config['system']['disablelargereceiveoffloading']);
-		}
-
-		if ($_POST['ip_change_kill_states'] == "yes") {
-			$config['system']['ip_change_kill_states'] = true;
-		} else {
-			unset($config['system']['ip_change_kill_states']);
 		}
 
 		setup_microcode();
@@ -289,14 +282,6 @@ $section->addInput(new Form_Checkbox(
 	isset($pconfig['sharednet'])
 ))->setHelp('This option will suppress ARP log messages when multiple interfaces '.
 	'reside on the same broadcast domain.');
-
-$section->addInput(new Form_Checkbox(
-	'ip_change_kill_states',
-	'Reset All States',
-	'Reset all states if WAN IP Address changes',
-	isset($pconfig['ip_change_kill_states'])
-))->setHelp('This option resets all states when a WAN IP Address changes instead of only '.
-    'states associated with the previous IP Address.');
 
 if (get_freebsd_version() == 8) {
 	$section->addInput(new Form_Checkbox(


### PR DESCRIPTION
_this supersedes PR #3822 and is retargeted at master_

- **ip_change_kill_states** preference was not actually getting saved properly, fixed
- moved checkbox from System > Advanced > Network to Firewall (fits better with other state settings on the NAT tab)
- slight update to the help text for clarity
- capitalization

_files changed:_
/usr/local/www/system_advanced_firewall.php
/usr/local/www/system_advanced_network.php
