### PR TITLE
Enable use of auth script for getting dynamic credentials on openvpn

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1074,6 +1074,11 @@ function openvpn_reconfigure($mode, $settings) {
 			if (!($settings['auth_user'] && $settings['auth_pass'])) {
 				$userpass .= "\n";
 			}
+
+			// if auth_script is not empty, we use its output instead of user/pass
+			if ($settings['auth_script']) {
+				$userpass = shell_exec($settings['auth_script']);
+			}
 			file_put_contents($up_file, $userpass);
 		}
 
@@ -1107,15 +1112,15 @@ function openvpn_reconfigure($mode, $settings) {
 		case 'server_tls':
 		case 'server_tls_user':
 		case 'server_user':
-			// ca_chain() expects parameter to be passed by reference. 
-			// avoid passing the whole settings array, as param names or 
-			// types might change in future releases. 
-			$param = array('caref' => $settings['caref']);	
+			// ca_chain() expects parameter to be passed by reference.
+			// avoid passing the whole settings array, as param names or
+			// types might change in future releases.
+			$param = array('caref' => $settings['caref']);
 			$ca = ca_chain($param);
 			$ca = base64_encode($ca);
-			
+
 			openvpn_add_keyfile($ca, $conf, $mode_id, "ca");
-			
+
 			unset($ca, $param);
 
 			if (!empty($settings['certref'])) {

--- a/src/usr/local/www/status.php
+++ b/src/usr/local/www/status.php
@@ -93,6 +93,7 @@ function doCmdT($title, $command, $method) {
 				$line = preg_replace("/<password>.*?<\\/password>/", "<password>xxxxx</password>", $line);
 				$line = preg_replace("/<auth_user>.*?<\\/auth_user>/", "<auth_user>xxxxx</auth_user>", $line);
 				$line = preg_replace("/<auth_pass>.*?<\\/auth_pass>/", "<auth_pass>xxxxx</auth_pass>", $line);
+				$line = preg_replace("/<auth_script>.*?<\\/auth_script>/", "<auth_script>xxxxx</auth_script>", $line);
 				$line = preg_replace("/<proxy_user>.*?<\\/proxy_user>/", "<proxy_user>xxxxx</proxy_user>", $line);
 				$line = preg_replace("/<proxy_passwd>.*?<\\/proxy_passwd>/", "<proxy_passwd>xxxxx</proxy_passwd>", $line);
 				$line = preg_replace("/<proxyuser>.*?<\\/proxyuser>/", "<proxyuser>xxxxx</proxyuser>", $line);

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -101,7 +101,7 @@ if ($act == "new") {
 }
 
 global $simplefields;
-$simplefields = array('auth_user', 'auth_pass');
+$simplefields = array('auth_user', 'auth_pass', 'auth_script');
 
 if ($act == "edit") {
 	if (isset($id) && $a_client[$id]) {
@@ -627,6 +627,13 @@ if ($act=="new" || $act=="edit"):
 		'password',
 		$pconfig['auth_pass']
 	))->setHelp('Leave empty when no password is needed');
+
+	$section->addInput(new Form_Textarea(
+		'auth_script',
+		'Auth Script',
+		$pconfig['auth_script']
+	))->setHelp('Script that would output credentials as "user<newline>password".' .
+	    'When defined, this will be executed and the results used instead of username and password. Allows use of OTP authentication.', '<br/>');
 
 	$section->addInput(new Form_Checkbox(
 		'auth-retry-none',


### PR DESCRIPTION
Patch for enabling the ability to specify auth scripts that do generate user/password for the openvpn client, enabling OTP users to configure persistent VPNs.

https://redmine.pfsense.org/issues/8122