### PR TITLE
xmlrpc, fix usage of space and + character that need different encoding in username/password

### DIFF
--- a/src/etc/inc/xmlrpc_client.inc
+++ b/src/etc/inc/xmlrpc_client.inc
@@ -65,8 +65,8 @@ class pfsense_xmlrpc_client {
 		if (is_ipaddrv6($syncip)) {
 			$syncip = "[{$syncip}]";
 		}
-		$user = urlencode($this->username);
-		$pass = urlencode($this->password);
+		$user = rawurlencode($this->username);
+		$pass = rawurlencode($this->password);
 		
 		$this->logurl = "{$scheme}://{$syncip}:{$port}/xmlrpc.php";
 		$this->url = "{$scheme}://{$user}:{$pass}@{$syncip}:{$port}/xmlrpc.php";


### PR DESCRIPTION
Fixes: https://redmine.pfsense.org/issues/8032