### PR TITLE
Fix widget refresh

### DIFF
--- a/src/usr/local/www/index.php
+++ b/src/usr/local/www/index.php
@@ -567,8 +567,6 @@ function set_widget_checkbox_events(checkbox_panel_ref, all_none_button_id) {
 // ---------------------Centralized widget refresh system -------------------------------------------
 // These need to live outside of the events.push() function to enable the widgets to see them
 var ajaxspecs = new Array();	// Array to hold widget refresh specifications (objects )
-var ajaxidx = 0;
-var ajaxmutex = false;
 var ajaxcntr = 0;
 
 // Add a widget refresh object to the array list
@@ -634,10 +632,9 @@ events.push(function() {
 	});
 
 	// --------------------- Centralized widget refresh system ------------------------------
-	ajaxtimeout = false;
-
 	function make_ajax_call(wd) {
-		ajaxmutex = true;
+		// Add a lock on the widget to prevent overlapping callbacks
+		wd.locked = true;
 
 		$.ajax({
 			type: 'POST',
@@ -648,52 +645,48 @@ events.push(function() {
 			success: function(data){
 				if (data.length > 0 ) {
 					// If the session has timed out, display a pop-up
-					if (data.indexOf("SESSION_TIMEOUT") === -1) {
-						wd.callback(data);
-					} else {
-						if (ajaxtimeout === false) {
-							ajaxtimeout = true;
-							alert("<?=$timeoutmessage?>");
-						}
+					if (data.indexOf("SESSION_TIMEOUT") > -1) {
+						alert("<?=$timeoutmessage?>");
+						return;
 					}
-				}
 
-				ajaxmutex = false;
+					// Else call the callback
+					wd.callback(data);
+				}
 			},
 
 			error: function(e){
 //				alert("Error: " + e);
-				ajaxmutex = false;
+			},
+
+			complete: function(){
+				// Regardless of success or error, remove the widget's lock
+				wd.locked = false;
 			}
 		});
 	}
 
 	// Loop through each AJAX widget refresh object, make the AJAX call and pass the
 	// results back to the widget's callback function
-	function executewidget() {
-		if (ajaxspecs.length > 0) {
-			var freq = ajaxspecs[ajaxidx].freq;	// widget can specify it should be called freq times around the loop
-
-			if (!ajaxmutex) {
-				if (((ajaxcntr % freq) === 0) && (typeof ajaxspecs[ajaxidx].callback === "function" )) {
-				    make_ajax_call(ajaxspecs[ajaxidx]);
-				}
-
-			    if (++ajaxidx >= ajaxspecs.length) {
-					ajaxidx = 0;
-
-					if (++ajaxcntr >= 4096) {
-						ajaxcntr = 0;
-					}
-			    }
+	function executewidgets() {
+		for (var ajaxidx = 0; ajaxidx < ajaxspecs.length; ajaxidx++) {
+			// If the widget is locked, continue
+			if (ajaxspecs[ajaxidx].locked) {
+				continue;
 			}
 
-		    setTimeout(function() { executewidget(); }, 1000);
-	  	}
+			var freq = ajaxspecs[ajaxidx].freq;	// widget can specify it should be called every freq seconds
+			if (((ajaxcntr % freq) === 0) && (typeof ajaxspecs[ajaxidx].callback === "function" )) {
+				make_ajax_call(ajaxspecs[ajaxidx]);
+			}
+		}
+		ajaxcntr++;
 	}
 
 	// Kick it off
-	executewidget();
+	if (ajaxspecs.length > 0) {
+		setInterval(executewidgets, 1000);
+	}
 
 	//----------------------------------------------------------------------------------------------------
 });


### PR DESCRIPTION
## Description:

This pull request resolves issues with the widget refresh system:
- The refresh system uses flawed logic, see below for an in-depth explanation.
- Widgets, despite using ajax callbacks, are not truly async - one widget can lock another if it takes too long to run.
- Session timeouts result in the dashboard continuing to attempt ajax callbacks, despite access being blocked due to the aforementioned session timeout.

**History:** This pull request is a simplified rework of #3879 (from my old Github account), but does not not default to a 1-second refresh interval for the Firewall Logs and Gateways widgets; in fact, it doesn't directly modify those widgets at all.

## Changes:

### /usr/local/www/index.php
- Widget locking:
    - Removed global mutex, preventing one long-running widget from hanging up others and ensuring true asynchronous operation.
    - Added per-widget lock, allowing a widget to execute only if it's not already executing.

- Widget refreshing:
  - Renamed function `executewidget()` to `executewidgets()` for the sake of grammar.
  - Changed execution to a `setInterval()` instead of a self-calling `setTimeout()`, as it is cleaner this way; allows for `clearInterval()` upon session timeout, if desired.
  - Fixed refresh logic, as it is logically flawed in its current implementation:
    - The function `executewidget()` is called every second.
    - `freq` is defined as the desired number of seconds between each execution of the `ajaxidx`th widget.
    - If `ajaxcntr % freq` is equal to 0, the `ajaxidx`th widget will run.
    - At the end of `executewidget()`, `ajaxidx` is increased.
      - If `ajaxidx` is greater than the number of widgets, it is reset to 0 and `ajaxcntr` is also increased. If `ajaxcntr` is greater than 4096, is it reset to 0.  
  - The end result is that each call of `executewidget()` takes `n` seconds to run, where `n` is the number of widgets on the dashboard, and each widget will only execute every `t` times `executewidget()` is run, resulting in an *actual* update time of `n * t`.
  - Example, for further illustration:
    - Suppose that there are **8 widgets** present on the pfSense dashboard, and the Firewall Logs widget is configured to have an "Update interval" of **10 seconds**.
    - A single call of `executewidget()` takes **8 seconds** (1 second per widget * 8 widgets total), and Firewall Logs only refreshes every **10 times** `updatewidget()` is called.
    - Thus Firewall Logs only refreshes every 8 * 10 seconds, or **80 seconds**. This is a bug, and incorrect behavior.
    - This has been fixed through the use of a single `for` loop, each time `executewidget()` is called, that "passes over" all widgets and decides on a per-widget basis if they should be executed (based on `ajaxcntr`).
  - In short, this change allows all widgets to operate independently of each other.

- Session timeouts:
  - Don't try to execute ajax callbacks if session timed out
  - Removed `ajaxtimeout` variable as it was not referenced

## Checklist:
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9917
- [X] Ready for review