### PR TITLE
system_routes.php: delete static routes from OS routing table

### DIFF
--- a/src/usr/local/www/system_routes.php
+++ b/src/usr/local/www/system_routes.php
@@ -93,7 +93,7 @@ function delete_static_route($id) {
 	foreach ($targets as $tgt) {
 		$family = (is_subnetv6($tgt) ? "-inet6" : "-inet");
 		$gateway = $a_gateways[$a_routes[$id]['gateway']]['gateway'];
-		mwexec("/sbin/route delete {$family} " . escapeshellarg($tgt) . " " . $escapeshellarg($gateway));
+		mwexec("/sbin/route delete {$family} " . escapeshellarg($tgt) . " " . escapeshellarg($gateway));
 	}
 
 	unset($targets);

--- a/src/usr/local/www/system_routes.php
+++ b/src/usr/local/www/system_routes.php
@@ -92,7 +92,8 @@ function delete_static_route($id) {
 
 	foreach ($targets as $tgt) {
 		$family = (is_subnetv6($tgt) ? "-inet6" : "-inet");
-		mwexec("/sbin/route delete {$family} " . escapeshellarg($tgt) . " " . $a_gateways[$a_routes[$id]['gateway']]['gateway']);
+		$gateway = $a_gateways[$a_routes[$id]['gateway']]['gateway'];
+		mwexec("/sbin/route delete {$family} " . escapeshellarg($tgt) . " " . $gateway);
 	}
 
 	unset($targets);

--- a/src/usr/local/www/system_routes.php
+++ b/src/usr/local/www/system_routes.php
@@ -67,7 +67,7 @@ if ($_POST['apply']) {
 }
 
 function delete_static_route($id) {
-	global $config, $a_routes, $changedesc_prefix;
+	global $config, $a_routes, $changedesc_prefix, $a_gateways;
 
 	if (!isset($a_routes[$id])) {
 		return;
@@ -92,7 +92,7 @@ function delete_static_route($id) {
 
 	foreach ($targets as $tgt) {
 		$family = (is_subnetv6($tgt) ? "-inet6" : "-inet");
-		mwexec("/sbin/route delete {$family} " . escapeshellarg($tgt));
+		mwexec("/sbin/route delete {$family} " . escapeshellarg($tgt) . " " . $a_gateways[$a_routes[$id]['gateway']]['gateway']);
 	}
 
 	unset($targets);

--- a/src/usr/local/www/system_routes.php
+++ b/src/usr/local/www/system_routes.php
@@ -93,7 +93,7 @@ function delete_static_route($id) {
 	foreach ($targets as $tgt) {
 		$family = (is_subnetv6($tgt) ? "-inet6" : "-inet");
 		$gateway = $a_gateways[$a_routes[$id]['gateway']]['gateway'];
-		mwexec("/sbin/route delete {$family} " . escapeshellarg($tgt) . " " . $gateway);
+		mwexec("/sbin/route delete {$family} " . escapeshellarg($tgt) . " " . $escapeshellarg($gateway));
 	}
 
 	unset($targets);


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9969
- [ ] Ready for review

need to use full command with GW, i.e.

old way:
```
# route delete -inet 5.5.5.0/24
route: route has not been found
delete net 5.5.5.0 fib 0: not in table
```

right way:
```
# route delete -inet 5.5.5.0/24 10.1.0.254
delete net 5.5.5.0: gateway 10.1.0.254
```