### PR TITLE
IPsec IPv6 dynamic FQDN Remote Gateways, resolve_retry() IPv6 support. Issue #9405

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -351,7 +351,7 @@ function ipsec_get_phase1_dst(& $ph1ent) {
 	$rg = $ph1ent['remote-gateway'];
 	if (!is_ipaddr($rg)) {
 		if (!platform_booting()) {
-			return resolve_retry($rg);
+			return resolve_retry($rg, $ph1ent['protocol']);
 		}
 	}
 	if (!is_ipaddr($rg)) {
@@ -1209,7 +1209,7 @@ function ipsec_setup_gwifs() {
 				$filterdns_list[] = "{$rg}";
 				add_hostname_to_watch($rg);
 				if (!platform_booting()) {
-					$rg = resolve_retry($rg);
+					$rg = resolve_retry($rg, $ph1ent['protocol']);
 				}
 				if (!is_ipaddr($rg)) {
 					continue;

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1932,22 +1932,55 @@ function mac_format($clientmac) {
 	}
 }
 
-function resolve_retry($hostname, $retries = 5) {
+function resolve_retry($hostname, $protocol = 'inet', $retries = 5, $numrecords = 1) {
 
-	if (is_ipaddr($hostname)) {
-		return $hostname;
-	}
-
+	$recresult = array();
+	$returnres = array();
 	for ($i = 0; $i < $retries; $i++) {
-		// FIXME: gethostbyname does not work for AAAA hostnames, boo, hiss
-		$ip = gethostbyname($hostname);
-
-		if ($ip && $ip != $hostname) {
-			/* success */
-			return $ip;
+		switch ($protocol) {
+			case 'any':
+				$checkproto = 'is_ipaddr';
+				$dnsproto = DNS_ANY;
+				$dnstype = array('A', 'AAAA');
+				break;
+			case 'inet6':
+				$checkproto = 'is_ipaddrv6';
+				$dnsproto = DNS_AAAA;
+				$dnstype = array('AAAA');
+				break;
+			case 'inet': 
+			default:
+				$checkproto = 'is_ipaddrv4';
+				$dnsproto = DNS_A;
+				$dnstype = array('A');
+				break;
+		}
+		if ($checkproto($hostname)) {
+			return $hostname;
+		}
+		$dnsresult = dns_get_record($hostname, $dnsproto);
+		foreach ($dnsresult as $dnsrec => $ip) {
+			if (is_array($ip)) {
+				if (in_array($ip['type'], $dnstype)) {
+				    if ($checkproto($ip['ip'])) { 
+					    $recresult[] = $ip['ip'];
+				    }
+				    if ($checkproto($ip['ipv6'])) { 
+					    $recresult[] = $ip['ipv6'];
+				    }
+				}
+			}
 		}
 
 		sleep(1);
+	}
+
+	if (!empty($recresult)) {
+		if ($numrecords == 1) {
+			return $recresult[0];
+		} else {
+			return array_slice($recresult, 0, $numrecords);
+		}
 	}
 
 	return false;


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9405
- [ ] Ready for review

IPsec IPv6 dynamic FQDN Remote Gateways support by adding IPv6 FQDN resolution ability to resolve_retry() 