### PR TITLE
strip ipsec hash algo from swanctl.conf if encryption algo is aes-gcm

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -1869,7 +1869,7 @@ function ipsec_setup_proposal_algo($ealg_id, $keylen, $halgo, $modp) {
 	}
 
 	/* Add the hash algorithm (if present) */
-	if (!empty($halgo)) {
+	if (!empty($halgo) && !strpos($ealg_id, "gcm")) {
 		/* If there is some content in the propsal already, add a
 		 * separator */
 		if (!empty($palgo)) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9726
- [ ] Ready for review

AES-GCM does not use hash algo, and strongswan does not use its value
do PR strip hash algo from swanctl.conf if ealgo is *gcm*
