### PR TITLE
allow to disable IPsec P1 when P2 is disabled VTI. Issue #10190

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -920,7 +920,7 @@ function ipsec_get_loglevels() {
 	return $levels;
 }
 
-function ipsec_vti($ph1ent, $returnaddresses = false) {
+function ipsec_vti($ph1ent, $returnaddresses = false, $skipdisabled = true) {
 	global $config;
 	if (empty($ph1ent) || !is_array($ph1ent) || !is_array($config['ipsec']['phase2'])) {
 		return false;
@@ -941,7 +941,11 @@ function ipsec_vti($ph1ent, $returnaddresses = false) {
 					'descr' => $ph2ent['descr'],
 				);
 			}
-			$is_vti = true;
+			if (!$skipdisabled && isset($ph2ent['disabled'])) {
+				continue;
+			} else {
+				$is_vti = true;
+			}
 		}
 	}
 	return ($returnaddresses) ? $vtisubnet_spec : $is_vti;

--- a/src/usr/local/www/vpn_ipsec.php
+++ b/src/usr/local/www/vpn_ipsec.php
@@ -178,7 +178,7 @@ if ($_POST['apply']) {
 		if (isset($a_phase1[$togglebtn]['disabled'])) {
 			unset($a_phase1[$togglebtn]['disabled']);
 		} else {
-			if (ipsec_vti($a_phase1[$togglebtn])) {
+			if (ipsec_vti($a_phase1[$togglebtn], false, false)) {
 				$input_errors[] = gettext("Cannot disable a Phase 1 with a child Phase 2 while the interface is assigned. Remove the interface assignment before disabling this P2.");
 			} else {
 				$a_phase1[$togglebtn]['disabled'] = true;

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -443,7 +443,7 @@ if ($_POST['save']) {
 			}
 		}
 	}
-	if (is_array($old_ph1ent) && ipsec_vti($old_ph1ent) && $pconfig['disabled']) {
+	if (is_array($old_ph1ent) && ipsec_vti($old_ph1ent, false, false) && $pconfig['disabled']) {
 		$input_errors[] = gettext("Cannot disable a Phase 1 with a child Phase 2 while the interface is assigned. Remove the interface assignment before disabling this P2.");
 	}
 


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10190
- [ ] Ready for review

The original ipsec_vti() doesn't check that P2 VTI is disabled or not
This PR fix it