### PR TITLE
CaptivePortal : Include zone name in Nas-Identifier (Redmine 8998)

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -1606,7 +1606,7 @@ function captiveportal_authenticate_user(&$login = '', &$password = '', $clientm
 		foreach ($auth_servers as $authcfg) {
 			if ($authlevel < 3) {
 				$radmac_error = false;
-				$attributes = array("nas_identifier" => "CaptivePortal",
+				$attributes = array("nas_identifier" => "CaptivePortal-{$cpzone}",
 					"nas_port_type" => RADIUS_ETHERNET,
 					"nas_port" => $pipeno,
 					"framed_ip" => $clientip);
@@ -2683,7 +2683,7 @@ function captiveportal_send_server_accounting($type = 'on', $ruleno = null, $use
 	}
 	$nasmac = get_interface_mac(find_ip_interface($nasip));
 	$racct->putAttribute(RADIUS_NAS_IP_ADDRESS, $nasip, "addr");
-	$racct->putAttribute(RADIUS_NAS_IDENTIFIER, 'CaptivePortal');
+	$racct->putAttribute(RADIUS_NAS_IDENTIFIER, "CaptivePortal-{$cpzone}");
 
 	if (is_int($ruleno)) {
 		$racct->putAttribute(RADIUS_NAS_PORT_TYPE, RADIUS_ETHERNET);


### PR DESCRIPTION
Since 2.4.4 RADIUS attribute ```NAS-Identifier``` is the same on all CaptivePortal zones. This is an issue for users that need to distinguish multiple zones and can't use ```NAS-Port``` for that

- [x] Redmine Issue: https://redmine.pfsense.org/issues/8998 
- [x] Ready for review