### PR TITLE
Fix a Bootstrap conversion error and empty lines in forms

### DIFF
--- a/src/usr/local/www/diag_smart.php
+++ b/src/usr/local/www/diag_smart.php
@@ -231,7 +231,7 @@ switch ($action) {
 
 		$section = new Form_Section('Information');
 		$group = new Form_Group('Select a drive and type:');
-		$group->add(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'action',
 			null,
 			'hidden',
@@ -274,7 +274,7 @@ switch ($action) {
 
 		$section = new Form_Section('View Logs');
 		$group = new Form_Group('Select a device and log');
-		$group->add(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'action',
 			null,
 			'hidden',
@@ -318,7 +318,7 @@ switch ($action) {
 
 		$section = new Form_Section('Perform self-tests');
 		$group = new Form_Group('Select a drive and test');
-		$group->add(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'action',
 			null,
 			'hidden',
@@ -363,7 +363,7 @@ switch ($action) {
 
 		$section = new Form_Section('Abort Tests');
 
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'action',
 			null,
 			'hidden',

--- a/src/usr/local/www/firewall_nat_npt_edit.php
+++ b/src/usr/local/www/firewall_nat_npt_edit.php
@@ -205,7 +205,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
 if (isset($id) && $a_npt[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/firewall_nat_out_edit.php
+++ b/src/usr/local/www/firewall_nat_out_edit.php
@@ -647,7 +647,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
 if (isset($id) && $a_out[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',
@@ -655,7 +655,7 @@ if (isset($id) && $a_out[$id]) {
 	));
 }
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'after',
 	null,
 	'hidden',

--- a/src/usr/local/www/firewall_schedule_edit.php
+++ b/src/usr/local/www/firewall_schedule_edit.php
@@ -442,7 +442,7 @@ $group->add(new Form_Button(
 $section->add($group);
 
 if (isset($id) && $a_schedules[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',
@@ -618,7 +618,7 @@ if ($getSchedule) {
 				'fa-trash'
 			))->setAttribute('type','button')->addClass('btn-xs btn-warning');
 
-			$group->add(new Form_Input(
+			$form->addGlobal(new Form_Input(
 				'schedule' . $counter,
 				null,
 				'hidden',

--- a/src/usr/local/www/firewall_virtual_ip_edit.php
+++ b/src/usr/local/www/firewall_virtual_ip_edit.php
@@ -426,7 +426,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
 if (isset($id) && $a_vip[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',
@@ -434,7 +434,7 @@ if (isset($id) && $a_vip[$id]) {
 	));
 }
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'uniqid',
 	null,
 	'hidden',

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -1869,13 +1869,13 @@ if ($show_address_controls) {
 		'IPv4/IPv6 Configuration',
 		"This interface type does not support manual address configuration on this page. "
 	));
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'type',
 		null,
 		'hidden',
 		'none'
 	));
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'type6',
 		null,
 		'hidden',
@@ -2648,7 +2648,7 @@ function build_ipv6interface_list() {
 	foreach ($dynv6ifs as $iface => $ifacedata) {
 		$list[$iface] = $ifacedata['name'];
 
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'ipv6-num-prefix-ids-' . $iface,
 			null,
 			'hidden',
@@ -2677,7 +2677,7 @@ $section->addInput(new Form_Input(
 	sprintf("%x", $pconfig['track6-prefix-id'])
 ))->setHelp('(%1$shexadecimal%2$s from 0 to %3$s) The value in this field is the (Delegated) IPv6 prefix ID. This determines the configurable network ID based on the dynamic IPv6 connection. The default value is 0.', '<b>', '</b>', '<span id="track6-prefix-id-range"></span>');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'track6-prefix-id-max',
 	null,
 	'hidden',
@@ -3005,7 +3005,7 @@ if (isset($wancfg['wireless'])) {
 			['off' => gettext('Off'), 'cts' => gettext('CTS to self'), 'rtscts' => gettext('RTS and CTS')]
 		))->setHelp('For IEEE 802.11g, use the specified technique for protecting OFDM frames in a mixed 11b/11g network.');
 	} else {
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'protmode',
 			null,
 			'hidden',

--- a/src/usr/local/www/interfaces_bridge_edit.php
+++ b/src/usr/local/www/interfaces_bridge_edit.php
@@ -625,7 +625,7 @@ foreach ($ifacelist as $ifn => $ifdescr) {
 	$i++;
 }
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'bridgeif',
 	null,
 	'hidden',
@@ -633,7 +633,7 @@ $section->addInput(new Form_Input(
 ));
 
 if (isset($id) && $a_bridges[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/interfaces_gif_edit.php
+++ b/src/usr/local/www/interfaces_gif_edit.php
@@ -220,7 +220,7 @@ $section->addInput(new Form_Input(
 	$pconfig['descr']
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'gifif',
 	null,
 	'hidden',
@@ -228,7 +228,7 @@ $section->addInput(new Form_Input(
 ));
 
 if (isset($id) && $a_gifs[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/interfaces_gre_edit.php
+++ b/src/usr/local/www/interfaces_gre_edit.php
@@ -206,7 +206,7 @@ $section->addInput(new Form_Input(
 	$pconfig['descr']
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'greif',
 	null,
 	'hidden',
@@ -214,7 +214,7 @@ $section->addInput(new Form_Input(
 ));
 
 if (isset($id) && $a_gres[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/interfaces_lagg_edit.php
+++ b/src/usr/local/www/interfaces_lagg_edit.php
@@ -245,7 +245,7 @@ $section->addInput(new Form_Input(
 	$pconfig['descr']
 ))->setHelp("Enter a description here for reference only (Not parsed).");
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'laggif',
 	null,
 	'hidden',
@@ -253,7 +253,7 @@ $section->addInput(new Form_Input(
 ));
 
 if (isset($id) && $a_laggs[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/interfaces_qinq_edit.php
+++ b/src/usr/local/www/interfaces_qinq_edit.php
@@ -294,7 +294,7 @@ $section->addInput(new Form_StaticText(
 ));
 
 if (isset($id) && $a_qinqs[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/interfaces_wireless_edit.php
+++ b/src/usr/local/www/interfaces_wireless_edit.php
@@ -189,7 +189,7 @@ $section->addInput(new Form_Input(
 	$pconfig['descr']
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'cloneif',
 	null,
 	'hidden',
@@ -197,7 +197,7 @@ $section->addInput(new Form_Input(
 ));
 
 if (isset($id) && $a_clones[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -819,7 +819,7 @@ if ($pconfig['page']['logouttext']) {
 	))->addClass('btn btn-danger btn-xs')->setAttribute("target", "_blank");
 	$section->add($group);
 }
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'zone',
 	null,
 	'hidden',

--- a/src/usr/local/www/services_captiveportal_filemanager.php
+++ b/src/usr/local/www/services_captiveportal_filemanager.php
@@ -156,7 +156,7 @@ if ($_REQUEST['act'] == 'add') {
 
 	$section = new Form_Section('Upload a New File');
 
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'zone',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_captiveportal_hostname_edit.php
+++ b/src/usr/local/www/services_captiveportal_hostname_edit.php
@@ -195,7 +195,7 @@ $section->addInput(new Form_Input(
 	$pconfig['bw_down']
 ))->setHelp('Enter a download limit to be enforced on this Hostname in Kbit/s');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'zone',
 	null,
 	'hidden',
@@ -203,7 +203,7 @@ $section->addInput(new Form_Input(
 ));
 
 if (isset($id) && $a_allowedhostnames[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_captiveportal_ip_edit.php
+++ b/src/usr/local/www/services_captiveportal_ip_edit.php
@@ -238,7 +238,7 @@ $section->addInput(new Form_Input(
 	$pconfig['bw_down']
 ))->setHelp('Enter a download limit to be enforced on this address in Kbit/s');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'zone',
 	null,
 	'hidden',
@@ -246,7 +246,7 @@ $section->addInput(new Form_Input(
 ));
 
 if (isset($id) && $a_allowedips[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_captiveportal_mac_edit.php
+++ b/src/usr/local/www/services_captiveportal_mac_edit.php
@@ -236,7 +236,7 @@ $section->addInput(new Form_Input(
 	$pconfig['bw_down']
 ))->setHelp('Enter a download limit to be enforced on this MAC in Kbit/s');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'zone',
 	null,
 	'hidden',
@@ -244,7 +244,7 @@ $section->addInput(new Form_Input(
 ));
 
 if (isset($id) && $a_passthrumacs[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',
@@ -253,7 +253,7 @@ if (isset($id) && $a_passthrumacs[$id]) {
 }
 
 if (isset($pconfig['username']) && $pconfig['username']) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'username',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_captiveportal_vouchers.php
+++ b/src/usr/local/www/services_captiveportal_vouchers.php
@@ -544,14 +544,14 @@ $section->addPassword(new Form_Input(
 	$pconfig['vouchersyncpass']
 ))->setHelp('This is the password of the master voucher nodes webConfigurator.');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'zone',
 	null,
 	'hidden',
 	$cpzone
 ));
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'exponent',
 	null,
 	'hidden',

--- a/src/usr/local/www/services_captiveportal_vouchers_edit.php
+++ b/src/usr/local/www/services_captiveportal_vouchers_edit.php
@@ -191,7 +191,7 @@ $section->addInput(new Form_Input(
 	$pconfig['descr']
 ))->setHelp('Can be used to further identify this roll. Ignored by the system.');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'zone',
 	null,
 	'hidden',
@@ -199,7 +199,7 @@ $section->addInput(new Form_Input(
 ));
 
 if (isset($id) && $a_roll[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_checkip_edit.php
+++ b/src/usr/local/www/services_checkip_edit.php
@@ -162,7 +162,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
 if (isset($id) && $a_checkip[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -999,7 +999,7 @@ $btnaddopt->removeClass('btn-primary')->addClass('btn-success btn-sm');
 
 $section->addInput($btnaddopt);
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'if',
 	null,
 	'hidden',

--- a/src/usr/local/www/services_dhcpv6_edit.php
+++ b/src/usr/local/www/services_dhcpv6_edit.php
@@ -245,7 +245,7 @@ if ($netboot_enabled) {
 }
 
 if (isset($id) && $a_maps[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',
@@ -253,7 +253,7 @@ if (isset($id) && $a_maps[$id]) {
 	));
 }
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'if',
 	null,
 	'hidden',

--- a/src/usr/local/www/services_dnsmasq_domainoverride_edit.php
+++ b/src/usr/local/www/services_dnsmasq_domainoverride_edit.php
@@ -156,7 +156,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
 if (isset($id) && $a_domainOverrides[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_dnsmasq_edit.php
+++ b/src/usr/local/www/services_dnsmasq_edit.php
@@ -225,7 +225,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
 if (isset($id) && $a_hosts[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -424,7 +424,7 @@ $section->addInput(new Form_Input(
 			'This field will be used in the Dynamic DNS Status Widget for Custom services.', '<br />');
 
 if (isset($id) && $a_dyndns[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_igmpproxy_edit.php
+++ b/src/usr/local/www/services_igmpproxy_edit.php
@@ -184,7 +184,7 @@ $section->addInput(new Form_Input(
 			'This setting is optional, and by default the threshold is 1.');
 
 if (isset($id) && $a_igmpproxy[$id]) {
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_pppoe_edit.php
+++ b/src/usr/local/www/services_pppoe_edit.php
@@ -538,7 +538,7 @@ $section->addInput(new Form_StaticText(
 
 // Hidden fields
 if (isset($id)) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',
@@ -547,7 +547,7 @@ if (isset($id)) {
 }
 
 if (isset($pconfig['pppoeid'])) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'pppoeid',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_rfc2136_edit.php
+++ b/src/usr/local/www/services_rfc2136_edit.php
@@ -299,7 +299,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
 if (isset($id) && $a_rfc2136[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -458,7 +458,7 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['rasamednsasdhcp6']
 ));
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'if',
 	null,
 	'hidden',

--- a/src/usr/local/www/services_unbound_acls.php
+++ b/src/usr/local/www/services_unbound_acls.php
@@ -189,14 +189,14 @@ if ($act == "new" || $act == "edit") {
 
 	$section = new Form_Section('New Access List');
 
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'aclid',
 		null,
 		'hidden',
 		$id
 	));
 
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'act',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_unbound_domainoverride_edit.php
+++ b/src/usr/local/www/services_unbound_domainoverride_edit.php
@@ -157,7 +157,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
 if (isset($id) && $a_domainOverrides[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/services_unbound_host_edit.php
+++ b/src/usr/local/www/services_unbound_host_edit.php
@@ -219,7 +219,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
 if (isset($id) && $a_hosts[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/status_captiveportal_expire.php
+++ b/src/usr/local/www/status_captiveportal_expire.php
@@ -84,7 +84,7 @@ $section->addInput(new Form_Textarea(
 	$_POST['vouchers']
 ))->setHelp('Enter multiple vouchers separated by space or newline. All valid vouchers will be marked as expired.');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'zone',
 	null,
 	'hidden',

--- a/src/usr/local/www/status_captiveportal_test.php
+++ b/src/usr/local/www/status_captiveportal_test.php
@@ -88,7 +88,7 @@ $section->addInput(new Form_Textarea(
 	$_POST['vouchers']
 ))->setHelp('Enter multiple vouchers separated by space or newline. The remaining time, if valid, will be shown for each voucher.');
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'zone',
 	null,
 	'hidden',

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -823,7 +823,7 @@ $section->addInput(new Form_Select(
 
 if (isset($id) && $a_server[$id])
 {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -1068,21 +1068,21 @@ if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 	))->setWidth(7)
 	  ->setHelp('Paste the certificate received from the certificate authority here.');
 
-	 if (isset($id) && $a_cert[$id]) {
-		 $section->addInput(new Form_Input(
+	if (isset($id) && $a_cert[$id]) {
+		$form->addGlobal(new Form_Input(
 			'id',
 			null,
 			'hidden',
 			$id
-		 ));
+		));
 
-		 $section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'act',
 			null,
 			'hidden',
 			'csr'
-		 ));
-	 }
+		));
+	}
 
 	$form->add($section);
 

--- a/src/usr/local/www/system_crlmanager.php
+++ b/src/usr/local/www/system_crlmanager.php
@@ -338,18 +338,17 @@ $tab_array[] = array(gettext("Certificate Revocation"), true, "system_crlmanager
 display_top_tabs($tab_array);
 
 if ($act == "new" || $act == gettext("Save") || $input_errors) {
+	$form = new Form();
+
+	$section = new Form_Section('Create new Revocation List');
+
 	if (!isset($id)) {
-		$form = new Form();
-
-		$section = new Form_Section('Create new Revocation List');
-
 		$section->addInput(new Form_Select(
 			'method',
 			'*Method',
 			$pconfig['method'],
 			build_method_list()
 		));
-
 	}
 
 	$section->addInput(new Form_Input(

--- a/src/usr/local/www/system_crlmanager.php
+++ b/src/usr/local/www/system_crlmanager.php
@@ -116,7 +116,6 @@ if ($act == "exp") {
 }
 
 if ($act == "addcert") {
-
 	unset($input_errors);
 	$pconfig = $_REQUEST;
 
@@ -402,7 +401,7 @@ if ($act == "new" || $act == gettext("Save") || $input_errors) {
 	$form->add($section);
 
 	if (isset($id) && $thiscrl) {
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'id',
 			null,
 			'hidden',
@@ -431,14 +430,14 @@ if ($act == "new" || $act == gettext("Save") || $input_errors) {
 		$pconfig['crltext']
 	))->setHelp('Paste a Certificate Revocation List in X.509 CRL format here.');
 
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'id',
 		null,
 		'hidden',
 		$id
 	));
 
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'act',
 		null,
 		'hidden',
@@ -541,21 +540,21 @@ if ($act == "new" || $act == gettext("Save") || $input_errors) {
 
 		$section->add($group);
 
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'id',
 			null,
 			'hidden',
 			$crl['refid']
 		));
 
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'act',
 			null,
 			'hidden',
 			'addcert'
 		));
 
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'crlref',
 			null,
 			'hidden',

--- a/src/usr/local/www/system_gateway_groups_edit.php
+++ b/src/usr/local/www/system_gateway_groups_edit.php
@@ -330,7 +330,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('A description may be entered here for administrative reference (not parsed).');
 
 if (isset($id) && $a_gateway_groups[$id]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 	'id',
 	null,
 	'hidden',

--- a/src/usr/local/www/system_usermanager_addprivs.php
+++ b/src/usr/local/www/system_usermanager_addprivs.php
@@ -210,7 +210,7 @@ $btnclear->setAttribute('type','button')->addClass('btn btn-warning');
 $form->addGlobal($btnclear);
 
 if (isset($userid)) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 	'userid',
 	null,
 	'hidden',

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -970,7 +970,7 @@ $section->addInput(new Form_Input(
 ))->setHelp('Number of consecutive failures allowed before disconnect. ');
 
 if (isset($p1index) && $a_phase1[$p1index]) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'p1index',
 		null,
 		'hidden',
@@ -979,7 +979,7 @@ if (isset($p1index) && $a_phase1[$p1index]) {
 }
 
 if ($pconfig['mobile']) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'mobile',
 		null,
 		'hidden',
@@ -987,7 +987,7 @@ if ($pconfig['mobile']) {
 	));
 }
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'ikeid',
 	null,
 	'hidden',

--- a/src/usr/local/www/vpn_ipsec_phase2.php
+++ b/src/usr/local/www/vpn_ipsec_phase2.php
@@ -717,7 +717,7 @@ $section->addInput(new Form_IpAddress(
 
 // Hidden inputs
 if ($pconfig['mobile']) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'mobile',
 		null,
 		'hidden',
@@ -725,7 +725,7 @@ if ($pconfig['mobile']) {
 	));
 }
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'ikeid',
 	null,
 	'hidden',
@@ -733,7 +733,7 @@ $section->addInput(new Form_Input(
 ));
 
 if (!empty($pconfig['reqid'])) {
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'reqid',
 		null,
 		'hidden',
@@ -741,7 +741,7 @@ if (!empty($pconfig['reqid'])) {
 	));
 }
 
-$section->addInput(new Form_Input(
+$form->addGlobal(new Form_Input(
 	'uniqid',
 	null,
 	'hidden',

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -952,7 +952,7 @@ if ($act=="new" || $act=="edit"):
 					'5: Output R and W characters to the console for each packet read and write. Uppercase is used for TCP/UDP packets and lowercase is used for TUN/TAP packets.%1$s' .
 					'6-11: Debug info range', '<br />');
 
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'act',
 		null,
 		'hidden',
@@ -960,7 +960,7 @@ if ($act=="new" || $act=="edit"):
 	));
 
 	if (isset($id) && $a_client[$id]) {
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'id',
 			null,
 			'hidden',

--- a/src/usr/local/www/vpn_openvpn_csc.php
+++ b/src/usr/local/www/vpn_openvpn_csc.php
@@ -582,7 +582,7 @@ if ($act == "new" || $act == "edit"):
 				'<br />');
 
 	// The hidden fields
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'act',
 		null,
 		'hidden',
@@ -590,7 +590,7 @@ if ($act == "new" || $act == "edit"):
 	));
 
 	if (isset($id) && $a_csc[$id]) {
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'id',
 			null,
 			'hidden',

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -1361,7 +1361,7 @@ if ($act=="new" || $act=="edit"):
 					'5: Output R and W characters to the console for each packet read and write. Uppercase is used for TCP/UDP packets and lowercase is used for TUN/TAP packets.%1$s' .
 					'6-11: Debug info range', '<br />');
 
-	$section->addInput(new Form_Input(
+	$form->addGlobal(new Form_Input(
 		'act',
 		null,
 		'hidden',
@@ -1369,7 +1369,7 @@ if ($act=="new" || $act=="edit"):
 	));
 
 	if (isset($id) && $a_server[$id]) {
-		$section->addInput(new Form_Input(
+		$form->addGlobal(new Form_Input(
 			'id',
 			null,
 			'hidden',


### PR DESCRIPTION
I noticed that there are a couple empty lines in forms on two pages in the Certificate Manager area, caused by using `addInput` instead of `addGlobal` to add hidden form inputs. This PR fixes them, along with all other such cases I could find throughout the GUI.

There's also a small logic error introduced during Bootstrap conversion, which is fixed as well.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9449
- [x] Ready for review
