### PR TITLE
[Fix for #3904] IPsec mobile clients with different (virtual) IP addresses by (EAP) identity

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -1498,7 +1498,7 @@ EOD;
 						continue;
 					}
 
-					if (strlen($mkent['pool_address'] < 1) || !is_ipaddr($mkent['pool_address'])) {
+					if (strlen($mkent['pool_address']) < 1 || !is_ipaddr($mkent['pool_address'])) {
 						continue;
 					}
 
@@ -1506,6 +1506,10 @@ EOD;
 					$ipsecfin .= "\talso = con-mobile\n";
 					$ipsecfin .= "\teap_identity = %identity\n";
 					$ipsecfin .= "\trightsourceip = {$mkent['pool_address']}/{$mkent['pool_netbits']}\n";
+
+					if (isset($mkent['dns_address']) && strlen($mkent['dns_address']) > 0 && is_ipaddr($mkent['dns_address'])) {
+						$ipsecfin .= "\trightdns = {$mkent['dns_address']}\n";
+					}
 
 					if ($mkent['ident_type'] == "none") {
 						$ipsecfin .= "\trightid = \"{$mkent['ident']}\"\n";

--- a/src/usr/local/www/vpn_ipsec_keys_edit.php
+++ b/src/usr/local/www/vpn_ipsec_keys_edit.php
@@ -185,20 +185,20 @@ $section->addInput(new Form_Input(
 
 $section->addInput(new Form_Select(
 	'ident_type',
-	'*Identifier type',
+	'Identifier type',
 	$pconfig['ident_type'],
 	build_ipsecid_list()
 ))->setWidth(4)->setHelp('Optional: specify identifier type for strongswan');
 
 $section->addInput(new Form_IpAddress(
 	'pool_address',
-	'*Virtual Address Pool',
+	'Virtual Address Pool',
 	$pconfig['pool_address']
 ))->setWidth(4)->setHelp('Optional. If used, must be IPv4 address. If left blank, "Virtual Address Pool" of "Mobile Clients" will be used.')->addMask('pool_netbits', $pconfig['pool_netbits'], 32, 0);
 
 $section->addInput(new Form_IpAddress(
 	'dns_address',
-	'*DNS Server',
+	'DNS Server',
 	$pconfig['dns_address']
 ))->setWidth(4)->setHelp('Optional. If used, must be IPv4 address. Individual DNS server only for this user. If left blank, "DNS Servers" of "Mobile Clients" will be used.');
 

--- a/src/usr/local/www/vpn_ipsec_keys_edit.php
+++ b/src/usr/local/www/vpn_ipsec_keys_edit.php
@@ -57,6 +57,7 @@ if (isset($id) && $a_secret[$id]) {
 	$pconfig['ident_type'] = $a_secret[$id]['ident_type'];
 	$pconfig['pool_address'] = $a_secret[$id]['pool_address'];
 	$pconfig['pool_netbits'] = $a_secret[$id]['pool_netbits'];
+	$pconfig['dns_address'] = $a_secret[$id]['dns_address'];
 }
 
 if ($_POST['save']) {
@@ -87,8 +88,12 @@ if ($_POST['save']) {
 		$input_errors[] = gettext("Pre-Shared Key contains invalid characters.");
 	}
 
-	if (isset($_POST['pool_address']) && strlen($_POST['pool_address'] > 1) && !is_ipaddr($_POST['pool_address'])) {
-		$input_errors[] = gettext("A valid IP address for 'Virtual Address Pool Network' must be specified.");
+	if (isset($_POST['pool_address']) && strlen($_POST['pool_address']) > 1 && !is_ipaddr($_POST['pool_address'])) {
+		$input_errors[] = gettext("A valid IP address for 'Virtual Address Pool' must be specified.");
+	}
+
+	if (isset($_POST['dns_address']) && strlen($_POST['dns_address']) > 1 && !is_ipaddr($_POST['dns_address'])) {
+		$input_errors[] = gettext("A valid IP address for 'DNS Server' must be specified.");
 	}
 
 	if (!$input_errors && !(isset($id) && $a_secret[$id])) {
@@ -113,6 +118,7 @@ if ($_POST['save']) {
 		$secretent['ident_type'] = $_POST['ident_type'];
 		$secretent['pool_address'] = $_POST['pool_address'];
 		$secretent['pool_netbits'] = $_POST['pool_netbits'];
+		$secretent['dns_address'] = $_POST['dns_address'];
 		$text = "";
 
 		if (isset($id) && $a_secret[$id]) {
@@ -186,9 +192,15 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_IpAddress(
 	'pool_address',
-	'*IPv4 address',
+	'*Virtual Address Pool',
 	$pconfig['pool_address']
-))->setWidth(4)->setHelp('Optional: Network configuration for Virtual Address Pool')->addMask('pool_netbits', $pconfig['pool_netbits'], 32, 0);
+))->setWidth(4)->setHelp('Optional. If used, must be IPv4 address. If left blank, "Virtual Address Pool" of "Mobile Clients" will be used.')->addMask('pool_netbits', $pconfig['pool_netbits'], 32, 0);
+
+$section->addInput(new Form_IpAddress(
+	'dns_address',
+	'*DNS Server',
+	$pconfig['dns_address']
+))->setWidth(4)->setHelp('Optional. If used, must be IPv4 address. Individual DNS server only for this user. If left blank, "DNS Servers" of "Mobile Clients" will be used.');
 
 if (isset($id) && $a_secret[$id]) {
 	$form->addGlobal(new Form_Input(


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/8292
- [x] Ready for review

there were 2 failures in #3904 which are now fixed. Also added support for individual DNS per user (strongswan config option).

sorry for the wrong brackets.