### PR TITLE
fix 'route delete' on 2.5

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -2026,19 +2026,19 @@ function save_gateway($gateway_settings, $realid = "") {
 		isset($a_gateway_item[$realid]["nonlocalgateway"])) {
 		$realif = get_real_interface($a_gateway_item[$realid]['interface']);
 		$inet = (!is_ipaddrv4($a_gateway_item[$realid]['gateway']) ? "-inet6" : "-inet");
-		$gateway = $a_gateway_item[$realid]['gateway'];
-		$cmd = "/sbin/route delete $inet " . escapeshellarg($a_gateway_item[$realid]['gateway']) . " -iface " . escapeshellarg($realif . " " . escapeshellarg($gateway));
+		$rgateway = $a_gateway_item[$realid]['gateway'];
+		$cmd = "/sbin/route delete $inet " . escapeshellarg($a_gateway_item[$realid]['gateway']) . " -iface " . escapeshellarg($realif . " " . escapeshellarg($rgateway));
 		mwexec($cmd);
 	}
 
 	/* NOTE: If monitor ip is changed need to cleanup the old static route */
 	if ($gateway_settings['monitor'] != "dynamic" && !empty($a_gateway_item[$realid]) && is_ipaddr($a_gateway_item[$realid]['monitor']) &&
 		$gateway_settings['monitor'] != $a_gateway_item[$realid]['monitor'] && $gateway['gateway'] != $a_gateway_item[$realid]['monitor']) {
-		$gateway = $a_gateway_item[$realid]['gateway'];
+		$rgateway = $a_gateway_item[$realid]['gateway'];
 		if (is_ipaddrv4($a_gateway_item[$realid]['monitor'])) {
-			mwexec("/sbin/route delete " . escapeshellarg($a_gateway_item[$realid]['monitor']) . " " . escapeshellarg($gateway));
+			mwexec("/sbin/route delete " . escapeshellarg($a_gateway_item[$realid]['monitor']) . " " . escapeshellarg($rgateway));
 		} else {
-			mwexec("/sbin/route delete -inet6 " . escapeshellarg($a_gateway_item[$realid]['monitor']) . " " . escapeshellarg($gateway));
+			mwexec("/sbin/route delete -inet6 " . escapeshellarg($a_gateway_item[$realid]['monitor']) . " " . escapeshellarg($rgateway));
 		}
 	}
 

--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -2026,17 +2026,19 @@ function save_gateway($gateway_settings, $realid = "") {
 		isset($a_gateway_item[$realid]["nonlocalgateway"])) {
 		$realif = get_real_interface($a_gateway_item[$realid]['interface']);
 		$inet = (!is_ipaddrv4($a_gateway_item[$realid]['gateway']) ? "-inet6" : "-inet");
-		$cmd = "/sbin/route delete $inet " . escapeshellarg($a_gateway_item[$realid]['gateway']) . " -iface " . escapeshellarg($realif);
+		$gateway = $a_gateway_item[$realid]['gateway'];
+		$cmd = "/sbin/route delete $inet " . escapeshellarg($a_gateway_item[$realid]['gateway']) . " -iface " . escapeshellarg($realif . " " . escapeshellarg($gateway));
 		mwexec($cmd);
 	}
 
 	/* NOTE: If monitor ip is changed need to cleanup the old static route */
 	if ($gateway_settings['monitor'] != "dynamic" && !empty($a_gateway_item[$realid]) && is_ipaddr($a_gateway_item[$realid]['monitor']) &&
 		$gateway_settings['monitor'] != $a_gateway_item[$realid]['monitor'] && $gateway['gateway'] != $a_gateway_item[$realid]['monitor']) {
+		$gateway = $a_gateway_item[$realid]['gateway'];
 		if (is_ipaddrv4($a_gateway_item[$realid]['monitor'])) {
-			mwexec("/sbin/route delete " . escapeshellarg($a_gateway_item[$realid]['monitor']));
+			mwexec("/sbin/route delete " . escapeshellarg($a_gateway_item[$realid]['monitor']) . " " . escapeshellarg($gateway));
 		} else {
-			mwexec("/sbin/route delete -inet6 " . escapeshellarg($a_gateway_item[$realid]['monitor']));
+			mwexec("/sbin/route delete -inet6 " . escapeshellarg($a_gateway_item[$realid]['monitor']) . " " . escapeshellarg($gateway));
 		}
 	}
 
@@ -2125,7 +2127,7 @@ function gateway_set_enabled($name, $enabled) {
 					$cgw = getcurrentdefaultgatewayip('inet6');
 				}
 				if ($gateway['gateway'] == $cgw) {
-					mwexec("/sbin/route delete -{$inet} default");
+					mwexec("/sbin/route delete -{$inet} default {$cgw}");
 				}
 			}
 			$gateway['disabled'] = true;

--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -2027,7 +2027,7 @@ function save_gateway($gateway_settings, $realid = "") {
 		$realif = get_real_interface($a_gateway_item[$realid]['interface']);
 		$inet = (!is_ipaddrv4($a_gateway_item[$realid]['gateway']) ? "-inet6" : "-inet");
 		$rgateway = $a_gateway_item[$realid]['gateway'];
-		$cmd = "/sbin/route delete $inet " . escapeshellarg($a_gateway_item[$realid]['gateway']) . " -iface " . escapeshellarg($realif . " " . escapeshellarg($rgateway));
+		$cmd = "/sbin/route delete $inet " . escapeshellarg($a_gateway_item[$realid]['gateway']) . " -iface " . escapeshellarg($realif) . " " . escapeshellarg($rgateway);
 		mwexec($cmd);
 	}
 
@@ -2127,7 +2127,7 @@ function gateway_set_enabled($name, $enabled) {
 					$cgw = getcurrentdefaultgatewayip('inet6');
 				}
 				if ($gateway['gateway'] == $cgw) {
-					mwexec("/sbin/route delete -{$inet} default {$cgw}");
+					mwexec("/sbin/route delete -{$inet} default " . escapeshellarg{$cgw});
 				}
 			}
 			$gateway['disabled'] = true;

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -202,8 +202,8 @@ function system_resolvconf_generate($dynupdate = false) {
 				route_add_or_change("-host {$inet6}{$dnsserver} {$gatewayip}");
 			} else {
 				/* Remove old route when disable gw */
-				$gatewayip = exec("/sbin/route -n show {$dnsserver} | grep gateway | cut -d' ' -f6");
-				mwexec("/sbin/route -q delete -host {$inet6}{$dnsserver} {$gatewayip}");
+				$gatewayip = exec("/sbin/route -n get {$dnsserver} | /usr/bin/awk '/gateway:/ {print $2;}'");
+				mwexec("/sbin/route -q delete -host {$inet6}{$dnsserver} " . escapeshellarg($gatewayip));
 				if (isset($config['system']['route-debug'])) {
 					$mt = microtime();
 					log_error("ROUTING debug: $mt - route delete -host {$inet6}{$dnsserver} {$gatewayip}");

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -203,7 +203,7 @@ function system_resolvconf_generate($dynupdate = false) {
 			} else {
 				/* Remove old route when disable gw */
 				$gatewayip = exec("/sbin/route -n show {$dnsserver} | grep gateway | cut -d' ' -f6");
-				mwexec("/sbin/route delete -host {$inet6}{$dnsserver} {$gatewayip}");
+				mwexec("/sbin/route -q delete -host {$inet6}{$dnsserver} {$gatewayip}");
 				if (isset($config['system']['route-debug'])) {
 					$mt = microtime();
 					log_error("ROUTING debug: $mt - route delete -host {$inet6}{$dnsserver} {$gatewayip}");

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -206,7 +206,7 @@ function system_resolvconf_generate($dynupdate = false) {
 				mwexec("/sbin/route delete -host {$inet6}{$dnsserver} {$gatewayip}");
 				if (isset($config['system']['route-debug'])) {
 					$mt = microtime();
-					log_error("ROUTING debug: $mt - route delete -host {$inet6}{$dnsserver}");
+					log_error("ROUTING debug: $mt - route delete -host {$inet6}{$dnsserver} {$gatewayip}");
 				}
 			}
 		}
@@ -942,7 +942,7 @@ function system_staticroutes_configure($interface = "", $update_dns = false) {
 				mwexec("/sbin/route delete " . escapeshellarg($ip) . " " . escapeshellarg($gatewayip), true);
 				if (isset($config['system']['route-debug'])) {
 					$mt = microtime();
-					log_error("ROUTING debug: $mt - route delete $ip ");
+					log_error("ROUTING debug: $mt - route delete $ip $gatewayip ");
 				}
 			}
 
@@ -952,7 +952,7 @@ function system_staticroutes_configure($interface = "", $update_dns = false) {
 					mwexec("/sbin/route delete " . escapeshellarg($ip) . " " . escapeshellarg($gatewayip), true);
 					if (isset($config['system']['route-debug'])) {
 						$mt = microtime();
-						log_error("ROUTING debug: $mt - route delete $ip ");
+						log_error("ROUTING debug: $mt - route delete $ip $gatewayip ");
 					}
 				}
 				continue;

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -202,7 +202,8 @@ function system_resolvconf_generate($dynupdate = false) {
 				route_add_or_change("-host {$inet6}{$dnsserver} {$gatewayip}");
 			} else {
 				/* Remove old route when disable gw */
-				mwexec("/sbin/route -q delete -host {$inet6}{$dnsserver}");
+				$gatewayip = exec("/sbin/route -n show {$dnsserver} | grep gateway | cut -d' ' -f6");
+				mwexec("/sbin/route delete -host {$inet6}{$dnsserver} {$gatewayip}");
 				if (isset($config['system']['route-debug'])) {
 					$mt = microtime();
 					log_error("ROUTING debug: $mt - route delete -host {$inet6}{$dnsserver}");
@@ -938,7 +939,7 @@ function system_staticroutes_configure($interface = "", $update_dns = false) {
 				if (in_array($ip, $ips)) {
 					continue;
 				}
-				mwexec("/sbin/route delete " . escapeshellarg($ip), true);
+				mwexec("/sbin/route delete " . escapeshellarg($ip) . " " . escapeshellarg($gatewayip), true);
 				if (isset($config['system']['route-debug'])) {
 					$mt = microtime();
 					log_error("ROUTING debug: $mt - route delete $ip ");
@@ -948,7 +949,7 @@ function system_staticroutes_configure($interface = "", $update_dns = false) {
 			if (isset($rtent['disabled'])) {
 				/* XXX: This can break things by deleting routes that shouldn't be deleted - OpenVPN, dynamic routing scenarios, etc. redmine #3709 */
 				foreach ($ips as $ip) {
-					mwexec("/sbin/route delete " . escapeshellarg($ip), true);
+					mwexec("/sbin/route delete " . escapeshellarg($ip) . " " . escapeshellarg($gatewayip), true);
 					if (isset($config['system']['route-debug'])) {
 						$mt = microtime();
 						log_error("ROUTING debug: $mt - route delete $ip ");

--- a/src/usr/local/www/system_gateways.php
+++ b/src/usr/local/www/system_gateways.php
@@ -142,9 +142,8 @@ function delete_gateway_item($id) {
 	    !isset($a_gateways[$id]['disabled']) &&
 	    isset($a_gateways[$id]['isdefaultgw'])) {
 		$inet = (!is_ipaddrv4($a_gateways[$id]['gateway']) ? '-inet6' : '-inet');
-		$rgateway = $a_gateways[$id]['gateway'];
 		file_put_contents("/dev/console", "\n[".getmypid()."] DEL_GW, route= delete {$inet} default");
-		mwexec("/sbin/route delete {$inet} default {$rgateway}");
+		mwexec("/sbin/route delete {$inet} default " . escapeshellarg($a_gateways[$id]['gateway']));
 	}
 
 	/* NOTE: Cleanup static routes for the interface route if any */

--- a/src/usr/local/www/system_gateways.php
+++ b/src/usr/local/www/system_gateways.php
@@ -142,8 +142,9 @@ function delete_gateway_item($id) {
 	    !isset($a_gateways[$id]['disabled']) &&
 	    isset($a_gateways[$id]['isdefaultgw'])) {
 		$inet = (!is_ipaddrv4($a_gateways[$id]['gateway']) ? '-inet6' : '-inet');
+		$rgateway = $a_gateways[$id]['gateway'];
 		file_put_contents("/dev/console", "\n[".getmypid()."] DEL_GW, route= delete {$inet} default");
-		mwexec("/sbin/route delete {$inet} default");
+		mwexec("/sbin/route delete {$inet} default {$rgateway}");
 	}
 
 	/* NOTE: Cleanup static routes for the interface route if any */
@@ -152,8 +153,9 @@ function delete_gateway_item($id) {
 	    isset($a_gateways[$id]["nonlocalgateway"])) {
 		$realif = get_real_interface($a_gateways[$id]['interface']);
 		$inet = (!is_ipaddrv4($a_gateways[$id]['gateway']) ? "-inet6" : "-inet");
+		$rgateway = $a_gateways[$id]['gateway'];
 		file_put_contents("/dev/console", "\n[".getmypid()."] DEL_GW, route= $inet " . escapeshellarg($a_gateways[$id]['gateway']) . " -iface " . escapeshellarg($realif));
-		$cmd = "/sbin/route delete $inet " . escapeshellarg($a_gateways[$id]['gateway']) . " -iface " . escapeshellarg($realif);
+		$cmd = "/sbin/route delete $inet " . escapeshellarg($a_gateways[$id]['gateway']) . " -iface " . escapeshellarg($realif) . " " . escapeshellarg($rgateway);
 		mwexec($cmd);
 	}
 	/* NOTE: Cleanup static routes for the monitor ip if any */
@@ -161,10 +163,11 @@ function delete_gateway_item($id) {
 	    $a_gateways[$id]['monitor'] != "dynamic" &&
 	    is_ipaddr($a_gateways[$id]['monitor']) &&
 	    $a_gateways[$id]['gateway'] != $a_gateways[$id]['monitor']) {
+		$rgateway = $a_gateways[$id]['gateway'];
 		if (is_ipaddrv4($a_gateways[$id]['monitor'])) {
-			mwexec("/sbin/route delete " . escapeshellarg($a_gateways[$id]['monitor']));
+			mwexec("/sbin/route delete " . escapeshellarg($a_gateways[$id]['monitor']) . " " . escapeshellarg($rgateway));
 		} else {
-			mwexec("/sbin/route delete -inet6 " . escapeshellarg($a_gateways[$id]['monitor']));
+			mwexec("/sbin/route delete -inet6 " . escapeshellarg($a_gateways[$id]['monitor']) . " " . escapeshellarg($rgateway)));
 		}
 	}
 

--- a/src/usr/local/www/system_routes_edit.php
+++ b/src/usr/local/www/system_routes_edit.php
@@ -199,8 +199,8 @@ if ($_POST['save']) {
 				foreach ($delete_targets as $dts) {
 					if (is_ipaddrv6($dts)) {
 						$family = "-inet6";
-					}
-					$toapplylist[] = "/sbin/route delete {$family} {$dts}";
+					$rgateway = exec("/sbin/route -n show {$dts} | grep gateway | cut -d' ' -f6");
+					$toapplylist[] = "/sbin/route delete {$family} {$dts} {$rgateway}";
 				}
 			}
 		}

--- a/src/usr/local/www/system_routes_edit.php
+++ b/src/usr/local/www/system_routes_edit.php
@@ -199,8 +199,9 @@ if ($_POST['save']) {
 				foreach ($delete_targets as $dts) {
 					if (is_ipaddrv6($dts)) {
 						$family = "-inet6";
-					$rgateway = exec("/sbin/route -n show {$dts} | grep gateway | cut -d' ' -f6");
-					$toapplylist[] = "/sbin/route delete {$family} {$dts} {$rgateway}";
+					}
+					$rgateway = exec("/sbin/route -n get {$dts} | /usr/bin/awk '/gateway:/ {print $2;}'");
+					$toapplylist[] = "/sbin/route delete {$family} {$dts} " . escapeshellarg($rgateway);
 				}
 			}
 		}

--- a/src/usr/local/www/vpn_ipsec.php
+++ b/src/usr/local/www/vpn_ipsec.php
@@ -197,7 +197,8 @@ if ($_POST['apply']) {
 	} else if (isset($delbtn)) {
 		/* remove static route if interface is not WAN */
 		if ($a_phase1[$delbtn]['interface'] <> "wan") {
-			mwexec("/sbin/route delete -host {$a_phase1[$delbtn]['remote-gateway']}");
+			$rgateway = exec("/sbin/route -n show {$a_phase1[$delbtn]['remote-gateway']} | grep gateway | cut -d' ' -f6");
+			mwexec("/sbin/route delete -host {$a_phase1[$delbtn]['remote-gateway']} {$rgateway}");
 		}
 
 		/* remove all phase2 entries that match the ikeid */

--- a/src/usr/local/www/vpn_ipsec.php
+++ b/src/usr/local/www/vpn_ipsec.php
@@ -197,8 +197,8 @@ if ($_POST['apply']) {
 	} else if (isset($delbtn)) {
 		/* remove static route if interface is not WAN */
 		if ($a_phase1[$delbtn]['interface'] <> "wan") {
-			$rgateway = exec("/sbin/route -n show {$a_phase1[$delbtn]['remote-gateway']} | grep gateway | cut -d' ' -f6");
-			mwexec("/sbin/route delete -host {$a_phase1[$delbtn]['remote-gateway']} {$rgateway}");
+			$rgateway = exec("/sbin/route -n get {$a_phase1[$delbtn]['remote-gateway']} | /usr/bin/awk '/gateway:/ {print $2;}'");
+			mwexec("/sbin/route delete -host {$a_phase1[$delbtn]['remote-gateway']} " escapeshellarg($rgateway));
 		}
 
 		/* remove all phase2 entries that match the ikeid */

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -468,8 +468,8 @@ if ($_POST['save']) {
 		/* the ipsec_configure() handles adding the route */
 		if ($pconfig['interface'] <> "wan") {
 			if ($old_ph1ent['remote-gateway'] <> $pconfig['remotegw']) {
-                                $rgateway = exec("/sbin/route -n show {$old_ph1ent} | grep gateway | cut -d' ' -f6");
-				mwexec("/sbin/route delete -host {$old_ph1ent['remote-gateway']} {$rgateway}");
+                                $rgateway = exec("/sbin/route -n get {$old_ph1ent} | /usr/bin/awk '/gateway:/ {print $2;}'");
+				mwexec("/sbin/route delete -host {$old_ph1ent['remote-gateway']} " . escapeshellarg($rgateway));
 			}
 		}
 

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -468,7 +468,8 @@ if ($_POST['save']) {
 		/* the ipsec_configure() handles adding the route */
 		if ($pconfig['interface'] <> "wan") {
 			if ($old_ph1ent['remote-gateway'] <> $pconfig['remotegw']) {
-				mwexec("/sbin/route delete -host {$old_ph1ent['remote-gateway']}");
+                                $rgateway = exec("/sbin/route -n show {$old_ph1ent} | grep gateway | cut -d' ' -f6");
+				mwexec("/sbin/route delete -host {$old_ph1ent['remote-gateway']} {$rgateway}");
 			}
 		}
 


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10001
- [ ] Ready for review

All code that uses “delete route” must use the full format with GW, i.e.

incorrect:
```
# route delete -inet 5.5.5.0/24
route: route has not been found
delete net 5.5.5.0 fib 0: not in table
```

correct:
```
# route delete -inet 5.5.5.0/24 10.1.0.254
delete net 5.5.5.0: gateway 10.1.0.254
```

no such issue with 2.4.4-p3 and 2.4.5
**it seems FreeBSD 12 issue**

Same issue: https://redmine.pfsense.org/issues/9969