### PR TITLE
Captive portal: fix per-user session timeouts

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -830,10 +830,12 @@ function captiveportal_prune_old() {
 		$term_cause = 1;
 		/* hard timeout or session_timeout from radius if enabled */
 		if (isset($cpcfg['radiussession_timeout'])) {
-			$timeout = (is_numeric($cpentry[7])) ? $cpentry[7] : $timeout;
+			$utimeout = (is_numeric($cpentry[7])) ? $cpentry[7] : $timeout;
+		} else {
+			$utimeout = $timeout;
 		}
-		if ($timeout) {
-			if (($pruning_time - $cpentry[0]) >= $timeout) {
+		if ($utimeout) {
+			if (($pruning_time - $cpentry[0]) >= $utimeout) {
 				$timedout = true;
 				$term_cause = 5; // Session-Timeout
 				$logout_cause = 'SESSION TIMEOUT';

--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -882,11 +882,13 @@ function captiveportal_prune_old() {
 
 		/* traffic quota, value retrieved from the radius attribute if the option is enabled */
 		if (isset($cpcfg['radiustraffic_quota'])) {
-			$trafficquota = (is_numeric($cpentry[11])) ? $cpentry[11] : $trafficquota;
+			$utrafficquota = (is_numeric($cpentry[11])) ? $cpentry[11] : $trafficquota;
+		} else {
+			$utrafficquota = $trafficquota;
 		}
-		if (!$timedout && $trafficquota > 0) {
+		if (!$timedout && $utrafficquota > 0) {
 			$volume = getVolume($cpentry[2], $cpentry[3]);
-			if (($volume['input_bytes'] + $volume['output_bytes']) > $trafficquota) {
+			if (($volume['input_bytes'] + $volume['output_bytes']) > $utrafficquota) {
 				$timedout = true;
 				$term_cause = 10; // NAS-Request
 				$logout_cause = 'QUOTA EXCEEDED';


### PR DESCRIPTION
Don't overwrite the global session timeout value with a user's radius-provided timeout
that would then be reused in the same run for users without a custom session timeout.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9208
- [x] Ready for review