### PR TITLE
Remove some legacy code in auth.inc

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -753,27 +753,9 @@ function local_user_del($user) {
 }
 
 function local_user_set_password(&$user, $password) {
-
 	unset($user['password']);
 	unset($user['md5-hash']);
 	$user['bcrypt-hash'] = password_hash($password, PASSWORD_BCRYPT);
-
-	/* Maintain compatibility with FreeBSD - change $2y$ prefix to $2b$
-	 * https://reviews.freebsd.org/D2742
-	 * XXX: Can be removed as soon as r284483 is MFC'd.
-	 */
-	if ($user['bcrypt-hash'][2] == "y") {
-		$user['bcrypt-hash'][2] = "b";
-	}
-
-	// Converts ascii to unicode.
-	$astr = (string) $password;
-	$ustr = '';
-	for ($i = 0; $i < strlen($astr); $i++) {
-		$a = ord($astr{$i}) << 8;
-		$ustr .= sprintf("%X", $a);
-	}
-
 }
 
 function local_user_get_groups($user, $all = false) {


### PR DESCRIPTION
There is a compat issue between PHP's `$2y$` bcrypt hashes and older versions of FreeBSD, which used `$2b$`. However, that issue was fixed long ago in [rS284483](https://reviews.freebsd.org/D2742) and appeared in [FreeBSD 11.0-RELEASE](https://www.freebsd.org/releases/11.0R/relnotes.html#userland-libraries).

This patch just removes that bit of legacy code, and another few of lines just after it "Convert ascii to unicode" that also appear completely unused. I checked for any other uses of those `$astr/$ustr` vars and found none:

`find / -type f \( -name "*.inc" -o -name "*.php" -o -name "rc.*" \) | xargs grep -En '(\$ustr|\$astr)'`

I tested this on my lab unit: Created some new user accounts, and tested login/logout/change password functions. Worked fine.

This was sparked by a recent discussion on [r/PFSENSE](https://www.reddit.com/r/PFSENSE/comments/93yezl/setting_user_passwords_in_config_xml_file/).

- [x] redmine issue [8742](https://redmine.pfsense.org/issues/8742)
- [x] Ready for review