### PR TITLE
RADVD: In managed mode, DNS servers / DNS Search List settings from DHCPv6 should be used

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -246,6 +246,8 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t\tRemoveRoute on;\n";
 		$radvdconf .= "\t};\n";
 
+		$assistedorunmanaged = $dhcpv6ifconf['ramode'] == "assist" || $dhcpv6ifconf['ramode'] == "unmanaged" ? true : false;
+
 		/* add DNS servers */
 		$dnslist = array();
 		if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && is_array($dhcpv6ifconf['dnsserver']) && !empty($dhcpv6ifconf['dnsserver'])) {
@@ -260,9 +262,9 @@ function services_radvd_configure($blacklist = array()) {
 					$dnslist[] = $server;
 				}
 			}
-		} elseif (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable'])) {
+		} elseif ($assistedorunmanaged && (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable']))) {
 			$dnslist[] = get_interface_ipv6($realif);
-		} elseif (is_array($config['system']['dnsserver']) && !empty($config['system']['dnsserver'])) {
+		} elseif ($assistedorunmanaged && (is_array($config['system']['dnsserver']) && !empty($config['system']['dnsserver']))) {
 			foreach ($config['system']['dnsserver'] as $server) {
 				if (is_ipaddrv6($server)) {
 					$dnslist[] = $server;
@@ -287,10 +289,12 @@ function services_radvd_configure($blacklist = array()) {
 		if (count($searchlist) > 0) {
 			$searchliststring = trim(implode(" ", $searchlist));
 		}
-		if (!empty($dhcpv6ifconf['domain'])) {
-			$radvdconf .= "\tDNSSL {$dhcpv6ifconf['domain']} {$searchliststring} { };\n";
-		} elseif (!empty($config['system']['domain'])) {
-			$radvdconf .= "\tDNSSL {$config['system']['domain']} {$searchliststring} { };\n";
+		if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && !empty($dhcpv6ifconf['domain'])) {
+			$radvdconf .= "\tDNSSL {$dhcpv6ifconf['domain']} { };\n";
+		} elseif (!isset($dhcpv6ifconf['rasamednsasdhcp6']) && !empty($searchliststring)) {
+			$radvdconf .= "\tDNSSL {$searchliststring} { };\n";
+		} elseif ($assistedorunmanaged && !empty($config['system']['domain'])) {
+			$radvdconf .= "\tDNSSL {$config['system']['domain']} { };\n";
 		}
 		$radvdconf .= "};\n";
 	}


### PR DESCRIPTION
1) Only include system defined DNS servers (or local DNS resolvers/forwarders) and system domain as DNS Search List in RA messages when RA mode is "assisted" or "unmanaged". In all other RA modes, these settings should come from DHCPv6.
2) When "Use same settings as DHCPv6 server" is checked, also use the domain defined in DHCPv6 as the DNS Search List in RA messages.
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/TBC
- [ ] Ready for review