### PR TITLE
fix vti remoteid hiding in WebGUI

### DIFF
--- a/src/usr/local/www/vpn_ipsec_phase2.php
+++ b/src/usr/local/www/vpn_ipsec_phase2.php
@@ -785,7 +785,9 @@ events.push(function() {
 		} else if (value == 'vti') {
 			hideClass('opt_localid', false);
 			hideClass('opt_natid', true);
-			$('#localid_type').val('network');
+			hideClass('opt_remoteid', false);
+			$('#localid_type').val('address');
+			disableInput('localid_type', true);
 			typesel_change_local(30);
 			$('#remoteid_type').val('address');
 			disableInput('remoteid_type', true);


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9720
- [ ] Ready for review

fix vti remoteid hiding in WebGUI when you switch to Transport mode and then to VTI ( see https://youtu.be/avQWWjNl53o )
It also fix localid type to Address for VTI mode