### PR TITLE
Fix dyndns update with gateway group

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -1330,7 +1330,7 @@ function validate_address_family($ipaddr, $gwname, $disabled = false) {
 }
 
 /* check if a interface is part of a gateway group */
-function interface_gateway_group_member($interface) {
+function interface_gateway_group_member($interface, $gwgroup_name = "") {
 	global $config;
 
 	if (is_array($config['gateways']['gateway_group'])) {
@@ -1345,7 +1345,8 @@ function interface_gateway_group_member($interface) {
 			foreach ($group['item'] as $item) {
 				$elements = explode("|", $item);
 				$gwname = $elements[0];
-				if ($interface == $gateways_arr[$gwname]['interface']) {
+				if ($interface == $gateways_arr[$gwname]['interface'] &&
+				    (empty($gwgroup_name) || $gwgroup_name == $group['name'])) {
 					unset($gateways_arr);
 					return true;
 				}

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1918,6 +1918,7 @@ function services_dyndns_configure($int = "") {
 			 */
 			$group_int = '';
 			$friendly_group_int = '';
+			$gwgroup_member = false;
 			if (is_array($gwgroups[$dyndns['interface']])) {
 				if (!empty($gwgroups[$dyndns['interface']][0]['vip'])) {
 					$group_int = $gwgroups[$dyndns['interface']][0]['vip'];
@@ -1926,9 +1927,14 @@ function services_dyndns_configure($int = "") {
 					$friendly_group_int =
 					    convert_real_interface_to_friendly_interface_name(
 						$group_int);
+					if (!empty($int)) {
+						$gwgroup_member =
+						    interface_gateway_group_member(get_real_interface($int),
+						    $dyndns['interface']);
+					}
 				}
 			}
-			if ((empty($int)) || ($int == $dyndns['interface']) ||
+			if ((empty($int)) || ($int == $dyndns['interface']) || $gwgroup_member ||
 			    ($int == $group_int) || ($int == $friendly_group_int)) {
 				$dyndns['verboselog'] = isset($dyndns['verboselog']);
 				$dyndns['curl_ipresolve_v4'] = isset($dyndns['curl_ipresolve_v4']);
@@ -2480,6 +2486,7 @@ function services_dnsupdate_process($int = "", $updatehost = "", $forced = false
 		 */
 		$group_int = '';
 		$friendly_group_int = '';
+		$gwgroup_member = false;
 		if (is_array($gwgroups[$dnsupdate['interface']])) {
 			if (!empty($gwgroups[$dnsupdate['interface']][0]['vip'])) {
 				$group_int = $gwgroups[$dnsupdate['interface']][0]['vip'];
@@ -2488,9 +2495,14 @@ function services_dnsupdate_process($int = "", $updatehost = "", $forced = false
 				$friendly_group_int =
 				    convert_real_interface_to_friendly_interface_name(
 					$group_int);
+				if (!empty($int)) {
+					$gwgroup_member =
+					    interface_gateway_group_member(get_real_interface($int),
+					    $dnsupdate['interface']);
+				}
 			}
 		}
-		if (!empty($int) && ($int != $dnsupdate['interface']) &&
+		if (!empty($int) && ($int != $dnsupdate['interface']) && !$gwgroup_member &&
 		    ($int != $group_int) && ($int != $friendly_group_int)) {
 			continue;
 		}


### PR DESCRIPTION
If dynamic dns interface is a gateway group, DNS entry is update only when primary route is up again. When primary route down, nothing happen.
This patch fix this issue.