### PR TITLE
Support shutdown scripts in /usr/local/etc/rc.d

### DIFF
--- a/src/etc/pfSense-rc.shutdown
+++ b/src/etc/pfSense-rc.shutdown
@@ -52,3 +52,13 @@ if [ "${USE_MFS_TMPVAR}" = "true" ] || [ "${DISK_TYPE}" = "md" ]; then
 	/etc/rc.backup_dhcpleases.sh
 	/etc/rc.backup_logs.sh
 fi
+
+# Invoke shutdown scripts if present
+scripts=/usr/local/etc/rc.d/shutdown.*.sh
+for script in $scripts
+do
+	if [ -f "$script" -a -x "$script" ]
+	then
+		$script
+	fi
+done


### PR DESCRIPTION
Support shutdown scripts in /usr/local/etc/rc.d. This allows packages to take critical shutdown actions such as UPS power kill in NUT.
