### PR TITLE
Mark authentication containers label as required field

### DIFF
--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -592,10 +592,10 @@ $section->addInput(new Form_StaticText(
 	'Level ' . $SSF . '<br />' . 'Base DN' . $SSB
 ));
 
-$group = new Form_Group('Authentication containers');
+$group = new Form_Group('*Authentication containers');
 $group->add(new Form_Input(
 	'ldapauthcontainers',
-	'*Containers',
+	'Containers',
 	'text',
 	$pconfig['ldap_authcn']
 ))->setHelp('Note: Semi-Colon separated. This will be prepended to the search '.


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/8337
- [x] Ready for review

The text "Containers" that appears as "backgorund hint" in the data entry box accidentally had the "magic *" in front of it.