### PR TITLE
Add RADIUS IP priority to vpn_ipsec_mobile.php. Implements #8160

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2192,10 +2192,6 @@ function filter_nat_rules_generate() {
 		update_filter_reload_status(gettext("Creating outbound NAT rules"));
 		$tonathosts_array = filter_nat_rules_automatic_tonathosts();
 		$tonathosts = implode(" ", $tonathosts_array);
-
-		// Remove %radius from string
-		$tonathosts = str_replace('%radius,', '', $tonathosts);
-
 		$numberofnathosts = count($tonathosts_array);
 
 		$natrules .= "\n# Subnets to NAT \n";

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2192,6 +2192,10 @@ function filter_nat_rules_generate() {
 		update_filter_reload_status(gettext("Creating outbound NAT rules"));
 		$tonathosts_array = filter_nat_rules_automatic_tonathosts();
 		$tonathosts = implode(" ", $tonathosts_array);
+
+		// Remove %radius from string
+		$tonathosts = str_replace('%radius,', '', $tonathosts);
+
 		$numberofnathosts = count($tonathosts_array);
 
 		$natrules .= "\n# Subnets to NAT \n";

--- a/src/usr/local/www/vpn_ipsec_mobile.php
+++ b/src/usr/local/www/vpn_ipsec_mobile.php
@@ -59,15 +59,8 @@ if (count($a_client)) {
 
 	$pconfig['user_source'] = $a_client['user_source'];
 	$pconfig['group_source'] = $a_client['group_source'];
-   
-	if (strpos($a_client['pool_address'], '%radius') !== false) {
 
-		$pconfig['pool_address'] = trim(explode(',', $a_client['pool_address'])[1]);
-		$pconfig['radius_ip_priority_enable'] = true;
-	} else {
-		$pconfig['pool_address'] = $a_client['pool_address'];
-	}
-
+	$pconfig['pool_address'] = $a_client['pool_address'];
 	$pconfig['pool_netbits'] = $a_client['pool_netbits'];
 	$pconfig['pool_address_v6'] = $a_client['pool_address_v6'];
 	$pconfig['pool_netbits_v6'] = $a_client['pool_netbits_v6'];
@@ -83,8 +76,7 @@ if (count($a_client)) {
 	$pconfig['wins_server2'] = $a_client['wins_server2'];
 	$pconfig['pfs_group'] = $a_client['pfs_group'];
 	$pconfig['login_banner'] = $a_client['login_banner'];
-	$pconfig['radius_ip_priority_enable'];
-	
+
 	if (isset($pconfig['enable'])) {
 		$pconfig['enable'] = true;
 	}
@@ -246,12 +238,6 @@ if ($_POST['save']) {
 		}
 	}
 
-	if ($pconfig['radius_ip_priority_enable']) {
-		if (!(isset($mobileph1) && $mobileph1['authentication_method'] == 'eap-radius')) {
-			$input_errors[] = gettext("RADIUS IP may only take prioriy when using EAP-RADIUS for authentication on the Mobile IPsec VPN.");
-		}
-	}
-
 	if (!$input_errors) {
 		$client = array();
 
@@ -266,13 +252,7 @@ if ($_POST['save']) {
 		$client['group_source'] = $pconfig['group_source'];
 
 		if ($pconfig['pool_enable']) {
-			if($pconfig['radius_ip_priority_enable'])
-			{
-				$client['pool_address'] = '%radius,' . $pconfig['pool_address'];
-			} else {
-				$client['pool_address'] = $pconfig['pool_address'];
-			}
-			
+			$client['pool_address'] = $pconfig['pool_address'];
 			$client['pool_netbits'] = $pconfig['pool_netbits'];
 		}
 
@@ -528,13 +508,6 @@ $group->add(new Form_Select(
 ))->setWidth(2);
 
 $section->add($group);
-
-$section->addInput(new Form_Checkbox(
-	'radius_ip_priority_enable',
-	'RADIUS IP address priority',
-	'IPv4 address pool is used if IP is not supplied by RADIUS server',
-	$pconfig['radius_ip_priority_enable']
-));
 
 $section->addInput(new Form_Checkbox(
 	'pool_enable_v6',


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/8160 (feature)
- [x] Ready for review

Hi,

I have to preface this PR by saying that I'm not very experienced with PHP or the inner workings with pfSense, so bear that in mind. 

I have a requirement to be able to have IPSec VPN clients receive their IP addresses via RADIUS for some groups and others from a simple pool. I decided to have a stab at implementing the solution mentioned in Redmine issue 8160.

Some basic manual testing has been done and it seems to be working correctly; enabling and disabling this feature also appears to work as expected. As a user of the Community Edition, I believe I ought to give back to the project by sharing my changes (however poor they may be :laughing:).

In implementing this feature, however, I had to add code to filter.inc (see line 2197) but this does not seem to be the correct place for that.

