### PR TITLE
routing, fix setting the default-route when the configured default gateway is a dynamic pppoe gateway

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -1370,13 +1370,12 @@ function dhclient_update_gateway_groups_defaultroute($interface = "wan") {
 
 function lookup_gateway_or_group_by_name($gwname) {
 	global $config;
-
-	if (is_array($config['gateways']['gateway_item'])) {
-		foreach ($config['gateways']['gateway_item'] as $gw) {
-			if ($gw['name'] == $gwname) {
-				$gw['type'] = 'gateway';
-				return $gw;
-			}
+	
+	$gateways_arr = return_gateways_array();
+	foreach ($gateways_arr as $gw) {
+		if ($gw['name'] == $gwname) {
+			$gw['type'] = 'gateway';
+			return $gw;
 		}
 	}
 

--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -1032,7 +1032,7 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 	} else {
 		$gwdefault = $config['gateways']['defaultgw6'];
 	}
-	if (isset($gateways_status[$gwdefault])) {
+	if (isset($gateways_arr[$gwdefault])) {
 		// the configured gateway is a regular one. (not a gwgroup) use it as is..
 		$dfltgwname = $gwdefault;
 	} else {

--- a/src/etc/rc.newwanip
+++ b/src/etc/rc.newwanip
@@ -183,7 +183,12 @@ if (!empty($gre)) {
 	}
 }
 
-if (platform_booting()) {
+if (platform_booting() && in_array(substr($interface_real, 0, 3), array("ppp", "ppt", "l2t"))) {
+	// unlike dhcp interfaces which wait until they get an ip, a ppp connection lets the boot continue while 
+	// trying to aquire a ip address so to avoid a race condition where it would be possible that the default
+	// route would not be set, this script must continue to use the new assigned ip even while booting
+	// https://redmine.pfsense.org/issues/8561
+	
 	// avoid race conditions in many of the below functions that occur during boot
 	// setting up gateways monitor doesn't seem to have issues here, and fixes the
 	// most commonly encountered bugs from earlier versions when everything below


### PR DESCRIPTION
fix setting the default-route when the configured default gateway is a dynamic pppoe gateway. It doesnt have a gateway-status when it hasn't connected yet.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8561
- [x] Ready for review