### PR TITLE
Set correct default MTU for GRE,GIF and GRE/IPsec. Issue #10222

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -29,6 +29,7 @@
 require_once("globals.inc");
 require_once("util.inc");
 require_once("gwlb.inc");
+require_once("ipsec.inc");
 
 function interfaces_bring_up($interface) {
 	if (!$interface) {
@@ -267,21 +268,6 @@ function interface_is_qinq($if = NULL) {
 		}
 	}
 
-	return (NULL);
-}
-
-function interface_is_lagg($if = NULL) {
-	global $config;
-
-	if (!isset($config['laggs']['lagg']) || !is_array($config['laggs']['lagg'])) {
-		return (NULL);
-	}
-
-	foreach ($config['laggs']['lagg'] as $lagg) {
-		if ($lagg['laggif'] == $if) {
-			return ($lagg);
-		}
-	}
 	return (NULL);
 }
 
@@ -1154,6 +1140,62 @@ function interface_gre_configure(&$gre, $grekey = "") {
 	interfaces_bring_up($greif);
 
 	return $greif;
+}
+
+function interface_is_type($if = NULL, $type) {
+	global $config;
+	switch ($type) {
+		case "gre":
+			$list = 'gres';
+			$entry = 'gre';
+			$entif = 'greif';
+			break;
+		case "gif":
+			$list = 'gifs';
+			$entry = 'gif';
+			$entif = 'gifif';
+			break;
+		case "lagg":
+			$list = 'laggs';
+			$entry = 'lagg';
+			$entif = 'laggif';
+			break;
+		default:
+			break;
+	}
+
+	if (!isset($config[$list][$entry]) || !is_array($config[$list][$entry])) {
+		return (NULL);
+	}
+
+	foreach ($config[$list][$entry] as $ent) {
+		if ($ent[$entif] == $if) {
+			return ($ent);
+		}
+	}
+	return (NULL);
+}
+
+function is_greipsec($if) {
+	global $config;
+
+	if (ipsec_enabled() && is_array($config['gres']) && 
+	    is_array($config['gres']['gre']) &&
+	    is_array($config['ipsec']['phase2'])) {
+		foreach ($config['gres']['gre'] as $gre) {
+			foreach ($config['ipsec']['phase1'] as $ph1ent) {
+				foreach ($config['ipsec']['phase2'] as $ph2ent) {
+					if (($ph1ent['ikeid'] == $ph2ent['ikeid']) && ($ph2ent['mode'] == 'transport') && 
+					    !isset($ph1ent['disabled']) && !isset($ph2ent['disabled']) && 
+					    ($ph1ent['interface'] == $gre['if']) && ($gre['greif'] == $if) &&
+					    ($ph1ent['remote-gateway'] == $gre['remote-addr'])) {
+						    return true;
+					}
+				}
+			}
+		}
+	}
+	return false;
 }
 
 function interfaces_gif_configure($checkparent = 0, $realif = "") {
@@ -3947,8 +3989,19 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 	if ($wantedmtu == 0) {
 		$wantedmtu = interface_mtu_wanted_for_pppoe($mtuif);
 	}
-	if ($wantedmtu == 0 && interface_is_vlan($mtuif) != NULL && interface_isppp_type($interface)) {
+	if (($wantedmtu == 0) && interface_is_vlan($mtuif) != NULL && interface_isppp_type($interface)) {
 		$wantedmtu = interface_mtu_wanted_for_pppoe($mtuhwif);
+	}
+	if (($wantedmtu == 0) && interface_is_type($mtuif, 'gre')) {
+		/* set MTU to 1400 for GRE over IPsec */
+		if (is_greipsec($mtuif)) {
+			$wantedmtu = 1400;
+		} else {
+			$wantedmtu = 1476;
+		}
+	}
+	if (($wantedmtu == 0) && interface_is_type($mtuif, 'gif')) {
+		$wantedmtu = 1280;
 	}
 
 	/* Set the MTU to 1500 if no explicit MTU configured. */
@@ -5526,7 +5579,7 @@ function get_parent_interface($interface, $avoidrecurse = false) {
 
 	if (empty($parents)) {
 		/* Handle LAGGs. */
-		$lagg = interface_is_lagg($realif);
+		$lagg = interface_is_type($realif, 'lagg');
 		if ($lagg != NULL && isset($lagg['members'])) {
 			$parents = explode(",", $lagg['members']);
 		}

--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -25,6 +25,7 @@
 require_once("filter.inc");
 require_once("auth.inc");
 require_once("certs.inc");
+require_once("interfaces.inc");
 
 /* IPsec defines */
 global $ipsec_loglevels;
@@ -2518,6 +2519,7 @@ function ipsec_configure($restart = false) {
 		sleep(2);
 		/* Shutdown enc0 interface*/
 		mwexec("/sbin/ifconfig enc0 down");
+		ipsec_gre_default_mtu(); 
 		return 0;
 	} else {
 		/* Startup enc0 interface */
@@ -2639,6 +2641,9 @@ function ipsec_configure($restart = false) {
 		}
 	}
 
+	/* set default MTU to 1400 for GRE over IPsec, othewise to 1476 */
+	ipsec_gre_default_mtu(); 
+
 	/* Manage process */
 	if ($restart === true) {
 		mwexec_bg("/usr/local/sbin/strongswanrc restart", false);
@@ -2689,5 +2694,19 @@ function ipsec_configure($restart = false) {
 
 	unlock($ipsecstartlock);
 	return count($filterdns_list);
+}
+
+function ipsec_gre_default_mtu() {
+	global $config;
+
+	foreach ($config['interfaces'] as $if => $ifdetail) { 
+		if (interface_is_type($ifdetail['if'], 'gre') && !isset($ifdetail['mtu'])) {
+			if (is_greipsec($ifdetail['if'])) {
+				set_interface_mtu($ifdetail['if'], 1400);
+			} else {
+				set_interface_mtu($ifdetail['if'], 1476);
+			}
+		}
+	}
 }
 ?>


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10222
- [ ] Ready for review

Default GRE MTU value is 1476
This is impossible in most cases when GRE/IPsec is used
It can be useful to set default MTU value for such cases to 1400

When you first create GRE/GIF interfaces, pfSense sets the correct MTU for it - 1476/1280
But with any change on the interface edit page, it set MTU to 1500
This PR also fixes this