### PR TITLE
status_ntpd.php: check ntp acl only for localhost block

### DIFF
--- a/src/usr/local/www/status_ntpd.php
+++ b/src/usr/local/www/status_ntpd.php
@@ -38,7 +38,8 @@ require_once("guiconfig.inc");
 $allow_query = !isset($config['ntpd']['noquery']);
 if (!empty($config['ntpd']['restrictions']['row']) && is_array($config['ntpd']['restrictions']['row'])) {
 	foreach ($config['ntpd']['restrictions']['row'] as $v) {
-		if (ip_in_subnet($_SERVER['REMOTE_ADDR'], "{$v['acl_network']}/{$v['mask']}")) {
+		if (ip_in_subnet('127.0.0.1', "{$v['acl_network']}/{$v['mask']}") || 
+		    ip_in_subnet('::1', "{$v['acl_network']}/{$v['mask']}")) {
 			$allow_query = !isset($v['noquery']);
 		}
 	}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9829
- [ ] Ready for review

Status/NTP displays "Statistics unavailable because ntpq and ntpdc queries are disabled in the NTP service settings" when noquery is set in an ACL which covers web clients IP address
- in this case, if you go to status_ntpd.php from ACLed workstation, you not able to see NTP status info

this PR fix it, and check ACL only for localhost blocking ACLs