### PR TITLE
Redmine #9931: Change default ntp server to 2.pfsense.pool.ntp.org

### DIFF
--- a/src/conf.default/config.xml
+++ b/src/conf.default/config.xml
@@ -34,7 +34,7 @@
 		</user>
 		<nextuid>2000</nextuid>
 		<nextgid>2000</nextgid>
-		<timeservers>0.pfsense.pool.ntp.org</timeservers>
+		<timeservers>2.pfsense.pool.ntp.org</timeservers>
 		<webgui>
 			<protocol>https</protocol>
 			<loginautocomplete/>


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9931
- [x] Ready for review