### PR TITLE
filter.inc, make filter_expand_alias_array() return consistent results between first and second call.

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -693,7 +693,6 @@ function filter_generate_nested_alias_recurse($name, $alias, &$aliasnesting, &$a
 				$filterdns["{$address}{$name}"] = "pf {$address} {$name}\n";
 			}
 		}
-		$finallist = '';
 	}
 
 	return $finallist;


### PR DESCRIPTION
filter.inc, make filter_expand_alias_array() return consistent results between first and second call.

Currently the 1st php call to: filter_expand_alias_array('mixed_ip_dns_alias') does not return the fixed IP's but a second call to filter_expand_alias_array('mixed_ip_dns_alias') does.. This is at least 'unexpected'.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8290
- [x] Ready for review