### PR TITLE
Interface description doesn't fit the console screen

### DIFF
--- a/src/etc/inc/config.console.inc
+++ b/src/etc/inc/config.console.inc
@@ -77,7 +77,7 @@ EOD;
 				$status = "(down)";
 			$ifsmallist = $ifsmallist . $iface. " ";
 			echo sprintf("%-7s %s %s %s\n", $iface, $ifa['mac'],
-				$status, substr($ifa['dmesg'], 0, 48));
+				$status, substr($ifa['dmesg'], 0, 46));
 		}
 	}
 


### PR DESCRIPTION
Strip 2 more chars from interface description because with the new font used by 2.4 it goes off screen on VGA console.