### PR TITLE
Add option to disable HSTS for nginx (Bug #6650)

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -425,7 +425,7 @@ function captiveportal_init_webgui_zone($cpcfg) {
 		}
 		system_generate_nginx_config("{$g['varetc_path']}/nginx-{$cpzone}-CaptivePortal-SSL.conf",
 			$crt, $key, $ca, "nginx-{$cpzone}-CaptivePortal-SSL.pid", $listenporthttps, "/usr/local/captiveportal",
-			"cert-{$cpzone}-portal.pem", "ca-{$cpzone}-portal.pem", $cpzone);
+			"cert-{$cpzone}-portal.pem", "ca-{$cpzone}-portal.pem", $cpzone, false);
 	}
 
 	/* generate nginx configuration */
@@ -436,7 +436,7 @@ function captiveportal_init_webgui_zone($cpcfg) {
 	}
 	system_generate_nginx_config("{$g['varetc_path']}/nginx-{$cpzone}-CaptivePortal.conf",
 		"", "", "", "nginx-{$cpzone}-CaptivePortal.pid", $listenporthttp, "/usr/local/captiveportal",
-		"", "", $cpzone);
+		"", "", $cpzone, false);
 
 	@unlink("{$g['varrun']}/nginx-{$cpzone}-CaptivePortal.pid");
 	/* attempt to start nginx */

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1335,12 +1335,13 @@ function system_webgui_start() {
 			$portarg = "443";
 		}
 		$ca = ca_chain($cert);
+		$hsts = isset($config['system']['webgui']['disablehsts']) ? false : true;
 	}
 
 	/* generate nginx configuration */
 	system_generate_nginx_config("{$g['varetc_path']}/nginx-webConfigurator.conf",
 		$crt, $key, $ca, "nginx-webConfigurator.pid", $portarg, "/usr/local/www/",
-		"cert.crt", "cert.key");
+		"cert.crt", "cert.key", false, $hsts);
 
 	/* kill any running nginx */
 	killbypid("{$g['varrun_path']}/nginx-webConfigurator.pid");

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1372,7 +1372,8 @@ function system_generate_nginx_config($filename,
 	$document_root = "/usr/local/www/",
 	$cert_location = "cert.crt",
 	$key_location = "cert.key",
-	$captive_portal = false) {
+	$captive_portal = false,
+	$hsts = true) {
 
 	global $config, $g;
 
@@ -1495,7 +1496,9 @@ EOD;
 		}
 		$nginx_config .= "\t\tssl_ciphers \"EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH\";\n";
 		$nginx_config .= "\t\tssl_prefer_server_ciphers       on;\n";
-		$nginx_config .= "\t\tadd_header Strict-Transport-Security \"max-age=31536000\";\n";
+		if ($captive_portal === false && $hsts !== false) {
+			$nginx_config .= "\t\tadd_header Strict-Transport-Security \"max-age=31536000\";\n";
+		}
 		$nginx_config .= "\t\tadd_header X-Content-Type-Options nosniff;\n";
 		$nginx_config .= "\t\tssl_session_tickets off;\n";
 		$nginx_config .= "\t\tssl_dhparam /etc/dh-parameters.4096;\n";

--- a/src/usr/local/www/system_advanced_admin.php
+++ b/src/usr/local/www/system_advanced_admin.php
@@ -41,6 +41,7 @@ $pconfig['webguiport'] = $config['system']['webgui']['port'];
 $pconfig['max_procs'] = ($config['system']['webgui']['max_procs']) ? $config['system']['webgui']['max_procs'] : 2;
 $pconfig['ssl-certref'] = $config['system']['webgui']['ssl-certref'];
 $pconfig['disablehttpredirect'] = isset($config['system']['webgui']['disablehttpredirect']);
+$pconfig['disablehsts'] = isset($config['system']['webgui']['disablehsts']);
 $pconfig['disableconsolemenu'] = isset($config['system']['disableconsolemenu']);
 $pconfig['noantilockout'] = isset($config['system']['webgui']['noantilockout']);
 $pconfig['nodnsrebindcheck'] = isset($config['system']['webgui']['nodnsrebindcheck']);
@@ -141,6 +142,20 @@ if ($_POST) {
 			}
 
 			unset($config['system']['webgui']['disablehttpredirect']);
+		}
+
+		if ($_POST['webgui-hsts'] == "yes") {
+			if ($config['system']['webgui']['disablehsts'] != true) {
+				$restart_webgui = true;
+			}
+
+			$config['system']['webgui']['disablehsts'] = true;
+		} else {
+			if ($config['system']['webgui']['disablehsts'] == true) {
+				$restart_webgui = true;
+			}
+
+			unset($config['system']['webgui']['disablehsts']);
 		}
 
 		if ($_POST['webgui-login-messages'] == "yes") {
@@ -372,6 +387,17 @@ $section->addInput(new Form_Checkbox(
 	'Check this box to disable this automatically added redirect rule.');
 
 $section->addInput(new Form_Checkbox(
+	'webgui-hsts',
+	'HSTS',
+	'Disable HTTP Strict Transport Security',
+	$pconfig['disablehsts']
+))->setHelp('When this is unchecked, Strict-Transport-Security HTTPS response header '.
+	'is sent by the webConfigurator to the browser. This will force the browser to use '.
+	'only HTTPS for future requests to the firewall FQDN. Check this box to disable HSTS. '.
+	'(NOTE: Browser-specific steps are required for disabling to take effect when the browser '.
+	'already visited the FQDN while HSTS was enabled.)');
+
+$section->addInput(new Form_Checkbox(
 	'loginautocomplete',
 	'WebGUI Login Autocomplete',
 	'Enable webConfigurator login autocomplete',
@@ -529,11 +555,13 @@ events.push(function() {
 	// ---------- On initial page load ------------------------------------------------------------
 
 	hideInput('ssl-certref', $('input[name=webguiproto]:checked').val() == 'http');
+	hideCheckbox('webgui-hsts', $('input[name=webguiproto]:checked').val() == 'http');
 
 	// ---------- Click checkbox handlers ---------------------------------------------------------
 
 	 $('[name=webguiproto]').click(function () {
 		hideInput('ssl-certref', $('input[name=webguiproto]:checked').val() == 'http');
+		hideCheckbox('webgui-hsts', $('input[name=webguiproto]:checked').val() == 'http');
 	});
 });
 //]]>


### PR DESCRIPTION
As far as webconfigurator is concerned, current default behavior remains unchanged (HSTS enabled with HTTPS) if the toggle is unset.

If HSTS is desired for CP, I can add a toggle there as well. IMNSHO, it's pretty much never desired since it makes testing or changing your mind very much impossible as you have no control over the CP clients in general.