### PR TITLE
attempt to show last IA_PD received from ISP by reading dhcpd.log

### DIFF
--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -668,6 +668,12 @@ $group->add($f2);
 
 $section->add($group);
 
+exec("/usr/local/sbin/clog /var/log/dhcpd.log | /usr/bin/awk '/IA_PD prefix:\ /{print $8}' | tail -n1", $ia_pd);
+$section->addInput(new Form_StaticText(
+	'Last PD Received',
+    $ia_pd ? implode($ia_pd):'No IA_PD found. Try a DHCP release/renew on your WAN interface.'
+    ));
+
 $f1 = new Form_Input(
 	'prefixrange_from',
 	null,


### PR DESCRIPTION
When DHCP6 is enabled on an interface and Prefix Delegation is requested, there is nowhere in the GUI to see:

- whether an IA_PD was received from the ISP
- what the prefix was

This is an attempt to get this info by parsing `dhcpd.log` and display it on the DHCPv6 Server page. I don't know if there is any other way but I am of course open to input!

_related forum thread: https://forum.netgate.com/topic/135723/ipv6-ra-prefix-doesn-t-match-interface-prefix-id_

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8946
- [x] Ready for review

_after applying this patch:_
![image](https://user-images.githubusercontent.com/1992842/45994406-77daf880-c061-11e8-9474-e77a6da941db.png)
