### PR TITLE
Host-Uniq

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2482,10 +2482,19 @@ EOD;
 EOD;
 		}
 		if ($type == "pppoe") {
+			// ng_pppoe.c:955 check ourmsg->data[hupos] == '0' && ourmsg->data[hupos + 1] == 'x'
+			$hostuniq = '';
+			if (isset($ppp['pppoe_host-uniq'])) {
+				if (preg_match('/^0x[a-f0-9]+$/', $ppp['pppoe_host-uniq'])) {
+					$hostuniq = $ppp['pppoe_host-uniq'] .'|';
+				} else if (preg_match('/^[a-z0-9]+$/i', $ppp['pppoe_host-uniq'])) {
+					$hostuniq = '0x' .bin2hex($ppp['pppoe_host-uniq']) .'|';
+				}
+			}
 			// Send a null service name if none is set.
 			$provider = isset($ppp['provider']) ? $ppp['provider'] : "";
 			$mpdconf .= <<<EOD
-	set pppoe service "{$provider}"
+	set pppoe service "{$hostuniq}{$provider}"
 
 EOD;
 		}

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -130,6 +130,9 @@ if ($wancfg['if'] == $a_ppps[$pppid]['if']) {
 		$pconfig['pppoe_username'] = $a_ppps[$pppid]['username'];
 		$pconfig['pppoe_password'] = base64_decode($a_ppps[$pppid]['password']);
 		$pconfig['provider'] = $a_ppps[$pppid]['provider'];
+		if (isset($a_ppps[$pppid]['pppoe_host-uniq'])) {
+			$pconfig['pppoe_host-uniq'] = $a_ppps[$pppid]['pppoe_host-uniq'];
+		}
 		$pconfig['pppoe_dialondemand'] = isset($a_ppps[$pppid]['ondemand']);
 		$pconfig['pppoe_idletimeout'] = $a_ppps[$pppid]['idletimeout'];
 
@@ -830,6 +833,9 @@ if ($_POST['apply']) {
 	if (($_POST['provider'] && (strpos($_POST['provider'], "\"")))) {
 		$input_errors[] = gettext("The service name may not contain quote characters.");
 	}
+	if (!empty($_POST['pppoe_host-uniq']) && !preg_match('/^[a-z0-9]+$/i', $_POST['pppoe_host-uniq'])) {
+		$input_errors[] = gettext("Host-Uniq value can only be hexadecimal or letters and numbers.");
+	}
 	if (($_POST['pppoe_idletimeout'] != "") && !is_numericint($_POST['pppoe_idletimeout'])) {
 		$input_errors[] = gettext("The idle timeout value must be an integer.");
 	}
@@ -1157,6 +1163,9 @@ if ($_POST['apply']) {
 		unset($wancfg['pptp_username']);
 		unset($wancfg['pptp_password']);
 		unset($wancfg['provider']);
+		if (isset($wancfg['pppoe_host-uniq'])) {
+			unset($wancfg['pppoe_host-uniq']);
+		}
 		unset($wancfg['ondemand']);
 		unset($wancfg['timeout']);
 		if (empty($wancfg['pppoe']['pppoe-reset-type'])) {
@@ -1267,6 +1276,9 @@ if ($_POST['apply']) {
 					$a_ppps[$pppid]['provider'] = $_POST['provider'];
 				} else {
 					$a_ppps[$pppid]['provider'] = true;
+				}
+				if (!empty($_POST['pppoe_host-uniq'])) {
+					$a_ppps[$pppid]['pppoe_host-uniq'] = $_POST['pppoe_host-uniq'];
 				}
 				$a_ppps[$pppid]['ondemand'] = $_POST['pppoe_dialondemand'] ? true : false;
 				if (!empty($_POST['pppoe_idletimeout'])) {
@@ -2798,6 +2810,13 @@ $section->addInput(new Form_Input(
 	'Service name',
 	'text',
 	$pconfig['provider']
+))->setHelp('This field can usually be left empty.');
+
+$section->addInput(new Form_Input(
+	'pppoe_host-uniq',
+	'Host-Uniq',
+	'text',
+	$pconfig['pppoe_host-uniq']
 ))->setHelp('This field can usually be left empty.');
 
 $section->addInput(new Form_Checkbox(

--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -130,6 +130,9 @@ if (isset($id) && $a_ppps[$id]) {
 			if (isset($a_ppps[$id]['provider']) and empty($a_ppps[$id]['provider'])) {
 				$pconfig['null_service'] = true;
 			}
+			if (isset($a_ppps[$id]['pppoe_host-uniq'])) {
+				$pconfig['pppoe_host-uniq'] = $a_ppps[$id]['pppoe_host-uniq'];
+			}
 			/* ================================================ */
 			/* = force a connection reset at a specific time? = */
 			/* ================================================ */
@@ -244,6 +247,9 @@ if ($_POST['save']) {
 	}
 	if ($_POST['provider'] && $_POST['null_service']) {
 		$input_errors[] = gettext("Do not specify both a Service name and a NULL Service name.");
+	}
+	if (!empty($_POST['pppoe_host-uniq']) && !preg_match('/^[a-z0-9]+$/i', $_POST['pppoe_host-uniq'])) {
+		$input_errors[] = gettext("Host-Uniq value can only be hexadecimal or letters and numbers.");
 	}
 	if (($_POST['idletimeout'] != "") && !is_numericint($_POST['idletimeout'])) {
 		$input_errors[] = gettext("The idle timeout value must be an integer.");
@@ -388,6 +394,9 @@ if ($_POST['save']) {
 				} else {
 					unset($ppp['provider']);
 					$ppp['provider'] = $_POST['null_service'] ? true : false;
+				}
+				if (!empty($_POST['pppoe_host-uniq'])) {
+					$ppp['pppoe_host-uniq'] = $_POST['pppoe_host-uniq'];
 				}
 				if (!empty($_POST['pppoe-reset-type'])) {
 					$ppp['pppoe-reset-type'] = $_POST['pppoe-reset-type'];
@@ -671,6 +680,13 @@ if ($pconfig['type'] == 'pppoe') {
 					'Check the "Configure NULL" box to configure a blank Service name.');
 
 	$section->add($group);
+
+	$section->addInput(new Form_Input(
+		'pppoe_host-uniq',
+		'Host-Uniq',
+		'text',
+		$pconfig['pppoe_host-uniq']
+	))->setHelp('This field can usually be left empty.');
 }
 
 $section->addInput(new Form_Select(


### PR DESCRIPTION
Host-Uniq untested

- [x] Redmine Issue: https://redmine.pfsense.org/issues/7618
- [ ] Ready for review

Code is "almost" fully tested in master but barely tested on 2.4.4-p2 since I'd like not to risk damaging RJ-45 pins and I'm still waiting for a RJ-11 RJ-45 cable.

Patch accept either plain text HostUniq or the hexadecimal value as 0xhostuniq.

I'm pretty sure help text or error message can be improved, please advise. 