### PR TITLE
status_ipsec.php: show encr-keysize

### DIFF
--- a/src/usr/local/www/status_ipsec.php
+++ b/src/usr/local/www/status_ipsec.php
@@ -342,7 +342,11 @@ function print_ipsec_body() {
 					print("</td>\n");
 					print("<td>\n");
 
-					print(htmlspecialchars($childsa['encr-alg']) . '<br/>');
+					print(htmlspecialchars($childsa['encr-alg']));
+                                        if ($childsa['encr-alg'] != '3DES_CBC') {
+                                                print('_' . htmlspecialchars($childsa['encr-keysize']));
+                                        }
+                                        print('<br/>');
 					print(htmlspecialchars($childsa['integ-alg']) . '<br/>');
 
 					if (!empty($childsa['prf-alg'])) {

--- a/src/usr/local/www/status_ipsec.php
+++ b/src/usr/local/www/status_ipsec.php
@@ -214,7 +214,7 @@ function print_ipsec_body() {
 			print("</td>\n");
 			print("<td>\n");
 			print(htmlspecialchars($ikesa['encr-alg']));
-			if ($ikesa['encr-alg'] != '3DES_CBC') { 
+			if ($ikesa['encr-alg'] != '3DES_CBC') {
 				print('_' . htmlspecialchars($ikesa['encr-keysize']));
 			}
 			print("<br/>");

--- a/src/usr/local/www/status_ipsec.php
+++ b/src/usr/local/www/status_ipsec.php
@@ -214,9 +214,9 @@ function print_ipsec_body() {
 			print("</td>\n");
 			print("<td>\n");
 			print(htmlspecialchars($ikesa['encr-alg']));
-			if ($ikesa['encr-alg'] != '3DES_CBC') {
-                                print('_' . htmlspecialchars($ikesa['encr-keysize']));
-                        }
+			if ($ikesa['encr-alg'] != '3DES_CBC') { 
+				print('_' . htmlspecialchars($ikesa['encr-keysize']));
+			}
 			print("<br/>");
 			print(htmlspecialchars($ikesa['integ-alg']));
 			print("<br/>");
@@ -343,9 +343,9 @@ function print_ipsec_body() {
 					print("<td>\n");
 
 					print(htmlspecialchars($childsa['encr-alg']));
-                                        if ($childsa['encr-alg'] != '3DES_CBC') {
-                                                print('_' . htmlspecialchars($childsa['encr-keysize']));
-                                        }
+					if ($childsa['encr-alg'] != '3DES_CBC') {
+						print('_' . htmlspecialchars($childsa['encr-keysize']));
+					}
                                         print('<br/>');
 					print(htmlspecialchars($childsa['integ-alg']) . '<br/>');
 

--- a/src/usr/local/www/status_ipsec.php
+++ b/src/usr/local/www/status_ipsec.php
@@ -214,6 +214,9 @@ function print_ipsec_body() {
 			print("</td>\n");
 			print("<td>\n");
 			print(htmlspecialchars($ikesa['encr-alg']));
+			if ($ikesa['encr-alg'] != '3DES_CBC') {
+                                print('_' . htmlspecialchars($ikesa['encr-keysize']));
+                        }
 			print("<br/>");
 			print(htmlspecialchars($ikesa['integ-alg']));
 			print("<br/>");


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9943
- [ ] Ready for review

Show size of selected encryption algo on Status \ IPsec page
without it, AES-GCM 128/192/256 is always displayed as AES_GCM_16,
instead of AES_GCM_16_128/AES_GCM_16_192/AES_GCM_16_256

'ipsec status' command format