### PR TITLE
Fix behaviour of determining dhcp primary/secondary

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -602,8 +602,8 @@ EOD;
 							/* this is the interface! */
 							if (is_numeric($vipent['advskew']) && (intval($vipent['advskew']) < 20)) {
 								$skew = 0;
-								break;
 							}
+							break;
 						}
 					}
 				}


### PR DESCRIPTION
When there is more than one CARP address per interface, with different
advskews which is typical in active/active configuration we need to
check only the first CARP if and skew in order to determine primary.

Previously if you had two CARP vips where VIP a had skew <20 on host A
and VIP b had skew <20 on host B, both hosts would be configured as
primary, and dhcp failover would not be configured correctly.

The caveat to this fix is that VIPs need to be configured in the same
order on both hosts.

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review