### PR TITLE
Reverting changes to RDNSS and DNSSL settings in RADVD

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -248,8 +248,6 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t\tRemoveRoute on;\n";
 		$radvdconf .= "\t};\n";
 
-		$usedefaultvalues = $dhcpv6ifconf['ramode'] == "managed" || $dhcpv6ifconf['ramode'] == "stateless_dhcp" ? false : true;
-
 		/* add DNS servers */
 		$dnslist = array();
 		if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && is_array($dhcpv6ifconf['dnsserver']) && !empty($dhcpv6ifconf['dnsserver'])) {
@@ -264,9 +262,9 @@ function services_radvd_configure($blacklist = array()) {
 					$dnslist[] = $server;
 				}
 			}
-		} elseif ($usedefaultvalues && (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable']))) {
+		} elseif (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable'])) {
 			$dnslist[] = get_interface_ipv6($realif);
-		} elseif ($usedefaultvalues && (is_array($config['system']['dnsserver']) && !empty($config['system']['dnsserver']))) {
+		} elseif (is_array($config['system']['dnsserver']) && !empty($config['system']['dnsserver'])) {
 			foreach ($config['system']['dnsserver'] as $server) {
 				if (is_ipaddrv6($server)) {
 					$dnslist[] = $server;
@@ -288,16 +286,13 @@ function services_radvd_configure($blacklist = array()) {
 				$searchlist[] = $sd;
 			}
 		}
-		$searchliststring = "";
 		if (count($searchlist) > 0) {
 			$searchliststring = trim(implode(" ", $searchlist));
 		}
-		if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && !empty($dhcpv6ifconf['domain'])) {
-			$radvdconf .= "\tDNSSL {$dhcpv6ifconf['domain']} { };\n";
-		} elseif (!isset($dhcpv6ifconf['rasamednsasdhcp6']) && !empty($searchliststring)) {
-			$radvdconf .= "\tDNSSL {$searchliststring} { };\n";
-		} elseif ($usedefaultvalues && !empty($config['system']['domain'])) {
-			$radvdconf .= "\tDNSSL {$config['system']['domain']} { };\n";
+		if (!empty($dhcpv6ifconf['domain'])) {
+			$radvdconf .= "\tDNSSL {$dhcpv6ifconf['domain']} {$searchliststring} { };\n";
+		} elseif (!empty($config['system']['domain'])) {
+			$radvdconf .= "\tDNSSL {$config['system']['domain']} {$searchliststring} { };\n";
 		}
 		$radvdconf .= "};\n";
 	}


### PR DESCRIPTION
Reverting this change as I think this requires more thought as per comments in #9302.

Revert "RADVD: In "managed" or "stateless_dhcp" mode, don't use default values for DNS servers etc (these should come from DHCPv6)"

This reverts commit dcc887a355aae49c7df0c29752c04e12922aca83.

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9302
- [ ] Ready for review