### PR TITLE
Hostname is not required for DNS-O-Matic

### DIFF
--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -87,8 +87,10 @@ if ($_POST['save'] || $_POST['force']) {
 	$reqdfieldsn = array(gettext("Service type"));
 
 	if ($pconfig['type'] != "custom" && $pconfig['type'] != "custom-v6") {
-		$reqdfields[] = "host";
-		$reqdfieldsn[] = gettext("Hostname");
+		if ($pconfig['type'] != "dnsomatic") {
+			$reqdfields[] = "host";
+			$reqdfieldsn[] = gettext("Hostname");
+		}
 		$reqdfields[] = "passwordfld";
 		$reqdfieldsn[] = gettext("Password");
 		$reqdfields[] = "username";


### PR DESCRIPTION
DNS-O-Matic allows updates to be sent without a hostname or service specified, in which case all services are updated. However, the pfSense UI requires a valid hostname, and will not allow this case. This change removes hostname validation for only this dynamics DNS service.

I've applied this change locally, forced an update to test the underlying update mechanism, and verified on the DNS-O-Matic site that all services were updated as expected.

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/7601
- [ ] Ready for review