### PR TITLE
radvd: In "managed" or "stateless_dhcp" mode, don't advertise default values for DNS servers etc (these should come from DHCPv6)

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -246,6 +246,8 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t\tRemoveRoute on;\n";
 		$radvdconf .= "\t};\n";
 
+		$usedefaultvalues = $dhcpv6ifconf['ramode'] == "managed" || $dhcpv6ifconf['ramode'] == "stateless_dhcp" ? false : true;
+
 		/* add DNS servers */
 		$dnslist = array();
 		if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && is_array($dhcpv6ifconf['dnsserver']) && !empty($dhcpv6ifconf['dnsserver'])) {
@@ -260,9 +262,9 @@ function services_radvd_configure($blacklist = array()) {
 					$dnslist[] = $server;
 				}
 			}
-		} elseif (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable'])) {
+		} elseif ($usedefaultvalues && (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable']))) {
 			$dnslist[] = get_interface_ipv6($realif);
-		} elseif (is_array($config['system']['dnsserver']) && !empty($config['system']['dnsserver'])) {
+		} elseif ($usedefaultvalues && (is_array($config['system']['dnsserver']) && !empty($config['system']['dnsserver']))) {
 			foreach ($config['system']['dnsserver'] as $server) {
 				if (is_ipaddrv6($server)) {
 					$dnslist[] = $server;
@@ -284,13 +286,16 @@ function services_radvd_configure($blacklist = array()) {
 				$searchlist[] = $sd;
 			}
 		}
+		$searchliststring = "";
 		if (count($searchlist) > 0) {
 			$searchliststring = trim(implode(" ", $searchlist));
 		}
-		if (!empty($dhcpv6ifconf['domain'])) {
-			$radvdconf .= "\tDNSSL {$dhcpv6ifconf['domain']} {$searchliststring} { };\n";
-		} elseif (!empty($config['system']['domain'])) {
-			$radvdconf .= "\tDNSSL {$config['system']['domain']} {$searchliststring} { };\n";
+		if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && !empty($dhcpv6ifconf['domain'])) {
+			$radvdconf .= "\tDNSSL {$dhcpv6ifconf['domain']} { };\n";
+		} elseif (!isset($dhcpv6ifconf['rasamednsasdhcp6']) && !empty($searchliststring)) {
+			$radvdconf .= "\tDNSSL {$searchliststring} { };\n";
+		} elseif ($usedefaultvalues && !empty($config['system']['domain'])) {
+			$radvdconf .= "\tDNSSL {$config['system']['domain']} { };\n";
 		}
 		$radvdconf .= "};\n";
 	}


### PR DESCRIPTION
1) Only include system defined DNS servers (or local DNS resolvers/forwarders) and system domain as DNS Search List in RA messages when RA mode is not "managed" or "stateless_dhcp".
2) When "Use same settings as DHCPv6 server" is checked, also use the domain defined in DHCPv6 as the DNS Search List in RA messages.
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9302
- [x] Ready for review