### PR TITLE
[services_dyndns_edit] Clarify use of @ for Cloudflare

### DIFF
--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -301,7 +301,8 @@ $group->setHelp('Enter the complete fully qualified domain name. Example: myhost
 			'he.net tunnelbroker: Enter the tunnel ID.%1$s' .
 			'GleSYS: Enter the record ID.%1$s' .
 			'DNSimple: Enter only the domain name.%1$s' .
-			'Namecheap, Cloudflare, GratisDNS, Hover, ClouDNS, GoDaddy: Enter the hostname and the domain separately, with the domain being the domain or subdomain zone being handled by the provider.', '<br />');
+			'Namecheap, Cloudflare, GratisDNS, Hover, ClouDNS, GoDaddy: Enter the hostname and the domain separately, with the domain being the domain or subdomain zone being handled by the provider.%1$s' .
+			'Cloudflare: Enter @ as the hostname to indicate an empty field.', '<br />');
 
 $section->add($group);
 


### PR DESCRIPTION
Add GUI prompts corresponding to #7357 that allows users to
enter @ for the hostname, and have it replaced with an empty hostname.

Signed-off-by: Earl Chew <earl_chew@yahoo.com>

- [x] Redmine Issue: https://redmine.pfsense.org/issues/7357
- [x] Ready for review