### PR TITLE
Extend maximum gateway monitoring probe interval

### DIFF
--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -323,7 +323,7 @@ $section->addInput(new Form_Input(
 	$pconfig['interval'],
 	[
 		'placeholder' => $dpinger_default['interval'],
-		'max' => 86400
+		'max' => 86400000
 	]
 ))->setHelp('How often an ICMP probe will be sent in milliseconds. Default is %d.', $dpinger_default['interval']);
 

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -323,7 +323,7 @@ $section->addInput(new Form_Input(
 	$pconfig['interval'],
 	[
 		'placeholder' => $dpinger_default['interval'],
-		'max' => 86400000
+		'max' => 3600000
 	]
 ))->setHelp('How often an ICMP probe will be sent in milliseconds. Default is %d.', $dpinger_default['interval']);
 


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/8593
- [X] Ready for review

The existing monitoring interval was a maximum of 86400 ms, or approximately 86 seconds. This can cause excessive data usage over strictly metered connections. This patch extends the maximum interval to 86,400,000 ms, or exactly 24 hours. Tested on pfSense 2.4.3, confirmed that dpinger runs correctly with maximal values.