### PR TITLE
Update to DNSimple APIv2 endpoint

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -849,10 +849,12 @@
 					curl_setopt($ch, CURLOPT_URL, $server .$port . '?hostname=' . $this->_dnsHost . '&myip=' . $this->_dnsIP);
 					break;
 				case 'dnsimple':
-					/* Uses DNSimple's REST API
-					   Requires username and Account API token passed in header
-					   Piggybacks on Route 53's ZoneID field for DNSimple record ID
-					   Data sent as JSON */
+					/* Uses DNSimple's v2 REST API
+					   Requires the Account ID as the username (found in the URL when pull up the domain)
+					   And an API Token for the password (generated in the User Settings -> API tokens area of the website)
+					   Piggybacks on Route 53's ZoneID field for the DNSimple record ID to update
+					   The DNS record MUST exist before it can update since it performs a PATCH operation
+					   Data sent as JSON over HTTPS */
 					$needsIP = TRUE;
 					$server = 'https://api.dnsimple.com/v2/';
 					curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PATCH");

--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -854,13 +854,11 @@
 					   Piggybacks on Route 53's ZoneID field for DNSimple record ID
 					   Data sent as JSON */
 					$needsIP = TRUE;
-					$server = 'https://api.dnsimple.com/v1/domains/';
-					$token = $this->_dnsUser . ':' . $this->_dnsPass;
-					$jsondata = '{"record":{"content":"' . $this->_dnsIP . '","ttl":"' . $this->_dnsTTL . '"}}';
-					curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
-					curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json', 'Content-Type: application/json', 'X-DNSimple-Token: ' . $token));
-					curl_setopt($ch, CURLOPT_URL, $server . $this->_dnsHost . '/records/' . $this->_dnsZoneID);
-					curl_setopt($ch, CURLOPT_POSTFIELDS, $jsondata);
+					$server = 'https://api.dnsimple.com/v2/';
+					curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PATCH");
+					curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json', 'Content-Type: application/json', 'Authorization: Bearer ' . $this->_dnsPass));
+					curl_setopt($ch, CURLOPT_URL, $server . $this->_dnsUser . '/zones/' . $this->_dnsHost . '/records/' . $this->_dnsZoneID);
+					curl_setopt($ch, CURLOPT_POSTFIELDS, '{"content":"' . $this->_dnsIP . '","ttl":"' . $this->_dnsTTL . '"}');
 					break;
 				case 'godaddy':
 				case 'godaddy-v6':

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -364,6 +364,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('Username is required for all types except Namecheap, FreeDNS and Custom Entries.%1$s' .
 	                'Azure: Enter your Azure AD application ID%1$s' .
 			'DNS Made Easy: Dynamic DNS ID%1$s' .
+			'DNSimple: User account ID (In the URL after the '/a/')%1$s' .
 			'Route 53: Enter the Access Key ID.%1$s' .
 			'GleSYS: Enter the API user.%1$s' .
 			'Dreamhost: Enter a value to appear in the DNS record comment.%1$s' .
@@ -378,6 +379,7 @@ $section->addPassword(new Form_Input(
 ))->setHelp('FreeDNS (freedns.afraid.org): Enter the "Authentication Token" provided by FreeDNS.%1$s' .
 	                'Azure: client secret of the AD application%1$s' .
 			'DNS Made Easy: Dynamic DNS Password%1$s' .
+			'DNSimple: User account token%1$s' .
 			'DigitalOcean: Enter API token%1$s' .
 			'Route 53: Enter the Secret Access Key.%1$s' .
 			'GleSYS: Enter the API key.%1$s' .

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -364,7 +364,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('Username is required for all types except Namecheap, FreeDNS and Custom Entries.%1$s' .
 	                'Azure: Enter your Azure AD application ID%1$s' .
 			'DNS Made Easy: Dynamic DNS ID%1$s' .
-			'DNSimple: User account ID (In the URL after the '/a/')%1$s' .
+			'DNSimple: User account ID (In the URL after the \'/a/\')%1$s' .
 			'Route 53: Enter the Access Key ID.%1$s' .
 			'GleSYS: Enter the API user.%1$s' .
 			'Dreamhost: Enter a value to appear in the DNS record comment.%1$s' .


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/8071
- [x] Ready for review

This PR updates the dnsimple dyndns integration by updating to the new v2 API endpoint. The v1 API is no longer available. I re-purposed the username to account ID and password to the API bearer token. I can assist with any documentation updates to make it clearer to the user what is required for each field since it won't be username and password anymore.

Let me know if you need help getting setup with an account to test this integration with the new API as I work for DNSimple.