### PR TITLE
Backport changes regarding login page

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -1567,6 +1567,7 @@ function get_user_settings($username) {
 	$settings['webgui']['dashboardcolumns'] = $config['system']['webgui']['dashboardcolumns'];
 	$settings['webgui']['webguihostnamemenu'] = $config['system']['webgui']['webguihostnamemenu'];
 	$settings['webgui']['webguicss'] = $config['system']['webgui']['webguicss'];
+	$settings['webgui']['logincss'] = $config['system']['webgui']['logincss'];
 	$settings['webgui']['interfacessort'] = isset($config['system']['webgui']['interfacessort']);
 	$settings['webgui']['dashboardavailablewidgetspanel'] = isset($config['system']['webgui']['dashboardavailablewidgetspanel']);
 	$settings['webgui']['webguifixedmenu'] = isset($config['system']['webgui']['webguifixedmenu']);

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -181,12 +181,14 @@ function get_css_files() {
 		$usrcss = $pfscss = $betacss = array();
 
 		foreach ($cssfiles as $css) {
-			if (strpos($css, "BETA") != 0) {
-				array_push($betacss, $css);
-			} else if (strpos($css, "pfSense") != 0) {
-				array_push($pfscss, $css);
-			} else {
-				array_push($usrcss, $css);
+			if (strpos($css, "login") == 0) {	// Don't display any login page related CSS files
+				if (strpos($css, "BETA") != 0) {
+					array_push($betacss, $css);
+				} else if (strpos($css, "pfSense") != 0) {
+					array_push($pfscss, $css);
+				} else {
+					array_push($usrcss, $css);
+				}
 			}
 		}
 


### PR DESCRIPTION
This commit improves consistency and prevents bugs by:
1) Not displaying the login CSS file in the theme list
2) Ensuring the login background color is respected (get_user_settings)

Code taken from the following commits:
1) 7f4b697fb5f97197dfea75ecf16bfc103df93040
2) e79ff1ee2c0fa2693cb415ff1aa0a16d1f9632b2

Contains the code changes of PR #3864

Tested and working!
Please backport to RELENG_2_3_5 as well if deemed appropriate. Thanks in advance!