### PR TITLE
routing, when wan connection is made gatewaymonitor should start before determining default route

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -1062,7 +1062,7 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 	} elseif (empty($gwdefault)) {
 		// 'automatic' mode, pick the first one thats 'up' or 'unmonitored' which is always considered up
 		$gateways_arr = order_gateways_as_configured($gateways_arr);
-
+		$fallback = "";
 		foreach($gateways_arr as $gwname => $gwsttng) {
 			if ($gwsttng['ipprotocol'] != $ipprotocol) {
 				continue;
@@ -1072,6 +1072,13 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 				$set_dfltgwname = $gwname;
 				break;
 			}
+			if (empty($fallback) && $gwsttng['interface'] != 'lo0') {
+				$fallback = $gwname;
+			}
+		}
+		if (empty($set_dfltgwname)) {
+			log_error(sprintf("Gateway, none 'available' for %s, use the first one configured. '%s'", $ipprotocol, $fallback));
+			$set_dfltgwname = $fallback;
 		}
 	} else {
 		// a gwgroup is selected

--- a/src/etc/rc.newwanip
+++ b/src/etc/rc.newwanip
@@ -223,11 +223,12 @@ if (!is_ipaddr($oldip) || $curwanip != $oldip || !is_ipaddrv4($config['interface
 	 */
 	filter_configure_sync();
 
+	/* reconfigure our gateway monitor, dpinger results need to be 
+	 * available when configuring the default gateway */
+	setup_gateways_monitor();
+
 	/* reconfigure static routes (kernel may have deleted them) */
 	system_routing_configure($interface);
-
-	/* reconfigure our gateway monitor */
-	setup_gateways_monitor();
 
 	/* reload unbound */
 	services_unbound_configure();

--- a/src/etc/rc.newwanipv6
+++ b/src/etc/rc.newwanipv6
@@ -132,11 +132,12 @@ link_interface_to_track6($interface, "update");
 /* regenerate resolv.conf if DNS overrides are allowed */
 system_resolvconf_generate(true);
 
+/* reconfigure our gateway monitor, dpinger results need to be 
+ * available when configuring the default gateway */
+setup_gateways_monitor();
+
 /* reconfigure static routes (kernel may have deleted them) */
 system_routing_configure($interface);
-
-/* reconfigure our gateway monitor */
-setup_gateways_monitor();
 
 if (platform_booting()) {
 	// avoid race conditions in many of the below functions that occur during boot


### PR DESCRIPTION
routing, when a new pppoe connection is made the gatewaymonitor should be started before decisions about default route can be properly made. also for 'automatic' provide a fallback to the first enabled gateway thats configured, just in case..
As found by w0w:  https://forum.netgate.com/post/776018

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8504
- [x] Ready for review

