### PR TITLE
fix pfsense book link

### DIFF
--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -431,7 +431,7 @@ if (!$g['disablehelpmenu']) {
 	$help_menu[] = array(gettext("User Forum"), "https://www.pfsense.org/j.php?jumpto=forum");
 	$help_menu[] = array(gettext("Documentation"), "https://www.pfsense.org/j.php?jumpto=doc");
 	$help_menu[] = array(gettext("Paid Support"), "https://www.netgate.com/support");
-	$help_menu[] = array(gettext("pfSense Book"), "https://www.pfsense.org/j.php?jumpto=book");
+	$help_menu[] = array(gettext("pfSense Book"), "https://docs.netgate.com/pfsense/en/latest/book/");
 	$help_menu[] = array(gettext("FreeBSD Handbook"), "https://www.pfsense.org/j.php?jumpto=fbsdhandbook");
 	$help_menu = msort(array_merge($help_menu, return_ext_menu("Help")), 0);
 }


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9996
- [ ] Ready for review

Help -> pfSense Book points to https://www.pfsense.org/j.php?jumpto=book,
which redirects to https://www.netgate.com/blog/pfsense-book-now-available-for-purchase.html page

it should redirects to https://docs.netgate.com/pfsense/en/latest/book/

this PR just point it directly to https://docs.netgate.com/pfsense/en/latest/book/