### PR TITLE
Minor fix to Outbound NAT page

### DIFF
--- a/src/usr/local/www/firewall_nat_out.php
+++ b/src/usr/local/www/firewall_nat_out.php
@@ -351,11 +351,11 @@ print($form);
 
 						if (isset($alias['src'])):
 ?>
-							<a href="/firewall_aliases_edit.php?id=<?=$alias['src']?>" data-toggle="popover" data-trigger="hover focus" title="Alias details" data-content="<?=alias_info_popup($alias['src'])?>" data-html="true">
+							<a href="/firewall_aliases_edit.php?id=<?=$alias['src']?>" data-toggle="popover" data-trigger="hover focus" title="<?=gettext('Alias details')?>" data-content="<?=alias_info_popup($alias['src'])?>" data-html="true">
 <?php
 						endif;
 ?>
-							<?=str_replace('_', ' ', htmlspecialchars($natent['source']['network']))?>
+							<?=str_replace('_', '_<wbr>', htmlspecialchars($natent['source']['network']))?>
 <?php
 						if (isset($alias['src'])):
 ?>
@@ -374,11 +374,11 @@ print($form);
 
 							if (isset($alias['srcport'])):
 ?>
-							<a href="/firewall_aliases_edit.php?id=<?=$alias['srcport']?>" data-toggle="popover" data-trigger="hover focus" title="Alias details" data-content="<?=alias_info_popup($alias['srcport'])?>" data-html="true" >
+							<a href="/firewall_aliases_edit.php?id=<?=$alias['srcport']?>" data-toggle="popover" data-trigger="hover focus" title="<?=gettext('Alias details')?>" data-content="<?=alias_info_popup($alias['srcport'])?>" data-html="true">
 <?php
 							endif;
 ?>
-							<?=str_replace('_', ' ', htmlspecialchars($natent['sourceport']))?>
+							<?=str_replace('_', '_<wbr>', htmlspecialchars(pprint_port($natent['sourceport'])))?>
 <?php
 							if (isset($alias['srcport'])):
 ?>
@@ -401,11 +401,11 @@ print($form);
 
 							if (isset($alias['dst'])):
 ?>
-							<a href="/firewall_aliases_edit.php?id=<?=$alias['dst']?>" data-toggle="popover" data-trigger="hover focus" title="Alias details" data-content="<?=alias_info_popup($alias['dst'])?>" data-html="true" >
+							<a href="/firewall_aliases_edit.php?id=<?=$alias['dst']?>" data-toggle="popover" data-trigger="hover focus" title="<?=gettext('Alias details')?>" data-content="<?=alias_info_popup($alias['dst'])?>" data-html="true">
 <?php
 							endif;
 ?>
-							<?=str_replace('_', ' ', htmlspecialchars($natent['destination']['address']))?>
+							<?=str_replace('_', '_<wbr>', htmlspecialchars($natent['destination']['address']))?>
 <?php
 							if (isset($alias['dst'])):
 ?>
@@ -425,11 +425,11 @@ print($form);
 						} else {
 							if (isset($alias['dstport'])):
 ?>
-							<a href="/firewall_aliases_edit.php?id=<?=$alias['dstport']?>" data-toggle="popover" data-trigger="hover focus" title="Alias details" data-content="<?=alias_info_popup($alias['dstport'])?>" data-html="true" >
+							<a href="/firewall_aliases_edit.php?id=<?=$alias['dstport']?>" data-toggle="popover" data-trigger="hover focus" title="<?=gettext('Alias details')?>" data-content="<?=alias_info_popup($alias['dstport'])?>" data-html="true">
 <?php
 							endif;
 ?>
-							<?=str_replace('_', ' ', htmlspecialchars($natent['dstport']))?>
+							<?=str_replace('_', '_<wbr>', htmlspecialchars(pprint_port($natent['dstport'])))?>
 <?php
 							if (isset($alias['dstport'])):
 ?>


### PR DESCRIPTION
Underscores (`_`) are currently replaced with spaces in alias names on the Outbound NAT page. This isn't consistent with the rest of the UI. I updated it to mirror the format used on the other NAT pages.

Also added `gettext()` wrapper around the hover labels for i18n.

![image](https://user-images.githubusercontent.com/1992842/45522432-095c8780-b791-11e8-86b5-581941641777.png)

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8893
- [x] Ready for review
