### PR TITLE
Routing, actually show the "(default)" mark on the default route as it is present on the OS

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -671,11 +671,11 @@ function return_gateways_array($disabled = false, $localhost = false, $inactive 
 			}
 
 			if ($gateway['ipprotocol'] == "inet" &&
-					($config['gateways']['defaultgw4'] == $gateway['name'] || $gateway['gateway'] == $cgw4)) {
+					($gateway['gateway'] == $cgw4)) {
 				$gateway['isdefaultgw'] = true;
 				$found_defaultv4 = 1;
 			} else if ($gateway['ipprotocol'] == "inet6" &&
-					($config['gateways']['defaultgw6'] == $gateway['name'] || $gateway['gateway'] == $cgw6)) {
+					($gateway['gateway'] == $cgw6)) {
 				$gateway['isdefaultgw'] = true;
 				$found_defaultv6 = 1;
 			}

--- a/src/usr/local/www/system_gateways.php
+++ b/src/usr/local/www/system_gateways.php
@@ -65,8 +65,6 @@ if ($_POST['order-store']) {
 	write_config("System - Gateways: save default gateway");
 }
 
-$a_gateways = return_gateways_array(true, false, true, true);
-
 if ($_POST['apply']) {
 
 	$retval = 0;
@@ -84,6 +82,7 @@ if ($_POST['apply']) {
 	}
 }
 
+$a_gateways = return_gateways_array(true, false, true, true);
 
 function can_delete_disable_gateway_item($id, $disable = false) {
 	global $config, $input_errors, $a_gateways;
@@ -343,7 +342,7 @@ foreach ($a_gateways as $i => $gateway):
 						<?=htmlspecialchars($gateway['name'])?>
 <?php
 						if (isset($gateway['isdefaultgw'])) {
-							echo " <strong>(default)</strong>";
+							echo ' <i class="fa fa-globe"></i>';
 						}
 ?>
 						</td>
@@ -445,6 +444,13 @@ $form->add($section);
 print $form;
 
 ?>
+<div class="infoblock">
+<?php
+print_info_box(
+	sprintf(gettext('%1$s%2$s%3$s is the current default route as present in the current routing table of the operating system'), '<strong>', '<i class="fa fa-globe"></i>', '</strong>')
+	);
+?>
+</div>
 <script type="text/javascript">
 //<![CDATA[
 events.push(function() {


### PR DESCRIPTION
Routing, actually show the "(default)" mark on the default route as it is present on the OS

Most obvious problem was when manually switching from WANGW1 to WANGW2 it showed both as (default) after saving the setting and before applying it. Also after applying it would require another page refresh to show the updated situation. Also add a little information box that shows what (Default) means for the user.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9292
- [x] Ready for review