### PR TITLE
Fix bug for rules 'permit ip any any' from LDAP/AD

### DIFF
--- a/src/etc/inc/ipsec.attributes.php
+++ b/src/etc/inc/ipsec.attributes.php
@@ -117,10 +117,10 @@ function parse_cisco_acl($attribs) {
 					$isblock = false;
 				}
 			} else if (trim($rule[$index]) == "any") {
-				$tmprule .= "from any";
+				$tmprule .= "from any ";
 				$index++;
 			} else {
-				$tmprule .= "from {$rule[$index]}";
+				$tmprule .= "from {$rule[$index]} ";
 				$index++;
 				$netmask = cisco_to_cidr($rule[$index]);
 				$tmprule .= "/{$netmask} ";


### PR DESCRIPTION
This commit fixes a problem with generated rules from Active Directory  (Cisco AV Pairs) for VPN IpSec connexions.
It has been tested on production with pfSense 2.1.5 version.