### PR TITLE
Prevent Clickjacking in CSRF error page

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -25,6 +25,7 @@
 
 /* Include authentication routines */
 /* THIS MUST BE ABOVE ALL OTHER CODE */
+header("X-Frame-Options: SAMEORIGIN");
 include_once('phpsessionmanager.inc');
 if (!$nocsrf) {
 	function csrf_startup() {
@@ -47,7 +48,6 @@ if (!$omit_nocacheheaders) {
 	header("Pragma: no-cache");
 }
 
-header("X-Frame-Options: SAMEORIGIN");
 require_once("authgui.inc");
 
 /* parse the configuration and include all configuration functions */


### PR DESCRIPTION
The X-Frame-Options header was set after the CSRF check, which allows for Clickjacking on the CSRF error page. This fix moves the X-Frame-Options header above the CSRF check.