### PR TITLE
enable ip send for FreeDNS DynDNS update

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -604,8 +604,8 @@
 					break;
 				case 'freedns':
 				case 'freedns-v6':
-					$needIP = FALSE;
-					curl_setopt($ch, CURLOPT_URL, 'https://freedns.afraid.org/dynamic/update.php?' . $this->_dnsPass);
+					$needIP = TRUE;
+					curl_setopt($ch, CURLOPT_URL, 'https://freedns.afraid.org/dynamic/update.php?' . $this->_dnsPass . '&address=' . $this->_dnsIP);
 					break;
 				case 'dnsexit':
 					$needsIP = TRUE;


### PR DESCRIPTION
without this, only legacy IP records get updated correctly.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8924
- [x] Ready for review