### PR TITLE
changes to mobile ipsec dns to support new features

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -522,25 +522,7 @@ EOD;
 
 	if (is_array($a_client) && isset($a_client['enable'])) {
 		$strongswan .= "\t\tattr {\n";
-
-		$cfgservers = array();
-		if (!empty($a_client['dns_server1'])) {
-			$cfgservers[] = $a_client['dns_server1'];
-		}
-		if (!empty($a_client['dns_server2'])) {
-			$cfgservers[] = $a_client['dns_server2'];
-		}
-		if (!empty($a_client['dns_server3'])) {
-			$cfgservers[] = $a_client['dns_server3'];
-		}
-		if (!empty($a_client['dns_server4'])) {
-			$cfgservers[] = $a_client['dns_server4'];
-		}
-
-		if (!empty($cfgservers)) {
-			$strongswan .= "\t\t\tdns = " . implode(",", $cfgservers) . "\n";
-		}
-		unset($cfgservers);
+		
 		$cfgservers = array();
 		if (!empty($a_client['wins_server1'])) {
 			$cfgservers[] = $a_client['wins_server1'];
@@ -1022,6 +1004,7 @@ EOD;
 			}
 
 			$rightsourceip = NULL;
+			$rightdnsserver = NULL;
 			if (isset($ph1ent['mobile'])) {
 				$rightsourceips = array();
 				if (!empty($a_client['pool_address'])) {
@@ -1035,6 +1018,24 @@ EOD;
 				}
 				if (count($rightsourceips)) {
 					$rightsourceip = "\trightsourceip = " . implode(',', $rightsourceips) . "\n";
+				}
+
+				$rightdnsservers = array();
+				if (!empty($a_client['dns_server1'])) {
+					$rightdnsservers[] = $a_client['dns_server1'];
+				}
+				if (!empty($a_client['dns_server2'])) {
+					$rightdnsservers[] = $a_client['dns_server2'];
+				}
+				if (!empty($a_client['dns_server3'])) {
+					$rightdnsservers[] = $a_client['dns_server3'];
+				}
+				if (!empty($a_client['dns_server4'])) {
+					$rightdnsservers[] = $a_client['dns_server4'];
+				}
+				
+				if (count($rightdnsservers)) {
+					$rightdnsserver = "\trightdns = " . implode(',', $rightdnsservers) . "\n";
 				}
 			}
 
@@ -1401,6 +1402,9 @@ EOD;
 			}
 			if (!empty($rightsourceip)) {
 				$ipsecconnect .= "{$rightsourceip}";
+			}
+			if (!empty($rightdnsserver)) {
+				$ipsecconnect .= "{$rightdnsserver}";
 			}
 			if (!empty($ealgosp1)) {
 				$ipsecconnect .= "\t{$ealgosp1}\n";


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/8644
- [x] Ready for review

discussion started in [redmine 8292](https://redmine.pfsense.org/issues/8292).
[strongswan wiki](https://wiki.strongswan.org/projects/strongswan/wiki/VirtualIp):

> **DNS servers**
> DNS servers and other attributes can be assigned by plugins (e.g. the attr plugin) or **since 5.0.1 directly in ipsec.conf by use of the rightdns option**. In swanctl.conf each pool in the pools section may define a list of attributes to assign to clients.

this change is linked to #3949

Now each client can have an individual assigned DNS.