### PR TITLE
Add options to disable pushing IPv6 DNS servers, fixes localized queries

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -249,7 +249,7 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t};\n";
 
 		/* add DNS servers */
-		if (($dhcpv6ifconf['enable-radvd-dns']) != 'disabled') {
+		if (($dhcpv6ifconf['radvd-dns']) != 'disabled') {
 			$dnslist = array();
 			if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && is_array($dhcpv6ifconf['dnsserver']) && !empty($dhcpv6ifconf['dnsserver'])) {
 				foreach ($dhcpv6ifconf['dnsserver'] as $server) {
@@ -371,7 +371,7 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t};\n";
 
 		/* add DNS servers */
-		if (($dhcpv6ifconf['enable-radvd-dns']) != 'disabled') {
+		if (($dhcpv6ifconf['radvd-dns']) != 'disabled') {
 			$dnslist = array();
 			if (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable'])) {
 				$dnslist[] = $ifcfgipv6;
@@ -1438,7 +1438,7 @@ EOD;
 			$dnscfgv6 .= "	do-forward-updates false;\n";
 		}
 
-		if (($dhcpv6ifconf['enable-dhcp6c-dns']) != 'disabled') {
+		if (($dhcpv6ifconf['dhcp6c-dns']) != 'disabled') {
 			if (is_array($dhcpv6ifconf['dnsserver']) && ($dhcpv6ifconf['dnsserver'][0])) {
 				$dnscfgv6 .= "	option dhcp6.name-servers " . join(",", $dhcpv6ifconf['dnsserver']) . ";";
 			} else if (((isset($config['dnsmasq']['enable'])) || isset($config['unbound']['enable'])) && (is_ipaddrv6($ifcfgipv6))) {

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -249,50 +249,52 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t};\n";
 
 		/* add DNS servers */
-		$dnslist = array();
-		if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && is_array($dhcpv6ifconf['dnsserver']) && !empty($dhcpv6ifconf['dnsserver'])) {
-			foreach ($dhcpv6ifconf['dnsserver'] as $server) {
-				if (is_ipaddrv6($server)) {
-					$dnslist[] = $server;
+		if (!isset($dhcpv6ifconf['disable-radvd-dns'])) {
+			$dnslist = array();
+			if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && is_array($dhcpv6ifconf['dnsserver']) && !empty($dhcpv6ifconf['dnsserver'])) {
+				foreach ($dhcpv6ifconf['dnsserver'] as $server) {
+					if (is_ipaddrv6($server)) {
+						$dnslist[] = $server;
+					}
+				}
+			} elseif (!isset($dhcpv6ifconf['rasamednsasdhcp6']) && isset($dhcpv6ifconf['radnsserver']) && is_array($dhcpv6ifconf['radnsserver'])) {
+				foreach ($dhcpv6ifconf['radnsserver'] as $server) {
+					if (is_ipaddrv6($server)) {
+						$dnslist[] = $server;
+					}
+				}
+			} elseif (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable'])) {
+				$dnslist[] = get_interface_ipv6($realif);
+			} elseif (is_array($config['system']['dnsserver']) && !empty($config['system']['dnsserver'])) {
+				foreach ($config['system']['dnsserver'] as $server) {
+					if (is_ipaddrv6($server)) {
+						$dnslist[] = $server;
+					}
 				}
 			}
-		} elseif (!isset($dhcpv6ifconf['rasamednsasdhcp6']) && isset($dhcpv6ifconf['radnsserver']) && is_array($dhcpv6ifconf['radnsserver'])) {
-			foreach ($dhcpv6ifconf['radnsserver'] as $server) {
-				if (is_ipaddrv6($server)) {
-					$dnslist[] = $server;
+			if (count($dnslist) > 0) {
+				$dnsstring = implode(" ", $dnslist);
+				if ($dnsstring <> "") {
+					$radvdconf .= "\tRDNSS {$dnsstring} { };\n";
 				}
 			}
-		} elseif (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable'])) {
-			$dnslist[] = get_interface_ipv6($realif);
-		} elseif (is_array($config['system']['dnsserver']) && !empty($config['system']['dnsserver'])) {
-			foreach ($config['system']['dnsserver'] as $server) {
-				if (is_ipaddrv6($server)) {
-					$dnslist[] = $server;
-				}
-			}
-		}
-		if (count($dnslist) > 0) {
-			$dnsstring = implode(" ", $dnslist);
-			if ($dnsstring <> "") {
-				$radvdconf .= "\tRDNSS {$dnsstring} { };\n";
-			}
-		}
 
-		$searchlist = array();
-		$domainsearchlist = explode(';', $dhcpv6ifconf['radomainsearchlist']);
-		foreach ($domainsearchlist as $sd) {
-			$sd = trim($sd);
-			if (is_hostname($sd)) {
-				$searchlist[] = $sd;
+			$searchlist = array();
+			$domainsearchlist = explode(';', $dhcpv6ifconf['radomainsearchlist']);
+			foreach ($domainsearchlist as $sd) {
+				$sd = trim($sd);
+				if (is_hostname($sd)) {
+					$searchlist[] = $sd;
+				}
 			}
-		}
-		if (count($searchlist) > 0) {
-			$searchliststring = trim(implode(" ", $searchlist));
-		}
-		if (!empty($dhcpv6ifconf['domain'])) {
-			$radvdconf .= "\tDNSSL {$dhcpv6ifconf['domain']} {$searchliststring} { };\n";
-		} elseif (!empty($config['system']['domain'])) {
-			$radvdconf .= "\tDNSSL {$config['system']['domain']} {$searchliststring} { };\n";
+			if (count($searchlist) > 0) {
+				$searchliststring = trim(implode(" ", $searchlist));
+			}
+			if (!empty($dhcpv6ifconf['domain'])) {
+				$radvdconf .= "\tDNSSL {$dhcpv6ifconf['domain']} {$searchliststring} { };\n";
+			} elseif (!empty($config['system']['domain'])) {
+				$radvdconf .= "\tDNSSL {$config['system']['domain']} {$searchliststring} { };\n";
+			}
 		}
 		$radvdconf .= "};\n";
 	}
@@ -369,24 +371,26 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t};\n";
 
 		/* add DNS servers */
-		$dnslist = array();
-		if (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable'])) {
-			$dnslist[] = $ifcfgipv6;
-		} elseif (is_array($config['system']['dnsserver']) && !empty($config['system']['dnsserver'])) {
-			foreach ($config['system']['dnsserver'] as $server) {
-				if (is_ipaddrv6($server)) {
-					$dnslist[] = $server;
+		if (!isset($dhcpv6ifconf['disable-radvd-dns'])) {
+			$dnslist = array();
+			if (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable'])) {
+				$dnslist[] = $ifcfgipv6;
+			} elseif (is_array($config['system']['dnsserver']) && !empty($config['system']['dnsserver'])) {
+				foreach ($config['system']['dnsserver'] as $server) {
+					if (is_ipaddrv6($server)) {
+						$dnslist[] = $server;
+					}
 				}
 			}
-		}
-		if (count($dnslist) > 0) {
-			$dnsstring = implode(" ", $dnslist);
-			if (!empty($dnsstring)) {
-				$radvdconf .= "\tRDNSS {$dnsstring} { };\n";
+			if (count($dnslist) > 0) {
+				$dnsstring = implode(" ", $dnslist);
+				if (!empty($dnsstring)) {
+					$radvdconf .= "\tRDNSS {$dnsstring} { };\n";
+				}
 			}
-		}
-		if (!empty($config['system']['domain'])) {
-			$radvdconf .= "\tDNSSL {$config['system']['domain']} { };\n";
+			if (!empty($config['system']['domain'])) {
+				$radvdconf .= "\tDNSSL {$config['system']['domain']} { };\n";
+			}
 		}
 		$radvdconf .= "};\n";
 	}
@@ -1434,20 +1438,24 @@ EOD;
 			$dnscfgv6 .= "	do-forward-updates false;\n";
 		}
 
-		if (is_array($dhcpv6ifconf['dnsserver']) && ($dhcpv6ifconf['dnsserver'][0])) {
-			$dnscfgv6 .= "	option dhcp6.name-servers " . join(",", $dhcpv6ifconf['dnsserver']) . ";";
-		} else if (((isset($config['dnsmasq']['enable'])) || isset($config['unbound']['enable'])) && (is_ipaddrv6($ifcfgipv6))) {
-			$dnscfgv6 .= "	option dhcp6.name-servers {$ifcfgipv6};";
-		} else if (is_array($syscfg['dnsserver']) && ($syscfg['dnsserver'][0])) {
-			$dns_arrv6 = array();
+		if (!isset($dhcpv6ifconf['disable-dhcp6c-dns'])) {
+			if (is_array($dhcpv6ifconf['dnsserver']) && ($dhcpv6ifconf['dnsserver'][0])) {
+				$dnscfgv6 .= "	option dhcp6.name-servers " . join(",", $dhcpv6ifconf['dnsserver']) . ";";
+			} else if (((isset($config['dnsmasq']['enable'])) || isset($config['unbound']['enable'])) && (is_ipaddrv6($ifcfgipv6))) {
+				$dnscfgv6 .= "	option dhcp6.name-servers {$ifcfgipv6};";
+			} else if (is_array($syscfg['dnsserver']) && ($syscfg['dnsserver'][0])) {
+				$dns_arrv6 = array();
 			foreach ($syscfg['dnsserver'] as $dnsserver) {
-				if (is_ipaddrv6($dnsserver)) {
-					$dns_arrv6[] = $dnsserver;
+					if (is_ipaddrv6($dnsserver)) {
+						$dns_arrv6[] = $dnsserver;
+					}
+				}
+				if (!empty($dns_arrv6)) {
+					$dnscfgv6 .= "	option dhcp6.name-servers " . join(",", $dns_arrv6) . ";";
 				}
 			}
-			if (!empty($dns_arrv6)) {
-				$dnscfgv6 .= "	option dhcp6.name-servers " . join(",", $dns_arrv6) . ";";
-			}
+		} else {
+			$dnscfgv6 .= "	#option dhcp6.name-servers --;";
 		}
 
 		if (!is_ipaddrv6($ifcfgipv6)) {

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -249,7 +249,7 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t};\n";
 
 		/* add DNS servers */
-		if (($dhcpv6ifconf['radvd-dns']) != 'disabled') {
+		if ($dhcpv6ifconf['radvd-dns'] != 'disabled') {
 			$dnslist = array();
 			if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && is_array($dhcpv6ifconf['dnsserver']) && !empty($dhcpv6ifconf['dnsserver'])) {
 				foreach ($dhcpv6ifconf['dnsserver'] as $server) {
@@ -371,7 +371,7 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t};\n";
 
 		/* add DNS servers */
-		if (($dhcpv6ifconf['radvd-dns']) != 'disabled') {
+		if ($dhcpv6ifconf['radvd-dns'] != 'disabled') {
 			$dnslist = array();
 			if (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable'])) {
 				$dnslist[] = $ifcfgipv6;
@@ -1438,7 +1438,7 @@ EOD;
 			$dnscfgv6 .= "	do-forward-updates false;\n";
 		}
 
-		if (($dhcpv6ifconf['dhcp6c-dns']) != 'disabled') {
+		if ($dhcpv6ifconf['dhcp6c-dns'] != 'disabled') {
 			if (is_array($dhcpv6ifconf['dnsserver']) && ($dhcpv6ifconf['dnsserver'][0])) {
 				$dnscfgv6 .= "	option dhcp6.name-servers " . join(",", $dhcpv6ifconf['dnsserver']) . ";";
 			} else if (((isset($config['dnsmasq']['enable'])) || isset($config['unbound']['enable'])) && (is_ipaddrv6($ifcfgipv6))) {

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -249,7 +249,7 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t};\n";
 
 		/* add DNS servers */
-		if (!isset($dhcpv6ifconf['disable-radvd-dns'])) {
+		if (($dhcpv6ifconf['enable-radvd-dns']) != 'disabled') {
 			$dnslist = array();
 			if (isset($dhcpv6ifconf['rasamednsasdhcp6']) && is_array($dhcpv6ifconf['dnsserver']) && !empty($dhcpv6ifconf['dnsserver'])) {
 				foreach ($dhcpv6ifconf['dnsserver'] as $server) {
@@ -371,7 +371,7 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\t};\n";
 
 		/* add DNS servers */
-		if (!isset($dhcpv6ifconf['disable-radvd-dns'])) {
+		if (($dhcpv6ifconf['enable-radvd-dns']) != 'disabled') {
 			$dnslist = array();
 			if (isset($config['dnsmasq']['enable']) || isset($config['unbound']['enable'])) {
 				$dnslist[] = $ifcfgipv6;
@@ -1438,14 +1438,14 @@ EOD;
 			$dnscfgv6 .= "	do-forward-updates false;\n";
 		}
 
-		if (!isset($dhcpv6ifconf['disable-dhcp6c-dns'])) {
+		if (($dhcpv6ifconf['enable-dhcp6c-dns']) != 'disabled') {
 			if (is_array($dhcpv6ifconf['dnsserver']) && ($dhcpv6ifconf['dnsserver'][0])) {
 				$dnscfgv6 .= "	option dhcp6.name-servers " . join(",", $dhcpv6ifconf['dnsserver']) . ";";
 			} else if (((isset($config['dnsmasq']['enable'])) || isset($config['unbound']['enable'])) && (is_ipaddrv6($ifcfgipv6))) {
 				$dnscfgv6 .= "	option dhcp6.name-servers {$ifcfgipv6};";
 			} else if (is_array($syscfg['dnsserver']) && ($syscfg['dnsserver'][0])) {
 				$dns_arrv6 = array();
-			foreach ($syscfg['dnsserver'] as $dnsserver) {
+				foreach ($syscfg['dnsserver'] as $dnsserver) {
 					if (is_ipaddrv6($dnsserver)) {
 						$dns_arrv6[] = $dnsserver;
 					}

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -141,6 +141,7 @@ if (is_array($config['dhcpdv6'][$if])) {
 	$pconfig['domainsearchlist'] = $config['dhcpdv6'][$if]['domainsearchlist'];
 	list($pconfig['wins1'], $pconfig['wins2']) = $config['dhcpdv6'][$if]['winsserver'];
 	list($pconfig['dns1'], $pconfig['dns2'], $pconfig['dns3'], $pconfig['dns4']) = $config['dhcpdv6'][$if]['dnsserver'];
+	$pconfig['disable-dhcp6c-dns'] = $config['dhcpdv6'][$if]['disable-dhcp6c-dns'];
 	$pconfig['enable'] = isset($config['dhcpdv6'][$if]['enable']);
 	$pconfig['ddnsdomain'] = $config['dhcpdv6'][$if]['ddnsdomain'];
 	$pconfig['ddnsdomainprimary'] = $config['dhcpdv6'][$if]['ddnsdomainprimary'];
@@ -441,7 +442,7 @@ if (isset($_POST['apply'])) {
 		if ($_POST['dns4']) {
 			$config['dhcpdv6'][$if]['dnsserver'][] = $_POST['dns4'];
 		}
-
+		$config['dhcpdv6'][$if]['disable-dhcp6c-dns'] = ($_POST['disable-dhcp6c-dns']) ? true : false;
 		$config['dhcpdv6'][$if]['domain'] = $_POST['domain'];
 		$config['dhcpdv6'][$if]['domainsearchlist'] = $_POST['domainsearchlist'];
 		$config['dhcpdv6'][$if]['enable'] = ($_POST['enable']) ? true : false;
@@ -707,6 +708,13 @@ for ($i=1;$i<=4; $i++) {
 
 $group->setHelp('Leave blank to use the system default DNS servers, this interface\'s IP if DNS forwarder is enabled, or the servers configured on the "General" page.');
 $section->add($group);
+$section->addInput(new Form_Checkbox(
+	'disable-dhcp6c-dns',
+	null,
+	'Do NOT provide DNS servers to DHCPv6 clients',
+	$pconfig['disable-dhcp6c-dns']
+))->setHelp('Checking this box disables the dhcp6.name-servers option in /var/dhcpd/etc/dhcpdv6.conf. ' .
+			'Use with caution, as the resulting behavior may violate some RFCs.');
 
 $section->addInput(new Form_Input(
 	'domain',

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -141,7 +141,7 @@ if (is_array($config['dhcpdv6'][$if])) {
 	$pconfig['domainsearchlist'] = $config['dhcpdv6'][$if]['domainsearchlist'];
 	list($pconfig['wins1'], $pconfig['wins2']) = $config['dhcpdv6'][$if]['winsserver'];
 	list($pconfig['dns1'], $pconfig['dns2'], $pconfig['dns3'], $pconfig['dns4']) = $config['dhcpdv6'][$if]['dnsserver'];
-	$pconfig['disable-dhcp6c-dns'] = $config['dhcpdv6'][$if]['disable-dhcp6c-dns'];
+	$pconfig['enable-dhcp6c-dns'] = ($config['dhcpdv6'][$if]['enable-dhcp6c-dns'] != 'disabled') ? "enabled" : "disabled";
 	$pconfig['enable'] = isset($config['dhcpdv6'][$if]['enable']);
 	$pconfig['ddnsdomain'] = $config['dhcpdv6'][$if]['ddnsdomain'];
 	$pconfig['ddnsdomainprimary'] = $config['dhcpdv6'][$if]['ddnsdomainprimary'];
@@ -442,7 +442,7 @@ if (isset($_POST['apply'])) {
 		if ($_POST['dns4']) {
 			$config['dhcpdv6'][$if]['dnsserver'][] = $_POST['dns4'];
 		}
-		$config['dhcpdv6'][$if]['disable-dhcp6c-dns'] = ($_POST['disable-dhcp6c-dns']) ? true : false;
+		$config['dhcpdv6'][$if]['enable-dhcp6c-dns'] = ($_POST['enable-dhcp6c-dns']) ? "enabled" : "disabled";
 		$config['dhcpdv6'][$if]['domain'] = $_POST['domain'];
 		$config['dhcpdv6'][$if]['domainsearchlist'] = $_POST['domainsearchlist'];
 		$config['dhcpdv6'][$if]['enable'] = ($_POST['enable']) ? true : false;
@@ -708,12 +708,13 @@ for ($i=1;$i<=4; $i++) {
 
 $group->setHelp('Leave blank to use the system default DNS servers, this interface\'s IP if DNS forwarder is enabled, or the servers configured on the "General" page.');
 $section->add($group);
+
 $section->addInput(new Form_Checkbox(
-	'disable-dhcp6c-dns',
+	'enable-dhcp6c-dns',
 	null,
-	'Do NOT provide DNS servers to DHCPv6 clients',
-	$pconfig['disable-dhcp6c-dns']
-))->setHelp('Checking this box disables the dhcp6.name-servers option in /var/dhcpd/etc/dhcpdv6.conf. ' .
+	'Provide DNS servers to DHCPv6 clients',
+	($pconfig['enable-dhcp6c-dns'] == "enabled")
+))->setHelp('Unchecking this box disables the dhcp6.name-servers option in /var/dhcpd/etc/dhcpdv6.conf. ' .
 			'Use with caution, as the resulting behavior may violate some RFCs.');
 
 $section->addInput(new Form_Input(

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -141,7 +141,7 @@ if (is_array($config['dhcpdv6'][$if])) {
 	$pconfig['domainsearchlist'] = $config['dhcpdv6'][$if]['domainsearchlist'];
 	list($pconfig['wins1'], $pconfig['wins2']) = $config['dhcpdv6'][$if]['winsserver'];
 	list($pconfig['dns1'], $pconfig['dns2'], $pconfig['dns3'], $pconfig['dns4']) = $config['dhcpdv6'][$if]['dnsserver'];
-	$pconfig['enable-dhcp6c-dns'] = ($config['dhcpdv6'][$if]['enable-dhcp6c-dns'] != 'disabled') ? "enabled" : "disabled";
+	$pconfig['dhcp6c-dns'] = ($config['dhcpdv6'][$if]['dhcp6c-dns'] != 'disabled') ? "enabled" : "disabled";
 	$pconfig['enable'] = isset($config['dhcpdv6'][$if]['enable']);
 	$pconfig['ddnsdomain'] = $config['dhcpdv6'][$if]['ddnsdomain'];
 	$pconfig['ddnsdomainprimary'] = $config['dhcpdv6'][$if]['ddnsdomainprimary'];
@@ -442,7 +442,7 @@ if (isset($_POST['apply'])) {
 		if ($_POST['dns4']) {
 			$config['dhcpdv6'][$if]['dnsserver'][] = $_POST['dns4'];
 		}
-		$config['dhcpdv6'][$if]['enable-dhcp6c-dns'] = ($_POST['enable-dhcp6c-dns']) ? "enabled" : "disabled";
+		$config['dhcpdv6'][$if]['dhcp6c-dns'] = ($_POST['dhcp6c-dns']) ? "enabled" : "disabled";
 		$config['dhcpdv6'][$if]['domain'] = $_POST['domain'];
 		$config['dhcpdv6'][$if]['domainsearchlist'] = $_POST['domainsearchlist'];
 		$config['dhcpdv6'][$if]['enable'] = ($_POST['enable']) ? true : false;
@@ -710,10 +710,10 @@ $group->setHelp('Leave blank to use the system default DNS servers, this interfa
 $section->add($group);
 
 $section->addInput(new Form_Checkbox(
-	'enable-dhcp6c-dns',
+	'dhcp6c-dns',
 	null,
 	'Provide DNS servers to DHCPv6 clients',
-	($pconfig['enable-dhcp6c-dns'] == "enabled")
+	($pconfig['dhcp6c-dns'] == "enabled")
 ))->setHelp('Unchecking this box disables the dhcp6.name-servers option in /var/dhcpd/etc/dhcpdv6.conf. ' .
 			'Use with caution, as the resulting behavior may violate some RFCs.');
 

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -84,6 +84,7 @@ if (is_array($config['dhcpdv6'][$if])) {
 
 	$pconfig['radomainsearchlist'] = $config['dhcpdv6'][$if]['radomainsearchlist'];
 	list($pconfig['radns1'], $pconfig['radns2'], $pconfig['radns3']) = $config['dhcpdv6'][$if]['radnsserver'];
+	$pconfig['disable-radvd-dns'] = isset($config['dhcpdv6'][$if]['disable-radvd-dns']);
 	$pconfig['rasamednsasdhcp6'] = isset($config['dhcpdv6'][$if]['rasamednsasdhcp6']);
 
 	$pconfig['subnets'] = $config['dhcpdv6'][$if]['subnets']['item'];
@@ -227,6 +228,7 @@ if ($_POST['save']) {
 			$config['dhcpdv6'][$if]['radnsserver'][] = $_POST['radns3'];
 		}
 
+		$config['dhcpdv6'][$if]['disable-radvd-dns'] = ($_POST['disable-radvd-dns']) ? true : false;
 		$config['dhcpdv6'][$if]['rasamednsasdhcp6'] = ($_POST['rasamednsasdhcp6']) ? true : false;
 
 		if (count($pconfig['subnets'])) {
@@ -452,6 +454,14 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['radomainsearchlist']
 ))->setHelp('The RA server can optionally provide a domain search list. Use the semicolon character as separator.');
+
+$section->addInput(new Form_Checkbox(
+	'disable-radvd-dns',
+	null,
+	'Do NOT provide DNS configuration via radvd',
+	$pconfig['disable-radvd-dns']
+))->setHelp('Checking this box disables the RDNSS/DNSSL options in /usr/local/etc/radvd.conf. ' .
+			'Use with caution, as the resulting behavior may violate some RFCs.');
 
 $section->addInput(new Form_Checkbox(
 	'rasamednsasdhcp6',

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -84,7 +84,7 @@ if (is_array($config['dhcpdv6'][$if])) {
 
 	$pconfig['radomainsearchlist'] = $config['dhcpdv6'][$if]['radomainsearchlist'];
 	list($pconfig['radns1'], $pconfig['radns2'], $pconfig['radns3']) = $config['dhcpdv6'][$if]['radnsserver'];
-	$pconfig['enable-radvd-dns'] = ($config['dhcpdv6'][$if]['enable-radvd-dns'] != 'disabled') ? "enabled" : "disabled";
+	$pconfig['radvd-dns'] = ($config['dhcpdv6'][$if]['radvd-dns'] != 'disabled') ? "enabled" : "disabled";
 	$pconfig['rasamednsasdhcp6'] = isset($config['dhcpdv6'][$if]['rasamednsasdhcp6']);
 
 	$pconfig['subnets'] = $config['dhcpdv6'][$if]['subnets']['item'];
@@ -228,7 +228,7 @@ if ($_POST['save']) {
 			$config['dhcpdv6'][$if]['radnsserver'][] = $_POST['radns3'];
 		}
 
-		$config['dhcpdv6'][$if]['enable-radvd-dns'] = ($_POST['enable-radvd-dns']) ? "enabled" : "disabled";
+		$config['dhcpdv6'][$if]['radvd-dns'] = ($_POST['radvd-dns']) ? "enabled" : "disabled";
 		$config['dhcpdv6'][$if]['rasamednsasdhcp6'] = ($_POST['rasamednsasdhcp6']) ? true : false;
 
 		if (count($pconfig['subnets'])) {
@@ -456,10 +456,10 @@ $section->addInput(new Form_Input(
 ))->setHelp('The RA server can optionally provide a domain search list. Use the semicolon character as separator.');
 
 $section->addInput(new Form_Checkbox(
-	'enable-radvd-dns',
+	'radvd-dns',
 	null,
 	'Provide DNS configuration via radvd',
-	($pconfig['enable-radvd-dns'] == "enabled")
+	($pconfig['radvd-dns'] == "enabled")
 ))->setHelp('Unchecking this box disables the RDNSS/DNSSL options in /var/etc/radvd.conf. ' .
 			'Use with caution, as the resulting behavior may violate some RFCs.');
 

--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -84,7 +84,7 @@ if (is_array($config['dhcpdv6'][$if])) {
 
 	$pconfig['radomainsearchlist'] = $config['dhcpdv6'][$if]['radomainsearchlist'];
 	list($pconfig['radns1'], $pconfig['radns2'], $pconfig['radns3']) = $config['dhcpdv6'][$if]['radnsserver'];
-	$pconfig['disable-radvd-dns'] = isset($config['dhcpdv6'][$if]['disable-radvd-dns']);
+	$pconfig['enable-radvd-dns'] = ($config['dhcpdv6'][$if]['enable-radvd-dns'] != 'disabled') ? "enabled" : "disabled";
 	$pconfig['rasamednsasdhcp6'] = isset($config['dhcpdv6'][$if]['rasamednsasdhcp6']);
 
 	$pconfig['subnets'] = $config['dhcpdv6'][$if]['subnets']['item'];
@@ -228,7 +228,7 @@ if ($_POST['save']) {
 			$config['dhcpdv6'][$if]['radnsserver'][] = $_POST['radns3'];
 		}
 
-		$config['dhcpdv6'][$if]['disable-radvd-dns'] = ($_POST['disable-radvd-dns']) ? true : false;
+		$config['dhcpdv6'][$if]['enable-radvd-dns'] = ($_POST['enable-radvd-dns']) ? "enabled" : "disabled";
 		$config['dhcpdv6'][$if]['rasamednsasdhcp6'] = ($_POST['rasamednsasdhcp6']) ? true : false;
 
 		if (count($pconfig['subnets'])) {
@@ -456,11 +456,11 @@ $section->addInput(new Form_Input(
 ))->setHelp('The RA server can optionally provide a domain search list. Use the semicolon character as separator.');
 
 $section->addInput(new Form_Checkbox(
-	'disable-radvd-dns',
+	'enable-radvd-dns',
 	null,
-	'Do NOT provide DNS configuration via radvd',
-	$pconfig['disable-radvd-dns']
-))->setHelp('Checking this box disables the RDNSS/DNSSL options in /usr/local/etc/radvd.conf. ' .
+	'Provide DNS configuration via radvd',
+	($pconfig['enable-radvd-dns'] == "enabled")
+))->setHelp('Unchecking this box disables the RDNSS/DNSSL options in /var/etc/radvd.conf. ' .
 			'Use with caution, as the resulting behavior may violate some RFCs.');
 
 $section->addInput(new Form_Checkbox(


### PR DESCRIPTION
**TL;DR— adds options that fix split-horizon DNS for dnsmasq + IPv6 setups.**

Out of the box, a pfSense install with working IPv6 will not be able to use dnsmasq to serve unique IPs (split-horizon DNS) via the [localise-queries](https://www.freebsd.org/cgi/man.cgi?query=dnsmasq) option, since that feature supports IPv4 only:

> **--localise-queries**
>     Return answers to DNS queries [..] which depend on the interface over which the query was received [..] If a name has more than one address associated with it [..] return only the address(es) on that subnet [..] **Currently this facility is limited to IPv4.**

Without the patch, LAN clients will typically submit DNS queries to pfSense's IPv6 address, which results in ALL records being returned instead of just the localised ones. This is unexpected and undesired. This adds the following options to the **DHCPv6 Server & RA** pages, allowing the options that push DNS servers via dhcpd + radvd to be disabled independently:

![image](https://user-images.githubusercontent.com/1992842/70763632-bb7f5800-1d22-11ea-9532-8b11dc40e5af.png)
![image](https://user-images.githubusercontent.com/1992842/70763644-c803b080-1d22-11ea-8d05-e5bda82e76e9.png)

This fixes the issue.

Putting something like this in the Custom options section of DNS Forwarder will activate this feature:
```
localise-queries
host-record=xyzzy.foo.lan,xyzzy,192.168.1.234
host-record=xyzzy.foo.lan,xyzzy,10.20.30.254
```
or you can use an external file:
```
localise-queries
addn-hosts=/usr/local/etc/dnsmasq-addn-hosts
```
Somewhat related discussion:
https://redmine.pfsense.org/issues/9302

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9302
- [x] Ready for review