### PR TITLE
Add option to increase parallel IKEv1 Phase 2 rekeys. Issue #9331

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -1368,6 +1368,10 @@ function ipsec_setup_strongswan() {
 		$ssconf['charon']['accept_unencrypted_mainmode_messages'] = "yes";
 	}
 
+	if (isset($config['ipsec']['maxexchange'])) {
+		$ssconf['charon']['max_ikev1_exchanges'] = $config['ipsec']['maxexchange'];
+	}
+
 	$unity_enabled = isset($config['ipsec']['unityplugin']) ? 'yes' : 'no';
 	$ssconf['charon']['cisco_unity'] = $unity_enabled;
 


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9331
- [ ] Ready for review

In certain situations remote firewalls might issue a rekey for
all CHILD_SAs in parallel. At least Watchguard firewall clusters
have been seen flooding rekeys after they failover.

strongSwan usually only allows for 3 concurrent rekeys. Nevertheless
it already has the option max_ikev1_exchanges to increase that
value. This patch adds a setting to the advanced VPN dialogue
to control the behaviour of the parameter

this is updated PR with resolved conflicts,
original PR https://github.com/pfsense/pfsense/pull/4052 can be closed