### PR TITLE
Add support for encrypted CA and certificate private keys

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -106,6 +106,22 @@ function & lookup_cert_by_name($name) {
 	}
 }
 
+// Get a map from ID to description for all certs with a private key,
+// optionally including certificates with an encrypted private key.
+function get_cert_list($include_encrypted = false) {
+	global $config;
+
+	$result = array();
+	if (is_array($config['cert'])) {
+		foreach ($config['cert'] as $cert) {
+			if ($cert['prv'] && ($include_encrypted || !is_encrypted_key($cert['prv']))) {
+				$result[$cert['refid']] = $cert['descr'];
+			}
+		}
+	}
+	return $result;
+}
+
 function & lookup_crl($refid) {
 	global $config;
 
@@ -855,6 +871,22 @@ function is_encrypted_key($str_key, $decode = true) {
 		$str_key = base64_decode($str_key);
 	}
 	return openssl_pkey_get_private($str_key) === false;
+}
+
+// Check whether the cert with the specified ID is valid for use on the firewall,
+// i.e. it exists and has a private key that is not encrypted.
+function is_valid_firewall_cert($certref) {
+	if (empty($certref)) {
+		return false;
+	}
+	
+	$cert = lookup_cert($certref);
+	if (!$cert || !$cert['prv']) {
+		return false;
+	} elseif (is_encrypted_key($cert['prv'])) {
+		return false;
+	}
+	return true;
 }
 
 function is_user_cert($certref) {

--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -319,7 +319,10 @@ function cert_import(& $cert, $crt_str, $key_str) {
 	return true;
 }
 
-function cert_create(& $cert, $caref, $keylen, $lifetime, $dn, $type = "user", $digest_alg = "sha256") {
+function cert_create(& $cert, $caref, $keylen, $lifetime, $dn, $type = "user", $digest_alg = "sha256", $capass = "", $keypass = null) {
+	if (empty($keypass)) {
+		$keypass = null;
+	}
 
 	$cert['type'] = $type;
 
@@ -333,7 +336,7 @@ function cert_create(& $cert, $caref, $keylen, $lifetime, $dn, $type = "user", $
 		$ca_str_crt = base64_decode($ca['crt']);
 		$ca_str_key = base64_decode($ca['prv']);
 		$ca_res_crt = openssl_x509_read($ca_str_crt);
-		$ca_res_key = openssl_pkey_get_private(array(0 => $ca_str_key, 1 => ""));
+		$ca_res_key = openssl_pkey_get_private($ca_str_key, $capass);
 		if (!$ca_res_key) {
 			return false;
 		}
@@ -389,7 +392,7 @@ function cert_create(& $cert, $caref, $keylen, $lifetime, $dn, $type = "user", $
 	}
 
 	// export our certificate data
-	if (!openssl_pkey_export($res_key, $str_key) ||
+	if (!openssl_pkey_export($res_key, $str_key, $keypass) ||
 	    !openssl_x509_export($res_crt, $str_crt)) {
 		return false;
 	}
@@ -401,7 +404,10 @@ function cert_create(& $cert, $caref, $keylen, $lifetime, $dn, $type = "user", $
 	return true;
 }
 
-function csr_generate(& $cert, $keylen, $dn, $type = "user", $digest_alg = "sha256") {
+function csr_generate(& $cert, $keylen, $dn, $type = "user", $digest_alg = "sha256", $keypass = null) {
+	if (empty($keypass)) {
+		$keypass = null;
+	}
 
 	$cert_type = cert_type_config_section($type);
 
@@ -434,7 +440,7 @@ function csr_generate(& $cert, $keylen, $dn, $type = "user", $digest_alg = "sha2
 	}
 
 	// export our request data
-	if (!openssl_pkey_export($res_key, $str_key) ||
+	if (!openssl_pkey_export($res_key, $str_key, $keypass) ||
 	    !openssl_csr_export($res_csr, $str_csr)) {
 		return false;
 	}
@@ -446,14 +452,14 @@ function csr_generate(& $cert, $keylen, $dn, $type = "user", $digest_alg = "sha2
 	return true;
 }
 
-function csr_sign($csr, & $ca, $duration, $type = "user", $altnames, $digest_alg = "sha256") {
+function csr_sign($csr, & $ca, $duration, $type = "user", $altnames, $digest_alg = "sha256", $capass = "") {
 	global $config;
 	$old_err_level = error_reporting(0);
 
 	// Gather the information required for signed cert
 	$ca_str_crt = base64_decode($ca['crt']);
 	$ca_str_key = base64_decode($ca['prv']);
-	$ca_res_key = openssl_pkey_get_private(array(0 => $ca_str_key, 1 => ""));
+	$ca_res_key = openssl_pkey_get_private($ca_str_key, $capass);
 	if (!$ca_res_key) {
 		return false;
 	}
@@ -476,7 +482,7 @@ function csr_sign($csr, & $ca, $duration, $type = "user", $altnames, $digest_alg
 	);
 
 	// Sign the new cert and export it in x509 format
-	openssl_x509_export(openssl_csr_sign($csr, $ca_str_crt, $ca_str_key, $duration, $args, $ca_serial), $n509);
+	openssl_x509_export(openssl_csr_sign($csr, $ca_str_crt, $ca_res_key, $duration, $args, $ca_serial), $n509);
 	error_reporting($old_err_level);
 
 	return $n509;

--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -199,7 +199,10 @@ function ca_import(& $ca, $str, $key = "", $serial = "") {
 	return true;
 }
 
-function ca_create(& $ca, $keylen, $lifetime, $dn, $digest_alg = "sha256") {
+function ca_create(& $ca, $keylen, $lifetime, $dn, $digest_alg = "sha256", $password = null) {
+	if (empty($password)) {
+		$password = null;
+	}
 
 	$args = array(
 		"x509_extensions" => "v3_ca",
@@ -227,7 +230,7 @@ function ca_create(& $ca, $keylen, $lifetime, $dn, $digest_alg = "sha256") {
 	}
 
 	// export our certificate data
-	if (!openssl_pkey_export($res_key, $str_key) ||
+	if (!openssl_pkey_export($res_key, $str_key, $password) ||
 	    !openssl_x509_export($res_crt, $str_crt)) {
 		return false;
 	}
@@ -240,7 +243,11 @@ function ca_create(& $ca, $keylen, $lifetime, $dn, $digest_alg = "sha256") {
 	return true;
 }
 
-function ca_inter_create(& $ca, $keylen, $lifetime, $dn, $caref, $digest_alg = "sha256") {
+function ca_inter_create(& $ca, $keylen, $lifetime, $dn, $caref, $digest_alg = "sha256", $capass = "", $keypass = null) {
+	if (empty($keypass)) {
+		$keypass = null;
+	}
+
 	// Create Intermediate Certificate Authority
 	$signing_ca =& lookup_ca($caref);
 	if (!$signing_ca) {
@@ -248,7 +255,7 @@ function ca_inter_create(& $ca, $keylen, $lifetime, $dn, $caref, $digest_alg = "
 	}
 
 	$signing_ca_res_crt = openssl_x509_read(base64_decode($signing_ca['crt']));
-	$signing_ca_res_key = openssl_pkey_get_private(array(0 => base64_decode($signing_ca['prv']) , 1 => ""));
+	$signing_ca_res_key = openssl_pkey_get_private(base64_decode($signing_ca['prv']), $capass);
 	if (!$signing_ca_res_crt || !$signing_ca_res_key) {
 		return false;
 	}
@@ -280,7 +287,7 @@ function ca_inter_create(& $ca, $keylen, $lifetime, $dn, $caref, $digest_alg = "
 	}
 
 	// export our certificate data
-	if (!openssl_pkey_export($res_key, $str_key) ||
+	if (!openssl_pkey_export($res_key, $str_key, $keypass) ||
 	    !openssl_x509_export($res_crt, $str_crt)) {
 		return false;
 	}

--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -603,7 +603,7 @@ function cert_get_issuer($str_crt, $decode = true) {
 }
 
 /* Works for both RSA and ECC (crt) and key (prv) */
-function cert_get_publickey($str_crt, $decode = true, $type = "crt") {
+function cert_get_publickey($str_crt, $decode = true, $type = "crt", $password = "") {
 	if ($decode) {
 		$str_crt = base64_decode($str_crt);
 	}
@@ -611,7 +611,19 @@ function cert_get_publickey($str_crt, $decode = true, $type = "crt") {
 	file_put_contents($certfn, $str_crt);
 	switch ($type) {
 		case 'prv':
-			exec("/usr/bin/openssl pkey -in {$certfn} -pubout", $out);
+			if ($password) {
+				$passfn = tempnam('/tmp', 'CGPKP');
+				file_put_contents($passfn, $password);
+
+				exec("/usr/bin/openssl pkey -in {$certfn} -passin file:{$passfn} -pubout 2>/dev/null", $out, $status);
+
+				unlink_if_exists($passfn);
+				if ($status != 0) {
+					$out = false;
+				}
+			} else {
+				exec("/usr/bin/openssl pkey -in {$certfn} -pubout", $out);
+			}
 			break;
 		case 'crt':
 			exec("/usr/bin/openssl x509 -in {$certfn} -inform pem -noout -pubkey", $out);
@@ -623,7 +635,41 @@ function cert_get_publickey($str_crt, $decode = true, $type = "crt") {
 			$out = array();
 			break;
 	}
-	unlink($certfn);
+	unlink_if_exists($certfn);
+	return (($out !== false) ? implode("\n", $out) : false);
+}
+
+function cert_encrypt_key($str_key, $password, $decode = true) {
+	if ($decode) {
+		$str_key = base64_decode($str_key);
+	}
+
+	$keyfn = tempnam('/tmp', 'CEK');
+	$passfn = tempnam('/tmp', 'CEKP');
+	file_put_contents($keyfn, $str_key);
+	file_put_contents($passfn, $password);
+
+	exec("/usr/bin/openssl pkey -in {$keyfn} -aes256 -passout file:{$passfn} 2>/dev/null", $out);
+
+	unlink_if_exists($keyfn);
+	unlink_if_exists($passfn);
+	return implode("\n", $out);
+}
+
+function cert_decrypt_key($str_key, $password, $decode = true) {
+	if ($decode) {
+		$str_key = base64_decode($str_key);
+	}
+
+	$keyfn = tempnam('/tmp', 'CDK');
+	$passfn = tempnam('/tmp', 'CDKP');
+	file_put_contents($keyfn, $str_key);
+	file_put_contents($passfn, $password);
+
+	exec("/usr/bin/openssl pkey -in {$keyfn} -passin file:{$passfn} 2>/dev/null", $out);
+
+	unlink_if_exists($keyfn);
+	unlink_if_exists($passfn);
 	return implode("\n", $out);
 }
 
@@ -789,6 +835,13 @@ function ca_in_use($caref) {
 		is_openvpn_client_ca($caref) ||
 		is_ipsec_peer_ca($caref) ||
 		is_ldap_peer_ca($caref));
+}
+
+function is_encrypted_key($str_key, $decode = true) {
+	if ($decode) {
+		$str_key = base64_decode($str_key);
+	}
+	return openssl_pkey_get_private($str_key) === false;
 }
 
 function is_user_cert($certref) {

--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -248,6 +248,10 @@ function openvpn_build_cert_list($include_none = false, $prioritize_server_certs
 	}
 
 	foreach ($a_cert as $cert) {
+		if (!$cert['prv'] || is_encrypted_key($cert['prv'])) {
+			continue;
+		}
+
 		$properties = array();
 		$propstr = "";
 		$ca = lookup_ca($cert['caref']);

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -267,6 +267,21 @@ function do_input_validation($postdata, $reqdfields, $reqdfieldsn, &$input_error
 	}
 }
 
+// If passwords for certificate private keys are given, check that they match and verify their length
+function validate_cert_passwords($pw1, $pw2, &$input_errors) {
+	if (!$pw1 && !$pw2) {
+		return;
+	}
+
+	if ($pw1 != $pw2) {
+		$input_errors[] = gettext("The passwords do not match.");
+	} elseif (strlen($pw1) < 4 || strlen($pw1) > 1023) {
+		// OpenSSL will silently accept a short password for encrypting
+		// a key, but will then fail to decrypt the key
+		$input_errors[] = gettext("The password must be between 4 and 1023 characters long.");
+	}
+}
+
 function print_input_errors($input_errors) {
 	echo '<div class="alert alert-danger input-errors">';
 	echo '<p>' . gettext('The following input errors were detected:') . '</p>';

--- a/src/usr/local/www/services_captiveportal.php
+++ b/src/usr/local/www/services_captiveportal.php
@@ -126,10 +126,7 @@ if ($_REQUEST['act'] == "viewhtml") {
 }
 
 init_config_arr(array('ca'));
-$a_ca = &$config['ca'];
-
 init_config_arr(array('cert'));
-$a_cert = &$config['cert'];
 
 if ($a_cp[$cpzone]) {
 	$cpzoneid = $pconfig['zoneid'] = $a_cp[$cpzone]['zoneid'];
@@ -227,6 +224,8 @@ if ($_POST['save']) {
 		if ($_POST['httpslogin_enable']) {
 			if (!$_POST['certref']) {
 				$input_errors[] = gettext("Certificate must be specified for HTTPS login.");
+			} elseif (!is_valid_firewall_cert($_POST['certref'])) {
+				$input_errors[] = gettext("Certificate for HTTPS login must not be encrypted.");
 			}
 			if (!$_POST['httpsname'] || !is_domain($_POST['httpsname'])) {
 				$input_errors[] = gettext("The HTTPS server name must be specified for HTTPS login.");
@@ -482,18 +481,6 @@ if ($_POST['save']) {
 			$pconfig['cinterface'] = implode(",", $_POST['cinterface']);
 		}
 	}
-}
-
-function build_cert_list() {
-	global $a_cert;
-
-	$list = array();
-
-	foreach ($a_cert as $cert) {
-		$list[$cert['refid']] = $cert['descr'];
-	}
-
-	return($list);
 }
 
 function build_authserver_list() {
@@ -1121,7 +1108,7 @@ $section->addInput(new Form_Select(
 	'certref',
 	'*SSL Certificate',
 	$pconfig['certref'],
-	build_cert_list()
+	get_cert_list()
 ))->setHelp('If no certificates are defined, one may be defined here: %1$sSystem &gt; Cert. Manager%2$s', '<a href="system_certmanager.php">', '</a>');
 
 $section->addInput(new Form_Checkbox(

--- a/src/usr/local/www/system_advanced_admin.php
+++ b/src/usr/local/www/system_advanced_admin.php
@@ -71,16 +71,9 @@ $pconfig['sshguard_detection_time'] = $config['system']['sshguard_detection_time
 $pconfig['sshguard_whitelist'] = $config['system']['sshguard_whitelist'] ?? '';
 
 init_config_arr(array('cert'));
-$a_cert = &$config['cert'];
-$certs_available = false;
+$certs = get_cert_list();
 
-if (is_array($a_cert) && count($a_cert)) {
-	$certs_available = true;
-} else {
-	$a_cert = array();
-}
-
-if (!$pconfig['webguiproto'] || !$certs_available) {
+if (!$pconfig['webguiproto'] || empty($certs)) {
 	$pconfig['webguiproto'] = "http";
 }
 
@@ -421,23 +414,18 @@ $group->add(new Form_Checkbox(
 	'https'
 ))->displayAsRadio();
 
-if (!$certs_available) {
+if (empty($certs)) {
 	$group->setHelp('No Certificates have been defined. A certificate is required before SSL can be enabled. %1$s Create or Import %2$s a Certificate.',
 		'<a href="system_certmanager.php">', '</a>');
 }
 
 $section->add($group);
 
-$values = array();
-foreach ($a_cert as $cert) {
-	$values[ $cert['refid'] ] = $cert['descr'];
-}
-
 $section->addInput($input = new Form_Select(
 	'ssl-certref',
 	'SSL Certificate',
 	$pconfig['ssl-certref'],
-	$values
+	$certs
 ));
 
 $section->addInput(new Form_Input(

--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -452,7 +452,12 @@ foreach ($a_ca as $i => $ca):
 ?>
 				<tr>
 					<td><?=$name?></td>
-					<td><i class="fa fa-<?= (!empty($ca['prv'])) ? "check" : "times" ; ?>"></i></td>
+					<td>
+						<i class="fa fa-<?= (!empty($ca['prv'])) ? "check" : "times" ; ?>"></i>
+						<?php if ($ca['prv'] && is_encrypted_key($ca['prv'])): ?>
+							<i class="fa fa-lock" title="<?=gettext("Encrypted private key")?>"></i>
+						<?php endif?>
+					</td>
 					<td><i><?=$issuer_name?></i></td>
 					<td><?=$certcount?></td>
 					<td>

--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -200,18 +200,9 @@ if ($_POST['save']) {
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 	if ($pconfig['method'] == "existing") {
-		$pass = $_POST['password1_existing'];
-		if ($pass) {
-			if ($pass != $_POST['password2_existing']) {
-				$input_errors[] = gettext("The passwords do not match.");
-			} elseif (strlen($pass) < 4 || strlen($pass) > 1023) {
-				// OpenSSL will silently accept a short password for encrypting
-				// a key, but will then fail to decrypt the key
-				$input_errors[] = gettext("The password must be between 4 and 1023 characters long.");
-			}
-		}
+		validate_cert_passwords($_POST['password1_existing'], $_POST['password2_existing'], $input_errors);
 		if (!$input_errors && $_POST['key']) {
-			$pubkey = cert_get_publickey($_POST['key'], false, 'prv', $pass);
+			$pubkey = cert_get_publickey($_POST['key'], false, 'prv', $_POST['password1_existing']);
 			if ($pubkey === false) {
 				$input_errors[] = gettext("The password does not match the submitted private key.");
 			} elseif ($pubkey != cert_get_publickey($_POST['cert'], false)) {
@@ -229,15 +220,7 @@ if ($_POST['save']) {
 		if (!in_array($_POST["digest_alg"], $openssl_digest_algs)) {
 			array_push($input_errors, gettext("Please select a valid Digest Algorithm."));
 		}
-		if ($pass = $_POST['password1_internal']) {
-			if ($pass != $_POST['password2_internal']) {
-				$input_errors[] = gettext("The passwords do not match.");
-			} elseif (strlen($pass) < 4 || strlen($pass) > 1023) {
-				// OpenSSL will silently accept a short password for encrypting
-				// a key, but will then fail to decrypt the key
-				$input_errors[] = gettext("The password must be between 4 and 1023 characters long.");
-			}
-		}
+		validate_cert_passwords($_POST['password1_internal'], $_POST['password2_internal'], $input_errors);
 	}
 	if ($pconfig['method'] == "intermediate") {
 		$signing_ca =& lookup_ca($_POST['caref']);

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -1358,7 +1358,11 @@ foreach ($a_cert as $i => $cert):
 ?>
 				<tr>
 					<td>
-						<?=$name?><br />
+						<?php if ($cert['prv'] && is_encrypted_key($cert['prv'])): ?>
+							<?=$name?>&nbsp;<i class="fa fa-lock" title="<?=gettext("Encrypted private key")?>"></i>
+						<?php else: ?>
+							<?=$name?>
+						<?php endif?><br />
 						<?php if ($cert['type']): ?>
 							<i><?=$cert_types[$cert['type']]?></i><br />
 						<?php endif?>

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -231,7 +231,7 @@ if ($_POST['save']) {
 			}
 
 			if ($_POST['csrtosign'] === "new" && $_POST['keypaste']) {
-				if (strpos($_POST['keypaste'], "ENCRYPTED") !== false || $_POST['encryptkey_paste']) {
+				if (is_encrypted_key($_POST['keypaste'], false) || $_POST['encryptkey_paste']) {
 					$reqdfields[] = "password1_paste";
 					$reqdfieldsn[] = gettext("Private Key Password");
 				} elseif (strpos($_POST['keypaste'], "PRIVATE KEY") === false) {
@@ -248,7 +248,7 @@ if ($_POST['save']) {
 				gettext("Descriptive name"),
 				gettext("Certificate data"),
 				gettext("Key data"));
-			if ($_POST['key'] && (strpos($_POST['key'], "ENCRYPTED") !== false || $_POST['encryptkey_existing'])) {
+			if ($_POST['key'] && (is_encrypted_key($_POST['key'], false) || $_POST['encryptkey_existing'])) {
 				$reqdfields[] = 'password1_existing';
 				$reqdfieldsn[] = gettext('Private Key Password');
 			}
@@ -366,7 +366,7 @@ if ($_POST['save']) {
 					}
 
 					$ca =& lookup_ca($_POST['caref']);
-					if ($ca && $ca['prv'] && strpos(base64_decode($ca['prv']), "ENCRYPTED") !== false) {
+					if ($ca && $ca['prv'] && is_encrypted_key($ca['prv'])) {
 						if (!$_POST['ca_password']) {
 							$input_errors[] = gettext("Password required for the selected Certificate Authority.");
 						} elseif (cert_get_publickey($ca['prv'], true, 'prv', $_POST['ca_password']) === false) {
@@ -388,7 +388,7 @@ if ($_POST['save']) {
 					}
 
 					$signing_ca =& lookup_ca($_POST['catosignwith']);
-					if ($signing_ca && $signing_ca['prv'] && strpos(base64_decode($signing_ca['prv']), "ENCRYPTED") !== false) {
+					if ($signing_ca && $signing_ca['prv'] && is_encrypted_key($signing_ca['prv'])) {
 						if (!$_POST['signca_password']) {
 							$input_errors[] = gettext("Password required for the selected Certificate Authority.");
 						} elseif (cert_get_publickey($signing_ca['prv'], true, 'prv', $_POST['signca_password']) === false) {
@@ -460,7 +460,7 @@ if ($_POST['save']) {
 
 					if ($pconfig['csrtosign'] === "new") {
 						if ($pconfig['keypaste']) {
-							$is_encrypted = (strpos($pconfig['keypaste'], "ENCRYPTED") !== false);
+							$is_encrypted = is_encrypted_key($pconfig['keypaste'], false);
 							if ($is_encrypted && !$pconfig['encryptkey_paste']) {
 								$pconfig['keypaste'] = cert_decrypt_key($pconfig['keypaste'], $pconfig['password1_paste'], false);
 							} elseif (!$is_encrypted && $pconfig['encryptkey_paste']) {
@@ -488,7 +488,7 @@ if ($_POST['save']) {
 				$old_err_level = error_reporting(0); /* otherwise openssl_ functions throw warnings directly to a page screwing menu tab */
 
 				if ($pconfig['method'] == "import") {
-					$is_encrypted = (strpos($pconfig['key'], "ENCRYPTED") !== false);
+					$is_encrypted = is_encrypted_key($pconfig['key'], false);
 					if ($is_encrypted && !$pconfig['encryptkey_existing']) {
 						$pconfig['key'] = cert_decrypt_key($pconfig['key'], $pconfig['password1_existing'], false);
 					} elseif (!$is_encrypted && $pconfig['encryptkey_existing']) {

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -197,21 +197,6 @@ if ($act == "csr") {
 }
 
 if ($_POST['save']) {
-	// If passwords are given, check that they match and verify their length
-	function validatePasswords(& $input_errors, $pw1, $pw2) {
-		if (!$pw1 && !$pw2) {
-			return;
-		}
-
-		if ($pw1 != $pw2) {
-			$input_errors[] = gettext("The passwords do not match.");
-		} elseif (strlen($pw1) < 4 || strlen($pw1) > 1023) {
-			// OpenSSL will silently accept a short password for encrypting
-			// a key, but will then fail to decrypt the key
-			$input_errors[] = gettext("The password must be between 4 and 1023 characters long.");
-		}
-	}
-
 	if ($_POST['save'] == gettext("Save")) {
 		$input_errors = array();
 		$pconfig = $_POST;
@@ -269,7 +254,7 @@ if ($_POST['save']) {
 				gettext("Lifetime"),
 				gettext("Common Name"));
 
-			validatePasswords($input_errors, $_POST['password1_internal'], $_POST['password2_internal']);
+			validate_cert_passwords($_POST['password1_internal'], $_POST['password2_internal'], $input_errors);
 		}
 
 		if ($pconfig['method'] == "external") {
@@ -280,7 +265,7 @@ if ($_POST['save']) {
 				gettext("Key length"),
 				gettext("Common Name"));
 
-			validatePasswords($input_errors, $_POST['password1_external'], $_POST['password2_external']);
+			validate_cert_passwords($_POST['password1_external'], $_POST['password2_external'], $input_errors);
 		}
 
 		if ($pconfig['method'] == "existing") {
@@ -402,7 +387,7 @@ if ($_POST['save']) {
 		}
 
 		if ($pconfig['method'] == "import") {
-			validatePasswords($input_errors, $_POST['password1_existing'], $_POST['password2_existing']);
+			validate_cert_passwords($_POST['password1_existing'], $_POST['password2_existing'], $input_errors);
 			if (!$input_errors && $_POST['key']) {
 				$pubkey = cert_get_publickey($_POST['key'], false, 'prv', $_POST['password1_existing']);
 				if ($pubkey === false) {
@@ -414,7 +399,7 @@ if ($_POST['save']) {
 		}
 
 		if ($pconfig['method'] == "sign") {
-			validatePasswords($input_errors, $_POST['password1_paste'], $_POST['password2_paste']);
+			validate_cert_passwords($_POST['password1_paste'], $_POST['password2_paste'], $input_errors);
 			if (!$input_errors && $_POST['keypaste']) {
 				if (cert_get_publickey($_POST['keypaste'], false, 'prv', $_POST['password1_paste']) === false) {
 					$input_errors[] = gettext("The password does not match the submitted private key.");

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -742,8 +742,6 @@ foreach ($a_user as $i => $userent):
 	exit;
 }
 
-// ($act == "new" || $act == "edit" || $input_errors) == true
-
 $form = new Form;
 
 $form->addGlobal(new Form_Input(

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -944,7 +944,7 @@ if ($act == "new" || $act == "edit" || $input_errors):
 	$form->add($section);
 
 	// ==== Effective privileges section ======================================
-	if (isset($pconfig['uid'])) {
+	if (isset($id)) {
 		// We are going to build an HTML table and add it to an Input_StaticText. It may be ugly, but it
 		// is the best way to make the display we need.
 

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -597,7 +597,11 @@ function build_cert_table() {
 			$revokedstr =	is_cert_revoked($cert) ? '<b> Revoked</b>':'';
 
 			$certhtml .=	'<tr>';
-			$certhtml .=		'<td>' . htmlspecialchars($cert['descr']) . $revokedstr . '</td>';
+			$certhtml .=		'<td>' . htmlspecialchars($cert['descr']) . $revokedstr;
+			if ($cert['prv'] && is_encrypted_key($cert['prv'])) {
+				$certhtml .= '&nbsp;<i class="fa fa-lock" title="' . gettext("Encrypted private key") . '"></i>';
+			}
+			$certhtml .=		'</td>';
 			$certhtml .=		'<td>' . htmlspecialchars($ca['descr']) . '</td>';
 			$certhtml .=		'<td>';
 			if (!$read_only) {

--- a/src/usr/local/www/system_usermanager.php
+++ b/src/usr/local/www/system_usermanager.php
@@ -182,7 +182,7 @@ if (($_POST['act'] == "delcert") && !$read_only) {
 	$savemsg = sprintf(gettext("Removed certificate association \"%s\" from user %s"), $certdeleted, $a_user[$id]['name']);
 	write_config($savemsg);
 	syslog($logging_level, "{$logging_prefix}: {$savemsg}");
-	$_POST['act'] = "edit";
+	$act = "edit";
 }
 
 if (($_POST['act'] == "delprivid") && !$read_only) {
@@ -192,7 +192,7 @@ if (($_POST['act'] == "delprivid") && !$read_only) {
 	$savemsg = sprintf(gettext("Removed Privilege \"%s\" from user %s"), $privdeleted, $a_user[$id]['name']);
 	write_config($savemsg);
 	syslog($logging_level, "{$logging_prefix}: {$savemsg}");
-	$_POST['act'] = "edit";
+	$act = "edit";
 }
 
 if ($_POST['save'] && !$read_only) {

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -617,20 +617,6 @@ function build_peerid_list() {
 	return($list);
 }
 
-function build_cert_list() {
-	global $config;
-
-	$list = array();
-
-	if (is_array($config['cert'])) {
-		foreach ($config['cert'] as $cert) {
-			$list[$cert['refid']] = $cert['descr'];
-		}
-	}
-
-	return($list);
-}
-
 function build_ca_list() {
 	global $config;
 
@@ -800,7 +786,7 @@ $section->addInput(new Form_Select(
 	'certref',
 	'*My Certificate',
 	$pconfig['certref'],
-	build_cert_list()
+	get_cert_list()
 ))->setHelp('Select a certificate previously configured in the Certificate Manager.');
 
 $section->addInput(new Form_Select(

--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -348,8 +348,12 @@ if ($_POST['save']) {
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
-	if (($pconfig['mode'] != "p2p_shared_key") && empty($pconfig['certref']) && empty($pconfig['auth_user']) && empty($pconfig['auth_pass'])) {
-		$input_errors[] = gettext("If no Client Certificate is selected, a username and/or password must be entered.");
+	if ($pconfig['mode'] != "p2p_shared_key") {
+		if (empty($pconfig['certref']) && empty($pconfig['auth_user']) && empty($pconfig['auth_pass'])) {
+			$input_errors[] = gettext("If no Client Certificate is selected, a username and/or password must be entered.");
+		} elseif (!empty($pconfig['certref']) && !is_valid_firewall_cert($pconfig['certref'])) {
+			$input_errors[] = gettext("The selected certificate is not valid");
+		}
 	}
 
 	if ($pconfig['auth_pass'] != $pconfig['auth_pass_confirm']) {

--- a/src/usr/local/www/vpn_openvpn_server.php
+++ b/src/usr/local/www/vpn_openvpn_server.php
@@ -420,7 +420,7 @@ if ($_POST['save']) {
 
 	/* If we are not in shared key mode, then we need the CA/Cert. */
 	if ($pconfig['mode'] != "p2p_shared_key") {
-		if (empty(trim($pconfig['certref']))) {
+		if (!is_valid_firewall_cert($pconfig['certref'])) {
 			$input_errors[] = gettext("The selected certificate is not valid");
 		}
 

--- a/src/usr/local/www/wizard.php
+++ b/src/usr/local/www/wizard.php
@@ -638,7 +638,7 @@ if ($pkg['step'][$stepid]['fields']['field'] != "") {
 				if ($field['displayname']) {
 					$etitle = $field['displayname'];
 				} else if (!$field['dontdisplayname']) {
-					$etitle =  fixup_string($field['name']);
+					$etitle = fixup_string($field['name']);
 				}
 
 				$section->addInput(new Form_Input(
@@ -721,6 +721,9 @@ if ($pkg['step'][$stepid]['fields']['field'] != "") {
 
 				foreach ($config['cert'] as $ca) {
 					if (stristr($ca['descr'], "webconf")) {
+						continue;
+					}
+					if ($ca['prv'] && is_encrypted_key($ca['prv'])) {
 						continue;
 					}
 

--- a/src/usr/local/www/wizards/openvpn_wizard.inc
+++ b/src/usr/local/www/wizards/openvpn_wizard.inc
@@ -537,6 +537,21 @@ function step12_submitphpaction() {
 	}
 
 	if (isset($pconfig['step9']['uselist'])) {
+		$capass = $pconfig['step9']['capass'];
+		if ($ca['prv'] && is_encrypted_key($ca['prv'])) {
+			if (!$capass) {
+				$message = gettext("Password required for the selected Certificate Authority.");
+				header("Location:wizard.php?xml=openvpn_wizard.xml&stepid=8&message={$message}");
+				exit;
+			} elseif (cert_get_publickey($ca['prv'], true, 'prv', $capass) === false) {
+				$message = gettext("Password does not match the selected Certificate Authority.");
+				header("Location:wizard.php?xml=openvpn_wizard.xml&stepid=8&message={$message}");
+				exit;
+			}
+		} else {
+			$capass = "";
+		}
+
 		$cert = array();
 		$cert['refid'] = uniqid();
 		$cert['descr'] = $pconfig['step9']['certname'];
@@ -558,7 +573,7 @@ function step12_submitphpaction() {
 			$dn['organizationName'] = cert_escape_x509_chars($pconfig['step9']['organization']);
 		}
 
-		cert_create($cert, $ca['refid'], $pconfig['step9']['keylength'], $pconfig['step9']['lifetime'], $dn, 'server', "sha256");
+		cert_create($cert, $ca['refid'], $pconfig['step9']['keylength'], $pconfig['step9']['lifetime'], $dn, 'server', "sha256", $capass);
 		if (!is_array($config['cert']))
 			$config['cert'] = array();
 
@@ -567,7 +582,8 @@ function step12_submitphpaction() {
 		$message = "Please choose a Certificate.";
 		header("Location:wizard.php?xml=openvpn_wizard.xml&stepid=7&message={$message}");
 		exit;
-	} else if (!($cert = lookup_cert($pconfig['step9']['authcertname']))) {
+	} else if (!($cert = lookup_cert($pconfig['step9']['authcertname'])) ||
+	           ($cert['prv'] && is_encrypted_key($cert['prv']))) {
 		$message = "An invalid Certificate has been specified.";
 		header("Location:wizard.php?xml=openvpn_wizard.xml&stepid=7&message={$message}");
 		exit;

--- a/src/usr/local/www/wizards/openvpn_wizard.xml
+++ b/src/usr/local/www/wizards/openvpn_wizard.xml
@@ -676,6 +676,14 @@
 			<bindstofield>ovpnserver->step9->organization</bindstofield>
 		</field>
 		<field>
+			<name>capass</name>
+			<displayname>CA Password</displayname>
+			<description>If an encrypted Certificate Authority was selected, enter the CA password.</description>
+			<type>password</type>
+			<size>30</size>
+			<bindstofield>ovpnserver->step9->capass</bindstofield>
+		</field>
+		<field>
 			<name>Create new Certificate</name>
 			<type>submit</type>
 		</field>


### PR DESCRIPTION
I've been working on adding support for encrypted private keys, I've added support to the CA and certificate managers, as well as the user manager. I'm working on the OpenVPN wizard now, but wanted to get some feedback on what I have so far. I'm not a PHP programmer at all, so I just tried to stick to the existing code; any feedback in that regard is more than welcome.

I've not added support to the CRL manager yet, because I think that would require a substantial change to its interface. I'd be happy to discuss that, but I wasn't sure if a PR was the right place. Since I don't think I'm going to use CRLs at all, I could also just leave that part out for someone else to implement, if the need is there.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/1257
- [x] Ready for review