### PR TITLE
optimize parsing of the openvpn server status socket

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1691,7 +1691,7 @@ function openvpn_get_server_status($server, $socket) {
 			}
 
 			/* parse end of output line */
-			if (strstr($line, "END") || strstr($line, "ERROR")) {
+			if (strstr($line, "END\n") || strstr($line, "ERROR")) {
 				break;
 			}
 


### PR DESCRIPTION
If your common name or username contains 'END' like 'BACKEND', it is matched by 

if (strstr($line, "END") || strstr($line, "ERROR"))
break;

and it never appear in the status page of the openvpn.