### PR TITLE
Fix custom dyndns issue: username and password was not sent with curl…

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -756,7 +756,6 @@
 						} else {
 							curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
 						}
-						curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
 						curl_setopt($ch, CURLOPT_USERPWD, "{$this->_dnsUser}:{$this->_dnsPass}");
 					}
 					$server = str_replace("%IP%", $this->_dnsIP, $this->_dnsUpdateURL);


### PR DESCRIPTION
Hello,

I tried to use a custom DynDNS provider, one that I host myself but whose API is a clone of dyndns.org and I was surprised to see that the username and the password are not sent in the HTTP request.

After comparing code for different dyndns providers it seems that only "custom" has CURLAUTH_ANY set. When I removed this flag, everything started to work.

I haven't opened an issue on Redmine, but on the forum people seem to have the exact same problem:

https://forum.netgate.com/post/743545