### PR TITLE
System Notifications: Asterisks was over writing current password causing notifications to stop working.

### DIFF
--- a/src/usr/local/www/system_advanced_notifications.php
+++ b/src/usr/local/www/system_advanced_notifications.php
@@ -95,7 +95,7 @@ if ($_POST) {
 		$config['notifications']['smtp']['notifyemailaddress'] = $_POST['smtpnotifyemailaddress'];
 		$config['notifications']['smtp']['username'] = $_POST['smtpusername'];
 
-		if ($_POST['smtppassword'] != DMYPWD) {
+		if (strcmp($_POST['smtppassword'], DMYPWD)!= 0) {
 			if ($_POST['smtppassword'] == $_POST['smtppassword_confirm']) {
 				$config['notifications']['smtp']['password'] = $_POST['smtppassword'];
 			} else {


### PR DESCRIPTION
Was failing the check if clicking test notifications twice in a row. It was saving the asterisks and overwriting the current password.

- [x] Ready for review
- [x] https://redmine.pfsense.org/issues/9684