### PR TITLE
export firewall aliases to txt file

### DIFF
--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -121,6 +121,12 @@ if ($_POST['save']) {
 	$origname = $pconfig['name'];
 }
 
+if ($_REQUEST['exportaliases']) {
+	$expdata = str_replace(' ',"\n",$a_aliases[$id]['address']);
+	$expdata .= "\n";
+	send_user_download('data', $expdata, "{$_POST['origname']}.txt");
+}
+
 $tab = $_REQUEST['tab'];
 
 if (empty($tab)) {
@@ -742,6 +748,15 @@ while ($counter < count($addresses)) {
 	$counter++;
 }
 
+if ((isset($id) && $a_aliases[$id]) && !preg_match("/url/i", $pconfig['type'])) {
+	$form->addGlobal(new Form_Button(
+		'exportaliases',
+		'Export to file',
+		null,
+		'fa-download'
+	))->addClass('btn-primary');
+}
+
 $form->addGlobal(new Form_Button(
 	'addrow',
 	$btn_str[$tab],
@@ -866,4 +881,5 @@ events.push(function() {
 </script>
 
 <?php
+
 include("foot.inc");

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -881,5 +881,4 @@ events.push(function() {
 </script>
 
 <?php
-
 include("foot.inc");


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9816
- [ ] Ready for review

This PR adds "Export to file" button on Aliases / Edit page
It can be very useful when you have a lot of manually added aliases - 
this makes it easy to copy it to another firewall or server (for urltable)
