### PR TITLE
force noatime mount option

### DIFF
--- a/src/etc/pfSense-rc
+++ b/src/etc/pfSense-rc
@@ -106,12 +106,12 @@ if [ ${FSCK_ACTION_NEEDED} = 1 ]; then
 	/sbin/fsck -y -t ufs
 fi
 
-/sbin/mount -a 2>/dev/null
+/sbin/mount -a -o noatime 2>/dev/null
 mount_rc=$?
 attempts=0
 while [ ${mount_rc} -ne 0 -a ${attempts} -lt 10 ]; do
 	/sbin/fsck -y -t ufs
-	/sbin/mount -a 2>/dev/null
+	/sbin/mount -a -o noatime 2>/dev/null
 	mount_rc=$?
 	attempts=$((attempts+1))
 done


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9483
- [ ] Ready for review

On a clean CE install using the default options the / filesystem (UFS) is not mounted noatime.
ZFS is ok

this PR will force noatime option for all filesystems from fstab