### PR TITLE
packet capture ospf/ospfv3 support

### DIFF
--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -514,16 +514,15 @@ if ($do_tcpdump) :
 	}
 
 	if (in_array($proto, $protos)) {
-		if ($proto == 'carp') {
-			$matches[] = fixup_not(str_replace('carp', 'proto 112', $proto));
-		} else {
-			if ($fam == 'ip') {
-				$matches[] = fixup_not(str_replace('ospf', 'ip[9] == 89', $proto));
-			} else if ($fam == 'ip6') {
-				$matches[] = fixup_not(str_replace('ospf', 'proto 0x59', $proto));
-			} else {
+		switch ($proto) {
+			case 'carp':
+				$matches[] = fixup_not(str_replace('carp', 'proto 112', $proto));
+				break;
+			case 'ospf':
 				$matches[] = fixup_not(str_replace('ospf', 'proto ospf', $proto));
-			}
+				break;
+			default:
+				break;
 		}
 	}
 

--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -521,12 +521,14 @@ if ($do_tcpdump) :
 		switch ($proto) {
 			case 'ospf':
 				$proto = str_replace('ospf', 'proto ospf', $proto);
+				break;
 			case 'carp':
 				$proto = str_replace('carp', 'proto 112', $proto);
+				break;
 			default:
-				$matches[] = fixup_not($proto);
 				break;
 		}
+		$matches[] = fixup_not($proto);
 	}
 
 	if ($port != "") {

--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -152,8 +152,8 @@ $count = 100;//default number of packets to capture
 $max_display_size = 50*1024*1024; // 50MB limit on GUI capture display. See https://redmine.pfsense.org/issues/9239
 
 $fams = array('ip', 'ip6');
-$protos = array('icmp', 'icmp6', 'tcp', 'udp', 'arp', 'carp', 'esp', 'pfsync',
-		        '!icmp', '!icmp6', '!tcp', '!udp', '!arp', '!carp', '!esp', '!pfsync');
+$protos = array('icmp', 'icmp6', 'tcp', 'udp', 'arp', 'carp', 'esp', 'pfsync', 'ospf',
+		        '!icmp', '!icmp6', '!tcp', '!udp', '!arp', '!carp', '!esp', '!pfsync', '!ospf');
 
 $input_errors = array();
 
@@ -322,7 +322,9 @@ $protocollist = array(
 	'pfsync' => 'pfsync',
 	'!pfsync' => $excl . ' pfsync',
 	'esp' => 'ESP',
-	'!esp' => $excl . ' ESP'
+	'!esp' => $excl . ' ESP',
+	'ospf' => 'OSPF',
+	'!ospf' => $excl . ' OSPF'
 );
 
 include("head.inc");
@@ -512,7 +514,17 @@ if ($do_tcpdump) :
 	}
 
 	if (in_array($proto, $protos)) {
-		$matches[] = fixup_not(str_replace('carp', 'proto 112', $proto));
+		if ($proto == 'carp') {
+			$matches[] = fixup_not(str_replace('carp', 'proto 112', $proto));
+		} else {
+			if ($fam == 'ip') {
+				$matches[] = fixup_not(str_replace('ospf', 'ip[9] == 89', $proto));
+			} else if ($fam == 'ip6') {
+				$matches[] = fixup_not(str_replace('ospf', 'proto 0x59', $proto));
+			} else {
+				$matches[] = fixup_not(str_replace('ospf', 'proto ospf', $proto));
+			}
+		}
 	}
 
 	if ($port != "") {

--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -59,7 +59,11 @@ function has_not($value) {
 }
 
 function fixup_not($value) {
-	return str_replace("!", "not ", $value);
+	if ($value == '!ospf') {
+		return "! proto ospf";
+	} else {
+		return str_replace("!", "not ", $value);
+	}
 }
 
 function strip_not($value) {
@@ -515,12 +519,8 @@ if ($do_tcpdump) :
 
 	if (in_array($proto, $protos)) {
 		switch ($proto) {
-			case '!ospf':
-				$matches[] = str_replace('!ospf', '! proto ospf', $proto);
-				break;
 			case 'ospf':
-				$matches[] = str_replace('ospf', 'proto ospf', $proto);
-				break;
+				$proto = str_replace('ospf', 'proto ospf', $proto);
 			case 'carp':
 				$proto = str_replace('carp', 'proto 112', $proto);
 			default:

--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -515,13 +515,16 @@ if ($do_tcpdump) :
 
 	if (in_array($proto, $protos)) {
 		switch ($proto) {
-			case 'carp':
-				$matches[] = fixup_not(str_replace('carp', 'proto 112', $proto));
+			case '!ospf':
+				$matches[] = str_replace('!ospf', '! proto ospf', $proto);
 				break;
 			case 'ospf':
-				$matches[] = fixup_not(str_replace('ospf', 'proto ospf', $proto));
+				$matches[] = str_replace('ospf', 'proto ospf', $proto);
 				break;
+			case 'carp':
+				$proto = str_replace('carp', 'proto 112', $proto);
 			default:
+				$matches[] = fixup_not($proto);
 				break;
 		}
 	}


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9905
- [x] Ready for review

Adds the ability to select OSPF in the protocol field
It can capture OSPF, OSPFv3 or both, depending of Address Family
Very useful for FRR troubleshooting