### PR TITLE
enable gateway duplicates on ipsec

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -4226,7 +4226,7 @@ function filter_generate_ipsec_rules($log = array()) {
 		foreach ($config['ipsec']['phase1'] as $ph1ent) {
 			$tracker += 10;
 
-			if (isset ($ph1ent['disabled'])) {
+			if (isset ($ph1ent['disabled']) || isset ($ph1ent['gw_duplicates'])) {
 				continue;
 			}
 			/* determine local and remote peer addresses */

--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -1675,7 +1675,7 @@ function ipsec_setup_bypasslan() {
  * RESULT
  *   Static routes in the OS routing table for IPsec peers
  ******/
-function ipsec_setup_routes($interface, $family, $sourcehost) {
+function ipsec_setup_routes($interface, $family, $sourcehost, $duplicates) {
 	if (substr($interface, 0, 4) == "_vip") {
 		$vpninterface = get_configured_vip_interface($interface);
 		if (substr($vpninterface, 0, 4) == "_vip") {

--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -1219,7 +1219,7 @@ function ipsec_setup_gwifs() {
 					continue;
 				}
 			}
-			if (array_search($rg, $rgmap)) {
+			if (!isset($ph1ent['gw_duplicates']) && array_search($rg, $rgmap)) {
 				log_error(sprintf(gettext("The remote gateway %s already exists on another phase 1 entry"), $rg));
 				continue;
 			}
@@ -1671,6 +1671,7 @@ function ipsec_setup_bypasslan() {
  *   $interface : The interface upon which routes will be configured.
  *   $family    : The address family ('inet' or 'inet6')
  *   $sourcehost: The local source address used for initiating connections.
+ *   $duplicates: If the ipsec tunnel allows duplicates remote peers
  * RESULT
  *   Static routes in the OS routing table for IPsec peers
  ******/
@@ -1700,7 +1701,7 @@ function ipsec_setup_routes($interface, $family, $sourcehost) {
 			/* if the remote gateway is in the local subnet, then don't add a route */
 			if (is_ipaddrv4($sourcehost) &&
 			    !ip_in_subnet($sourcehost, "{$subnet_ip}/{$subnet_bits}")) {
-				if (is_ipaddrv4($gatewayip)) {
+				if (is_ipaddrv4($gatewayip) && !$duplicates) {
 					// log_error("IPSEC interface is not WAN but {$ifacesuse}, adding static route for VPN endpoint {$rgip} via {$gatewayip}");
 					route_add_or_change("-host {$sourcehost} {$gatewayip}");
 				}
@@ -1715,7 +1716,7 @@ function ipsec_setup_routes($interface, $family, $sourcehost) {
 			/* if the remote gateway is in the local subnet, then don't add a route */
 			if (is_ipaddrv6($sourcehost) &&
 			    !ip_in_subnet($sourcehost, "{$subnet_ip}/{$subnet_bits}")) {
-				if (is_ipaddrv6($gatewayip)) {
+				if (is_ipaddrv6($gatewayip) && !$duplicates) {
 					// log_error("IPSEC interface is not WAN but {$ifacesuse}, adding static route for VPN endpoint {$rgip} via {$gatewayip}");
 					route_add_or_change("-inet6 -host {$sourcehost} {$gatewayip}");
 				}
@@ -2018,7 +2019,7 @@ function ipsec_setup_tunnels() {
 		} else {
 			$remote_spec = $ph1ent['remote-gateway'];
 			$sourcehost = (is_ipaddr($remote_spec)) ? $remote_spec : $rgmap[$remote_spec];
-			$ifacesuse = ipsec_setup_routes($ph1ent['interface'], $ph1ent['protocol'], $sourcehost);
+			$ifacesuse = ipsec_setup_routes($ph1ent['interface'], $ph1ent['protocol'], $sourcehost, isset($ph1ent['gw_duplicates']));
 		}
 
 		/* Setup IKE proposals */

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -949,8 +949,8 @@ $section->addInput(new Form_Checkbox(
 	'gw_duplicates',
 	'Gateway duplicates',
 	'Enable this to allow multiple phase 1 configurations with the same endpoint. ' .
-		'When enabled, you are responsible for doing proper source routing configuration to the endpoints. '.
-		'When disabled, pfSense will create a static route and routing rules to the remote gateway.',
+		'When enabled, pfSense does not manage routing to the remote gateway and traffic will follow the default route '.
+		'without regard for the chosen interface. Static routes can override this behavior.'.
 	$pconfig['gw_duplicates']
 ));
 

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -115,6 +115,12 @@ if (isset($p1index) && $a_phase1[$p1index]) {
 	$pconfig['descr'] = $a_phase1[$p1index]['descr'];
 	$pconfig['nat_traversal'] = $a_phase1[$p1index]['nat_traversal'];
 	$pconfig['mobike'] = $a_phase1[$p1index]['mobike'];
+	$pconfig['gw_duplicates'] = $a_phase1[$p1index]['gw_duplicates'];
+
+	if (isset($a_phase1[$p1index]['gw_duplicates'])) {
+		$pconfig['gw_duplicates'] = true;
+	}
+
 	$pconfig['closeaction'] = $a_phase1[$p1index]['closeaction'];
 
 	if (isset($a_phase1[$p1index]['responderonly'])) {
@@ -286,7 +292,7 @@ if ($_POST['save']) {
 		foreach ($a_phase1 as $ph1tmp) {
 			if ($p1index != $t) {
 				$tremotegw = $pconfig['remotegw'];
-				if (($ph1tmp['remote-gateway'] == $tremotegw) && !isset($ph1tmp['disabled'])) {
+				if (($ph1tmp['remote-gateway'] == $tremotegw) && !isset($ph1tmp['disabled']) && (!isset($pconfig['gw_duplicates']) || !isset($ph1tmp['gw_duplicates']))) {
 					$input_errors[] = sprintf(gettext('The remote gateway "%1$s" is already used by phase1 "%2$s".'), $tremotegw, $ph1tmp['descr']);
 				}
 			}
@@ -500,6 +506,14 @@ if ($_POST['save']) {
 		$ph1ent['descr'] = $pconfig['descr'];
 		$ph1ent['nat_traversal'] = $pconfig['nat_traversal'];
 		$ph1ent['mobike'] = $pconfig['mobike'];
+
+		if ( isset($pconfig['gw_duplicates'])) {
+			$ph1ent['gw_duplicates'] = true;
+		}
+		else {
+			unset($ph1ent['gw_duplicates']);
+		}
+
 		$ph1ent['closeaction'] = $pconfig['closeaction'];
 
 		if (isset($pconfig['responderonly'])) {
@@ -932,6 +946,13 @@ $section->addInput(new Form_Select(
 	$pconfig['mobike'],
 	array('on' => gettext('Enable'), 'off' => gettext('Disable'))
 ))->setHelp('Set this option to control the use of MOBIKE');
+
+$section->addInput(new Form_Checkbox(
+	'gw_duplicates',
+	'Gateway duplicates',
+	'Enable this to allow multiple phase 1 configurations with the same endpoint. When enabled, you are responsible for doing proper source routing configuration to the endpoints. When disabled, pfSense will create a static route and routing rules to the remote gateway.',
+	$pconfig['gw_duplicates']
+));
 
 $section->addInput(new Form_Checkbox(
 	'splitconn',

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -949,8 +949,8 @@ $section->addInput(new Form_Checkbox(
 	'gw_duplicates',
 	'Gateway duplicates',
 	'Enable this to allow multiple phase 1 configurations with the same endpoint. ' .
-		'When enabled, pfSense does not manage routing to the remote gateway and traffic will follow the default route '.
-		'without regard for the chosen interface. Static routes can override this behavior.'.
+		'When enabled, pfSense does not manage routing to the remote gateway and traffic will follow the default route ' .
+		'without regard for the chosen interface. Static routes can override this behavior.',
 	$pconfig['gw_duplicates']
 ));
 

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -115,7 +115,6 @@ if (isset($p1index) && $a_phase1[$p1index]) {
 	$pconfig['descr'] = $a_phase1[$p1index]['descr'];
 	$pconfig['nat_traversal'] = $a_phase1[$p1index]['nat_traversal'];
 	$pconfig['mobike'] = $a_phase1[$p1index]['mobike'];
-	$pconfig['gw_duplicates'] = $a_phase1[$p1index]['gw_duplicates'];
 
 	if (isset($a_phase1[$p1index]['gw_duplicates'])) {
 		$pconfig['gw_duplicates'] = true;
@@ -509,8 +508,7 @@ if ($_POST['save']) {
 
 		if ( isset($pconfig['gw_duplicates'])) {
 			$ph1ent['gw_duplicates'] = true;
-		}
-		else {
+		} else {
 			unset($ph1ent['gw_duplicates']);
 		}
 
@@ -950,7 +948,9 @@ $section->addInput(new Form_Select(
 $section->addInput(new Form_Checkbox(
 	'gw_duplicates',
 	'Gateway duplicates',
-	'Enable this to allow multiple phase 1 configurations with the same endpoint. When enabled, you are responsible for doing proper source routing configuration to the endpoints. When disabled, pfSense will create a static route and routing rules to the remote gateway.',
+	'Enable this to allow multiple phase 1 configurations with the same endpoint. ' .
+		'When enabled, you are responsible for doing proper source routing configuration to the endpoints. '.
+		'When disabled, pfSense will create a static route and routing rules to the remote gateway.',
 	$pconfig['gw_duplicates']
 ));
 


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/10214
- [x] Ready for review

This PR enables ipsec phases 1 to share the same endpoint threw a new option.
When the option is enabled, the static route to the endpoint is not added and the automatic rules for the ipsec tunnel are not generated.