### PR TITLE
Fix typo preventing dashboard display

### DIFF
--- a/src/etc/inc/copynotice.inc
+++ b/src/etc/inc/copynotice.inc
@@ -57,7 +57,7 @@ $copyrightfile = "/var/db/copyright";
 					<button type=\"button\" class=\"btn btn-xs btn-success\" data-dismiss=\"modal\" aria-label=\"Close\">
 							<span aria-hidden=\"true\">Accept</span>
 					</button>
-					</div>)");
+					</div>"));
 			}
 ?>
 


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review

Displays error at the bottom of the dasboard and prevents accepting license in a popup.