### PR TITLE
config, xmlparse throw exception instead of calling die()

### DIFF
--- a/src/etc/inc/config.lib.inc
+++ b/src/etc/inc/config.lib.inc
@@ -759,11 +759,16 @@ function cleanup_backupcache($lock = false) {
 			if (platform_booting()) {
 				echo ".";
 			}
-			$newxml = parse_xml_config($backup, array($g['xml_rootobj'], 'pfsense'));
+			try {
+				$newxml = parse_xml_config($backup, array($g['xml_rootobj'], 'pfsense'));
+			} catch (Exception $exc) {
+				log_error(sprintf(gettext("The backup cache file %s is corrupted. Parser error message: %s"), $backup, $exc->getMessage()));
+				$newxml = "-1";
+			}
+
 			if ($newxml == "-1") {
 				log_error(sprintf(gettext("The backup cache file %s is corrupted.  Unlinking."), $backup));
 				unlink($backup);
-				log_error(sprintf(gettext("The backup cache file %s is corrupted.  Unlinking."), $backup));
 				continue;
 			}
 			if ($newxml['revision']['description'] == "") {

--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -84,7 +84,8 @@ function startElement($parser, $name, $attrs) {
 
 	} else if (isset($ptr)) {
 		/* multiple entries not allowed for this element, bail out */
-		die(sprintf(gettext('XML error: %1$s at line %2$d cannot occur more than once') . "\n",
+		throw new Exception(
+		    sprintf(gettext('XML error: %1$s at line %2$d cannot occur more than once') . "\n",
 		    $name,
 		    xml_get_current_line_number($parser)));
 	}


### PR DESCRIPTION
config, xmlparse throw exception instead of calling die(), so corruption check will properly handle the unlink action of the corrupted config