### PR TITLE
Remove bogus warning on limiter/shaper deletion. Issue #9334

### DIFF
--- a/src/usr/local/www/firewall_shaper.php
+++ b/src/usr/local/www/firewall_shaper.php
@@ -430,7 +430,7 @@ if (!$dfltmsg && $sform)  {
 			$queue ? 'Delete this queue':'Disable shaper on interface',
 			$url,
 			'fa-trash'
-		))->addClass('btn-danger');
+		))->addClass('btn-danger nowarn');
 
 	}
 

--- a/src/usr/local/www/firewall_shaper_vinterface.php
+++ b/src/usr/local/www/firewall_shaper_vinterface.php
@@ -420,7 +420,7 @@ if (!$dfltmsg) {
 					($queue && ($qname != $pipe)) ? 'Delete this queue':'Delete Limiter',
 					$url,
 					'fa-trash'
-				))->addClass('btn-danger');
+				))->addClass('btn-danger nowarn');
 			}
 		}
 	}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9334
- [ ] Ready for review

When deleting the last row of the Limiter config - an error "The last row may not be deleted." appears.
Clicking OK then presents "Are you sure you wish to delete limiter?".
On clicking OK the limiter is deleted.

This PR removes "The last row may not be deleted." dialogue.