### PR TITLE
Keep "Show all configured leases" enabled after deleting DHCP leases.

### DIFF
--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -253,7 +253,7 @@ foreach ($leases['lease'] as $data):
 <?php endif; ?>
 
 <?php if ($data['type'] == $dynamic_string && $data['online'] != $online_string):?>
-						<a class="fa fa-trash" title="<?=gettext('Delete lease')?>"	href="status_dhcp_leases.php?deleteip=<?=htmlspecialchars($data['ip'])?>&amp;all=<?=intval($_POST['all'])?>" usepost></a>
+						<a class="fa fa-trash" title="<?=gettext('Delete lease')?>"	href="status_dhcp_leases.php?deleteip=<?=htmlspecialchars($data['ip'])?>&amp;all=<?=intval($_REQUEST['all'])?>" usepost></a>
 <?php endif; ?>
 					</td>
 				</tr>


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9133
- [x] Ready for review

all=1 not honoured after deleting an IPv4 DHCP lease. 

To reproduce:
Status -> DHCP Leases
Click "Show all configured leases"
Delete a DHCP lease

