### PR TITLE
check user certificates for correct ECDSA curves

### DIFF
--- a/src/usr/local/www/system_certmanager.php
+++ b/src/usr/local/www/system_certmanager.php
@@ -1016,9 +1016,10 @@ if (in_array($act, array('new', 'edit')) || (($_POST['save'] == gettext("Save"))
 	$section->addClass('toggle-existing collapse');
 
 	$existCerts = array();
+	$ecdsagood = cert_build_list('cert', 'IPsec');
 
 	foreach ($config['cert'] as $cert) {
-		if (!is_array($cert) || empty($cert)) {
+		if (!is_array($cert) || empty($cert) || !in_array($cert['refid'], array_keys($ecdsagood))) {
 			continue;
 		}
 		if (is_array($config['system']['user'][$userid]['cert'])) { // Could be MIA!


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9918
- [x] Ready for review

Show only correct (IPsec = OpenVPN) ECDSA when adding existing certificates to users, 
'Choose an Existing Certificate' on System \ Certificate Manager \ Certificates \ Edit page