### PR TITLE
Add option to increase parallel IKEv1 Phase 2 rekeys

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -383,6 +383,11 @@ function vpn_ipsec_configure($restart = false) {
 		$accept_unencrypted = "accept_unencrypted_mainmode_messages = yes";
 	}
 
+	$ikev1_maxexchange = "";
+	if (isset($config['ipsec']['maxexchange'])) {
+		$ikev1_maxexchange = "max_ikev1_exchanges = " . $config['ipsec']['maxexchange'];
+	}
+
 	$stronconf = '';
 	if (file_exists("{$g['varetc_path']}/ipsec/strongswan.conf")) {
 		$stronconf = file_get_contents("{$g['varetc_path']}/ipsec/strongswan.conf");
@@ -442,6 +447,7 @@ charon {
 	ignore_acquire_ts = yes
 	{$i_dont_care_about_security_and_use_aggressive_mode_psk}
 	{$accept_unencrypted}
+	{$ikev1_maxexchange}
 	cisco_unity = {$unity_enabled}
 	{$ifacesuse}
 	{$makebeforebreak}

--- a/src/usr/local/www/vpn_ipsec_settings.php
+++ b/src/usr/local/www/vpn_ipsec_settings.php
@@ -158,9 +158,7 @@ if ($_POST['save']) {
 		}
 
 		if (isset($_POST['maxexchange']) && (strlen($_POST['maxexchange']) > 0)) {
-			if (!isset($config['ipsec']['maxexchange'])) {
-				$needsrestart = true;
-			} elseif ($pconfig['maxexchange'] != $config['ipsec']['maxexchange']) {
+			if (!isset($config['ipsec']['maxexchange']) || ($pconfig['maxexchange'] != $config['ipsec']['maxexchange'])) {
 				$needsrestart = true;
 			}
 			$config['ipsec']['maxexchange'] = (int)$_POST['maxexchange'];

--- a/src/usr/local/www/vpn_ipsec_settings.php
+++ b/src/usr/local/www/vpn_ipsec_settings.php
@@ -322,8 +322,8 @@ $section->addInput(new Form_Input(
 	['placeholder' => '3']
 ))->setHelp(
 	'IKEv1 phase 2 rekeying for one VPN gateway can be initiated in parallel. By default only 3 parallel rekeys are allowed. ' .
-	'Too low values can break VPN connections with many tunnel definitions. ' .
-	'If unsure set this value to the VPN connection with the maximum number of tunnels.'
+	'Undersized values can break VPN connections with many phase 2 definitions. ' .
+	'If unsure, set this value to match the largest number of phase 2 entries on any phase 1.'
 );
 
 $section->addInput(new Form_Checkbox(


### PR DESCRIPTION
In certain situations remote firewalls might issue a rekey for
all CHILD_SAs in parallel. At least Watchguard firewall clusters
have been seen flooding rekeys after they failover.

strongSwan usually only allows for 3 concurrent rekeys. Nevertheless
it already has the option max_ikev1_exchanges to increase that
value. This patch adds a setting to the advanced VPN dialogue
to control the behaviour of the parameter

More details at https://redmine.pfsense.org/issues/9331

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review