### PR TITLE
Don't leave sshlockout_pf process orphans when restarting syslogd (Bug #7984)

### DIFF
--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -700,14 +700,12 @@ function service_control_stop($name, $extras) {
 			sigkillbyname("relayd", "TERM");
 			break;
 		case 'syslogd':
-			if (isvalidpid("{$g['varrun_path']}/syslog.pid")) {
-				sigkillbypid("{$g['varrun_path']}/syslog.pid", "TERM");
-				usleep(100000);
-			}
-			if (isvalidpid("{$g['varrun_path']}/syslog.pid")) {
-				sigkillbypid("{$g['varrun_path']}/syslog.pid", "KILL");
-				usleep(100000);
-			}
+			sigkillbypid("{$g['varrun_path']}/syslog.pid", "TERM");
+			usleep(100000);
+			sigkillbypid("{$g['varrun_path']}/syslog.pid", "KILL");
+			usleep(100000);
+			// Bug #7984: do not leave sshlockout_pf process orphans
+			sigkillbyname("sshlockout_pf", "TERM");
 			break;
 		default:
 			stop_service($name);

--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -703,7 +703,6 @@ function service_control_stop($name, $extras) {
 			sigkillbypid("{$g['varrun_path']}/syslog.pid", "TERM");
 			usleep(100000);
 			sigkillbypid("{$g['varrun_path']}/syslog.pid", "KILL");
-			usleep(100000);
 			// Bug #7984: do not leave sshlockout_pf process orphans
 			sigkillbyname("sshlockout_pf", "TERM");
 			break;

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1242,7 +1242,6 @@ EOD;
 
 		// if it still hasn't responded to the TERM, KILL it.
 		sigkillbypid("{$g['varrun_path']}/syslog.pid", "KILL");
-		usleep(100000);
 
 		// Bug #7984: do not leave sshlockout_pf process orphans
 		sigkillbyname("sshlockout_pf", "TERM");

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1237,16 +1237,15 @@ EOD;
 	}
 
 	if (!$sighup) {
-		if (isvalidpid("{$g['varrun_path']}/syslog.pid")) {
-			sigkillbypid("{$g['varrun_path']}/syslog.pid", "TERM");
-			usleep(100000); // syslogd often doesn't respond to a TERM quickly enough for the starting of syslogd below to be successful
-		}
+		sigkillbypid("{$g['varrun_path']}/syslog.pid", "TERM");
+		usleep(100000); // syslogd often doesn't respond to a TERM quickly enough for the starting of syslogd below to be successful
 
-		if (isvalidpid("{$g['varrun_path']}/syslog.pid")) {
-			// if it still hasn't responded to the TERM, KILL it.
-			sigkillbypid("{$g['varrun_path']}/syslog.pid", "KILL");
-			usleep(100000);
-		}
+		// if it still hasn't responded to the TERM, KILL it.
+		sigkillbypid("{$g['varrun_path']}/syslog.pid", "KILL");
+		usleep(100000);
+
+		// Bug #7984: do not leave sshlockout_pf process orphans
+		sigkillbyname("sshlockout_pf", "TERM");
 
 		$retval = mwexec_bg("/usr/sbin/syslogd -s -c -c {$syslogd_sockets} -P {$g['varrun_path']}/syslog.pid {$syslogd_extra}");
 	} else {


### PR DESCRIPTION
Also remove redundant checks while here, since they are already done by sigkillbypid().