### PR TITLE
Patch for specifying router preference for the default ipv6 route pushed by radvd.conf

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -232,6 +232,17 @@ function services_radvd_configure($blacklist = array()) {
 			}
 		}
 		$radvdconf .= "\troute ::/0 {\n";
+		switch ($dhcpv6ifconf['rapriority']) {
+			case "low":
+				$radvdconf .= "\t\tAdvRoutePreference low;\n";
+				break;
+			case "high":
+				$radvdconf .= "\t\tAdvRoutePreference high;\n";
+				break;
+			default:
+				$radvdconf .= "\t\tAdvRoutePreference medium;\n";
+				break;
+		}
 		$radvdconf .= "\t\tRemoveRoute on;\n";
 		$radvdconf .= "\t};\n";
 


### PR DESCRIPTION
This patch simply adds AdvRoutePreference to the default route pushed by radvd.conf so that router preference is honored.

This fixes https://redmine.pfsense.org/issues/6237 and https://redmine.pfsense.org/issues/7204.

The issue is that on systems with multiple RAs with different priorities (master and backup, for example), the default route/gateway might be taken from the first received RA because the explicit default ::/0 route doesn't specify priority, i.e. defaults to medium for both/all RAs.

Alternative fix would be to exclude the route ::/0 {} directive altogether as the RA advertiser is taken as default gateway by default.