### PR TITLE
IPsec mobile clients with different (virtual) IP addresses by (EAP) identity

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -1387,7 +1387,12 @@ EOD;
 					log_error(sprintf(gettext("No phase2 specifications for tunnel with REQID = %s"), $ikeid));
 				}
 			} else {
-				$ipsecfin = "\nconn con{$ph1ent['ikeid']}\n";
+				if (isset($ph1ent['mobile'])) {
+					$ipsecfin = "\nconn con-mobile\n";
+				}
+				else {
+					$ipsecfin = "\nconn con{$ph1ent['ikeid']}\n";
+				}
 				//if (!empty($reqids[$idx])) {
 				//	$ipsecfin .= "\treqid = " . $reqids[0] . "\n";
 				//}


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/8292
- [ ] Ready for review

this is the first mod for extending mobile connection. this enables multiple mobile clients with different IPsec options handled by firewall rules.
this is a strongswan default feature, it's just not configurable by the WebUI of pfSense.

please also have a look at the forum post: https://forum.pfsense.org/index.php?topic=142560.0