### PR TITLE
small change to fixup redmine #8851

### DIFF
--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -101,6 +101,7 @@ if ($act == "edit") {
 		pfSenseHeader("system_camanager.php");
 		exit;
 	}
+	$pconfig['method'] = 'existing';
 	$pconfig['descr']  = $a_ca[$id]['descr'];
 	$pconfig['refid']  = $a_ca[$id]['refid'];
 	$pconfig['cert']   = base64_decode($a_ca[$id]['crt']);


### PR DESCRIPTION
Since @jim-p committed [b0a5c28]( https://github.com/pfsense/pfsense/commit/b0a5c280a407ac26af2e6f055ac1049304034672) to make Create Internal the default action in Cert Manager, there was a small gitch where clicking edit would open the form with the wrong sections collapsed, resulting in a dead Save button. This sets `$pconfig['method'] = existing` when `$act == edit` to prevent this.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8851
- [x] Ready for review