### PR TITLE
OpenVPN server cert default lifetime 825 days

### DIFF
--- a/src/usr/local/www/wizards/openvpn_wizard.xml
+++ b/src/usr/local/www/wizards/openvpn_wizard.xml
@@ -637,10 +637,10 @@
 		<field>
 			<name>lifetime</name>
 			<displayname>Lifetime</displayname>
-			<description>Lifetime in days. This is commonly set to 3650 (Approximately 10 years.)</description>
+			<description>Lifetime in days. Server certificates should not have a lifetime over 825 days or some platforms may consider the certificate invalid.</description>
 			<type>input</type>
 			<size>10</size>
-			<value>3650</value>
+			<value>825</value>
 			<bindstofield>ovpnserver->step9->lifetime</bindstofield>
 		</field>
 		<field>


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9825
- [ ] Ready for review

set default cert lifetime to 825 days in Wizard / OpenVPN Remote Access Server Setup

one server certificate is usually used by different services, so it’s better to use the 825 lifetime there
also see https://github.com/OpenVPN/easy-rsa/issues/333

