### PR TITLE
Allow gateways to be excluded from default gw switching

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -643,6 +643,15 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 					$found_defaultv6 = 1;
 				}
 			}
+
+			if (isset($gateway['no_defgw_switch'])) {
+				$gateway['no_defgw_switch'] = true;
+			}
+
+			if (isset($gateway['notifications_disable'])) {
+				$gateway['notifications_disable'] = true;
+			}
+
 			/* include the gateway index as the attribute */
 			$gateway['attribute'] = $i;
 
@@ -921,6 +930,17 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 		/* XXX: Blacklist lan for now since it might cause issues to those who have a gateway set for it */
 		if (empty($upgw) && ($gwsttng['ipprotocol'] == $ipprotocol) && (isset($gwsttng['monitor_disable']) || isset($gwsttng['action_disable']) || $gateways_status[$gwname]['status'] == "none") && $gwsttng[$gwname]['friendlyiface'] != "lan") {
 			$upgw = $gwname;
+			if ($gwsttng['no_defgw_switch']) {
+				// do not elect this gateway if the `skip` option is set
+				if ($g['debug']) {
+					log_error(sprintf(gettext('Found UP gateway %1$s but it was administratively skipped due to gateway settings'), $gwname));
+				}
+			} else {
+				if ($g['debug']) {
+					log_error(sprintf(gettext('Found UP gateway %1$s'), $gwname));
+				}
+				$upgw = $gwname;
+			}
 		}
 		if ($dfltgwdown == true && !empty($upgw)) {
 			break;
@@ -1035,8 +1055,10 @@ function return_gateway_groups_array() {
 							$msg .= "\n".implode("|", $status);
 							touch("/tmp/.down.{$gwname}");
 							log_error($msg);
-							notify_via_growl($msg);
-							notify_via_smtp($msg);
+							if (!isset($gateways_arr[$gwname]['notifications_disable'])) {
+								notify_via_growl($msg);
+								notify_via_smtp($msg);
+							}
 						}
 					} else {
 						$pluginparams['event'] = 'gateway.up';
@@ -1049,8 +1071,10 @@ function return_gateway_groups_array() {
 							$msg = sprintf(gettext('MONITOR: %1$s is available now, adding to routing group %2$s'), $gwname, $group['name']);
 							$msg .= "\n".implode("|", $status);
 							log_error($msg);
-							notify_via_growl($msg);
-							notify_via_smtp($msg);
+							if (!isset($gateways_arr[$gwname]['notifications_disable'])) {
+								notify_via_growl($msg);
+								notify_via_smtp($msg);
+							}
 						}
 					}
 					if (isset($gateways_arr[$gwname]['interface']))
@@ -1518,6 +1542,11 @@ function validate_gateway($gateway_settings, $id = "", $parent_ip = "", $parent_
 		}
 	}
 
+	if (($gateway_settings['no_defgw_switch'] == "yes") && ($gateway_settings['defaultgw'] == "yes")) {
+		/* marking a gateway as the default is mutually exclusive with this option */
+		$input_errors[] = gettext("Gateway cannot be both the default and also excluded from gateway switching. Choose one or the other.");
+	}
+
 	if (isset($gateway_settings['name'])) {
 		/* check for overlaps */
 		foreach ($a_gateways as $gateway) {
@@ -1753,6 +1782,14 @@ function save_gateway($gateway_settings, $realid = "") {
 		} else {
 			mwexec("/sbin/route delete -inet6 " . escapeshellarg($a_gateway_item[$realid]['monitor']));
 		}
+	}
+
+	if ($gateway_settings['no_defgw_switch'] == "yes" || $gateway_settings['no_defgw_switch'] == "on") {
+		$gateway['no_defgw_switch'] = true;
+	}
+
+	if ($gateway_settings['notifications_disable'] == "yes" || $gateway_settings['notifications_disable'] == "on") {
+		$gateway['notifications_disable'] = true;
 	}
 
 	if ($gateway_settings['defaultgw'] == "yes" || $gateway_settings['defaultgw'] == "on") {

--- a/src/usr/local/www/system_advanced_misc.php
+++ b/src/usr/local/www/system_advanced_misc.php
@@ -385,8 +385,11 @@ $section->addInput(new Form_Checkbox(
 	'Enable default gateway switching',
 	$pconfig['gw_switch_default']
 ))->setHelp('If the default gateway goes down, switch the default gateway to '.
-	'another available one. This is not enabled by default, as it\'s unnecessary in '.
-	'most all scenarios, which instead use gateway groups.');
+	'another available one. If you do not enable this option, traffic originating '.
+	'from the firewall itself (e.g. SMTP notifications) may fail if the default '.
+	'gateway is down, even if other gateways are still up. Individual gateways '.
+	'can be omitted from being marked as default by enabling the "Skip Default" '.
+	'checkbox on their respective %1$sGateway Settings%2$s page.','<a href="system_gateways.php">','</a>');
 
 $form->add($section);
 $section = new Form_Section('Power Savings');

--- a/src/usr/local/www/system_gateways.php
+++ b/src/usr/local/www/system_gateways.php
@@ -248,6 +248,7 @@ display_top_tabs($tab_array);
 					<tr>
 						<th></th>
 						<th><?=gettext("Name")?></th>
+						<th><?=gettext("Skip Def.")?></th>
 						<th><?=gettext("Interface")?></th>
 						<th><?=gettext("Gateway")?></th>
 						<th><?=gettext("Monitor IP")?></th>
@@ -281,6 +282,14 @@ foreach ($a_gateways as $i => $gateway):
 				echo " <strong>(default)</strong>";
 			}
 ?>
+						</td>
+						<td>
+							<?php
+								if (isset($gateway['no_defgw_switch'])) {
+									echo '<i class="fa fa-arrow-circle-o-down" title="This gateway will be skipped during default gateway switching"></i>';
+								}
+							?>
+							&nbsp;
 						</td>
 						<td>
 							<?=htmlspecialchars(convert_friendly_interface_to_friendly_descr($gateway['friendlyiface']))?>

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -76,11 +76,13 @@ if (isset($id) && $a_gateways[$id]) {
 	$pconfig['monitor'] = $a_gateways[$id]['monitor'];
 	$pconfig['monitor_disable'] = isset($a_gateways[$id]['monitor_disable']);
 	$pconfig['action_disable'] = isset($a_gateways[$id]['action_disable']);
+	$pconfig['notifications_disable'] = isset($a_gateways[$id]['notifications_disable']);
 	$pconfig['data_payload'] = $a_gateways[$id]['data_payload'];
 	$pconfig['nonlocalgateway'] = isset($a_gateways[$id]['nonlocalgateway']);
 	$pconfig['descr'] = $a_gateways[$id]['descr'];
 	$pconfig['attribute'] = $a_gateways[$id]['attribute'];
 	$pconfig['disabled'] = isset($a_gateways[$id]['disabled']);
+	$pconfig['no_defgw_switch'] = isset($a_gateways[$id]['no_defgw_switch']);
 }
 
 if (isset($_REQUEST['dup']) && is_numericint($_REQUEST['dup'])) {
@@ -199,7 +201,29 @@ $section->addInput(new Form_Checkbox(
 	'Default Gateway',
 	'This will select the above gateway as the default gateway.',
 	$pconfig['defaultgw']
-));
+))->toggles('.toggle-nodefgwswitch');
+
+$group = new Form_Group('Skip Default');
+$group->addClass('toggle-nodefgwswitch', 'collapse');
+
+if ($pconfig['defaultgw'] == false)
+	$group->addClass('in');
+
+$group->add(new Form_Checkbox(
+	'no_defgw_switch',
+	null,
+	'Not eligible to become the default gateway',
+	$pconfig['no_defgw_switch']
+))->setHelp('If checked, this gateway will not be chosen during default gateway switching (see %1$sSystem &gt; Advanced%2$s).','<a href="system_advanced_misc.php">','</a>');
+
+$section->add($group);
+
+$section->addInput(new Form_Checkbox(
+	'notifications_disable',
+	'Notifications',
+	'Disable Gateway Notifications',
+	$pconfig['notifications_disable']
+))->setHelp('Notifications will not be sent for gateway events.');
 
 $section->addInput(new Form_Checkbox(
 	'monitor_disable',


### PR DESCRIPTION
Unified default gw switching + notifications patch
supersedes PR#3827 and PR#3609, targets 2.4.2+/master