### PR TITLE
#9004 set the default gateway when system start and a gateway_group is default IPV4 gateway

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -1109,7 +1109,7 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 			$currentdefaultgwip = getcurrentdefaultgatewayip($ipprotocol);
 			$found_current = false;
 			foreach($gwg_members as $gwgroupitem) {
-				if ($gwgroupitem['gwip'] == $currentdefaultgwip) {
+				if (!empty($currentdefaultgwip) AND $gwgroupitem['gwip'] == $currentdefaultgwip) {
 					$set_dfltgwname = $gwgroupitem['gw'];
 					$found_current = true;
 					if (isset($config['system']['gw-debug'])) {

--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -1109,7 +1109,7 @@ function fixup_default_gateway($ipprotocol, $gateways_status, $gateways_arr) {
 			$currentdefaultgwip = getcurrentdefaultgatewayip($ipprotocol);
 			$found_current = false;
 			foreach($gwg_members as $gwgroupitem) {
-				if (!empty($currentdefaultgwip) AND $gwgroupitem['gwip'] == $currentdefaultgwip) {
+				if (!empty($currentdefaultgwip) && ($gwgroupitem['gwip'] == $currentdefaultgwip)) {
 					$set_dfltgwname = $gwgroupitem['gw'];
 					$found_current = true;
 					if (isset($config['system']['gw-debug'])) {


### PR DESCRIPTION
Correct BUG 9004 -> set the default gateway when system start and a gateway_group is default IPV4 gateway

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9004
- [ ] Ready for review