### PR TITLE
auto-remove empty zombie fw aliases

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -492,9 +492,7 @@ function filter_configure_sync($delete_states_if_needed = true) {
 	// get aliases names from pfctl -sT
 	exec("/sbin/pfctl -sT", $pftables);
 	// compare config and pfctl aliases
-	$diff = array_diff($pftables, $aliasesnames);
-	// don't delete special aliases
-	$diff = array_diff($diff, $reserved_table_names);
+	$diff = array_diff($pftables, $aliasesnames, $reserved_table_names);
 	// delete unused aliases
 	foreach ($diff as $alias) {
 		$_grbg = exec("/sbin/pfctl -t " . escapeshellarg($alias) . " -T kill 2>/dev/null");

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -256,6 +256,7 @@ function filter_configure_sync($delete_states_if_needed = true) {
 	}
 	update_filter_reload_status(gettext("Creating aliases"));
 	$aliases = filter_generate_aliases();
+
 	$gateways = filter_generate_gateways();
 	if (platform_booting() == true) {
 		echo ".";
@@ -481,6 +482,24 @@ function filter_configure_sync($delete_states_if_needed = true) {
 	# If we are not using bogonsv6 then we can remove any bogonsv6 table from the running pf (if the table is not there, the kill is still fine).
 	if (!is_bogonsv6_used()) {
 		$_grbg = exec("/sbin/pfctl -t bogonsv6 -T kill 2>/dev/null");
+	}
+	
+	// get aliases names from config
+	$aliasesnames = array();
+	foreach ($config['aliases']['alias'] as $alias) {
+		array_push($aliasesnames, $alias['name']);
+	}
+
+	// get aliases names from pfctl -sT
+	$pftables = explode("\n",shell_exec("/sbin/pfctl -sT"));
+	// compare config and pfctl aliases
+	$diff = array_diff($pftables, $aliasesnames);
+	// don't delete special aliases
+	$diff_exceptions = array('bogons','bogonsv6','snort2c','sshguard','negate_networks','tonatsubnets','virusprot','vpn_networks');
+	$diff = array_diff($diff, $diff_exceptions);
+	// delete unused aliases
+	foreach ($diff as $alias) {
+		$_grbg = exec("/sbin/pfctl -t " . $alias . " -T kill 2>/dev/null");
 	}
 
 	if (!platform_booting()) {
@@ -814,28 +833,6 @@ function filter_generate_aliases() {
 					$aliases .= "table <{$aliased['name']}> { {$addrlist} } \n";
 				}
 
-				$aliases .= "{$aliased['name']} = \"<{$aliased['name']}>\"\n";
-				break;
-			case "openvpn":
-				$openvpncfg = array();
-				if ($config['openvpn']['user']) {
-					/* XXX: Check if we have a correct ip? */
-					foreach ($config['openvpn']['user'] as $openvpn) {
-						$openvpncfg[$openvpn['name']] = $openvpn['ip'];
-					}
-				}
-				$vpn_lines = explode("\n", $addrlist);
-				foreach ($vpn_lines as $vpn_line) {
-					$vpn_address_split = explode(" ", $vpn_line);
-					foreach ($vpn_address_split as $vpnsplit) {
-						if (isset($openvpncfg[$vpnsplit])) {
-							$newaddress .= " ";
-							$newaddress .= $openvpn[$vpnsplit];
-							break;
-						}
-					}
-				}
-				$aliases .= "table <{$aliased['name']}> { {$newaddress} } \n";
 				$aliases .= "{$aliased['name']} = \"<{$aliased['name']}>\"\n";
 				break;
 			case "urltable":
@@ -1786,7 +1783,7 @@ function filter_nat_rules_generate_if ($if, $descr = "", $ipprotocol = "", $src 
 	if (!$if_friendly) {
 		return "# Could not convert {$if} to friendly name(alias) {$descr}\n";
 	}
-	
+
 	$inet = "";
 	if (is_v4($src) || is_v4($dst) || is_v4($natip)) {
 		$inet = "inet";
@@ -1804,7 +1801,7 @@ function filter_nat_rules_generate_if ($if, $descr = "", $ipprotocol = "", $src 
 	if (!empty($ipprotocol)) {
 		$inet = $ipprotocol; //if ipprotocol is set specifically to ipv4 or ipv6 then that has to be used
 	}
-	
+
 	/* Set tgt4 for IPv4 */
 	if ($inet == "" || $inet == 'inet') {
 		if ($natip != "") {
@@ -1853,7 +1850,7 @@ function filter_nat_rules_generate_if ($if, $descr = "", $ipprotocol = "", $src 
 	} else {
 		$protocol = "";
 	}
-	
+
 
 	$tgtport = "";
 	/* Add the hard set source port (useful for ISAKMP) */
@@ -1894,7 +1891,7 @@ function filter_nat_rules_generate_if ($if, $descr = "", $ipprotocol = "", $src 
 	if (!empty($descr)) {
 		$descr = " # " . $descr;
 	}
-	
+
 	if (empty($if_friendly) || empty($src) || empty($dst)) {
 		return "# validation of rule properties failed to verify the interface/source/destination" . " in nat rule: {$descr}\n";
 	}
@@ -1910,7 +1907,7 @@ function filter_nat_rules_generate_if ($if, $descr = "", $ipprotocol = "", $src 
 			} else {
 				$natrules .= "nat on \${$if_friendly} inet{$protocol} from {$src} to {$dst} -> {$tgt4}{$tgtport} {$poolopts}{$staticnatport_txt}{$descr}\n";
 			}
-		} 
+		}
 		if ($inet == "" || $inet == 'inet6') {
 			if (empty($tgt6)) {
 				$natrules .= "# validation of rule properties failed to verify the IPv6 target" . " in nat rule: {$descr}\n";
@@ -2788,10 +2785,11 @@ function filter_generate_user_rule($rule) {
 			$aline['interface'] = "";
 		}
 	} else if (!array_key_exists($rule['interface'], $FilterIflist)) {
-			foreach ($FilterIflist as $oc) {
-				$items .= $oc['descr'] . " ";
-			}
-			return "# array key \"{$rule['interface']}\" does not exist for \"" . $rule['descr'] . "\" in array: {{$items}}";
+		$items = "";
+		foreach ($FilterIflist as $oc) {
+			$items .= $oc['descr'] . " ";
+		}
+		return "# array key \"{$rule['interface']}\" does not exist for \"" . $rule['descr'] . "\" in array: {{$items}}";
 	} else if ((array_key_exists($rule['interface'], $FilterIflist)) &&
 	    (is_array($FilterIflist[$rule['interface']])) &&
 	    (is_array($FilterIflist[$rule['interface']][0]))) {
@@ -3278,7 +3276,7 @@ EOD;
 	if (isset($config['system']['ipv6allow'])) {
 		$ipfrules .= <<<EOD
 
-# IPv6 ICMP is not auxilary, it is required for operation
+# IPv6 ICMP is not auxiliary, it is required for operation
 # See man icmp6(4)
 # 1    unreach         Destination unreachable
 # 2    toobig          Packet too big

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -491,7 +491,7 @@ function filter_configure_sync($delete_states_if_needed = true) {
 	}
 	// get aliases names from pfctl -sT
 	exec("/sbin/pfctl -sT", $pftables);
-	// compare config and pfctl aliases
+	// compare config with pfctl aliases and reserved table names
 	$diff = array_diff($pftables, $aliasesnames, $reserved_table_names);
 	// delete unused aliases
 	foreach ($diff as $alias) {

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -256,7 +256,6 @@ function filter_configure_sync($delete_states_if_needed = true) {
 	}
 	update_filter_reload_status(gettext("Creating aliases"));
 	$aliases = filter_generate_aliases();
-
 	$gateways = filter_generate_gateways();
 	if (platform_booting() == true) {
 		echo ".";

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -5,7 +5,9 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2006 Peter Allgeyer
- * Copyright (c) 2008-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2008-2013 BSD Perimeter
+ * Copyright (c) 2013-2016 Electric Sheep Fencing
+ * Copyright (c) 2014-2019 Rubicon Communications, LLC (Netgate)
  * All rights reserved.
  *
  * originally part of m0n0wall (http://m0n0.ch/wall)
@@ -1257,7 +1259,7 @@ function filter_generate_optcfg_array() {
 		$FilterIflist['openvpn'] = $oic;
 	}
 	/* add interface groups */
-	if (is_array($config['ifgroups']['ifgroupentry'])) {
+	if (isset($config['ifgroups']['ifgroupentry']) && is_array($config['ifgroups']['ifgroupentry'])) {
 		foreach ($config['ifgroups']['ifgroupentry'] as $ifgen) {
 			$oc = array();
 			$oc['if'] = $ifgen['ifname'];
@@ -2240,10 +2242,6 @@ function filter_nat_rules_generate() {
 		}
 		unset($tonathosts, $tonathosts_array, $numberofnathosts);
 	}
-
-	/* load balancer anchor */
-	$natrules .= "\n# Load balancing anchor\n";
-	$natrules .= "rdr-anchor \"relayd/*\"\n";
 
 	update_filter_reload_status(gettext("Setting up TFTP helper"));
 	$natrules .= "# TFTP proxy\n";
@@ -3244,8 +3242,6 @@ function filter_rules_generate() {
 	$ipfrules = "";
 	$ipfrules .= discover_pkg_rules("pfearly");
 
-	/* relayd */
-	$ipfrules .= "anchor \"relayd/*\"\n";
 	/* OpenVPN user rules from radius */
 	$ipfrules .= "anchor \"openvpn/*\"\n";
 	/* IPsec user rules from radius */
@@ -3506,7 +3502,7 @@ EOD;
 		$tracker = $saved_tracker;
 
 		$isbridged = false;
-		if (is_array($config['bridges']['bridged'])) {
+		if (isset($config['bridges']['bridged']) && is_array($config['bridges']['bridged'])) {
 			foreach ($config['bridges']['bridged'] as $oc2) {
 				if (stristr($oc2['members'], $on)) {
 					$isbridged = true;

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -483,21 +483,21 @@ function filter_configure_sync($delete_states_if_needed = true) {
 		$_grbg = exec("/sbin/pfctl -t bogonsv6 -T kill 2>/dev/null");
 	}
 
+	global $reserved_table_names;
 	// get aliases names from config
 	$aliasesnames = array();
 	foreach ($config['aliases']['alias'] as $alias) {
 		array_push($aliasesnames, $alias['name']);
 	}
 	// get aliases names from pfctl -sT
-	$pftables = explode("\n",shell_exec("/sbin/pfctl -sT"));
+	exec("/sbin/pfctl -sT", $pftables);
 	// compare config and pfctl aliases
 	$diff = array_diff($pftables, $aliasesnames);
 	// don't delete special aliases
-	$diff_exceptions = array('bogons','bogonsv6','snort2c','sshguard','negate_networks','tonatsubnets','virusprot','vpn_networks');
-	$diff = array_diff($diff, $diff_exceptions);
+	$diff = array_diff($diff, $reserved_table_names);
 	// delete unused aliases
 	foreach ($diff as $alias) {
-		$_grbg = exec("/sbin/pfctl -t " . $alias . " -T kill 2>/dev/null");
+		$_grbg = exec("/sbin/pfctl -t " . escapeshellarg($alias) . " -T kill 2>/dev/null");
 	}
 
 	if (!platform_booting()) {

--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -5,9 +5,7 @@
  * part of pfSense (https://www.pfsense.org)
  * Copyright (c) 2005 Bill Marquette
  * Copyright (c) 2006 Peter Allgeyer
- * Copyright (c) 2008-2013 BSD Perimeter
- * Copyright (c) 2013-2016 Electric Sheep Fencing
- * Copyright (c) 2014-2019 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2008-2019 Rubicon Communications, LLC (Netgate)
  * All rights reserved.
  *
  * originally part of m0n0wall (http://m0n0.ch/wall)
@@ -482,13 +480,12 @@ function filter_configure_sync($delete_states_if_needed = true) {
 	if (!is_bogonsv6_used()) {
 		$_grbg = exec("/sbin/pfctl -t bogonsv6 -T kill 2>/dev/null");
 	}
-	
+
 	// get aliases names from config
 	$aliasesnames = array();
 	foreach ($config['aliases']['alias'] as $alias) {
 		array_push($aliasesnames, $alias['name']);
 	}
-
 	// get aliases names from pfctl -sT
 	$pftables = explode("\n",shell_exec("/sbin/pfctl -sT"));
 	// compare config and pfctl aliases
@@ -832,6 +829,28 @@ function filter_generate_aliases() {
 					$aliases .= "table <{$aliased['name']}> { {$addrlist} } \n";
 				}
 
+				$aliases .= "{$aliased['name']} = \"<{$aliased['name']}>\"\n";
+				break;
+			case "openvpn":
+				$openvpncfg = array();
+				if ($config['openvpn']['user']) {
+					/* XXX: Check if we have a correct ip? */
+					foreach ($config['openvpn']['user'] as $openvpn) {
+						$openvpncfg[$openvpn['name']] = $openvpn['ip'];
+					}
+				}
+				$vpn_lines = explode("\n", $addrlist);
+				foreach ($vpn_lines as $vpn_line) {
+					$vpn_address_split = explode(" ", $vpn_line);
+					foreach ($vpn_address_split as $vpnsplit) {
+						if (isset($openvpncfg[$vpnsplit])) {
+							$newaddress .= " ";
+							$newaddress .= $openvpn[$vpnsplit];
+							break;
+						}
+					}
+				}
+				$aliases .= "table <{$aliased['name']}> { {$newaddress} } \n";
 				$aliases .= "{$aliased['name']} = \"<{$aliased['name']}>\"\n";
 				break;
 			case "urltable":
@@ -1238,7 +1257,7 @@ function filter_generate_optcfg_array() {
 		$FilterIflist['openvpn'] = $oic;
 	}
 	/* add interface groups */
-	if (isset($config['ifgroups']['ifgroupentry']) && is_array($config['ifgroups']['ifgroupentry'])) {
+	if (is_array($config['ifgroups']['ifgroupentry'])) {
 		foreach ($config['ifgroups']['ifgroupentry'] as $ifgen) {
 			$oc = array();
 			$oc['if'] = $ifgen['ifname'];
@@ -1782,7 +1801,7 @@ function filter_nat_rules_generate_if ($if, $descr = "", $ipprotocol = "", $src 
 	if (!$if_friendly) {
 		return "# Could not convert {$if} to friendly name(alias) {$descr}\n";
 	}
-
+	
 	$inet = "";
 	if (is_v4($src) || is_v4($dst) || is_v4($natip)) {
 		$inet = "inet";
@@ -1800,7 +1819,7 @@ function filter_nat_rules_generate_if ($if, $descr = "", $ipprotocol = "", $src 
 	if (!empty($ipprotocol)) {
 		$inet = $ipprotocol; //if ipprotocol is set specifically to ipv4 or ipv6 then that has to be used
 	}
-
+	
 	/* Set tgt4 for IPv4 */
 	if ($inet == "" || $inet == 'inet') {
 		if ($natip != "") {
@@ -1849,7 +1868,7 @@ function filter_nat_rules_generate_if ($if, $descr = "", $ipprotocol = "", $src 
 	} else {
 		$protocol = "";
 	}
-
+	
 
 	$tgtport = "";
 	/* Add the hard set source port (useful for ISAKMP) */
@@ -1890,7 +1909,7 @@ function filter_nat_rules_generate_if ($if, $descr = "", $ipprotocol = "", $src 
 	if (!empty($descr)) {
 		$descr = " # " . $descr;
 	}
-
+	
 	if (empty($if_friendly) || empty($src) || empty($dst)) {
 		return "# validation of rule properties failed to verify the interface/source/destination" . " in nat rule: {$descr}\n";
 	}
@@ -1906,7 +1925,7 @@ function filter_nat_rules_generate_if ($if, $descr = "", $ipprotocol = "", $src 
 			} else {
 				$natrules .= "nat on \${$if_friendly} inet{$protocol} from {$src} to {$dst} -> {$tgt4}{$tgtport} {$poolopts}{$staticnatport_txt}{$descr}\n";
 			}
-		}
+		} 
 		if ($inet == "" || $inet == 'inet6') {
 			if (empty($tgt6)) {
 				$natrules .= "# validation of rule properties failed to verify the IPv6 target" . " in nat rule: {$descr}\n";
@@ -2221,6 +2240,10 @@ function filter_nat_rules_generate() {
 		}
 		unset($tonathosts, $tonathosts_array, $numberofnathosts);
 	}
+
+	/* load balancer anchor */
+	$natrules .= "\n# Load balancing anchor\n";
+	$natrules .= "rdr-anchor \"relayd/*\"\n";
 
 	update_filter_reload_status(gettext("Setting up TFTP helper"));
 	$natrules .= "# TFTP proxy\n";
@@ -2784,11 +2807,10 @@ function filter_generate_user_rule($rule) {
 			$aline['interface'] = "";
 		}
 	} else if (!array_key_exists($rule['interface'], $FilterIflist)) {
-		$items = "";
-		foreach ($FilterIflist as $oc) {
-			$items .= $oc['descr'] . " ";
-		}
-		return "# array key \"{$rule['interface']}\" does not exist for \"" . $rule['descr'] . "\" in array: {{$items}}";
+			foreach ($FilterIflist as $oc) {
+				$items .= $oc['descr'] . " ";
+			}
+			return "# array key \"{$rule['interface']}\" does not exist for \"" . $rule['descr'] . "\" in array: {{$items}}";
 	} else if ((array_key_exists($rule['interface'], $FilterIflist)) &&
 	    (is_array($FilterIflist[$rule['interface']])) &&
 	    (is_array($FilterIflist[$rule['interface']][0]))) {
@@ -3222,6 +3244,8 @@ function filter_rules_generate() {
 	$ipfrules = "";
 	$ipfrules .= discover_pkg_rules("pfearly");
 
+	/* relayd */
+	$ipfrules .= "anchor \"relayd/*\"\n";
 	/* OpenVPN user rules from radius */
 	$ipfrules .= "anchor \"openvpn/*\"\n";
 	/* IPsec user rules from radius */
@@ -3275,7 +3299,7 @@ EOD;
 	if (isset($config['system']['ipv6allow'])) {
 		$ipfrules .= <<<EOD
 
-# IPv6 ICMP is not auxiliary, it is required for operation
+# IPv6 ICMP is not auxilary, it is required for operation
 # See man icmp6(4)
 # 1    unreach         Destination unreachable
 # 2    toobig          Packet too big
@@ -3482,7 +3506,7 @@ EOD;
 		$tracker = $saved_tracker;
 
 		$isbridged = false;
-		if (isset($config['bridges']['bridged']) && is_array($config['bridges']['bridged'])) {
+		if (is_array($config['bridges']['bridged'])) {
 			foreach ($config['bridges']['bridged'] as $oc2) {
 				if (stristr($oc2['members'], $on)) {
 					$isbridged = true;

--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -232,6 +232,18 @@ $pf_reserved_keywords = array(
 	"flush", "sloppy", "tagged", "tag", "ifbound", "floating", "statepolicy", "statedefaults", "route", "settos",
 	"divertto", "divertreply", "max", "min", "pptp", "pppoe", "L2TP", "OpenVPN", "IPsec");
 
+global $reserved_table_names;
+$reserved_table_names = array(
+	"bogons",
+	"bogonsv6",
+	"negate_networks",
+	"snort2c",
+	"sshguard",
+	"tonatsubnets",
+	"virusprot",
+	"vpn_networks",
+);
+
 /* VLAN Prio values. */
 $vlanprio_values = array(
 	"bk" => 0,

--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -232,6 +232,7 @@ $pf_reserved_keywords = array(
 	"flush", "sloppy", "tagged", "tag", "ifbound", "floating", "statepolicy", "statedefaults", "route", "settos",
 	"divertto", "divertreply", "max", "min", "pptp", "pppoe", "L2TP", "OpenVPN", "IPsec");
 
+/* Reserved table names to avoid collision */
 global $reserved_table_names;
 $reserved_table_names = array(
 	"bogons",

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -83,18 +83,6 @@ if (!$ignorefirmwarelock) {
 	}
 }
 
-/* Reserved table names to avoid collision */
-$reserved_table_names = array(
-	"bogons",
-	"bogonsv6",
-	"negate_networks",
-	"snort2c",
-	"sshguard",
-	"tonatsubnets",
-	"virusprot",
-	"vpn_networks",
-);
-
 $firewall_rules_dscp_types = array(
 	"af11",
 	"af12",


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9790
- [x] Ready for review

auto-remove empty zombie fw aliases

If you create Alias table under Firewall / Aliases / IP with FQDNs,
PF table with such name stays in system after you delete alias.
it just became empty after "deleting".

if works as garbage collector, checking which aliases presents in config and removes other

original issue:

If you create Alias table under Firewall / Aliases / IP with FQDNs,
PF table with such name stays in system after you delete alias.
it just became empty after "deleting".

you can see that empty table on Diagnostics / Tables or with pfctl -sT
it's not deleted if you do "Filter reload".

it seems there is needed "pfctl -t <alias_name> -T kill" command 