### PR TITLE
enable urltable alias to return > 1 IPs

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1867,23 +1867,43 @@ function get_uptime_sec() {
 	return $uptime;
 }
 
-function fqdn_to_ip($hostname, $ipv6 = false) {
-	$domrecords = array();
-	$domips = array();
-	$qtype = ($ipv6 ? 'AAAA' : 'A');
-	exec("/usr/bin/host -t {$qtype} " . escapeshellarg($hostname), $domrecords, $rethost);
-	if ($rethost == 0) {
-		foreach ($domrecords as $domr) {
-			$doml = explode(" ", $domr);
-			$domip = ($ipv6 ? $doml[4] : $doml[3]);
-			/* fill array with domain ip addresses */
-			if (is_ipaddr($domip)) {
-				$domips[] = $domip;
-			}
+function resolve_host_addresses($host, $recordtypes = array(DNS_A, DNS_AAAA, DNS_CNAME), $index = true) {
+	$dnsresult = array();
+	$resolved = array();
+	$errreporting = error_reporting();
+	error_reporting($errreporting & ~E_WARNING);// dns_get_record throws a warning if nothing is resolved..
+	foreach ($recordtypes as $recordtype) {
+		$tmp = dns_get_record($host, $recordtype);
+		if (is_array($tmp)) {
+			$dnsresult = array_merge($dnsresult, $tmp);
 		}
 	}
-	sort($domips);
-	return $domips;
+	error_reporting($errreporting);// restore original php warning/error settings.
+	foreach ($dnsresult as $item) {
+		$newitem = array();
+		$newitem['type'] = $item['type'];
+		switch ($item['type']) {
+			case 'CNAME':
+				$newitem['data'] = $item['target'];
+				$resolved[] = $newitem;
+				break;
+			case 'A':
+				$newitem['data'] = $item['ip'];
+				$resolved[] = $newitem;
+				break;
+			case 'AAAA':
+				$newitem['data'] = $item['ipv6'];
+				$resolved[] = $newitem;
+				break;
+		}
+	}
+	if ($index == false) {
+		foreach ($resolved as $res) {
+			$noind[] = $res['data'];
+		}
+		$resolved = $noind;
+	}
+	return $resolved;
 }
 
 function add_hostname_to_watch($hostname) {
@@ -1893,7 +1913,7 @@ function add_hostname_to_watch($hostname) {
 	$result = array();
 	if ((is_fqdn($hostname)) && (!is_ipaddr($hostname))) {
 		$contents = "";
-		$domips = fqdn_to_ip($hostname);
+		$domips = resolve_host_addresses($hostname, array(DNS_A), false);
 		if (!empty($domips)) {
 			foreach ($domips as $ip) {
 				$contents .= "$ip\n";
@@ -1944,7 +1964,7 @@ function compare_hostname_to_dnscache($hostname) {
 	}
 	if ((is_fqdn($hostname)) && (!is_ipaddr($hostname))) {
 		$contents = "";
-		$domips = fqdn_to_ip($hostname);
+		$domips = resolve_host_addresses($hostname, array(DNS_A), false);
 		if (!empty($domips)) {
 			foreach ($domips as $ip) {
 				$contents .= "$ip\n";
@@ -2386,9 +2406,7 @@ function parse_aliases_file($filename, $type = "url", $max_items = -1, $kflc = f
 						break;
 					}
 					if (is_fqdn($tmp)) {
-						$domipsv4 = fqdn_to_ip($tmp);
-						$domipsv6 = fqdn_to_ip($tmp, true);
-						$results = array_merge($domipsv4, $domipsv6);
+						$results = resolve_host_addresses($tmp, array(DNS_A, DNS_AAAA), false);
 						if (!empty($results)) {
 							foreach ($results as $ip) {
 								if (is_ipaddr($ip)) {

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1867,27 +1867,33 @@ function get_uptime_sec() {
 	return $uptime;
 }
 
+function fqdn_to_ip($hostname, $ipv6 = false) {
+	$domrecords = array();
+	$domips = array();
+	$qtype = ($ipv6 ? 'AAAA' : 'A');
+	exec("/usr/bin/host -t {$qtype} " . escapeshellarg($hostname), $domrecords, $rethost);
+	if ($rethost == 0) {
+		foreach ($domrecords as $domr) {
+			$doml = explode(" ", $domr);
+			$domip = ($ipv6 ? $doml[4] : $doml[3]);
+			/* fill array with domain ip addresses */
+			if (is_ipaddr($domip)) {
+				$domips[] = $domip;
+			}
+		}
+	}
+	sort($domips);
+	return $domips;
+}
+
 function add_hostname_to_watch($hostname) {
 	if (!is_dir("/var/db/dnscache")) {
 		mkdir("/var/db/dnscache");
 	}
 	$result = array();
 	if ((is_fqdn($hostname)) && (!is_ipaddr($hostname))) {
-		$domrecords = array();
-		$domips = array();
-		exec("/usr/bin/host -t A " . escapeshellarg($hostname), $domrecords, $rethost);
-		if ($rethost == 0) {
-			foreach ($domrecords as $domr) {
-				$doml = explode(" ", $domr);
-				$domip = $doml[3];
-				/* fill array with domain ip addresses */
-				if (is_ipaddr($domip)) {
-					$domips[] = $domip;
-				}
-			}
-		}
-		sort($domips);
 		$contents = "";
+		$domips = fqdn_to_ip($hostname);
 		if (!empty($domips)) {
 			foreach ($domips as $ip) {
 				$contents .= "$ip\n";
@@ -1937,21 +1943,8 @@ function compare_hostname_to_dnscache($hostname) {
 		$oldcontents = "";
 	}
 	if ((is_fqdn($hostname)) && (!is_ipaddr($hostname))) {
-		$domrecords = array();
-		$domips = array();
-		exec("/usr/bin/host -t A " . escapeshellarg($hostname), $domrecords, $rethost);
-		if ($rethost == 0) {
-			foreach ($domrecords as $domr) {
-				$doml = explode(" ", $domr);
-				$domip = $doml[3];
-				/* fill array with domain ip addresses */
-				if (is_ipaddr($domip)) {
-					$domips[] = $domip;
-				}
-			}
-		}
-		sort($domips);
 		$contents = "";
+		$domips = fqdn_to_ip($hostname);
 		if (!empty($domips)) {
 			foreach ($domips as $ip) {
 				$contents .= "$ip\n";
@@ -2385,13 +2378,38 @@ function parse_aliases_file($filename, $type = "url", $max_items = -1, $kflc = f
 			if (!empty($tmp_str)) {
 				$tmp = $tmp_str;
 			}
-			$valid = (($type == "url" || $type == "urltable") && (is_ipaddr($tmp) || is_subnet($tmp))) ||
-				(($type == "url_ports" || $type == "urltable_ports") && is_port_or_range($tmp));
-			if ($valid) {
-				$items[] = $tmp;
-				if (count($items) == $max_items) {
+			switch ($type) {
+				case "url":
+				case "urltable":
+					if (is_ipaddr($tmp) || is_subnet($tmp)) {
+						$items[] = $tmp;
+						break;
+					}
+					if (is_fqdn($tmp)) {
+						$domipsv4 = fqdn_to_ip($tmp);
+						$domipsv6 = fqdn_to_ip($tmp, true);
+						$results = array_merge($domipsv4, $domipsv6);
+						if (!empty($results)) {
+							foreach ($results as $ip) {
+								if (is_ipaddr($ip)) {
+									$items[] = $ip;
+								}
+							}
+						}
+					}
+					break;
+				case "url_ports":
+				case "urltable_ports":
+					if (is_port_or_range($tmp)) {
+						$items[] = $tmp;
+					}
+					break;
+				default:
+					/* unknown type */
 					break;
 				}
+			if (count($items) == $max_items) {
+				break;
 			}
 		}
 	}

--- a/src/usr/local/www/diag_dns.php
+++ b/src/usr/local/www/diag_dns.php
@@ -30,6 +30,7 @@
 
 $pgtitle = array(gettext("Diagnostics"), gettext("DNS Lookup"));
 require_once("guiconfig.inc");
+require_once("pfsense-utils.inc");
 
 $host = trim($_REQUEST['host'], " \t\n\r\0\x0B[];\"'");
 
@@ -45,41 +46,6 @@ foreach ($a_aliases as $a) {
 		$id = $counter;
 	}
 	$counter++;
-}
-
-function resolve_host_addresses($host) {
-	$recordtypes = array(DNS_A, DNS_AAAA, DNS_CNAME);
-	$dnsresult = array();
-	$resolved = array();
-	$errreporting = error_reporting();
-	error_reporting($errreporting & ~E_WARNING);// dns_get_record throws a warning if nothing is resolved..
-	foreach ($recordtypes as $recordtype) {
-		$tmp = dns_get_record($host, $recordtype);
-		if (is_array($tmp)) {
-			$dnsresult = array_merge($dnsresult, $tmp);
-		}
-	}
-	error_reporting($errreporting);// restore original php warning/error settings.
-
-	foreach ($dnsresult as $item) {
-		$newitem = array();
-		$newitem['type'] = $item['type'];
-		switch ($item['type']) {
-			case 'CNAME':
-				$newitem['data'] = $item['target'];
-				$resolved[] = $newitem;
-				break;
-			case 'A':
-				$newitem['data'] = $item['ip'];
-				$resolved[] = $newitem;
-				break;
-			case 'AAAA':
-				$newitem['data'] = $item['ipv6'];
-				$resolved[] = $newitem;
-				break;
-		}
-	}
-	return $resolved;
 }
 
 if (isAllowedPage('firewall_aliases_edit.php') && isset($_POST['create_alias']) && (is_hostname($host) || is_ipaddr($host))) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/8531
- [ ] Ready for review

Patch that enables URL Table aliases to return a mix of IPv4/IPv6 entries as well as accomodate multiple entries per FQDN
Original patch by Luke Hamburg:
https://github.com/luckman212/pfsense/commit/063fa3a4a0832da86f9076040417903aa5d4ca7c

it's a bit modified by creating separate function fqdn_to_ip()