### PR TITLE
Fix issue where Alias URL lists are not correctly stored

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -290,11 +290,15 @@ if ($_POST['save']) {
 				}
 
 				if (file_exists("{$temp_filename}/aliases")) {
-					$address = parse_aliases_file("{$temp_filename}/aliases", $_POST['type'], 5000);
-					if ($address == null) {
+					$t_address = array();
+					$t_address = parse_aliases_file("{$temp_filename}/aliases", $_POST['type'], 5000);
+					if ($t_address == null) {
 						/* nothing was found */
 						$input_errors[] = sprintf(gettext("A valid URL must be provided. Could not fetch usable data from '%s'."), $_POST['address' . $x]);
+					} else {
+						array_push($address, ...$t_address);
 					}
+					unset($t_address);
 					mwexec("/bin/rm -rf " . escapeshellarg($temp_filename));
 				} else {
 					$input_errors[] = sprintf(gettext("URL '%s' is not valid."), $_POST['address' . $x]);

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -290,7 +290,6 @@ if ($_POST['save']) {
 				}
 
 				if (file_exists("{$temp_filename}/aliases")) {
-					$t_address = array();
 					$t_address = parse_aliases_file("{$temp_filename}/aliases", $_POST['type'], 5000);
 					if ($t_address == null) {
 						/* nothing was found */


### PR DESCRIPTION
Issue:

When creating an Alias URL list under Firewall->Aliases->URLs, only the IP's from the last-most URL in the list is what is stored in the `/cf/conf/config.xml` file. The other previous URLs in the list, even though correctly validated & checked, are not kept.

This ensures that the `$address array` is correctly updated when processing each URL of an Alias list.

- [X] Redmine Issue: https://redmine.pfsense.org/issues/9074
- [X] Ready for review