### PR TITLE
routing, fix setting the default-route when the configured default gateway is a dynamic pppoe gateway

### DIFF
--- a/src/etc/rc.newwanip
+++ b/src/etc/rc.newwanip
@@ -183,7 +183,7 @@ if (!empty($gre)) {
 	}
 }
 
-if (platform_booting() && in_array(substr($interface_real, 0, 3), array("ppp", "ppt", "l2t"))) {
+if (platform_booting() && !in_array(substr($interface_real, 0, 3), array("ppp", "ppt", "l2t"))) {
 	// unlike dhcp interfaces which wait until they get an ip, a ppp connection lets the boot continue while 
 	// trying to aquire a ip address so to avoid a race condition where it would be possible that the default
 	// route would not be set, this script must continue to use the new assigned ip even while booting


### PR DESCRIPTION
fix setting the default-route when the configured default gateway is a dynamic pppoe gateway. It doesnt have a gateway-status when it hasn't connected yet.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8561
- [x] Ready for review