### PR TITLE
set correct MTU for static and default IPv6 routes. Issue #6868

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3995,6 +3995,7 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 	} else {
 		if ($wantedmtu != get_interface_mtu($mtuif)) {
 			pfSense_interface_mtu($mtuif, $wantedmtu);
+			set_ipv6routes_mtu($mtuif, $wantedmtu);
 		}
 	}
 	/* XXX: What about gre/gif/.. ? */
@@ -6700,6 +6701,7 @@ function set_interface_mtu($interface, $mtu) {
 		}
 	} else {
 		pfSense_interface_mtu($interface, $mtu);
+		set_ipv6routes_mtu($interface, $mtu);
 	}
 }
 

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2514,6 +2514,36 @@ function route_add_or_change($args) {
 	return ($rc == 0);
 }
 
+function set_ipv6routes_mtu($interface, $mtu) {
+        global $config, $g;
+
+        $ipv6mturoutes = array();
+        $if = convert_real_interface_to_friendly_interface_name($interface);
+        if ($config['interfaces'][$if]['ipaddrv6']) {
+                $a_gateways = return_gateways_array();
+                $a_staticroutes = get_staticroutes(false, false, true);
+                foreach ($a_gateways as $gate) {
+                        foreach ($a_staticroutes as $sroute) {
+                                if (($gate['interface'] == $interface) && ($sroute['gateway'] == $gate['name'])) {
+                                        $tgt = $sroute['network'];
+                                        $gateway = $gate['gateway'];
+                                        $ipv6mturoutes[$tgt] = $gateway;
+                                }
+                        }
+                        if (($gate['interface'] == $interface) && $gate['isdefaultgw']) {
+                                $tgt = "default";
+                                $gateway = $gate['gateway'];
+                                $ipv6mturoutes[$tgt] = $gateway;
+                        }
+                }
+                if (!empty($ipv6mturoutes)) {
+                        foreach ($ipv6mturoutes as $tgt => $gateway) {
+                                mwexec("/sbin/route change -6 -mtu " . escapeshellarg($mtu) . " " . escapeshellarg($tgt) . " " . escapeshellarg($gateway));
+                        }
+                }
+        }
+}
+
 function alias_to_subnets_recursive($name, $returnhostnames = false) {
 	global $aliastable;
 	$result = array();


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/6868
- [ ] Ready for review

If I adjust the MTU of an assigned interface, only link route for IPv6 on the interface has its MTU adjusted, not others.

This PR set correct MTU for static and default IPv6 routes of interface