### PR TITLE
Update DH group warnings to say that group 5 is also weak. Issue #10221

### DIFF
--- a/src/usr/local/www/vpn_ipsec_mobile.php
+++ b/src/usr/local/www/vpn_ipsec_mobile.php
@@ -683,7 +683,7 @@ $group->add(new Form_Select(
 	'Group',
 	$pconfig['pfs_group'],
 	$p2_pfskeygroups
-))->setHelp('Note: Groups 1, 2, 22, 23, and 24 provide weak security and should be avoided.');
+))->setHelp('Note: Groups 1, 2, 5, 22, 23, and 24 provide weak security and should be avoided.');
 
 $section->add($group);
 

--- a/src/usr/local/www/vpn_ipsec_phase2.php
+++ b/src/usr/local/www/vpn_ipsec_phase2.php
@@ -691,7 +691,7 @@ $section->add($group);
 
 $sm = (!isset($pconfig['mobile']) || !isset($a_client['pfs_group']));
 $helpstr = $sm ? '':'Set globally in mobile client options. ';
-$helpstr .= 'Note: Groups 1, 2, 22, 23, and 24 provide weak security and should be avoided.';
+$helpstr .= 'Note: Groups 1, 2, 5, 22, 23, and 24 provide weak security and should be avoided.';
 
 $section->addInput(new Form_Select(
 	'pfsgroup',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10221
- [ ] Ready for review

from https://wiki.strongswan.org/projects/strongswan/wiki/SecurityRecommendations:
```
It is advised to adhere to the recommendation of the appropriate security authority when choosing ciphers
to secure the tunnel cryptographically. www.keylength.com lists some of the standards for western Europe
and the US. It is strongly advised to use at least 2048 bit key length for MODP Diffie-Hellman groups.
```

DH group 5 = 1536 bits, avoid

original PR https://github.com/pfsense/pfsense/pull/4134 can be closed