### PR TITLE
Bug in get_interface_ip

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -5890,7 +5890,8 @@ function get_possible_traffic_source_addresses($include_ipv6_link_local=false) {
 }
 
 function get_interface_ip($interface = "wan") {
-
+	global $config;
+	
 	if (substr($interface, 0, 4) == '_vip') {
 		return get_configured_vip_ipv4($interface);
 	} else if (substr($interface, 0, 5) == '_lloc') {


### PR DESCRIPTION
Global variable $config was not available, and IP was always fetched using find_interface_ip