### PR TITLE
support variable value length in queue stats parser

### DIFF
--- a/src/etc/inc/shaper.inc
+++ b/src/etc/inc/shaper.inc
@@ -284,10 +284,26 @@ function get_queue_stats() {
 			$interfacestats[$currentqueueif][$currentqueuename] = &$newqueue;
 		} else {
 			if ($items[3] == "pkts:") {
-				$newqueue["pkts"] = trim(substr($line, 10, 10));
-				$newqueue["bytes"] = trim(substr($line, 29, 10));
-				$newqueue["droppedpkts"] = trim(substr($line, 55, 6));
-				$newqueue["droppedbytes"] = trim(substr($line, 69, 6));
+				$pktsquery = "pkts:";
+				$pktsstart = strpos($line, $pktsquery);
+				$pktsend = $pktsstart + strlen($pktsquery);
+
+				$bytesquery = "bytes:";
+				$bytesstart = strpos($line, $bytesquery);
+				$bytesend = $bytesstart + strlen($bytesquery);
+
+				$droppedpktsquery = "dropped pkts:";
+				$droppedpktsstart = strpos($line, $droppedpktsquery);
+				$droppedpktsend = $droppedpktsstart + strlen($droppedpktsquery);
+
+				$droppedbytesquery = "bytes:";
+				$droppedbytesstart = strpos($line, $droppedbytesquery, $droppedpktsend);
+				$droppedbytesend = $droppedbytesstart + strlen($droppedbytesquery);
+
+				$newqueue["pkts"] = trim(substr($line, $pktsend, $bytesstart-$pktsend));
+				$newqueue["bytes"] = trim(substr($line, $bytesend, $droppedpktsstart-$bytesend));
+				$newqueue["droppedpkts"] = trim(substr($line, $droppedpktsend, $droppedbytesstart-$droppedpktsend));
+				$newqueue["droppedbytes"] = trim(substr($line, $droppedbytesend, strlen($line)-1-$droppedbytesend));
 			}
 			if ($items[3] == "qlength:") {
 				$subitems = explode("/", substr($line, 13, 8));

--- a/src/etc/inc/shaper.inc
+++ b/src/etc/inc/shaper.inc
@@ -284,26 +284,11 @@ function get_queue_stats() {
 			$interfacestats[$currentqueueif][$currentqueuename] = &$newqueue;
 		} else {
 			if ($items[3] == "pkts:") {
-				$pktsquery = "pkts:";
-				$pktsstart = strpos($line, $pktsquery);
-				$pktsend = $pktsstart + strlen($pktsquery);
-
-				$bytesquery = "bytes:";
-				$bytesstart = strpos($line, $bytesquery);
-				$bytesend = $bytesstart + strlen($bytesquery);
-
-				$droppedpktsquery = "dropped pkts:";
-				$droppedpktsstart = strpos($line, $droppedpktsquery);
-				$droppedpktsend = $droppedpktsstart + strlen($droppedpktsquery);
-
-				$droppedbytesquery = "bytes:";
-				$droppedbytesstart = strpos($line, $droppedbytesquery, $droppedpktsend);
-				$droppedbytesend = $droppedbytesstart + strlen($droppedbytesquery);
-
-				$newqueue["pkts"] = trim(substr($line, $pktsend, $bytesstart-$pktsend));
-				$newqueue["bytes"] = trim(substr($line, $bytesend, $droppedpktsstart-$bytesend));
-				$newqueue["droppedpkts"] = trim(substr($line, $droppedpktsend, $droppedbytesstart-$droppedpktsend));
-				$newqueue["droppedbytes"] = trim(substr($line, $droppedbytesend, strlen($line)-1-$droppedbytesend));
+				preg_match('/pkts:\s+(\d+)\s+bytes:\s+(\d+)\s+dropped pkts:\s+(\d+)\s+bytes:\s+(\d+)/', $line, $matches);
+				$newqueue["pkts"] = $matches[1];
+				$newqueue["bytes"] = $matches[2];
+				$newqueue["droppedpkts"] = $matches[3];
+				$newqueue["droppedbytes"] = $matches[4];
 			}
 			if ($items[3] == "qlength:") {
 				$subitems = explode("/", substr($line, 13, 8));


### PR DESCRIPTION
Hello,
currently the queue stats parser in the file "/etc/inc/shaper.inc" assumes that the bytes value does not exceed the length of 10. If this limit is exceed the page "/status_queues.php" displays wrong values. After a filter reload the bytes value is reset and the values are correct for a few minutes until the bytes value is too large again.

Decisive line from "/sbin/pfctl -s queue -v" output
Displays correct:
`'  [ pkts:    6653183  bytes: 9993145948  dropped pkts:      0 bytes:      0 ]'`

Displays incorrect:
`'  [ pkts:    6661877  bytes: 10006205865  dropped pkts:      0 bytes:      0 ]'`


- [x] Redmine Issue: https://redmine.pfsense.org/issues/9938
- [x] Ready for review