### PR TITLE
Fix #6319 again by adding missing dns-servers

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1448,6 +1448,7 @@ EOD;
 				foreach ($ptr_zones as $ptr_zone) {
 					$reversezone = array();
 					$reversezone['ptr-domain'] = $ptr_zone;
+					$reversezone['dns-servers'][] = $dhcpv6ifconf['ddnsdomainprimary'];
 					$reversezone['ddnsdomainkeyname'] = $dhcpv6ifconf['ddnsdomainkeyname'];
 					$reversezone['ddnsdomainkey'] = $dhcpv6ifconf['ddnsdomainkey'];
 					$ddns_zones[] = $reversezone;


### PR DESCRIPTION
Not sure how I missed this but the change in pull request #3886 is wrong. The $reversezone['dns-servers'] array needs to be set for dhcpdzones() to create the correct reverse zone definition in dhcpdv6.conf