### PR TITLE
Fix DigitalOcean DynDNS client

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -998,7 +998,9 @@
 						$output->domain_records = array();
 					}
 					foreach($output->domain_records as $dnsRecord) {
-						if ($this->_dnsHost == $dnsRecord->name) {
+						// NS records are named @ in DO's API, so check type as well 
+						// https://redmine.pfsense.org/issues/9171
+						if ($this->_dnsHost == $dnsRecord->name && $dnsRecord->type == 'A') {
 							$recordID = $dnsRecord->id;
 							break;
 						}
@@ -1845,7 +1847,9 @@
 					}
 					break;
 				case 'digitalocean':
-					if (preg_match("/\s200\sOK/i", $header)) {
+					// Creating new records returns an HTTP 201, updating existing records get 200
+					// https://redmine.pfsense.org/issues/9171
+					if (preg_match("/HTTP\/2\s20[0,1]/i", $header)) {
 						$status = $status_intro . $success_str . gettext("IP Address Updated Successfully!");
 						$successful_update = true;
 					} else {

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -113,6 +113,8 @@ if ($_POST['save'] || $_POST['force']) {
 			$host_to_check = $_POST['domainname'];
 		} elseif ((($pconfig['type'] == "godaddy") || ($pconfig['type'] == "godaddy-v6")) && ($_POST['host'] == '@.' || $_POST['host'] == '@')) {
 			$host_to_check = $_POST['domainname'];
+		} elseif (($pconfig['type'] == "digitalocean") && ($_POST['host'] == '@.' || $_POST['host'] == '@')) {
+			$host_to_check = $_POST['domainname'];
 		} else {
 			$host_to_check = $_POST['host'];
 
@@ -300,7 +302,7 @@ $group->setHelp('Enter the complete fully qualified domain name. Example: myhost
 			'GleSYS: Enter the record ID.%1$s' .
 			'DNSimple: Enter only the domain name.%1$s' .
 			'Namecheap, Cloudflare, GratisDNS, Hover, ClouDNS, GoDaddy: Enter the hostname and the domain separately, with the domain being the domain or subdomain zone being handled by the provider.%1$s' .
-			'Cloudflare: Enter @ as the hostname to indicate an empty field.', '<br />');
+			'Cloudflare and DigitalOcean: Enter @ as the hostname to indicate an empty field.', '<br />');
 
 $section->add($group);
 


### PR DESCRIPTION
Fixes the check on the return value since it's been updated to use
HTTP/2 syntax. Also adds logic to allow using `@` to denote updating the
root domain A record as well.

Updating my settings to log the header object, this is what ends up in logs:
```
/services_dyndns_edit.php: phpDynDNS (@): PAYLOAD: HTTP/2 200 ^M date: Thu, 06 Dec 2018 05:27:10 GMT^M content-type: application/json; charset=utf-8^M content-length: 154^M set-cookie: __cfduid=<snip>; expires=Fri, 06-Dec-19 05:27:10 GMT; path=/; domain=.digitalocean.com; HttpOnly^M cache-control: max-age=0, private, must-revalidate^M etag: "edb266b12ef88418d31c470fd39d5359"^M ratelimit-limit: 5000^M ratelimit-remaining: 4982^M ratelimit-reset: 1544072841^M x-content-type-options: nosniff^M x-frame-options: SAMEORIGIN^M x-gateway: Edge-Gateway^M x-request-id: db9b2919-ce43-4bb6-b7f3-61a19c1abf03^M x-response-from: service^M x-runtime: 0.207846^M x-xss-protection: 1; mode=block^M expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"^M server: cloudflare^M cf-ray: 484c57811ae35011-DEN^M ^M
```

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9171
- [x] Ready for review