### PR TITLE
Fix hostname not showing with some UIDs

### DIFF
--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -114,10 +114,10 @@ $awk = "/usr/bin/awk";
 /* this pattern sticks comments into a single array item */
 $cleanpattern = "'{ gsub(\"#.*\", \"\");} { gsub(\";\", \"\"); print;}'";
 /* We then split the leases file by } */
-$splitpattern = "'BEGIN { RS=\"}\";} {for (i=1; i<=NF; i++) printf \"%s \", \$i; printf \"}\\n\";}'";
+$splitpattern = "'BEGIN{ RS=\"#\";} {for (i=1; i<=NF; i++) printf \"%s \", \$i; printf \"}\\n\";}'";
 
 /* stuff the leases file in a proper format into a array by line */
-exec("/bin/cat {$leasesfile} | {$awk} {$cleanpattern} | {$awk} {$splitpattern}", $leases_content);
+exec("/bin/cat {$leasesfile} | {$awk} {$cleanpattern} | sed 's/^}/#/g' | {$awk} {$splitpattern}", $leases_content);
 $leases_count = count($leases_content);
 exec("/usr/sbin/arp -an", $rawdata);
 $arpdata_ip = array();


### PR DESCRIPTION
Proper parsing for the end of the individual DHCP lease block.
In some cases the uid contains } symbol, which breaks the old parsing and 
excludes the client-hostname from being displayed in the Web UI.

Before:
![No hostname shown](https://i.imgur.com/ARgqNE7.png)

After:
![Hostname shown](https://i.imgur.com/6wFjkR0.png)

- [x] Redmine Issue: https://redmine.pfsense.org/issues/3500
- [x] Ready for review