### PR TITLE
The Shabang is crashing the check.

### DIFF
--- a/src/etc/inc/openvpn.tls-verify.php
+++ b/src/etc/inc/openvpn.tls-verify.php
@@ -1,4 +1,3 @@
-#!/usr/local/bin/php-cgi -f
 <?php
 /*
  * openvpn.tls-verify.php


### PR DESCRIPTION
I don't think there's any need, the script is executed only by /usr/local/sbin/ovpn_auth_verify

