### PR TITLE
Bug #8469 - Fix for errant display of DHCP Server Dynamic DNS Advanced Parameters

### DIFF
--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1555,7 +1555,7 @@ events.push(function() {
 				empty($pconfig['ddnsdomain']) &&
 				empty($pconfig['ddnsdomainprimary']) &&
 			    empty($pconfig['ddnsdomainkeyname']) &&
-			    empty($pconfig['ddnsdomainkeyalgorithm']) &&
+			    (empty($pconfig['ddnsdomainkeyalgorithm']) || ($pconfig['ddnsdomainkeyalgorithm'] == "hmac-md5")) &&
 			    (empty($pconfig['ddnsclientupdates']) || ($pconfig['ddnsclientupdates'] == "allow")) &&
 			    empty($pconfig['ddnsdomainkey'])) {
 				$showadv = false;


### PR DESCRIPTION
This PR modifies the services_dhcp.php file, specifically the logic for whether or not to display the DHCP Server Dynamic DNS Advanced configuration settings on pageload.

The current code does not allow for the default ddnsdomainkeyalgorithm element value ("hmac-md5") which is automatically set whenever the configuration is saved. The proposed change adds a logical OR operator to allow for either an empty value or the default value.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8469
- [x] Ready for review