### PR TITLE
Allow import of PKCS12 (pfx) certificates

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -168,6 +168,7 @@ function ca_import(& $ca, $str, $key = "", $serial = "") {
 	}
 	$subject = cert_get_subject($str, false);
 	$issuer = cert_get_issuer($str, false);
+	$serialNumber = cert_get_serial($str, false);
 
 	// Find my issuer unless self-signed
 	if ($issuer <> $subject) {
@@ -180,6 +181,11 @@ function ca_import(& $ca, $str, $key = "", $serial = "") {
 	/* Correct if child certificate was loaded first */
 	if (is_array($config['ca'])) {
 		foreach ($config['ca'] as & $oca) {
+			// check by serial number if CA already exists
+			$osn = cert_get_serial($oca['crt']);
+			if ($ca['refid'] <> $oca['refid'] && $serialNumber == $osn) {
+				return false;
+			}
 			$issuer = cert_get_issuer($oca['crt']);
 			if ($ca['refid'] <> $oca['refid'] && $issuer == $subject) {
 				$oca['caref'] = $ca['refid'];

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -222,10 +222,13 @@ if ($_POST['save']) {
 		}
 
 		if ($pconfig['method'] == "import") {
-			$reqdfields = array("descr");
-			$reqdfieldsn = array(gettext("Descriptive name"));
 			$pkcs12_data = '';
-			if (empty($_FILES['pkcs12_cert'])) {
+			if ($_POST['import_type'] == 'x509') {
+				$reqdfields = explode(" ", "descr cert key");
+				$reqdfieldsn = array(
+					gettext("Descriptive name"),
+					gettext("Certificate data"),
+					gettext("Key data"));
 				if ($_POST['cert'] && (!strstr($_POST['cert'], "BEGIN CERTIFICATE") || !strstr($_POST['cert'], "END CERTIFICATE"))) {
 					$input_errors[] = gettext("This certificate does not appear to be valid.");
 				}
@@ -234,9 +237,13 @@ if ($_POST['save']) {
 					$input_errors[] = gettext("The submitted private key does not match the submitted certificate data.");
 				}
 			} else {
-				$pkcs12_file = file_get_contents($_FILES['pkcs12_cert']['tmp_name']);
-				if (!openssl_pkcs12_read($pkcs12_file, $pkcs12_data, $_POST['pkcs12_pass'])) {
-					$input_errors[] = gettext("The submitted password does not unlock the submitted PKCS #12 certificate.");
+				if (!empty($_FILES['pkcs12_cert']) && is_uploaded_file($_FILES['pkcs12_cert']['tmp_name'])) {
+					$pkcs12_file = file_get_contents($_FILES['pkcs12_cert']['tmp_name']);
+					if (!openssl_pkcs12_read($pkcs12_file, $pkcs12_data, $_POST['pkcs12_pass'])) {
+						$input_errors[] = gettext("The submitted password does not unlock the submitted PKCS #12 certificate.");
+					}
+				} else {
+					$input_errors[] = gettext("A PKCS #12 certificate store was not uploaded.");
 				}
 			}
 		}

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -620,7 +620,7 @@ display_top_tabs($tab_array);
 
 if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 	$form = new Form();
-	$form->setAction('system_certmanager.php?act=edit');
+	$form->setAction('system_certmanager.php?act=edit')->setMultipartEncoding();
 
 	if (isset($userid) && $a_user) {
 		$form->addGlobal(new Form_Input(
@@ -736,6 +736,26 @@ if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 	$section = new Form_Section('Import Certificate');
 	$section->addClass('toggle-import collapse');
 
+	$group = new Form_Group('Certificate Type');
+
+	$group->add(new Form_Checkbox(
+		'import_type',
+		'Certificate Type',
+		'X.509 (PEM)',
+		true,
+		'x509'
+	))->displayAsRadio()->addClass('import_type_toggle');
+
+	$group->add(new Form_Checkbox(
+		'import_type',
+		'Certificate Type',
+		'PKCS #12 (PFX)',
+		false,
+		'pkcs12'
+	))->displayAsRadio()->addClass('import_type_toggle');
+
+	$section->add($group);
+
 	$section->addInput(new Form_Textarea(
 		'cert',
 		'Certificate data',
@@ -753,12 +773,12 @@ if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 		'PKCS #12 certificate',
 		'file',
 		$pconfig['pkcs12_cert']
-	))->setHelp('Upload a PKCS #12 certificate store here.');
+	))->setHelp('Select a PKCS #12 certificate store.');
 
 	$section->addInput(new Form_Input(
 		'pkcs12_pass',
 		'PKCS #12 certificate password',
-		'text'
+		'text'                                              
 	))->setHelp('Enter the password to unlock the PKCS #12 certificate store.');
 
 	$form->add($section);
@@ -1394,6 +1414,16 @@ events.push(function() {
 <script type="text/javascript">
 //<![CDATA[
 events.push(function() {
+
+	$('.import_type_toggle').click(function() {
+		var x509 = (this.value === 'x509');
+		hideInput('cert', !x509);
+		hideInput('key', !x509);
+		hideInput('pkcs12_cert', x509);
+		hideInput('pkcs12_pass', x509);
+	});
+	hideInput('pkcs12_cert', true);
+	hideInput('pkcs12_pass', true);
 
 <?php if ($internal_ca_count): ?>
 	function internalca_change() {

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -761,7 +761,7 @@ if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 		'import_type',
 		'Certificate Type',
 		'X.509 (PEM)',
-		true,
+		(!isset($pconfig['import_type']) || $pconfig['import_type'] == 'x509'),
 		'x509'
 	))->displayAsRadio()->addClass('import_type_toggle');
 
@@ -769,7 +769,7 @@ if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 		'import_type',
 		'Certificate Type',
 		'PKCS #12 (PFX)',
-		false,
+		(isset($pconfig['import_type']) && $pconfig['import_type'] == 'pkcs12'),
 		'pkcs12'
 	))->displayAsRadio()->addClass('import_type_toggle');
 
@@ -797,14 +797,14 @@ if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 	$section->addInput(new Form_Input(
 		'pkcs12_pass',
 		'PKCS #12 certificate password',
-		'text'                                              
+		'password'
 	))->setHelp('Enter the password to unlock the PKCS #12 certificate store.');
 
 	$section->addInput(new Form_Checkbox(
 		'pkcs12_intermediate',
 		'Intermediates',
 		'Import intermediate CAs',
-		false
+		isset($pconfig['pkcs12_intermediate'])
 	))->setHelp('Import any intermediate certificate authorities found in the PKCS #12 certificate store.');
 
 	$form->add($section);
@@ -1449,9 +1449,14 @@ events.push(function() {
 		hideInput('pkcs12_pass', x509);
 		hideInput('pkcs12_intermediate', x509);
 	});
-	hideInput('pkcs12_cert', true);
-	hideInput('pkcs12_pass', true);
-	hideInput('pkcs12_intermediate', true);
+	if ($('input[name=import_type]:checked').val() == 'x509') {
+		hideInput('pkcs12_cert', true);
+		hideInput('pkcs12_pass', true);
+		hideInput('pkcs12_intermediate', true);
+	} else {
+		hideInput('cert', true);
+		hideInput('key', true);
+	}
 
 <?php if ($internal_ca_count): ?>
 	function internalca_change() {

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -432,9 +432,10 @@ if ($_POST['save']) {
 						$pconfig['key'] = $pkcs12_data['pkey'];
 						if ($_POST['pkcs_intermediate'] && is_array($pkcs12_data['extracerts'])) {
 							foreach ($pkcs12_data['extracerts'] as $intermediate) {
-								if (!openssl_x509_parse($intermediate)) continue;
-								$cn = cert_get_cn($intermediate);
-								$int_ca = array('descr' => $cn);
+								$int_data = openssl_x509_parse($intermediate);
+								if (!$int_data) continue;
+								$cn = $int_data['subject']['CN'];
+								$int_ca = array('descr' => $cn, 'refid' => uniqid());
 								ca_import($int_ca, $intermediate);
 								$a_ca[] = $int_ca;
 							}
@@ -1444,9 +1445,11 @@ events.push(function() {
 		hideInput('key', !x509);
 		hideInput('pkcs12_cert', x509);
 		hideInput('pkcs12_pass', x509);
+		hideInput('pkcs12_intermediate', x509);
 	});
 	hideInput('pkcs12_cert', true);
 	hideInput('pkcs12_pass', true);
+	hideInput('pkcs12_intermediate', true);
 
 <?php if ($internal_ca_count): ?>
 	function internalca_change() {

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -222,12 +222,8 @@ if ($_POST['save']) {
 		}
 
 		if ($pconfig['method'] == "import") {
-			$reqdfields = explode(" ",
-				"descr cert key");
-			$reqdfieldsn = array(
-				gettext("Descriptive name"),
-				gettext("Certificate data"),
-				gettext("Key data"));
+			$reqdfields = array("descr");
+			$reqdfieldsn = array(gettext("Descriptive name"));
 			$pkcs12_data = '';
 			if (empty($_FILES['pkcs12_cert'])) {
 				if ($_POST['cert'] && (!strstr($_POST['cert'], "BEGIN CERTIFICATE") || !strstr($_POST['cert'], "END CERTIFICATE"))) {
@@ -238,8 +234,8 @@ if ($_POST['save']) {
 					$input_errors[] = gettext("The submitted private key does not match the submitted certificate data.");
 				}
 			} else {
-				$pkcs12_data = file_get_contents($_FILES['pkcs12_cert']['tmp_name']);
-				if (!openssl_pkcs12_read($pkcs12_data, $data, $_POST['pkcs12_pass'])) {
+				$pkcs12_file = file_get_contents($_FILES['pkcs12_cert']['tmp_name']);
+				if (!openssl_pkcs12_read($pkcs12_file, $pkcs12_data, $_POST['pkcs12_pass'])) {
 					$input_errors[] = gettext("The submitted password does not unlock the submitted PKCS #12 certificate.");
 				}
 			}
@@ -424,9 +420,9 @@ if ($_POST['save']) {
 				$old_err_level = error_reporting(0); /* otherwise openssl_ functions throw warnings directly to a page screwing menu tab */
 
 				if ($pconfig['method'] == "import") {
-					if ($pkcs12_data && openssl_pkcs12_read($pkcs12_data, $data, $pconfig['pkcs12_pass'])) {
-						$pconfig['cert'] = $data['cert'];
-						$pconfig['key'] = $data['pkey'];
+					if ($pkcs12_data) {
+						$pconfig['cert'] = $pkcs12_data['cert'];
+						$pconfig['key'] = $pkcs12_data['pkey'];
 					}
 					cert_import($cert, $pconfig['cert'], $pconfig['key']);
 				}
@@ -742,19 +738,19 @@ if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 
 	$section->addInput(new Form_Textarea(
 		'cert',
-		'*Certificate data',
+		'Certificate data',
 		$pconfig['cert']
 	))->setHelp('Paste a certificate in X.509 PEM format here.');
 
 	$section->addInput(new Form_Textarea(
 		'key',
-		'*Private key data',
+		'Private key data',
 		$pconfig['key']
 	))->setHelp('Paste a private key in X.509 PEM format here.');
 
 	$section->addInput(new Form_Input(
 		'pkcs12_cert',
-		'*PKCS #12 certificate',
+		'PKCS #12 certificate',
 		'file',
 		$pconfig['pkcs12_cert']
 	))->setHelp('Upload a PKCS #12 certificate store here.');

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -237,6 +237,8 @@ if ($_POST['save']) {
 					$input_errors[] = gettext("The submitted private key does not match the submitted certificate data.");
 				}
 			} else {
+				$reqdfields = array('descr');
+				$reqdfieldsn = array(gettext("Descriptive name"));
 				if (!empty($_FILES['pkcs12_cert']) && is_uploaded_file($_FILES['pkcs12_cert']['tmp_name'])) {
 					$pkcs12_file = file_get_contents($_FILES['pkcs12_cert']['tmp_name']);
 					if (!openssl_pkcs12_read($pkcs12_file, $pkcs12_data, $_POST['pkcs12_pass'])) {
@@ -430,7 +432,7 @@ if ($_POST['save']) {
 					if ($pkcs12_data) {
 						$pconfig['cert'] = $pkcs12_data['cert'];
 						$pconfig['key'] = $pkcs12_data['pkey'];
-						if ($_POST['pkcs_intermediate'] && is_array($pkcs12_data['extracerts'])) {
+						if ($_POST['pkcs12_intermediate'] && is_array($pkcs12_data['extracerts'])) {
 							foreach ($pkcs12_data['extracerts'] as $intermediate) {
 								$int_data = openssl_x509_parse($intermediate);
 								if (!$int_data) continue;
@@ -799,7 +801,7 @@ if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 	))->setHelp('Enter the password to unlock the PKCS #12 certificate store.');
 
 	$section->addInput(new Form_Checkbox(
-		'pkcs_intermediate',
+		'pkcs12_intermediate',
 		'Intermediates',
 		'Import intermediate CAs',
 		false

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -797,7 +797,7 @@ if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 	$section->addInput(new Form_Input(
 		'pkcs12_pass',
 		'PKCS #12 certificate password',
-		'password'
+		'password',
 		$pconfig['pkcs12_pass']
 	))->setHelp('Enter the password to unlock the PKCS #12 certificate store.');
 

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -798,6 +798,7 @@ if ($act == "new" || (($_POST['save'] == gettext("Save")) && $input_errors)) {
 		'pkcs12_pass',
 		'PKCS #12 certificate password',
 		'password'
+		$pconfig['pkcs12_pass']
 	))->setHelp('Enter the password to unlock the PKCS #12 certificate store.');
 
 	$section->addInput(new Form_Checkbox(
@@ -1444,18 +1445,27 @@ events.push(function() {
 	$('.import_type_toggle').click(function() {
 		var x509 = (this.value === 'x509');
 		hideInput('cert', !x509);
+		setRequired('cert', x509);
 		hideInput('key', !x509);
+		setRequired('key', x509);
 		hideInput('pkcs12_cert', x509);
+		setRequired('pkcs12_cert', !x509);
 		hideInput('pkcs12_pass', x509);
-		hideInput('pkcs12_intermediate', x509);
+		hideCheckbox('pkcs12_intermediate', x509);
 	});
 	if ($('input[name=import_type]:checked').val() == 'x509') {
 		hideInput('pkcs12_cert', true);
+		setRequired('pkcs12_cert', false);
 		hideInput('pkcs12_pass', true);
-		hideInput('pkcs12_intermediate', true);
+		hideCheckbox('pkcs12_intermediate', true);
+		setRequired('cert', true);
+		setRequired('key', true);
 	} else {
 		hideInput('cert', true);
+		setRequired('cert', false);
 		hideInput('key', true);
+		setRequired('key', false);
+		setRequired('pkcs12_cert', false);
 	}
 
 <?php if ($internal_ca_count): ?>

--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -438,8 +438,9 @@ if ($_POST['save']) {
 								if (!$int_data) continue;
 								$cn = $int_data['subject']['CN'];
 								$int_ca = array('descr' => $cn, 'refid' => uniqid());
-								ca_import($int_ca, $intermediate);
-								$a_ca[] = $int_ca;
+								if (ca_import($int_ca, $intermediate)) {
+									$a_ca[] = $int_ca;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/8645
- [x] Ready for review

Allows user to select a PKCS #12 certificate store to import a certificate. Optionally allows for import of bundled intermediate certificates. Tested with a couple of different certificates.