### PR TITLE
Fix NAT reflection rules if dest > 1 IP. Issue #7614

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2425,8 +2425,11 @@ function filter_nat_rules_generate() {
 			}
 
 			$localport_nat = $localport;
-			if (empty($localport_nat) && is_port($dstaddr_port[count($dstaddr_port)-1])) {
-				$localport_nat = " port " . $dstaddr_port[count($dstaddr_port)-1];
+
+			if (empty($localport_nat)) {
+				$natreftarget = $dstaddr_reflect;
+			} else {
+				$natreftarget = "{$target}{$localport_nat}";
 			}
 
 			if ($srcaddr <> "" && $dstaddr <> "" && $natif) {
@@ -2472,7 +2475,7 @@ function filter_nat_rules_generate() {
 
 				$natrules .= "\n";
 				if (!isset($rule['nordr'])) {
-					$natrules .= filter_generate_reflection_nat($rule, $route_table, $nat_if_list, $protocol, "{$target}{$localport_nat}", $target_ip);
+					$natrules .= filter_generate_reflection_nat($rule, $route_table, $nat_if_list, $protocol, $natreftarget, $target_ip);
 				}
 			}
 		}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/7614
- [ ] Ready for review

For example if the chosen destination is 'WAN net' and there is a VIP on the WAN in the different subnet.

NAT reflection is enabled and "Enable automatic outbound NAT for Reflection" is also enabled.

The rule created might be:

NAT Inbound Redirects
rdr on igb1 proto tcp from any to { 172.21.16.0/24 175.65.58.9/32 } port 5201 -> 192.168.211.10
Reflection redirect
rdr on { igb0 igb4_vlan1002 igb5_vlan1003 openvpn } proto tcp from any to { 172.21.16.0/24 175.65.58.9/32 } port 5201 -> 192.168.211.10
no nat on igb0 proto tcp from igb0 to 192.168.211.10 port 175.65.58.9/32
nat on igb0 proto tcp from 192.168.211.0/24 to 192.168.211.10 port 175.65.58.9/32 -> 192.168.211.1 port 1024:65535
The additional IP/subnet is placed in the port variable position resulting in an invalid ruleset...

In case of VIP filter_generate_adress() return string with more than one address, i.e.
{ 172.21.16.0/24 175.65.58.9/32 } port 5201

and 
```php
if (empty($localport_nat) && $dstaddr_port[2]) {
				$localport_nat = " port " . $dstaddr_port[2]
}
```
take a second IP as a port

this fix just use the filter_generate_adress() output as-is to pass it to the filter_generate_reflection_nat() if $localport is not defined


