### PR TITLE
do not show incompatible ECDSA certs for DNS Resolver

### DIFF
--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -343,7 +343,7 @@ if ($certs_available) {
 		'sslcertref',
 		'SSL/TLS Certificate',
 		$pconfig['sslcertref'],
-		cert_build_list('cert', 'HTTPS')
+		cert_build_list('cert', 'IPsec')
 	))->setHelp('The server certificate to use for SSL/TLS service. The CA chain will be determined automatically.');
 } else {
 	$section->addInput(new Form_StaticText(

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -348,7 +348,7 @@ if ($certs_available) {
 		'sslcertref',
 		'SSL/TLS Certificate',
 		$pconfig['sslcertref'],
-		$values
+		cert_build_list('cert', 'HTTPS')
 	))->setHelp('The server certificate to use for SSL/TLS service. The CA chain will be determined automatically.');
 } else {
 	$section->addInput(new Form_StaticText(

--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -339,11 +339,6 @@ $section->addInput(new Form_Checkbox(
 		'Activating this option disables automatic interface response routing behavior, thus it works best with specific interface bindings.' );
 
 if ($certs_available) {
-	$values = array();
-	foreach ($a_cert as $cert) {
-		$values[ $cert['refid'] ] = $cert['descr'];
-	}
-
 	$section->addInput($input = new Form_Select(
 		'sslcertref',
 		'SSL/TLS Certificate',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9907
- [ ] Ready for review

Do not show incompatible ECDSA certs for DNS Resolver
It is difficult to find EC curves supported by each DNS implementation, so
It’s better to use the “safe list” of curves anyway

same as https://redmine.pfsense.org/issues/9897

p.s. 1.1.1.1 and 9.9.9.9 uses secp256r1