### PR TITLE
Fixes #9362: Cloudflare DDNS with proxy enabled doesn't work at all

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1960,6 +1960,7 @@ function services_dyndns_configure($int = "") {
 				$dyndns['verboselog'] = isset($dyndns['verboselog']);
 				$dyndns['curl_ipresolve_v4'] = isset($dyndns['curl_ipresolve_v4']);
 				$dyndns['curl_ssl_verifypeer'] = isset($dyndns['curl_ssl_verifypeer']);
+				$dyndns['proxied'] = isset($dyndns['proxied']);
 				services_dyndns_configure_client($dyndns);
 				sleep(1);
 			}


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9362
- [x] Ready for review

The proxy value must be a boolean. Therefore we cannot pass the property directly from the *config* to *services_dyndns_configure_client*. If the property *proxied* is present in the config, we have to map it to true, otherwise to false.

Code was tested manually for Cloudflare.