### PR TITLE
Add wait-interval to diag_ping.php

### DIFF
--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -39,9 +39,12 @@ require_once("guiconfig.inc");
 
 define('MAX_COUNT', 10);
 define('DEFAULT_COUNT', 3);
+define('MAX_WAIT', 10);
+define('DEFAULT_COUNT', 1);
 $do_ping = false;
 $host = '';
 $count = DEFAULT_COUNT;
+$wait = DEFAULT_WAIT;
 
 if ($_POST || $_REQUEST['host']) {
 	unset($input_errors);
@@ -55,7 +58,11 @@ if ($_POST || $_REQUEST['host']) {
 	if (($_REQUEST['count'] < 1) || ($_REQUEST['count'] > MAX_COUNT)) {
 		$input_errors[] = sprintf(gettext("Count must be between 1 and %s"), MAX_COUNT);
 	}
-
+	
+	if (($_REQUEST['wait'] < 1) || ($_REQUEST['wait'] > MAX_WAIT)) {
+		$input_errors[] = sprintf(gettext("Wait must be between 1 and %s"), MAX_WAIT);
+	}
+	
 	$host = trim($_REQUEST['host']);
 	$ipproto = $_REQUEST['ipproto'];
 	if (($ipproto == "ipv4") && is_ipaddrv6($host)) {
@@ -75,6 +82,10 @@ if ($_POST || $_REQUEST['host']) {
 		$count = $_REQUEST['count'];
 		if (preg_match('/[^0-9]/', $count)) {
 			$count = DEFAULT_COUNT;
+		}
+		$count = $_REQUEST['wait'];
+		if (preg_match('/[^0-9]/', wait)) {
+			$count = DEFAULT_WAIT;
 		}
 	}
 }
@@ -108,7 +119,7 @@ if ($do_ping) {
 		}
 	}
 
-	$cmd = "{$command} {$srcip} -c" . escapeshellarg($count) . " " . escapeshellarg($host);
+	$cmd = "{$command} {$srcip} -c" . escapeshellarg($count) . " -i " . escapeshellarg($wait) . " " . escapeshellarg($host);
 	//echo "Ping command: {$cmd}\n";
 	$result = shell_exec($cmd);
 
@@ -156,6 +167,13 @@ $section->addInput(new Form_Select(
 	$count,
 	array_combine(range(1, MAX_COUNT), range(1, MAX_COUNT))
 ))->setHelp('Select the maximum number of pings.');
+
+$section->addInput(new Form_Select(
+	'wait',
+	'Number of seconds to wait between pings',
+	$wait,
+	array_combine(range(1, MAX_WAIT), range(1, MAX_WAIT))
+))->setHelp('Select the number of seconds to wait between pings.');
 
 $form->add($section);
 

--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -164,7 +164,7 @@ $section->addInput(new Form_Select(
 	'Seconds between pings',
 	$wait,
 	array_combine(range(1, MAX_WAIT), range(1, MAX_WAIT))
-))->setHelp('Number of seconds to wait between pings.');
+))->setHelp('Select the number of seconds to wait between pings.');
 
 $form->add($section);
 

--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -84,7 +84,7 @@ if ($_POST || $_REQUEST['host']) {
 			$count = DEFAULT_COUNT;
 		}
 		$wait = $_REQUEST['wait'];
-		if (preg_match('/[^0-9]/', wait)) {
+		if (preg_match('/[^0-9]/', $wait)) {
 			$wait = DEFAULT_WAIT;
 		}
 	}

--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -40,7 +40,7 @@ require_once("guiconfig.inc");
 define('MAX_COUNT', 10);
 define('DEFAULT_COUNT', 3);
 define('MAX_WAIT', 10);
-define('DEFAULT_COUNT', 1);
+define('DEFAULT_WAIT', 1);
 $do_ping = false;
 $host = '';
 $count = DEFAULT_COUNT;

--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -173,7 +173,7 @@ $section->addInput(new Form_Select(
 	'Number of seconds to wait between pings',
 	$wait,
 	array_combine(range(1, MAX_WAIT), range(1, MAX_WAIT))
-))->setHelp('Select the number of seconds to wait between pings.');
+))->setHelp('Number of seconds to wait between pings.');
 
 $form->add($section);
 

--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -54,15 +54,12 @@ if ($_POST || $_REQUEST['host']) {
 	$reqdfields = explode(" ", "host count");
 	$reqdfieldsn = array(gettext("Host"), gettext("Count"));
 	do_input_validation($_REQUEST, $reqdfields, $reqdfieldsn, $input_errors);
-
-	if (($_REQUEST['count'] < 1) || ($_REQUEST['count'] > MAX_COUNT)) {
+	if (($_REQUEST['count'] < 1) || ($_REQUEST['count'] > MAX_COUNT) || (!is_numericint($_REQUEST['wait']))) {
 		$input_errors[] = sprintf(gettext("Count must be between 1 and %s"), MAX_COUNT);
-	}
-	
-	if (($_REQUEST['wait'] < 1) || ($_REQUEST['wait'] > MAX_WAIT)) {
+	}	
+	if (($_REQUEST['wait'] < 1) || ($_REQUEST['wait'] > MAX_WAIT) || (!is_numericint($_REQUEST['wait']))) {
 		$input_errors[] = sprintf(gettext("Wait must be between 1 and %s"), MAX_WAIT);
-	}
-	
+	}	
 	$host = trim($_REQUEST['host']);
 	$ipproto = $_REQUEST['ipproto'];
 	if (($ipproto == "ipv4") && is_ipaddrv6($host)) {
@@ -79,14 +76,8 @@ if ($_POST || $_REQUEST['host']) {
 		if (isset($_REQUEST['sourceip'])) {
 			$sourceip = $_REQUEST['sourceip'];
 		}
-		$count = $_REQUEST['count'];
-		if (preg_match('/[^0-9]/', $count)) {
-			$count = DEFAULT_COUNT;
-		}
-		$wait = $_REQUEST['wait'];
-		if (preg_match('/[^0-9]/', $wait)) {
-			$wait = DEFAULT_WAIT;
-		}
+		$count = (empty($_REQUEST['count'])) ? DEFAULT_WAIT : $_REQUEST['count'];
+		$wait = (empty($_REQUEST['wait'])) ? DEFAULT_WAIT : $_REQUEST['wait'];
 	}
 }
 
@@ -170,7 +161,7 @@ $section->addInput(new Form_Select(
 
 $section->addInput(new Form_Select(
 	'wait',
-	'Number of seconds to wait between pings',
+	'Seconds between pings',
 	$wait,
 	array_combine(range(1, MAX_WAIT), range(1, MAX_WAIT))
 ))->setHelp('Number of seconds to wait between pings.');

--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -119,7 +119,7 @@ if ($do_ping) {
 		}
 	}
 
-	$cmd = "{$command} {$srcip} -c" . escapeshellarg($count) . " -i " . escapeshellarg($wait) . " " . escapeshellarg($host);
+	$cmd = "{$command} {$srcip} -c" . escapeshellarg($count) . " -i" . escapeshellarg($wait) . " " . escapeshellarg($host);
 	//echo "Ping command: {$cmd}\n";
 	$result = shell_exec($cmd);
 

--- a/src/usr/local/www/diag_ping.php
+++ b/src/usr/local/www/diag_ping.php
@@ -83,9 +83,9 @@ if ($_POST || $_REQUEST['host']) {
 		if (preg_match('/[^0-9]/', $count)) {
 			$count = DEFAULT_COUNT;
 		}
-		$count = $_REQUEST['wait'];
+		$wait = $_REQUEST['wait'];
 		if (preg_match('/[^0-9]/', wait)) {
-			$count = DEFAULT_WAIT;
+			$wait = DEFAULT_WAIT;
 		}
 	}
 }


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9862
- [x] Ready for review

The diagnostic page for ping does not have support for waiting for a different amount of time between pings. I added this function as I wanted to use it. I tested on my 2.4.x version, and it works for me. 