### PR TITLE
inverse matching of tags. Issue #10186

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2997,6 +2997,9 @@ function filter_generate_user_rule($rule) {
 	if (!empty($rule['vlanprioset']) && ($rule['vlanprioset'] != "none")) {
 		$aline['vlanprioset'] = " set prio " . $vlanprio_values[$rule['vlanprioset']] . " ";
 	}
+	if (!empty($rule['tagged']) && isset($rule['nottagged'])) {
+		$aline['nottagged'] = " ! ";
+	}
 	if ($type == "pass") {
 		if (isset($rule['allowopts'])) {
 			$aline['allowopts'] = " allow-opts ";
@@ -3188,7 +3191,7 @@ function filter_generate_user_rule($rule) {
 		$negate_networks = " to <negate_networks> " . filter_generate_port($rule, "destination");
 		$line .= $aline['type'] . $aline['direction'] . $aline['log'] . $aline['quick'] .
 			$aline['interface'] . $aline['ipprotocol'] . $aline['prot'] . $aline['src'] . $aline['os'] .
-			$negate_networks . $aline['icmp-type'] . $aline['icmp6-type'] . $aline['tag'] . $aline['tagged'] .
+			$negate_networks . $aline['icmp-type'] . $aline['icmp6-type'] . $aline['tag'] . $aline['nottagged'] . $aline['tagged'] .
 			$aline['vlanprio'] . $aline['vlanprioset'] . $aline['dscp'] . filter_negaterule_tracker() . $aline['allowopts'] . $aline['flags'] .
 			$aline['queue'] . $aline['dnpipe'] . $aline['schedlabel'] .
 			" label \"NEGATE_ROUTE: Negate policy routing for destination\"\n";
@@ -3197,7 +3200,7 @@ function filter_generate_user_rule($rule) {
 	/* piece together the actual user rule */
 	$line .= $aline['type'] . $aline['direction'] . $aline['log'] . $aline['quick'] . $aline['interface'] .
 		$aline['reply'] . $aline['route'] . $aline['ipprotocol'] . $aline['prot'] . $aline['src'] . $aline['os'] . $aline['dst'] .
-		$aline['icmp-type'] . $aline['icmp6-type'] . $aline['tag'] . $aline['tagged'] . $aline['dscp'] . $aline['tracker'] .
+		$aline['icmp-type'] . $aline['icmp6-type'] . $aline['tag'] . $aline['nottagged'] . $aline['tagged'] . $aline['dscp'] . $aline['tracker'] .
 		$aline['vlanprio'] . $aline['vlanprioset'] . $aline['allowopts'] . $aline['flags'] . $aline['queue'] . $aline['dnpipe'] . $aline['schedlabel'];
 
 	unset($aline);

--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -101,6 +101,7 @@ function is_aoadv_used($rule_config) {
 	    (isset($rule_config['disablereplyto'])) ||
 	    ($rule_config['tag'] != "") ||
 	    ($rule_config['tagged'] != "") ||
+	    (isset($rule_config['nottagged'])) ||
 	    ($rule_config['max'] != "") ||
 	    ($rule_config['max-src-nodes'] != "") ||
 	    ($rule_config['max-src-conn'] != "") ||
@@ -273,6 +274,9 @@ if (isset($id) && $a_filter[$id]) {
 	}
 	if (isset($a_filter[$id]['disablereplyto'])) {
 		$pconfig['disablereplyto'] = true;
+	}
+	if (isset($a_filter[$id]['nottagged'])) {
+		$pconfig['nottagged'] = true;
 	}
 
 	/* advanced */
@@ -519,6 +523,10 @@ if ($_POST['save']) {
 	if ((isset($_POST['srcnot']) && ($_POST['srctype'] == 'any')) ||
 	    (isset($_POST['dstnot']) && ($_POST['dsttype'] == 'any'))) {
 		$input_errors[] = gettext("Invert match cannot be selected with 'any'.");
+	}
+
+	if (isset($_POST['nottagged']) && empty($_POST['tagged'])) {
+		$input_errors[] = gettext("Invert tagged match cannot be selected without any tags.");
 	}
 
 	if (!$_POST['srcbeginport']) {
@@ -901,6 +909,11 @@ if ($_POST['save']) {
 			$filterent['disablereplyto'] = true;
 		} else {
 			unset($filterent['disablereplyto']);
+		}
+		if ($_POST['nottagged'] == "yes") {
+			$filterent['nottagged'] = true;
+		} else {
+			unset($filterent['nottagged']);
 		}
 		$filterent['max'] = $_POST['max'];
 		$filterent['max-src-nodes'] = $_POST['max-src-nodes'];
@@ -1570,12 +1583,25 @@ $section->addInput(new Form_Input(
 ))->setHelp('A packet matching this rule can be marked and this mark used to match '.
 	'on other NAT/filter rules. It is called %1$sPolicy filtering%2$s.', '<b>', '</b>');
 
-$section->addInput(new Form_Input(
-	'tagged',
-	'Tagged',
-	'text',
-	$pconfig['tagged']
-))->setHelp('A packet can be matched on a mark placed before on another rule.');
+$group = new Form_Group('Tagged');
+
+$group->add(new Form_Checkbox(
+	'nottagged',
+	'nottagged',
+	'Invert',
+	$pconfig['nottagged']
+))->setWidth(1);
+
+$group->add(new Form_Input(
+'tagged',
+'Tagged',
+'text',
+$pconfig['tagged']
+))->setWidth(4);
+
+$group->setHelp('Match a mark placed on a packet by a different rule with the Tag option. Check Invert to match packets which do not contain this tag.');
+
+$section->add($group);
 
 $section->addInput(new Form_Input(
 	'max',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10186
- [ ] Ready for review

allow to inverse tagged rules
i.e.
`block out quick on RED_NET ! tagged RED_NET_OK`