### PR TITLE
Improve building of non pfSense builds

### DIFF
--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -1582,7 +1582,7 @@ poudriere_rename_ports() {
 		fi
 
 		if [ -d ${_pdir}/${_pname}/files ]; then
-			for fd in $(find ${_pdir}/${_pname}/files d -name '*pfSense*'); do
+			for fd in $(find ${_pdir}/${_pname}/files -name '*pfSense*'); do
 				local _fddir=$(dirname ${fd})
 				local _fdname=$(echo $(basename ${fd}) | sed "s,pfSense,${PRODUCT_NAME},")
 


### PR DESCRIPTION
* Remove redirection on jail delete so user receives delete prompt
* Fix editing ports that don't contain a pkg-descr file by testing for file's existence first 
* Fix renaming of pfSense.c file in php module
* Renaming of php_pfSense.h references in pfSense.c and dummynet.c
* Allow for renaming of pfSense files to include both files and directories

A pull request for sysutils/pfSense-repo/makefile is also suggested in FreeBSD-ports.

See 2.5 Development Snapshot "Minor issues with non-pfSense rename logic"  discussion and redmine #10161

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10161
- [ ] Ready for review