### PR TITLE
Widget refresh fix; minor widget UI tweaks

### DIFF
--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -608,8 +608,8 @@ function gen_customwidgetinterval_div($widgetinterval) {
 }
 
 function set_customwidgetinterval(& $user_settings) {
-	if ($_POST['interval']) {
-		$user_settings['widgets'][$_POST['widgetkey']]['interval'] = trim($_POST['interval']);
+	if ($_POST['interval'] && is_numeric($_POST['interval'])) {
+		$user_settings['widgets'][$_POST['widgetkey']]['interval'] = int_val($_POST['interval']);
 	} else {
 		unset($user_settings['widgets'][$_POST['widgetkey']]['interval']);
 	}

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -596,6 +596,25 @@ function set_customwidgettitle(& $user_settings) {
 	}
 }
 
+function gen_customwidgetinterval_div($widgetinterval) {
+	$divstr = '<div class="form-group">';
+	$divstr .= '  <label for="interval" class="col-sm-4 control-label">' . gettext('Widget interval'). '</label>';
+	$divstr .= '  <div class="col-sm-4">';
+	$divstr .= '    <input type="text" name="interval" id="interval" value="'. $widgetinterval . '" class="form-control" />';
+	$divstr .= '  </div>';
+	$divstr .= '</div>';
+
+        return $divstr;
+}
+
+function set_customwidgetinterval(& $user_settings) {
+	if ($_POST['interval']) {
+		$user_settings['widgets'][$_POST['widgetkey']]['interval'] = trim($_POST['interval']);
+	} else {
+		unset($user_settings['widgets'][$_POST['widgetkey']]['interval']);
+	}
+}
+
 /* update the changedesc and changecount(er) variables */
 function update_changedesc($update) {
 	global $changedesc;

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -598,7 +598,7 @@ function set_customwidgettitle(& $user_settings) {
 
 function gen_customwidgetinterval_div($widgetinterval) {
 	$divstr = '<div class="form-group">';
-	$divstr .= '  <label for="interval" class="col-sm-4 control-label">' . gettext('Widget interval'). '</label>';
+	$divstr .= '  <label for="interval" class="col-sm-4 control-label">' . gettext('Update interval'). '</label>';
 	$divstr .= '  <div class="col-sm-4">';
 	$divstr .= '    <input type="text" name="interval" id="interval" value="'. $widgetinterval . '" class="form-control" />';
 	$divstr .= '  </div>';

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -601,8 +601,6 @@ function set_widget_checkbox_events(checkbox_panel_ref, all_none_button_id) {
 // ---------------------Centralized widget refresh system -------------------------------------------
 // These need to live outsie of the events.push() function to enable the widgets to see them
 var ajaxspecs = new Array();	// Array to hold widget refresh specifications (objects )
-var ajaxidx = 0;
-var ajaxmutex = false;
 var ajaxcntr = 0;
 
 // Add a widget refresh object to the array list
@@ -668,11 +666,10 @@ events.push(function() {
 	});
 
 	// --------------------- Centralized widget refresh system ------------------------------
-	ajaxtimeout = false;
-
 	function make_ajax_call(wd) {
-		ajaxmutex = true;
-
+		// Add a lock on the widget to prevent overlapping callbacks
+		wd.locked = true;
+		
 		$.ajax({
 			type: 'POST',
 			url: wd.url,
@@ -682,52 +679,48 @@ events.push(function() {
 			success: function(data){
 				if (data.length > 0 ) {
 					// If the session has timed out, display a pop-up
-					if (data.indexOf("SESSION_TIMEOUT") === -1) {
-						wd.callback(data);
-					} else {
-						if (ajaxtimeout === false) {
-							ajaxtimeout = true;
-							alert("<?=$timeoutmessage?>");
-						}
+					if (data.indexOf("SESSION_TIMEOUT") > -1) {
+						alert("<?=$timeoutmessage?>");
+						return;
 					}
-				}
 
-				ajaxmutex = false;
+					// Else call the callback
+					wd.callback(data);
+				}
 			},
 
 			error: function(e){
 //				alert("Error: " + e);
-				ajaxmutex = false;
+			},
+			
+			complete: function() {
+				// Regardless of success or error, remove the widget's lock
+				wd.locked = false;
 			}
 		});
 	}
 
 	// Loop through each AJAX widget refresh object, make the AJAX call and pass the
 	// results back to the widget's callback function
-	function executewidget() {
-		if (ajaxspecs.length > 0) {
-			var freq = ajaxspecs[ajaxidx].freq;	// widget can specifify it should be called freq times around hte loop
-
-			if (!ajaxmutex) {
-				if (((ajaxcntr % freq) === 0) && (typeof ajaxspecs[ajaxidx].callback === "function" )) {
-				    make_ajax_call(ajaxspecs[ajaxidx]);
-				}
-
-			    if (++ajaxidx >= ajaxspecs.length) {
-					ajaxidx = 0;
-
-					if (++ajaxcntr >= 4096) {
-						ajaxcntr = 0;
-					}
-			    }
+	function executewidgets() {
+		for (var ajaxidx = 0; ajaxidx < ajaxspecs.length; ajaxidx++) {
+			if (ajaxspecs[ajaxidx].locked) {
+				continue;
 			}
 
-		    setTimeout(function() { executewidget(); }, 1000);
-	  	}
+			var freq = ajaxspecs[ajaxidx].freq;	// widget can specify it should be called every freq seconds
+
+			if (((ajaxcntr % freq) === 0) && (typeof ajaxspecs[ajaxidx].callback === "function" )) {
+				make_ajax_call(ajaxspecs[ajaxidx]);
+			}
+		}
+		ajaxcntr++;
 	}
 
 	// Kick it off
-	executewidget();
+	if (ajaxspecs.length > 0) {
+		setInterval(executewidgets, 1000);
+	}
 
 	//----------------------------------------------------------------------------------------------------
 });

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -327,7 +327,7 @@ if ($user_settings['widgets']['sequence'] != "") {
 		if (isset($user_settings['widgets'][$widgetkey]['interval']) && is_numeric($user_settings['widgets'][$widgetkey]['interval'])) {
 			$interval = intval($user_settings['widgets'][$widgetkey]['interval']);
 		} else {
-			$interval = 10;
+			$interval = 1;
 		}
 
 		$widgetsfromconfig[$widgetkey] = array(

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -324,9 +324,16 @@ if ($user_settings['widgets']['sequence'] != "") {
 			}
 		}
 
+		if (isset($user_settings['widgets'][$widgetkey]['interval']) && is_int($user_settings['widgets'][$widgetkey]['interval'])) {
+			$interval = intval($user_settings['widgets'][$widgetkey]['interval']);
+		} else {
+			$interval = 10;
+		}
+
 		$widgetsfromconfig[$widgetkey] = array(
 			'basename' => $basename,
 			'title' => $widgettitle,
+			'interval' => $interval,
 			'col' => $col,
 			'display' => $display,
 			'copynum' => $copynum,

--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -324,7 +324,7 @@ if ($user_settings['widgets']['sequence'] != "") {
 			}
 		}
 
-		if (isset($user_settings['widgets'][$widgetkey]['interval']) && is_int($user_settings['widgets'][$widgetkey]['interval'])) {
+		if (isset($user_settings['widgets'][$widgetkey]['interval']) && is_numeric($user_settings['widgets'][$widgetkey]['interval'])) {
 			$interval = intval($user_settings['widgets'][$widgetkey]['interval']);
 		} else {
 			$interval = 10;

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -201,7 +201,7 @@ if ($_POST['widgetkey']) {
 $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period'] * 1000 : 10000;
 $widgetkey_nodash = str_replace("-", "", $widgetkey);
 
-$ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 10;
+$ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 1;
 
 ?>
 

--- a/src/usr/local/www/widgets/widgets/gateways.widget.php
+++ b/src/usr/local/www/widgets/widgets/gateways.widget.php
@@ -170,6 +170,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 
 if ($_POST['widgetkey']) {
 	set_customwidgettitle($user_settings);
+	set_customwidgetinterval($user_settings);
 
 	if (!is_array($user_settings["widgets"][$_POST['widgetkey']])) {
 		$user_settings["widgets"][$_POST['widgetkey']] = array();
@@ -200,6 +201,8 @@ if ($_POST['widgetkey']) {
 $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period'] * 1000 : 10000;
 $widgetkey_nodash = str_replace("-", "", $widgetkey);
 
+$ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 10;
+
 ?>
 
 <div class="table-responsive">
@@ -224,6 +227,8 @@ $widgetkey_nodash = str_replace("-", "", $widgetkey);
 </div><div id="<?=$widget_panel_footer_id?>" class="panel-footer collapse">
 <form action="/widgets/widgets/gateways.widget.php" method="post" class="form-horizontal">
 	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
+	<?=gen_customwidgetinterval_div($widgetconfig['interval']); ?>
+
 	<div class="form-group">
 		<label class="col-sm-4 control-label"><?=gettext('Display')?></label>
 		<?php
@@ -325,7 +330,7 @@ events.push(function(){
 	gatewaysObject.url = "/widgets/widgets/gateways.widget.php";
 	gatewaysObject.callback = gateways_callback;
 	gatewaysObject.parms = postdata;
-	gatewaysObject.freq = 1;
+	gatewaysObject.freq = <?=$ninterval?>;
 
 	// Register the AJAX object
 	register_ajax(gatewaysObject);

--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -208,8 +208,7 @@ $ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_se
 
 <form action="/widgets/widgets/interface_statistics.widget.php" method="post" class="form-horizontal">
 	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
-	<?=gen_customwidgetinterval_div($widgetconfig['interval']); ?>
-
+	
 	<div class="form-group">
 		<label class="col-sm-3 control-label"><?=gettext('Orientation')?></label>
 		<?php
@@ -291,6 +290,8 @@ $ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_se
 			</div>
 		</div>
 	</div>
+
+	<?=gen_customwidgetinterval_div($widgetconfig['interval']); ?>
 
 	<div class="form-group">
 		<div class="col-sm-offset-3 col-sm-6">

--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -159,6 +159,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 	exit;
 } else if ($_POST['widgetkey']) {
 	set_customwidgettitle($user_settings);
+	set_customwidgetinterval($user_settings);
 
 	if (isset($_POST['orientation_type'])) {
 		$user_settings['widgets'][$_POST['widgetkey']]['orientation_type'] = $_POST['orientation_type'];
@@ -195,6 +196,8 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period'] * 1000 : 10000;
 $widgetkey_nodash = str_replace("-", "", $widgetkey);
 
+$ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 10;
+
 ?>
 <table id="<?=htmlspecialchars($widgetkey)?>-iftbl" class="table table-striped table-hover">
 	<tr><td><?=gettext("Retrieving interface data")?></td></tr>
@@ -205,6 +208,8 @@ $widgetkey_nodash = str_replace("-", "", $widgetkey);
 
 <form action="/widgets/widgets/interface_statistics.widget.php" method="post" class="form-horizontal">
 	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
+	<?=gen_customwidgetinterval_div($widgetconfig['interval']); ?>
+
 	<div class="form-group">
 		<label class="col-sm-3 control-label"><?=gettext('Orientation')?></label>
 		<?php
@@ -336,7 +341,7 @@ $widgetkey_nodash = str_replace("-", "", $widgetkey);
 		ifstatObject.url = "/widgets/widgets/interface_statistics.widget.php";
 		ifstatObject.callback = interface_statistics_callback;
 		ifstatObject.parms = postdata;
-		ifstatObject.freq = 1;
+		ifstatObject.freq = <?=$ninterval?>;;
 
 		// Register the AJAX object
 		register_ajax(ifstatObject);

--- a/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
+++ b/src/usr/local/www/widgets/widgets/interface_statistics.widget.php
@@ -196,7 +196,7 @@ if ($_REQUEST && $_REQUEST['ajax']) {
 $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period'] * 1000 : 10000;
 $widgetkey_nodash = str_replace("-", "", $widgetkey);
 
-$ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 10;
+$ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 1;
 
 ?>
 <table id="<?=htmlspecialchars($widgetkey)?>-iftbl" class="table table-striped table-hover">
@@ -341,7 +341,7 @@ $ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_se
 		ifstatObject.url = "/widgets/widgets/interface_statistics.widget.php";
 		ifstatObject.callback = interface_statistics_callback;
 		ifstatObject.parms = postdata;
-		ifstatObject.freq = <?=$ninterval?>;;
+		ifstatObject.freq = <?=$ninterval?>;
 
 		// Register the AJAX object
 		register_ajax(ifstatObject);

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -162,7 +162,7 @@ endif;
 
 <form action="/widgets/widgets/interfaces.widget.php" method="post" class="form-horizontal">
 	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
-	<?=gen_customwidgetinterval_div($widgetconfig['title']); ?>
+	<?=gen_customwidgetinterval_div($widgetconfig['interval']); ?>
 
 	<div class="panel panel-default col-sm-10">
 		<div class="panel-body">

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -63,7 +63,7 @@ if ($_REQUEST['widgetkey']) {
 	$widgetkey = $_REQUEST['widgetkey'];
 }
 
-$ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 60;
+$ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 10;
 
 ?>
 

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -35,12 +35,6 @@ if ($_POST['widgetkey'] && !$_REQUEST['ajax']) {
 	set_customwidgettitle($user_settings);
 	set_customwidgetinterval($user_settings);
 
-	if (is_numeric($_POST['interval'])) {
-		$user_settings['widgets'][$_POST['widgetkey']]['interval'] = intval($_POST['interval']);
-	} else {
-		$user_settings['widgets'][$_POST['widgetkey']]['interval'] = 10;
-	}
-
 	$validNames = array();
 
 	foreach ($ifdescrs as $ifdescr => $ifname) {

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -241,7 +241,7 @@ if ($_REQUEST['ajax']) {
 		interfacesObject.url = "/widgets/widgets/interfaces.widget.php";
 		interfacesObject.callback = interfaces_callback;
 		interfacesObject.parms = postdata;
-		interfacesObject.freq = 1;
+		interfacesObject.freq = <?=$nifinterval?>;
 
 		// Register the AJAX object
 		register_ajax(interfacesObject);

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -63,7 +63,7 @@ if ($_REQUEST['widgetkey']) {
 	$widgetkey = $_REQUEST['widgetkey'];
 }
 
-$nifinterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 60;
+$ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 60;
 
 ?>
 
@@ -241,7 +241,7 @@ if ($_REQUEST['ajax']) {
 		interfacesObject.url = "/widgets/widgets/interfaces.widget.php";
 		interfacesObject.callback = interfaces_callback;
 		interfacesObject.parms = postdata;
-		interfacesObject.freq = <?=$nifinterval?>;
+		interfacesObject.freq = <?=$ninterval?>;
 
 		// Register the AJAX object
 		register_ajax(interfacesObject);

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -33,6 +33,13 @@ $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period
 
 if ($_POST['widgetkey'] && !$_REQUEST['ajax']) {
 	set_customwidgettitle($user_settings);
+	set_customwidgetinterval($user_settings);
+
+	if (is_numeric($_POST['interval'])) {
+		$user_settings['widgets'][$_POST['widgetkey']]['interval'] = intval($_POST['interval']);
+	} else {
+		$user_settings['widgets'][$_POST['widgetkey']]['interval'] = 10;
+	}
 
 	$validNames = array();
 
@@ -55,6 +62,8 @@ if ($_POST['widgetkey'] && !$_REQUEST['ajax']) {
 if ($_REQUEST['widgetkey']) {
 	$widgetkey = $_REQUEST['widgetkey'];
 }
+
+$nifinterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 60;
 
 ?>
 
@@ -159,6 +168,8 @@ endif;
 
 <form action="/widgets/widgets/interfaces.widget.php" method="post" class="form-horizontal">
 	<?=gen_customwidgettitle_div($widgetconfig['title']); ?>
+	<?=gen_customwidgetinterval_div($widgetconfig['title']); ?>
+
 	<div class="panel panel-default col-sm-10">
 		<div class="panel-body">
 			<input type="hidden" name="widgetkey" value="<?=htmlspecialchars($widgetkey); ?>">

--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -31,6 +31,7 @@ require_once("filter_log.inc");
 
 if ($_REQUEST['widgetkey'] && !$_REQUEST['ajax']) {
 	set_customwidgettitle($user_settings);
+	set_customwidgetinterval($user_settings);
 
 	if (is_numeric($_POST['filterlogentries'])) {
 		$user_settings['widgets'][$_POST['widgetkey']]['filterlogentries'] = $_POST['filterlogentries'];
@@ -62,12 +63,6 @@ if ($_REQUEST['widgetkey'] && !$_REQUEST['ajax']) {
 		unset($user_settings['widgets'][$_POST['widgetkey']]['filterlogentriesinterfaces']);
 	}
 
-	if (is_numeric($_POST['filterlogentriesinterval'])) {
-		$user_settings['widgets'][$_POST['widgetkey']]['filterlogentriesinterval'] = $_POST['filterlogentriesinterval'];
-	} else {
-		unset($user_settings['widgets'][$_POST['widgetkey']]['filterlogentriesinterval']);
-	}
-
 	save_widget_settings($_SESSION['Username'], $user_settings["widgets"], gettext("Saved Filter Log Entries via Dashboard."));
 	Header("Location: /");
 	exit(0);
@@ -92,7 +87,7 @@ $filterfieldsarray = array(
 	"interface" => isset($iface_descr_arr[$nentriesinterfaces]) ? $iface_descr_arr[$nentriesinterfaces] : $nentriesinterfaces
 );
 
-$nentriesinterval = isset($user_settings['widgets'][$widgetkey]['filterlogentriesinterval']) ? $user_settings['widgets'][$widgetkey]['filterlogentriesinterval'] : 60;
+$ninterval = isset($user_settings['widgets'][$widgetkey]['interval']) ? $user_settings['widgets'][$widgetkey]['interval'] : 1;
 
 $filter_logfile = "{$g['varlog_path']}/filter.log";
 
@@ -212,7 +207,7 @@ events.push(function(){
 	logsObject.url = "/widgets/widgets/log.widget.php";
 	logsObject.callback = logs_callback;
 	logsObject.parms = postdata;
-	logsObject.freq = <?=$nentriesinterval?>;
+	logsObject.freq = <?=$ninterval?>;
 
 	// Register the AJAX object
 	register_ajax(logsObject);
@@ -276,14 +271,7 @@ $pconfig['nentriesinterval'] = isset($user_settings['widgets'][$widgetkey]['filt
 			</div>
 		</div>
 
-		<div class="form-group">
-			<label for="filterlogentriesinterval" class="col-sm-4 control-label"><?=gettext('Update interval')?></label>
-			<div class="col-sm-4">
-				<input type="number" name="filterlogentriesinterval" id="filterlogentriesinterval" value="<?=$pconfig['nentriesinterval']?>" placeholder="60"
-					min="1" class="form-control" />
-			</div>
-			<?=gettext('Seconds');?>
-		</div>
+		<?=gen_customwidgetinterval_div($widgetconfig['interval']); ?>
 
 		<div class="form-group">
 			<div class="col-sm-offset-4 col-sm-6">

--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -208,11 +208,11 @@ events.push(function(){
 
 	// Create an object defining the widget refresh AJAX call
 	var logsObject = new Object();
-	logsObject.name = "Gateways";
+	logsObject.name = "Firewall Logs";
 	logsObject.url = "/widgets/widgets/log.widget.php";
 	logsObject.callback = logs_callback;
 	logsObject.parms = postdata;
-	logsObject.freq = <?=$nentriesinterval?>/5;
+	logsObject.freq = <?=$nentriesinterval?>;
 
 	// Register the AJAX object
 	register_ajax(logsObject);


### PR DESCRIPTION
executewidget
- Renamed function to executewidgets for grammar's sake
- Moved ajaxspecs.length check out of the loop - if ajaxspecs.length isn't more than 0 at page load, there's no reason to keep checking it. can always move the check back into executewidgets function if there ever arises a case where widgets can be inserted into ajaxspecs dynamically.
- Changed to a setInterval instead of a self-calling setTimeout - code is cleaner that way
- Fixed logic in widget loop - previously, the setTimeout loop was only incrementing ajaxidx every time it was executed, which means that the function is only checking one single widget every second. If you have 6 widgets registered (my case, for example), that means that the loop only comes back around to a given widget (log.widget.php for example) every 6th run. So if you have your interval set to 1, it actually only refreshes every 6 seconds; if the interval is set to 2, it refreshes every 12 seconds. Changed ajaxidx to a for loop, checking each widget every setInterval execution.

make_ajax_call
- Improved logic flow - should be doing your failure checks, then continuing if no failures are detected
- Cleaned up unnecessary variable ajaxtimeout - don't need to capture this in a variable if it's not checked elsewhere
- Cleaned up unnecessary variable ajaxmutex - you shouldn't use a global widget lock; see next point for replacement
- Added a per-widget lock, which expires regardless of success or failure