### PR TITLE
Make WOL page default to the lan interface

### DIFF
--- a/src/usr/local/www/services_wol.php
+++ b/src/usr/local/www/services_wol.php
@@ -132,6 +132,11 @@ if ($savemsg) {
 	print_info_box($savemsg, $class);
 }
 
+$selected_if = (empty($if) ? 'lan' : $if);
+if (!isset(get_configured_interface_list(false)[$selected_if])) {
+	$selected_if = null;
+}
+
 $form = new Form(false);
 
 $section = new Form_Section('Wake-on-LAN');
@@ -139,7 +144,7 @@ $section = new Form_Section('Wake-on-LAN');
 $section->addInput(new Form_Select(
 	'if',
 	'*Interface',
-	(link_interface_to_bridge($if) ? null : $if),
+	$selected_if,
 	get_configured_interface_with_descr()
 ))->setHelp('Choose which interface the host to be woken up is connected to.');
 


### PR DESCRIPTION
Small convenience fix. Currently when entering WOL page, the first interface (alphabetically) is selected. This is usaully not the correct int, and could be a WAN, VPN tunnel etc. This change just selects the `lan` interface by default when no other int is chosen by form submission which is a bit more user friendly

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8926
- [x] Ready for review