### PR TITLE
Update crypto defaults for OpenVPN/IPsec

### DIFF
--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -36,7 +36,7 @@ $ca_methods = array(
 	"internal" => gettext("Create an internal Certificate Authority"),
 	"intermediate" => gettext("Create an intermediate Certificate Authority"));
 
-$ca_keylens = array("512", "1024", "2048", "3072", "4096", "7680", "8192", "15360", "16384");
+$ca_keylens = array("1024", "2048", "3072", "4096", "6144", "7680", "8192", "15360", "16384");
 global $openssl_digest_algs;
 
 if (isset($_REQUEST['id']) && is_numericint($_REQUEST['id'])) {

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -38,7 +38,7 @@ $cert_methods = array(
 	"sign" => gettext("Sign a Certificate Signing Request")
 );
 
-$cert_keylens = array("512", "1024", "2048", "3072", "4096", "7680", "8192", "15360", "16384");
+$cert_keylens = array("1024", "2048", "3072", "4096", "6144", "7680", "8192", "15360", "16384");
 $cert_types = array(
 	"server" => "Server Certificate",
 	"user" => "User Certificate");

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -170,8 +170,7 @@ if (isset($p1index) && $a_phase1[$p1index]) {
 // default value for new P1 and failsafe to always have at least 1 encryption item for the Form_ListItem
 if (!is_array($pconfig['encryption']['item']) || count($pconfig['encryption']['item']) == 0) {
 	$item = array();
-	$item['encryption-algorithm'] = array('name' => "aes");
-	$item['encryption-algorithm'] = array('keylen' => 128);
+	$item['encryption-algorithm'] = array('name' => "aes", 'keylen' => 128);
 	$item['hash-algorithm'] = "sha256";
 	$item['dhgroup'] = "14";
 	$pconfig['encryption']['item'][] = $item;

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -171,8 +171,9 @@ if (isset($p1index) && $a_phase1[$p1index]) {
 if (!is_array($pconfig['encryption']['item']) || count($pconfig['encryption']['item']) == 0) {
 	$item = array();
 	$item['encryption-algorithm'] = array('name' => "aes");
-	$item['hash-algorithm'] = "sha1";
-	$item['dhgroup'] = "2";
+	$item['encryption-algorithm'] = array('keylen' => 128);
+	$item['hash-algorithm'] = "sha256";
+	$item['dhgroup'] = "14";
 	$pconfig['encryption']['item'][] = $item;
 }
 

--- a/src/usr/local/www/vpn_ipsec_phase2.php
+++ b/src/usr/local/www/vpn_ipsec_phase2.php
@@ -107,7 +107,9 @@ if ($ph2found === true) {
 	$pconfig['localid_type'] = "lan";
 	$pconfig['remoteid_type'] = "network";
 	$pconfig['proto'] = "esp";
-	$pconfig['ealgos'] = explode(",", "aes");
+	$pconfig['ealgos'] = explode(",", "aes,aes128gcm");
+	$pconfig['keylen_aes'] = 128;
+	$pconfig['keylen_aes128gcm'] = 128;
 	$pconfig['halgos'] = explode(",", "hmac_sha256");
 	$pconfig['pfsgroup'] = "14";
 	$pconfig['lifetime'] = "3600";

--- a/src/usr/local/www/vpn_ipsec_phase2.php
+++ b/src/usr/local/www/vpn_ipsec_phase2.php
@@ -108,8 +108,8 @@ if ($ph2found === true) {
 	$pconfig['remoteid_type'] = "network";
 	$pconfig['proto'] = "esp";
 	$pconfig['ealgos'] = explode(",", "aes");
-	$pconfig['halgos'] = explode(",", "hmac_sha1");
-	$pconfig['pfsgroup'] = "0";
+	$pconfig['halgos'] = explode(",", "hmac_sha256");
+	$pconfig['pfsgroup'] = "14";
 	$pconfig['lifetime'] = "3600";
 	$pconfig['uniqid'] = uniqid();
 

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -93,15 +93,14 @@ if ($_POST['act'] == "del") {
 
 if ($act == "new") {
 	$pconfig['ncp_enable'] = "enabled";
-	$pconfig['ncp-ciphers'] = "AES-256-GCM,AES-128-GCM";
+	$pconfig['ncp-ciphers'] = "AES-128-GCM";
 	$pconfig['autokey_enable'] = "yes";
 	$pconfig['tlsauth_enable'] = "yes";
 	$pconfig['autotls_enable'] = "yes";
 	$pconfig['interface'] = "wan";
 	$pconfig['server_port'] = 1194;
 	$pconfig['verbosity_level'] = 1; // Default verbosity is 1
-	// OpenVPN Defaults to SHA1
-	$pconfig['digest'] = "SHA1";
+	$pconfig['digest'] = "SHA256";
 }
 
 global $simplefields;
@@ -134,7 +133,7 @@ if ($act == "edit") {
 		if (isset($a_client[$id]['ncp-ciphers'])) {
 			$pconfig['ncp-ciphers'] = $a_client[$id]['ncp-ciphers'];
 		} else {
-			$pconfig['ncp-ciphers'] = "AES-256-GCM,AES-128-GCM";
+			$pconfig['ncp-ciphers'] = "AES-128-GCM";
 		}
 		if (isset($a_client[$id]['ncp_enable'])) {
 			$pconfig['ncp_enable'] = $a_client[$id]['ncp_enable'];
@@ -156,8 +155,7 @@ if ($act == "edit") {
 			$pconfig['shared_key'] = base64_decode($a_client[$id]['shared_key']);
 		}
 		$pconfig['crypto'] = $a_client[$id]['crypto'];
-		// OpenVPN Defaults to SHA1 if unset
-		$pconfig['digest'] = !empty($a_client[$id]['digest']) ? $a_client[$id]['digest'] : "SHA1";
+		$pconfig['digest'] = !empty($a_client[$id]['digest']) ? $a_client[$id]['digest'] : "SHA256";
 		$pconfig['engine'] = $a_client[$id]['engine'];
 
 		$pconfig['tunnel_network'] = $a_client[$id]['tunnel_network'];
@@ -797,7 +795,7 @@ if ($act=="new" || $act=="edit"):
 		openvpn_get_digestlist()
 		))->setHelp('The algorithm used to authenticate data channel packets, and control channel packets if a TLS Key is present.%1$s' .
 		    'When an AEAD Encryption Algorithm mode is used, such as AES-GCM, this digest is used for the control channel only, not the data channel.%1$s' .
-		    'Leave this set to SHA1 unless the server uses a different value. SHA1 is the default for OpenVPN. ', '<br />');
+		    'Set this to the same value as the server. While SHA1 is the default for OpenVPN, this algorithm is insecure. ', '<br />');
 
 	$section->addInput(new Form_Select(
 		'engine',

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -101,19 +101,18 @@ if ($_POST['act'] == "del") {
 
 if ($act == "new") {
 	$pconfig['ncp_enable'] = "enabled";
-	$pconfig['ncp-ciphers'] = "AES-256-GCM,AES-128-GCM";
+	$pconfig['ncp-ciphers'] = "AES-128-GCM";
 	$pconfig['autokey_enable'] = "yes";
 	$pconfig['tlsauth_enable'] = "yes";
 	$pconfig['autotls_enable'] = "yes";
-	$pconfig['dh_length'] = 1024;
+	$pconfig['dh_length'] = 2048;
 	$pconfig['dev_mode'] = "tun";
 	$pconfig['interface'] = "wan";
 	$pconfig['local_port'] = openvpn_port_next('UDP');
 	$pconfig['cert_depth'] = 1;
 	$pconfig['create_gw'] = "both"; // v4only, v6only, or both (default: both)
 	$pconfig['verbosity_level'] = 1; // Default verbosity is 1
-	// OpenVPN Defaults to SHA1
-	$pconfig['digest'] = "SHA1";
+	$pconfig['digest'] = "SHA256";
 }
 
 if ($act == "edit") {
@@ -126,7 +125,7 @@ if ($act == "edit") {
 		if (isset($a_server[$id]['ncp-ciphers'])) {
 			$pconfig['ncp-ciphers'] = $a_server[$id]['ncp-ciphers'];
 		} else {
-			$pconfig['ncp-ciphers'] = "AES-256-GCM,AES-128-GCM";
+			$pconfig['ncp-ciphers'] = "AES-128-GCM";
 		}
 		if (isset($a_server[$id]['ncp_enable'])) {
 			$pconfig['ncp_enable'] = $a_server[$id]['ncp_enable'];
@@ -168,8 +167,7 @@ if ($act == "edit") {
 			$pconfig['shared_key'] = base64_decode($a_server[$id]['shared_key']);
 		}
 		$pconfig['crypto'] = $a_server[$id]['crypto'];
-		// OpenVPN Defaults to SHA1 if unset
-		$pconfig['digest'] = !empty($a_server[$id]['digest']) ? $a_server[$id]['digest'] : "SHA1";
+		$pconfig['digest'] = !empty($a_server[$id]['digest']) ? $a_server[$id]['digest'] : "SHA256";
 		$pconfig['engine'] = $a_server[$id]['engine'];
 
 		$pconfig['tunnel_network'] = $a_server[$id]['tunnel_network'];
@@ -963,7 +961,7 @@ if ($act=="new" || $act=="edit"):
 		openvpn_get_digestlist()
 		))->setHelp('The algorithm used to authenticate data channel packets, and control channel packets if a TLS Key is present.%1$s' .
 		    'When an AEAD Encryption Algorithm mode is used, such as AES-GCM, this digest is used for the control channel only, not the data channel.%1$s' .
-		    'Leave this set to SHA1 unless all clients are set to match. SHA1 is the default for OpenVPN. ',
+		    'The server and all clients must have the same setting. While SHA1 is the default for OpenVPN, this algorithm is insecure. ',
 			'<br />');
 
 	$section->addInput(new Form_Select(

--- a/src/usr/local/www/wizards/openvpn_wizard.xml
+++ b/src/usr/local/www/wizards/openvpn_wizard.xml
@@ -366,10 +366,6 @@
 			<bindstofield>ovpnserver->step6->keylength</bindstofield>
 			<options>
 				<option>
-					<name>512 bit</name>
-					<value>512</value>
-				</option>
-				<option>
 					<name>1024 bit</name>
 					<value>1024</value>
 				</option>
@@ -520,10 +516,6 @@
 			<value>2048</value>
 			<bindstofield>ovpnserver->step9->keylength</bindstofield>
 			<options>
-				<option>
-					<name>512 bit</name>
-					<value>512</value>
-				</option>
 				<option>
 					<name>1024 bit</name>
 					<value>1024</value>

--- a/src/usr/local/www/wizards/openvpn_wizard.xml
+++ b/src/usr/local/www/wizards/openvpn_wizard.xml
@@ -386,6 +386,10 @@
 					<value>4096</value>
 				</option>
 				<option>
+					<name>6144 bit</name>
+					<value>6144</value>
+				</option>
+				<option>
 					<name>7680 bit</name>
 					<value>7680</value>
 				</option>
@@ -535,6 +539,10 @@
 				<option>
 					<name>4096 bit</name>
 					<value>4096</value>
+				</option>
+				<option>
+					<name>6144 bit</name>
+					<value>6144</value>
 				</option>
 				<option>
 					<name>7680 bit</name>
@@ -730,6 +738,10 @@
 					<value>4096</value>
 				</option>
 				<option>
+					<name>6144 bit</name>
+					<value>6144</value>
+				</option>
+				<option>
 					<name>7680 bit</name>
 					<value>7680</value>
 				</option>
@@ -753,7 +765,7 @@
 			<type>select</type>
 			<displayname>Encryption Algorithm</displayname>
 			<bindstofield>ovpnserver->step10->crypto</bindstofield>
-			<value>AES-256-CBC</value>
+			<value>AES-128-CBC</value>
 			<options>
 				<option>
 					<name>dummy</name>
@@ -773,7 +785,7 @@
 					<value>dummy</value>
 				</option>
 			</options>
-			<value>SHA1</value>
+			<value>SHA256</value>
 			<description>&lt;br/&gt;The method used to authenticate traffic between endpoints. This setting must match on the client and server side, but is otherwise set however desired.</description>
 		</field>
 		<field>


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/8594
- [x] Ready for review

Updated default cipher to AES-128, default hash to SHA256, default DH group to 2048 bit (IPsec DH group 14). These are **potential changes**, and are here as a placeholder while the proposal to update them is being discussed. In the mean time, please make sure that I've touched everything necessary to make the UI/admin experience consistent.