### PR TITLE
Option to hide Kernel PTI from sysinfo widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -38,6 +38,7 @@ $sysinfo_items = array(
 	'version' => gettext('Version'),
 	'cpu_type' => gettext('CPU Type'),
 	'hwcrypto' => gettext('Hardware Crypto'),
+	'kernel_pti' => gettext('Kernel PTI'),
 	'uptime' => gettext('Uptime'),
 	'current_datetime' => gettext('Current Date/Time'),
 	'dns_servers' => gettext('DNS Server(s)'),
@@ -278,15 +279,18 @@ $temp_use_f = (isset($user_settings['widgets']['thermal_sensors-0']) && !empty($
 		<?php endif; ?>
 <?php
 	endif;
-	$pti = get_single_sysctl('vm.pmap.pti');
-	if (strlen($pti) > 0) {
+	if (!in_array('kernel_pti', $skipsysinfoitems)):
+		$rows_displayed = true;
+		$pti = get_single_sysctl('vm.pmap.pti');
+		if (strlen($pti) > 0) {
 ?>
-		<tr>
-			<th><?=gettext("Kernel PTI");?></th>
-			<td><?=($pti == 0) ? gettext("Disabled") : gettext("Enabled");?></td>
-		</tr>
+			<tr>
+				<th><?=gettext("Kernel PTI");?></th>
+				<td><?=($pti == 0) ? gettext("Disabled") : gettext("Enabled");?></td>
+			</tr>
 <?php
-	}
+		}
+	endif;
 	if (!in_array('uptime', $skipsysinfoitems)):
 		$rows_displayed = true;
 ?>


### PR DESCRIPTION
Add the option to hide the Kernel PTI entry from the system information dashboard widget.

To gain more viewing space I have two sysinfo widgets to split the information on the dashboard, one showing mostly the progress bars (visible) and the other (out of view) showing everything else. Because the Kernel PTI item cannot be hidden I'm forced to have that item visible in BOTH widgets.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9323
- [x] Ready for review