### PR TITLE
Compare compressed IPv6 CARP VIP. Issue #6579

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -121,8 +121,15 @@ function does_vip_exist($vip) {
 	}
 
 	$ifacedata = pfSense_getall_interface_addresses($realif);
+
+	if (is_subnetv6("{$vip['subnet']}/{$vip['subnet_bits']}")) {	
+		$comparevip = text_to_compressed_ip6("{$vip['subnet']}/{$vip['subnet_bits']}");
+	} else {
+		$comparevip = "{$vip['subnet']}/{$vip['subnet_bits']}";
+	}
+
 	foreach ($ifacedata as $vipips) {
-		if ($vipips == "{$vip['subnet']}/{$vip['subnet_bits']}") {
+		if ($vipips == $comparevip) {
 			return true;
 		}
 	}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/6579
- [ ] Ready for review

If you have IPv6 CARP VIPs specified with non-significant zeros, such as `fdaa:1234:0012::1`, the secondary will see that as an old VIP and delete it upon config sync.

Since pfSense_getall_interface_addresses() returns compressed IPv6 addresses, the $vip address from config.xml must also be compressed by text_to_compressed_ip6() for comparison