### PR TITLE
Fix ID issues when edit/delete DNS Forwarding rule

### DIFF
--- a/src/usr/local/www/services_dnsmasq.php
+++ b/src/usr/local/www/services_dnsmasq.php
@@ -50,7 +50,7 @@ function hosts_sort() {
 		return;
 	}
 
-	usort($a_hosts, "hostcmp");
+	uasort($a_hosts, "hostcmp");
 }
 
 // Sort domain entries for display in alphabetical order
@@ -65,7 +65,7 @@ function domains_sort() {
 		return;
 	}
 
-	usort($a_domainOverrides, "domaincmp");
+	uasort($a_domainOverrides, "domaincmp");
 }
 
 $pconfig['enable'] = isset($config['dnsmasq']['enable']);
@@ -188,12 +188,6 @@ if ($_POST['save']) {
 
 if ($_POST['act'] == "del") {
 	if ($_POST['type'] == 'host') {
-		// it gets sorted by hostname on load
-		// sort it by index so it deletes the correct one.
-		usort($a_hosts, function($a,$b){
-			return($a['idx'] > $b['idx']);
-		});
-
 		if ($a_hosts[$_POST['id']]) {
 			unset($a_hosts[$_POST['id']]);
 			write_config();
@@ -202,12 +196,6 @@ if ($_POST['act'] == "del") {
 			exit;
 		}
 	} elseif ($_POST['type'] == 'doverride') {
-		// gets sorted by name on load
-		// sort by index to delete the correct one.
-		usort($a_domainOverrides, function($a,$b){
-			return($a['idx'] > $b['idx']);
-		});
-
 		if ($a_domainOverrides[$_POST['id']]) {
 			unset($a_domainOverrides[$_POST['id']]);
 			write_config();


### PR DESCRIPTION
Hello,

We had an issue when trying to edit or delete some rules / alias in DNS Forwarding section.
Sometimes, when I click on edit button, it's not the good rule that is edited. Same problem occurred when deleting rules (it's more dangerous...), another rule was deleted.

In line 99, we have:
```php
for ($idx=0; $idx<count($a_hosts); $idx++) {
	$a_hosts[$idx]['idx'] = $idx;
}
```

I find multiples lines where array's index is used or item "idx" property.

Examples:

Line 407 (item idx property):
```php
<a class="fa fa-pencil"	title="<?=gettext('Edit host override')?>" 	href="services_dnsmasq_edit.php?id=<?=$hostent['idx']?>"></a>
```

Line 431 (array index):
```php
<a class="fa fa-pencil"	title="<?=gettext('Edit host override')?>" 	href="services_dnsmasq_edit.php?id=<?=$i?>"></a>
```

But, for working properly, array's index AND item "idx" property must be the same!

Problem is in line 46:
```php
function hosts_sort() {
	global $a_hosts;
	if (!is_array($a_hosts)) {
		return;
	}
	usort($a_hosts, "hostcmp");
}
```

PHP **usort()** doesn't preserve array indexes when sorting! But **uasort()** does!
So, **usort()** calls must be replaced by a **uasort()** call like my commit.

Everything works properly on our production environment now!

PS: this issue is the same on domain override feature. I include these two features in my commit!

Thanks for your review,