### PR TITLE
Change group length from 16 to 32 Characters

### DIFF
--- a/src/usr/local/www/system_groupmanager.php
+++ b/src/usr/local/www/system_groupmanager.php
@@ -149,8 +149,8 @@ if (isset($_POST['save'])) {
 		}
 	}
 
-	if (strlen($_POST['groupname']) > 16) {
-		$input_errors[] = gettext("The group name is longer than 16 characters.");
+	if (strlen($_POST['groupname']) > 32) {
+		$input_errors[] = gettext("The group name is longer than 32 characters.");
 	}
 
 	/* Check the POSTed members to ensure they are valid and exist */


### PR DESCRIPTION
FreeBSD used to only support 16 character usernames, at some point this was increased to 32. 
Was already fixed for the username field. Updated group length to 32 (needed as group names must match remote ldap groups, which can be longer than 16 characters...)

No redmine issue.
https://redmine.pfsense.org/projects/pfsense/repository/revisions/a84fb5453202fa80803cd75037cd5554fc585c89