### PR TITLE
Adding OMAPI functionality to the DHCP Server settings. 

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -566,11 +566,11 @@ EOD;
 	if (isset($dhcpifconf['omapi_port']) && is_numeric($dhcpifconf['omapi_port'])) {
 		$dhcpdconf .= <<<EOD
 
-omapi-port {$dhcpifconf['omapi_port']};
 key omapi_key {
-  algorithm hmac-md5;
+  algorithm {$dhcpifconf['omapi_key_algorithm']};
   secret "{$dhcpifconf['omapi_key']}";
 };
+omapi-port {$dhcpifconf['omapi_port']};
 omapi-key omapi_key;
 
 EOD;

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -562,6 +562,20 @@ EOD;
 		$dhcpdconf .= "always-broadcast on\n";
 	}
 
+	// OMAPI Settings
+	if (isset($dhcpifconf['omapi_port']) && is_numeric($dhcpifconf['omapi_port'])) {
+		$dhcpdconf .= <<<EOD
+
+omapi-port {$dhcpifconf['omapi_port']};
+key omapi_key {
+  algorithm HMAC-MD5;
+  secret "{$dhcpifconf['omapi_key']}";
+};
+omapi-key omapi_key;
+\n
+EOD;
+	}
+
 	$dhcpdifs = array();
 	$enable_add_routers = false;
 	$gateways_arr = return_gateways_array();

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -568,7 +568,7 @@ EOD;
 
 omapi-port {$dhcpifconf['omapi_port']};
 key omapi_key {
-  algorithm HMAC-MD5;
+  algorithm hmac-md5;
   secret "{$dhcpifconf['omapi_key']}";
 };
 omapi-key omapi_key;

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -572,7 +572,7 @@ key omapi_key {
   secret "{$dhcpifconf['omapi_key']}";
 };
 omapi-key omapi_key;
-\n
+
 EOD;
 	}
 

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1136,12 +1136,9 @@ function is_port($port) {
 
 /* returns true if $port is in use */
 function is_port_in_use($port, $proto = "tcp", $ip_version = 4) {
-	exec("/usr/bin/netstat -an{$ip_version}p {$proto} | /usr/bin/awk '{print $4}' | /usr/bin/egrep -o '*([0-9]{1,5})$' | /usr/bin/sort -u", $port_info);
+	exec("/usr/bin/netstat -an " . escapeshellarg('-' . $ip_version) . " -p " . escapeshellarg($proto) . " | /usr/bin/awk '{print $4}' | /usr/bin/egrep -o '*([0-9]{1,5})$' | /usr/bin/sort -u", $port_info);
 	
-	if (in_array($port, $port_info)) {
-		return true;
-	}
-	return false;
+	return in_array($port, $port_info);
 }
 
 /* returns true if $portrange is a valid TCP/UDP portrange ("<port>:<port>") */

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1134,6 +1134,16 @@ function is_port($port) {
 	return false;
 }
 
+/* returns true if $port is in use */
+function is_port_in_use($port, $proto = "tcp", $ip_version = 4) {
+	exec("/usr/bin/netstat -an{$ip_version}p {$proto} | /usr/bin/awk '{print $4}' | /usr/bin/egrep -o '*([0-9]{1,5})$' | /usr/bin/sort -u", $port_info);
+	
+	if (in_array($port, $port_info)) {
+		return true;
+	}
+	return false;
+}
+
 /* returns true if $portrange is a valid TCP/UDP portrange ("<port>:<port>") */
 function is_portrange($portrange) {
 	$ports = explode(":", $portrange);

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1136,7 +1136,16 @@ function is_port($port) {
 
 /* returns true if $port is in use */
 function is_port_in_use($port, $proto = "tcp", $ip_version = 4) {
-	exec("/usr/bin/netstat -an " . escapeshellarg('-' . $ip_version) . " -p " . escapeshellarg($proto) . " | /usr/bin/awk '{print $4}' | /usr/bin/egrep -o '*([0-9]{1,5})$' | /usr/bin/sort -u", $port_info);
+	$port_info = array();
+	exec("/usr/bin/netstat --libxo json -an " . escapeshellarg('-' . $ip_version) . " -p " . escapeshellarg($proto), $rawdata, $rc);
+	if ($rc == 0) {
+		$netstatarr = json_decode(implode(" ", $rawdata), JSON_OBJECT_AS_ARRAY);
+		$netstatarr = $netstatarr['statistics']['socket'];
+		
+		foreach($netstatarr as $index => $portstats){
+			array_push($port_info, $portstats['local']['port']);
+		}
+	}
 	
 	return in_array($port, $port_info);
 }

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -267,19 +267,23 @@ if (isset($_POST['save'])) {
 				$input_errors[] = gettext("OMAPI key must be at least 256 bits.");
 			}
 		} elseif($_POST['omapi_gen_key'] == "yes") {
-			//Build the command to generate and capture the key
-			$cmd = "/usr/local/sbin/dnssec-keygen -r /dev/urandom -a HMAC-MD5 -b 512 -n HOST omapi_key; "; //Generate the key
-			$cmd .= "/bin/cat Komapi_key.+*.private | /usr/bin/grep ^Key | /usr/bin/cut -d ' ' -f2-; "; //Capture the key
-			$cmd .= "/bin/rm -f Komapi_key*"; //Cleanup key files
+		    // Set the output directory
+            $output_dir = "/tmp/dnssec-keygen";
 
-			//Execute the command
+			// Build the command to generate and capture the key
+            $cmd = "/bin/mkdir {$output_dir}; "; // Create output directory
+            $cmd .= "/usr/local/sbin/dnssec-keygen -r /dev/urandom -K {$output_dir} -a HMAC-MD5 -b 512 -n HOST omapi_key; "; // Generate the key
+			$cmd .= "/bin/cat {$output_dir}/Komapi_key.+*.private | /usr/bin/grep ^Key | /usr/bin/cut -d ' ' -f2-; "; // Capture the key
+			$cmd .= "/bin/rm -Rf {$output_dir}"; // Cleanup key files
+
+			// Execute the command
 			exec($cmd, $cmd_output);
 
-			//Set the key
+			// Set the key
 			$_POST['omapi_key'] = $cmd_output[1];
 			$pconfig['omapi_key'] = $cmd_output[1];
 
-			//Uncheck the generate box
+			// Uncheck the generate box
 			unset($_POST['omapi_gen_key']);
 			unset($pconfig['omapi_gen_key']);
 		} else {

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -264,32 +264,26 @@ if (isset($_POST['save'])) {
 
 		// Generate a key if checked
 		if ($_POST['omapi_gen_key'] == "yes") {
-			// Check to see if the utility is installed
-			$cmd = "/usr/bin/which ddns-confgen";
+			// Set some vars
+			$key_bit_len = 256;
+			$key_bytes_len = $key_bit_len / 8; // 8 bits = 1 Byte
 
-			// Execute the command
-			$cmd_output = exec_command($cmd);
+			// Generate random bytes based on key length
+			$ran_bytes = openssl_random_pseudo_bytes($key_bytes_len);
 
-			if (strstr($cmd_output, "ddns-confgen")) {
-				// Generate and capture the key
-				$cmd = "/usr/local/sbin/ddns-confgen -a HMAC-MD5 -k omapi_key -q | /usr/bin/grep secret | /usr/bin/cut -d'\"' -f2;";
+			// Encode the bytes to get the key string
+			$key_str = base64_encode($ran_bytes);
 
-				// Execute the command
-				$cmd_output = exec_command($cmd);
-
-				// Set the key
-				$_POST['omapi_key'] = $cmd_output;
-				$pconfig['omapi_key'] = $cmd_output;
-			} else {
-				$input_errors[] = gettext("Key generation utility not found. Please go to System -> Package Manager and install the bind package.");
-			}
+			// Set the key
+			$_POST['omapi_key'] = $key_str;
+			$pconfig['omapi_key'] = $key_str;
 
 			// Uncheck the generate box
 			unset($_POST['omapi_gen_key']);
 			unset($pconfig['omapi_gen_key']);
 		} elseif (!empty($_POST['omapi_key'])) { // Check the key if it's not being generated
-			if (strlen($_POST['omapi_key']) >= 25) {
-				$input_errors[] = gettext("Please specify a valid OMAPI key. Key must use HMAC-MD5 and be a minimum length of 128bit.");
+			if (strlen($_POST['omapi_key']) < 44) {
+				$input_errors[] = gettext("Please specify a valid OMAPI key. Key must use HMAC-MD5 and be a minimum length of 256 bits.");
 			}
 		} else {
 			$input_errors[] = gettext("A key is required when OMAPI is enabled (port specified).");
@@ -1091,7 +1085,7 @@ $section->addInput(new Form_Input(
 	'OMAPI Port',
 	'text',
 	$pconfig['omapi_port']
-))->setHelp('Set the port that OMAPI will listen on. The default port is 7911, leave blank to disable.');
+))->setAttribute('placeholder', 'OMAPI Port')->setHelp('Set the port that OMAPI will listen on. The default port is 7911, leave blank to disable.');
 
 $group = new Form_Group('OMAPI Key');
 
@@ -1100,14 +1094,14 @@ $group->add(new Form_Input(
 	'OMAPI Key',
 	'text',
 	$pconfig['omapi_key']
-))->setHelp('Set the key used to secure the connection to the OMAPI endpoint. The minimum HMAC-MD5 key length is 128 bits.');
+))->setAttribute('placeholder', 'OMAPI Key')->setHelp('Set the key used to secure the connection to the OMAPI endpoint. The minimum HMAC-MD5 key length is 256 bits.');
 
 $group->add(new Form_Checkbox(
 	'omapi_gen_key',
 	'',
 	'Generate New Key',
 	$pconfig['omapi_gen_key']
-))->setHelp('Key Bits: 128<br />Algorithm: HMAC-MD5');
+))->setHelp('Key Bits: 256<br />Algorithm: HMAC-MD5');
 
 $section->add($group);
 

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -251,13 +251,13 @@ if (isset($_POST['save'])) {
 	 */
 	if (!empty($_POST['omapi_port'])) {
 		// Check the port entry
-		if (is_port($_POST['omapi_port']) &&
-			($_POST['omapi_port'] > 1024) &&
-			is_port_in_use($_POST['omapi_port']) &&
-			($_POST['omapi_port'] != $dhcpdconf['omapi_port'])) {
+		switch(true){
+			case !is_port($_POST['omapi_port']) || $_POST['omapi_port'] <= 1024:
+				$input_errors[] = gettext("The specified OMAPI port number is invalid. Port number must be between 1024 and 65635.");
+				break;
+			case is_port_in_use($_POST['omapi_port']) && $_POST['omapi_port'] != $dhcpdconf['omapi_port']:
 				$input_errors[] = gettext("Specified port number for OMAPI is in use. Please choose another port or consider using the default.");
-		} else {
-			$input_errors[] = gettext("The specified OMAPI port number is invalid. Port number must be between 1024 and 65635.");
+				break;
 		}
 
 		// Define the minimum base64 character length for each algorithm

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -267,12 +267,12 @@ if (isset($_POST['save'])) {
 				$input_errors[] = gettext("OMAPI key must be at least 256 bits.");
 			}
 		} elseif($_POST['omapi_gen_key'] == "yes") {
-		    // Set the output directory
-            $output_dir = "/tmp/dnssec-keygen";
+			// Set the output directory
+			$output_dir = "/tmp/dnssec-keygen";
 
 			// Build the command to generate and capture the key
-            $cmd = "/bin/mkdir {$output_dir}; "; // Create output directory
-            $cmd .= "/usr/local/sbin/dnssec-keygen -r /dev/urandom -K {$output_dir} -a HMAC-MD5 -b 512 -n HOST omapi_key; "; // Generate the key
+			$cmd = "/bin/mkdir {$output_dir}; "; // Create output directory
+			$cmd .= "/usr/local/sbin/dnssec-keygen -r /dev/urandom -K {$output_dir} -a HMAC-MD5 -b 512 -n HOST omapi_key; "; // Generate the key
 			$cmd .= "/bin/cat {$output_dir}/Komapi_key.+*.private | /usr/bin/grep ^Key | /usr/bin/cut -d ' ' -f2-; "; // Capture the key
 			$cmd .= "/bin/rm -Rf {$output_dir}"; // Cleanup key files
 

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -252,11 +252,8 @@ if (isset($_POST['save'])) {
 	if (!empty($_POST['omapi_port'])) {
 		// Check the port entry
 		if (is_port($_POST['omapi_port']) && $_POST['omapi_port'] > 1024) {
-			// Get the list of open or listening ports locally
-			exec("/usr/bin/netstat -an4p tcp | /usr/bin/awk '{print $4}' | /usr/bin/egrep -o '*([0-9]{1,5})$' | /usr/bin/sort -u", $port_info);
-
-			// Check to see if the port is in the list
-			if (in_array($_POST['omapi_port'], $port_info) && $_POST['omapi_port'] != $dhcpdconf['omapi_port']){
+		    // Check to see if the port is in the list
+			if (is_port_in_use($_POST['omapi_port']) && $_POST['omapi_port'] != $dhcpdconf['omapi_port']){
 				$input_errors[] = gettext("Specified port number for OMAPI is in use. Please choose another port or consider using the default.");
 			}
 		} else {
@@ -731,8 +728,7 @@ if (isset($_POST['save'])) {
 			$dhcpdconf['omapi_key'] = $_POST['omapi_key'];
 			$dhcpdconf['omapi_key_algorithm'] = $_POST['omapi_key_algorithm'];
 		}
-
-
+  
 		write_config(gettext("DHCP Server - Settings changed for interface " . strtoupper($if)));
 	}
 }

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -251,11 +251,11 @@ if (isset($_POST['save'])) {
 	 */
 	if (!empty($_POST['omapi_port'])) {
 		// Check the port entry
-		if (is_port($_POST['omapi_port']) && $_POST['omapi_port'] > 1024) {
-		    // Check to see if the port is in the list
-			if (is_port_in_use($_POST['omapi_port']) && $_POST['omapi_port'] != $dhcpdconf['omapi_port']){
+		if (is_port($_POST['omapi_port']) &&
+			($_POST['omapi_port'] > 1024) &&
+			is_port_in_use($_POST['omapi_port']) &&
+			($_POST['omapi_port'] != $dhcpdconf['omapi_port'])) {
 				$input_errors[] = gettext("Specified port number for OMAPI is in use. Please choose another port or consider using the default.");
-			}
 		} else {
 			$input_errors[] = gettext("The specified OMAPI port number is invalid. Port number must be between 1024 and 65635.");
 		}


### PR DESCRIPTION
Supports setting a port and defining or generating a key. Service is enabled when settings are defined. Validation logic added on saving to verify the port is valid and not in use as well as that a key is defined or being generated. If validation fails, the user is presented with a descriptive error message.

Feature#7304

Also updated the write_settings call on the DHCP server page. No arguments were being passed so changes came up as unknown on the config history screen. Config history will now reflect the UI section and interface where change was made.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/7304
- [x] Ready for review