### PR TITLE
Increase number of parallel IKEv1 Phase 2 rekeys

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -434,6 +434,7 @@ starter {
 charon {
 # number of worker threads in charon
 	threads = 16
+	max_ikev1_exchanges = 22
 	ikesa_table_size = 32
 	ikesa_table_segments = 4
 	init_limit_half_open = 1000


### PR DESCRIPTION
In certain situations remote firewalls might issue a rekey for
all CHILD_SAs in parallel. At least Watchguard firewall clusters
have been seen flooding rekeys after they failover.

strongSwan usually only allows for 3 concurrent rekeys. Nevertheless
it already has the option max_ikev1_exchanges to increase that
value. This patch adds the setting to /etc/inc/vpn.inc and makes
it persistent for future releases.

More details at https://redmine.pfsense.org/issues/9331
