### PR TITLE
prefer-ip6 option added to advanced resolver options

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -315,6 +315,7 @@ EOF;
 	$prefetch = isset($unboundcfg['prefetch']) ? "yes" : "no";
 	$prefetch_key = isset($unboundcfg['prefetchkey']) ? "yes" : "no";
 	$dns_record_cache = isset($unboundcfg['dnsrecordcache']) ? "yes" : "no";
+	$prefer_ip6 = isset($unboundcfg['preferip6']) ? "yes" : "no";
 	$outgoing_num_tcp = isset($unboundcfg['outgoing_num_tcp']) ? $unboundcfg['outgoing_num_tcp'] : "10";
 	$incoming_num_tcp = isset($unboundcfg['incoming_num_tcp']) ? $unboundcfg['incoming_num_tcp'] : "10";
 	$edns_buffer_size = (!empty($unboundcfg['edns_buffer_size'])) ? $unboundcfg['edns_buffer_size'] : "4096";
@@ -447,6 +448,7 @@ hide-version: {$hide_version}
 harden-glue: yes
 do-ip4: yes
 do-ip6: {$ipv6_allow}
+prefer-ip6: {$prefer_ip6}
 do-udp: yes
 do-tcp: yes
 do-daemonize: yes

--- a/src/usr/local/www/services_unbound_advanced.php
+++ b/src/usr/local/www/services_unbound_advanced.php
@@ -68,6 +68,10 @@ if (isset($config['unbound']['dnsrecordcache'])) {
 	$pconfig['dnsrecordcache'] = true;
 }
 
+if (isset($config['unbound']['preferip6'])) {
+	$pconfig['preferip6'] = true;
+}
+
 $pconfig['msgcachesize'] = $config['unbound']['msgcachesize'];
 $pconfig['outgoing_num_tcp'] = isset($config['unbound']['outgoing_num_tcp']) ? $config['unbound']['outgoing_num_tcp'] : '10';
 $pconfig['incoming_num_tcp'] = isset($config['unbound']['incoming_num_tcp']) ? $config['unbound']['incoming_num_tcp'] : '10';
@@ -185,6 +189,11 @@ if ($_POST) {
 			} else {
 				unset($config['unbound']['dnsrecordcache']);
 			}
+			if (isset($_POST['preferip6'])) {
+				$config['unbound']['preferip6'] = true;
+			} else {
+				unset($config['unbound']['preferip6']);
+			}
 			$config['unbound']['msgcachesize'] = $_POST['msgcachesize'];
 			$config['unbound']['outgoing_num_tcp'] = $_POST['outgoing_num_tcp'];
 			$config['unbound']['incoming_num_tcp'] = $_POST['incoming_num_tcp'];
@@ -281,6 +290,13 @@ $section->addInput(new Form_Checkbox(
 $form->add($section);
 
 $section = new Form_Section('Advanced Resolver Options');
+
+$section->addInput(new Form_Checkbox(
+	'preferip6',
+	'Prefer IPv6',
+	'Prefer IPv6 transport for sending DNS queries to internet nameservers',
+	$pconfig['preferip6']
+))->setHelp('Causes IPv6 transport to be preferred for sending queries, if IPv6 nameserver targets are available.');
 
 $section->addInput(new Form_Checkbox(
 	'prefetch',


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9797
- [x] Ready for review

from man unbound.conf(5):

```
prefer-ip6: <yes or no>
              If enabled, prefer IPv6 transport for sending DNS queries to internet nameservers. Default is no.
```
this patch will add option to Advanced Resolver Options page