### PR TITLE
Captive Portal : Automatically store the user name linked to a MAC added as pass-through

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -1028,7 +1028,7 @@ function captiveportal_prune_old_automac() {
 	global $g, $config, $cpzone, $cpzoneid;
 
 	if (is_array($config['captiveportal'][$cpzone]['passthrumac']) &&
-	    isset($config['captiveportal'][$cpzone]['passthrumacaddusername'])) {
+	    isset($config['captiveportal'][$cpzone]['passthrumacadd'])) {
 		$tmpvoucherdb = array();
 		$macrules = "";
 		$writecfg = false;
@@ -2210,7 +2210,7 @@ function captiveportal_reapply_attributes($cpentry, $attributes) {
 }
 
 function portal_allow($clientip, $clientmac, $username, $password = null, $attributes = null, $pipeno = null, $authmethod = null, $context = 'first') {
-	global $redirurl, $g, $config, $type, $passthrumac, $_POST, $cpzone, $cpzoneid;
+	global $redirurl, $g, $config, $type, $_POST, $cpzone, $cpzoneid;
 
 	// Ensure we create an array if we are missing attributes
 	if (!is_array($attributes)) {
@@ -2231,9 +2231,7 @@ function portal_allow($clientip, $clientmac, $username, $password = null, $attri
 	$writecfg = false;
 	/* If both "Add MAC addresses of connected users as pass-through MAC" and "Disable concurrent logins" are checked, 
 	then we need to check if the user was already authenticated using another MAC Address, and if so remove the previous Pass-Through MAC. */	
-	if ((isset($config['captiveportal'][$cpzone]['noconcurrentlogins'])) &&
-	    $passthrumac &&
-	    isset($config['captiveportal'][$cpzone]['passthrumacadd'])) {
+	if ((isset($config['captiveportal'][$cpzone]['noconcurrentlogins'])) && ($username != 'unauthenticated') && isset($config['captiveportal'][$cpzone]['passthrumacadd'])) {
 		$mac = captiveportal_passthrumac_findbyname($username);
 		if (!empty($mac)) {
 			foreach ($config['captiveportal'][$cpzone]['passthrumac'] as $idx => $macent) {
@@ -2330,20 +2328,20 @@ function portal_allow($clientip, $clientmac, $username, $password = null, $attri
 			$bw_down = round($dwfaultbw_down,0);
 		}
 
-		if ($passthrumac) {
+		if (isset($config['captiveportal'][$cpzone]['passthrumacadd'])) {
 
 			$mac = array();
 			$mac['action'] = 'pass';
 			$mac['mac'] = $clientmac;
 			$mac['ip'] = $clientip; /* Used only for logging */
-			if (isset($config['captiveportal'][$cpzone]['passthrumacaddusername'])) {
-				$mac['username'] = $username;
-				if ($attributes['voucher']) {
-					$mac['logintype'] = "voucher";
-				}
+			$mac['username'] = $username;
+			if ($attributes['voucher']) {
+				$mac['logintype'] = "voucher";
 			}
 			if ($username == "unauthenticated") {
 				$mac['descr'] = "Auto-added";
+			} else if ($authmethod == "voucher") {
+				$mac['descr'] = "Auto-added for voucher {$username}";
 			} else {
 				$mac['descr'] = "Auto-added for user {$username}";
 			}
@@ -2456,7 +2454,7 @@ function portal_allow($clientip, $clientmac, $username, $password = null, $attri
 		$my_redirurl = $config['captiveportal'][$cpzone]['redirurl'];
 	}
 
-	if (isset($config['captiveportal'][$cpzone]['logoutwin_enable']) && !$passthrumac) {
+	if (isset($config['captiveportal'][$cpzone]['logoutwin_enable']) && !isset($config['captiveportal'][$cpzone]['passthrumacadd'])) {
 		$ourhostname = portal_hostname_from_client_ip($clientip);
 		$protocol = (isset($config['captiveportal'][$cpzone]['httpslogin'])) ? 'https://' : 'http://';
 		$logouturl = "{$protocol}{$ourhostname}/";

--- a/src/usr/local/captiveportal/index.php
+++ b/src/usr/local/captiveportal/index.php
@@ -101,10 +101,9 @@ if (!empty($cpcfg['redirurl'])) {
 }
 
 $macfilter = !isset($cpcfg['nomacfilter']);
-$passthrumac = isset($cpcfg['passthrumacadd']);
 
 /* find MAC address for client */
-if ($macfilter || $passthrumac) {
+if ($macfilter || isset($cpcfg['passthrumacadd'])) {
 	$tmpres = pfSense_ip_to_mac($clientip);
 	if (!is_array($tmpres)) {
 		/* unable to find MAC address - shouldn't happen! - bail out */

--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -177,7 +177,6 @@ if ($a_cp[$cpzone]) {
 	$pconfig['radiustraffic_quota'] = isset($a_cp[$cpzone]['radiustraffic_quota']);
 	$pconfig['radiusperuserbw'] = isset($a_cp[$cpzone]['radiusperuserbw']);
 	$pconfig['passthrumacadd'] = isset($a_cp[$cpzone]['passthrumacadd']);
-	$pconfig['passthrumacaddusername'] = isset($a_cp[$cpzone]['passthrumacaddusername']);
 	$pconfig['radmac_format'] = $a_cp[$cpzone]['radmac_format'];
 	$pconfig['reverseacct'] = isset($a_cp[$cpzone]['reverseacct']);
 	$pconfig['includeidletime'] = isset($a_cp[$cpzone]['includeidletime']);
@@ -388,7 +387,6 @@ if ($_POST['save']) {
 		$newcp['radiustraffic_quota'] = $_POST['radiustraffic_quota'] ? true : false;
 		$newcp['radiusperuserbw'] = $_POST['radiusperuserbw'] ? true : false;
 		$newcp['passthrumacadd'] = $_POST['passthrumacadd'] ? true : false;
-		$newcp['passthrumacaddusername'] = $_POST['passthrumacaddusername'] ? true : false;
 		$newcp['radmac_format'] = $_POST['radmac_format'] ? $_POST['radmac_format'] : false;
 		$newcp['reverseacct'] = $_POST['reverseacct'] ? true : false;
 		$newcp['includeidletime'] = $_POST['includeidletime'] ? true : false;
@@ -662,13 +660,6 @@ $section->addInput(new Form_Checkbox(
 			'never have to authenticate again. To remove the passthrough MAC entry either log in and remove it manually from the ' .
 			'%1$sMAC tab%2$s or send a POST from another system. '  .
 			'If this is enabled, the logout window will not be shown.', "<a href=\"services_captiveportal_mac.php?zone={$cpzone}\">", '</a>');
-
-$section->addInput(new Form_Checkbox(
-	'passthrumacaddusername',
-	null,
-	'Include username in the created Pass-through entry',
-	$pconfig['passthrumacaddusername']
-))->setHelp('If enabled the username used during authentication will be saved in the "Description" Field.');
 
 $section->addInput(new Form_Checkbox(
 	'peruserbw',
@@ -1199,7 +1190,6 @@ events.push(function() {
 		}
 
 		disableInput("logoutwin_enable", !hide);
-		hideCheckbox('passthrumacaddusername', hide);
 	}
 
 	function hidePerUserBandwith(hide) {


### PR DESCRIPTION
- [x] Resolve bug mentioned in comments of redmine Issue https://redmine.pfsense.org/issues/3124
- [x] Ready for review