### PR TITLE
Unbound: Disable IPv6 outgoing queries if IPv6 blocked in firewall, a…

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -246,6 +246,7 @@ EOF;
 	$port = (is_port($unboundcfg['port'])) ? $unboundcfg['port'] : "53";
 	$hide_identity = isset($unboundcfg['hideidentity']) ? "yes" : "no";
 	$hide_version = isset($unboundcfg['hideversion']) ? "yes" : "no";
+	$ipv6_allow = ($config['system']['ipv6allow'] ? "yes" : "no";
 	$harden_dnssec_stripped = isset($unboundcfg['dnssecstripped']) ? "yes" : "no";
 	$prefetch = isset($unboundcfg['prefetch']) ? "yes" : "no";
 	$prefetch_key = isset($unboundcfg['prefetchkey']) ? "yes" : "no";
@@ -337,7 +338,7 @@ hide-identity: {$hide_identity}
 hide-version: {$hide_version}
 harden-glue: yes
 do-ip4: yes
-do-ip6: yes
+do-ip6: {$ipv6_allow}
 do-udp: yes
 do-tcp: yes
 do-daemonize: yes


### PR DESCRIPTION
…s they can never go anywhere

If IPv6 is disallowed in system->advanced->network, then any IPv6 lookups by Unbound will always be blocked, so there's no point sending them.

The practical purpose is that they also clog up the log and may fractionally slow down the resolver because the resolver then has to deal with IPv6 not replying, fallback lookups, etc.

I'm aware that we state that the system setting doesn't affect any service, but in this case the service simply doesn't send packets that we know will be blocked anyway on egress, so it's probably not going to be an issue. If it is, we can add an explicit "Disable IPv6" setting to this and other functions, but then if IPv6 is later used, the user has to remember to unset "IPv6 not allowed" in all the pages they were set, which is a pain and pretty much duplicates the main setting for all practical purposes.