### PR TITLE
reduce the log spew for gateway switch events

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -1257,13 +1257,11 @@ function get_gwgroup_members_inner($group, $gateways_status, $gateways_arr, $vip
 	$tiers_count = count($tiers);
 	if ($tiers_count == 0) {
 		/* Oh dear, we have no members! Engage Plan B */
-		if (!platform_booting()) {
-			if (isset($config['system']['gw-debug'])) {
-				$msg = sprintf(gettext('Gateways status could not be determined, considering all as up/active. (Group: %s)'), $group['name']);
-				log_error($msg);
-				notify_via_growl($msg);
-				//notify_via_smtp($msg);
-			}
+		if (isset($config['system']['gw-debug']) && (!platform_booting())) {
+			$msg = sprintf(gettext('Gateways status could not be determined, considering all as up/active. (Group: %s)'), $group['name']);
+			log_error($msg);
+			notify_via_growl($msg);
+			//notify_via_smtp($msg);
 		}
 		$tiers = $backupplan;
 	}

--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -1105,7 +1105,9 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 				if ($gwgroupitem['gwip'] == $currentdefaultgwip) {
 					$set_dfltgwname = $gwgroupitem['gw'];
 					$found_current = true;
-					log_error("Keep current gateway, its already part of the group members.");
+					if (isset($config['system']['gw-debug'])) {
+						log_error("Keep current gateway, its already part of the group members.");
+					}
 					break;
 				}
 			}
@@ -1256,10 +1258,12 @@ function get_gwgroup_members_inner($group, $gateways_status, $gateways_arr, $vip
 	if ($tiers_count == 0) {
 		/* Oh dear, we have no members! Engage Plan B */
 		if (!platform_booting()) {
-			$msg = sprintf(gettext('Gateways status could not be determined, considering all as up/active. (Group: %s)'), $group['name']);
-			log_error($msg);
-			notify_via_growl($msg);
-			//notify_via_smtp($msg);
+			if (isset($config['system']['gw-debug'])) {
+				$msg = sprintf(gettext('Gateways status could not be determined, considering all as up/active. (Group: %s)'), $group['name']);
+				log_error($msg);
+				notify_via_growl($msg);
+				//notify_via_smtp($msg);
+			}
 		}
 		$tiers = $backupplan;
 	}


### PR DESCRIPTION
When a gateway failure/defgw switch event occurs, there seem to be some code paths that get iterated over dozens of times in a very short span of time. This floods system.log making it hard to read. Specifically, these 2 phrases are repeated over and over:
```
...Gateways status could not be determined, considering all as up/active
...Keep current gateway, its already part of the group members
```

This is part of an effort to try to make the logs readable again, while still allowing verbose logging if needed via a new hidden config option from the developer shell:

    $config['system']['gw-debug'] = true;
    write_config("Enable verbose gateway switch logging");
    exec
    exit

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8914
- [x] Ready for review
