### PR TITLE
Fix handing of DNSimple API response

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -2005,10 +2005,12 @@
 					   Responds with HTTP 4xx on error.
 					   Returns JSON data as body */
 ;
-					if (preg_match("/\s200\sOK/i", $header)) {
+                                        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+					
+					if ($code == "200") {
 						$status = $status_intro . $success_str . gettext("IP Address Updated Successfully!");
 						$successful_update = true;
-					} else if (preg_match("/\s4\d\d\s/i", $header)) {
+					} else if (preg_match("/4\d\d/i", $code)) {
 						$arrbody = json_decode($data, true);
 						$message = $arrbody['message'] . ".";
 						if (isset($arrbody['errors']['content'])) {
@@ -2018,7 +2020,7 @@
 						}
 						$status = $status_intro . $error_str . $message;
 					} else {
-						$status = $status_intro . "(" . gettext("Unknown Response") . ")";
+						$status = $status_intro . "(" . gettext("Unknown Response") . ": " . $code .")";
 						log_error($status_intro . gettext("PAYLOAD:") . " " . $data);
 						$this->_debug($data);
 					}


### PR DESCRIPTION
It seems DNSimple started using HTTP/2, which broke the regex the dnsimple updater was using to check for success. I changed it to use the CURLINFO_HTTP_CODE instead.

I noticed several other providers are using the regex status match instead of HTTP_CODE, but I didn't touch those. I haven't written any PHP in 20 years, and I don't use those providers to test them. This change works for me for DNSimple now.

The HTTP/2 response the API was sending back (missing the "OK" the regex was looking for):

```
HTTP/2 200 \r\n
server: nginx
...
```

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9580
- [ ] Ready for review