### PR TITLE
openvpn server ocsp support

### DIFF
--- a/src/usr/local/sbin/ovpn_auth_verify
+++ b/src/usr/local/sbin/ovpn_auth_verify
@@ -22,7 +22,11 @@
 
 
 if [ "$1" = "tls" ]; then
-	RESULT=$(/usr/local/sbin/fcgicli -f /etc/inc/openvpn.tls-verify.php -d "servercn=$2&depth=$3&certdepth=$4&certsubject=$5")
+	for ((check_depth=$3; check_depth>=0; check_depth--));
+	do
+		eval serial="\$tls_serial_${check_depth}"
+		RESULT=$(/usr/local/sbin/fcgicli -f /etc/inc/openvpn.tls-verify.php -d "servercn=$2&depth=$3&certdepth=$4&certsubject=$5&serial=$serial&config=$config")
+	done
 else
 	# Single quoting $password breaks getting the value from the variable.
 	# Base64 and urlEncode usernames and passwords


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/7767
- [ ] Ready for review


Based on https://github.com/OpenVPN/openvpn/blob/master/contrib/OCSP_check/OCSP_check.sh
but for latest openssl 1.1.1a output
shell script uses $config env to find correct vpnid from config

Do we need 'nonce' option here?
Do we need to check all certs in chain?
Bypass users on 'soft fail'? (server is not available)

Needs more testing!