### PR TITLE
Fix a warning on captiveportal settings page

### DIFF
--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -345,7 +345,10 @@ if ($_POST['save']) {
 		if ($_POST['auth_method'] != 'none') {
 			$newcp['auth_server'] = implode(",", $_POST['auth_server']);
 		}
-		$newcp['auth_server2'] = implode(",", $_POST['auth_server2']);
+		$newcp['auth_server2'] = '';
+		if (!empty($_POST['auth_server2']) && $_POST['auth_method'] === 'authserver') {
+			$newcp['auth_server2'] = implode(",", $_POST['auth_server2']);
+		}
 		$newcp['radacct_server'] = $_POST['radacct_server'];
 		$newcp['localauth_priv'] = isset($_POST['localauth_priv']);
 		$newcp['radacct_enable'] = $_POST['radacct_enable'] ? true : false;


### PR DESCRIPTION
i got a warning while testing new Captive Portal settings.

```[15-Aug-2018 15:59:12 Etc/UTC] PHP Warning:  implode(): Invalid arguments passed in /usr/local/www/services_captiveportal.php on line 348```

This warning happens when (re) configuring a captiveportal with "use Authentication Server", and no second auth server selected.



- [x] Redmine Issue: https://redmine.pfsense.org/issues/8789
- [X] Ready for review