### PR TITLE
OpenVPN: allow to fully disable compression

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -126,13 +126,12 @@ $openvpn_client_modes = array(
 global $openvpn_compression_modes;
 $openvpn_compression_modes = array(
 	'none' => gettext("Disable Compression, retain compression packet framing [compress]"),
-	'disable' => gettext("Fully Disable Compression, prevent from pushing settings later."),
 	'lz4' => gettext("LZ4 Compression [compress lz4]"),
 	'lz4-v2' => gettext("LZ4 Compression v2 [compress lz4-v2]"),
 	'lzo' => gettext("LZO Compression [compress lzo, equivalent to comp-lzo yes for compatibility]"),
 	'stub' => gettext("Enable Compression (stub) [compress stub]"),
 	'stub-v2' => gettext("Enable Compression (stub v2) [compress stub-v2]"),
-	'' => gettext("Omit Preference (Use OpenVPN Default)"),
+	'' => gettext("Fully Disable Compression, prevent from pushing settings later."),
 	'noadapt' => gettext("Omit Preference, + Disable Adaptive LZO Compression [Legacy style, comp-noadapt]"),
 	'adaptive' => gettext("Adaptive LZO Compression [Legacy style, comp-lzo adaptive]"),
 	'yes' => gettext("LZO Compression [Legacy style, comp-lzo yes]"),
@@ -1311,8 +1310,6 @@ function openvpn_reconfigure($mode, $settings) {
 	switch ($settings['compression']) {
 		case 'none':
 			$settings['compression'] = '';
-		case 'disable':
-			break;
 		case 'lz4':
 		case 'lz4-v2':
 		case 'lzo':

--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -126,6 +126,7 @@ $openvpn_client_modes = array(
 global $openvpn_compression_modes;
 $openvpn_compression_modes = array(
 	'none' => gettext("Disable Compression, retain compression packet framing [compress]"),
+	'disable' => gettext("Fully Disable Compression, prevent from pushing settings later."),
 	'lz4' => gettext("LZ4 Compression [compress lz4]"),
 	'lz4-v2' => gettext("LZ4 Compression v2 [compress lz4-v2]"),
 	'lzo' => gettext("LZO Compression [compress lzo, equivalent to comp-lzo yes for compatibility]"),
@@ -1310,6 +1311,8 @@ function openvpn_reconfigure($mode, $settings) {
 	switch ($settings['compression']) {
 		case 'none':
 			$settings['compression'] = '';
+		case 'disable':
+			break;
 		case 'lz4':
 		case 'lz4-v2':
 		case 'lzo':


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10177
- [ ] Ready for review

From openvpn(8):
If  the  algorithm  parameter  is  empty, compression will be turned off, but the packet framing for compression will still be enabled, **allowing a different setting to be pushed later**.

This PR allow to completely remove 'compress' option from config file