### PR TITLE
Issue 9595

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1584,6 +1584,8 @@ function openvpn_resync_all($interface = "") {
 				if (trim(file_get_contents($fpath), " \t\n") != get_failover_interface($settings['interface'])) {
 					openvpn_resync('server', $settings);
 				}
+			} else {
+				openvpn_resync('server', $settings);
 			}
 		}
 	}
@@ -1595,6 +1597,8 @@ function openvpn_resync_all($interface = "") {
 				if (trim(file_get_contents($fpath), " \t\n") != get_failover_interface($settings['interface'])) {
 					openvpn_resync('client', $settings);
 				}
+			} else {
+				openvpn_resync('client', $settings);
 			}
 		}
 	}

--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1581,11 +1581,11 @@ function openvpn_resync_all($interface = "") {
 			$mode_id = "server" . $settings['vpnid'];
 			$fpath = "{$g['varetc_path']}/openvpn/{$mode_id}.interface";
 			$gw_group_change = FALSE;
-			$ip_change = ($interface === $settings['interface']);
-			if (file_exists($fpath)) {
+			$ip_change = ($interface === "") || ($interface === $settings['interface']);
+			if (!$ip_change && file_exists($fpath)) {
 				$gw_group_change = (trim(file_get_contents($fpath), " \t\n") != get_failover_interface($settings['interface']));
 			}
-			if ($interface === "" || $ip_change || $gw_group_change) {
+			if ($ip_change || $gw_group_change) {
 				openvpn_resync('server', $settings);
 			}
 		}
@@ -1595,11 +1595,11 @@ function openvpn_resync_all($interface = "") {
 			$mode_id = "client" . $settings['vpnid'];
 			$fpath = "{$g['varetc_path']}/openvpn/{$mode_id}.interface";
 			$gw_group_change = FALSE;
-			$ip_change = ($interface === $settings['interface']);
-			if (file_exists($fpath)) {
+			$ip_change = ($interface === "") || ($interface === $settings['interface']);
+			if (!$ip_change && file_exists($fpath)) {
 				$gw_group_change = (trim(file_get_contents($fpath), " \t\n") != get_failover_interface($settings['interface']));
 			}
-			if ($interface === "" || $ip_change || $gw_group_change) {
+			if ($ip_change || $gw_group_change) {
 				openvpn_resync('client', $settings);
 			}
 		}

--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1575,16 +1575,17 @@ function openvpn_resync_all($interface = "") {
 		log_error(gettext("Resyncing OpenVPN instances."));
 	}
 
-	// Check if OpenVPN clients and servers are running on the correct interfaces.
+	// Check if OpenVPN clients and servers require a resync.
 	if (is_array($config['openvpn']['openvpn-server'])) {
 		foreach ($config['openvpn']['openvpn-server'] as & $settings) {
 			$mode_id = "server" . $settings['vpnid'];
 			$fpath = "{$g['varetc_path']}/openvpn/{$mode_id}.interface";
+			$gw_group_change = FALSE;
+			$ip_change = ($interface === $settings['interface']);
 			if (file_exists($fpath)) {
-				if (trim(file_get_contents($fpath), " \t\n") != get_failover_interface($settings['interface'])) {
-					openvpn_resync('server', $settings);
-				}
-			} else {
+				$gw_group_change = (trim(file_get_contents($fpath), " \t\n") != get_failover_interface($settings['interface']));
+			}
+			if ($interface === "" || $ip_change || $gw_group_change) {
 				openvpn_resync('server', $settings);
 			}
 		}
@@ -1593,11 +1594,12 @@ function openvpn_resync_all($interface = "") {
 		foreach ($config['openvpn']['openvpn-client'] as & $settings) {
 			$mode_id = "client" . $settings['vpnid'];
 			$fpath = "{$g['varetc_path']}/openvpn/{$mode_id}.interface";
+			$gw_group_change = FALSE;
+			$ip_change = ($interface === $settings['interface']);
 			if (file_exists($fpath)) {
-				if (trim(file_get_contents($fpath), " \t\n") != get_failover_interface($settings['interface'])) {
-					openvpn_resync('client', $settings);
-				}
-			} else {
+				$gw_group_change = (trim(file_get_contents($fpath), " \t\n") != get_failover_interface($settings['interface']));
+			}
+			if ($interface === "" || $ip_change || $gw_group_change) {
 				openvpn_resync('client', $settings);
 			}
 		}

--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1575,21 +1575,27 @@ function openvpn_resync_all($interface = "") {
 		log_error(gettext("Resyncing OpenVPN instances."));
 	}
 
+	// Check if OpenVPN clients and servers are running on the correct interfaces.
 	if (is_array($config['openvpn']['openvpn-server'])) {
 		foreach ($config['openvpn']['openvpn-server'] as & $settings) {
-			if ($interface <> "" && $interface != $settings['interface']) {
-				continue;
+			$mode_id = "server" . $settings['vpnid'];
+			$fpath = "{$g['varetc_path']}/openvpn/{$mode_id}.interface";
+			if (file_exists($fpath)) {
+				if (trim(file_get_contents($fpath), " \t\n") != get_failover_interface($settings['interface'])) {
+					openvpn_resync('server', $settings);
+				}
 			}
-			openvpn_resync('server', $settings);
 		}
 	}
-
 	if (is_array($config['openvpn']['openvpn-client'])) {
 		foreach ($config['openvpn']['openvpn-client'] as & $settings) {
-			if ($interface <> "" && $interface != $settings['interface']) {
-				continue;
+			$mode_id = "client" . $settings['vpnid'];
+			$fpath = "{$g['varetc_path']}/openvpn/{$mode_id}.interface";
+			if (file_exists($fpath)) {
+				if (trim(file_get_contents($fpath), " \t\n") != get_failover_interface($settings['interface'])) {
+					openvpn_resync('client', $settings);
+				}
 			}
-			openvpn_resync('client', $settings);
 		}
 	}
 


### PR DESCRIPTION
# OpenVPN Gateway Group Fix

Implementation now checks if OpenVPN client/server running on gateway group should resync when IP changes occur or if cables are unplugged/replugged.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9595
- [x] Ready for review

## Replication Steps

### VirtualBox
1. Use VirtualBox with 3 NAT adapters (WAN1, WAN2, and a monitoring link).
2. Set up a gateway group with WAN1 (T1) and WAN2 (T2).
3. Define ovpn client on gwgroup interface.
4. Alternate adapters within virtualbox between "NAT" and "Not Attached", one will notice that OpenVPN never resyncs to WAN1 when interface comes back online.

### Physical Device
1. Set up gateway group with 2 interfaces on differing tiers.
2. Unplug WAN1 cable, openvpn resyncs to WAN2.
3. Replug WAN1 cable, openvpn hugs WAN2 still.

## Fix Information
Fix brings the codebase more in line with the currrent implementation defined in [rc.openvpn](https://github.com/pfsense/pfsense/blob/48fee584e6c2cf7cb1d0821dd45288da2fd8e126/src/etc/rc.openvpn) which accounts for situations where OpenVPN instances run on gateway groups.