### PR TITLE
Allow to select QinQ interfaces for PPP interface. Issue #9472

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -6978,6 +6978,16 @@ function get_interface_ports() {
 		}
 	}
 
+	if (is_array($config['qinqs']['qinqentry']) && count($config['qinqs']['qinqentry'])) {
+		foreach ($config['qinqs']['qinqentry'] as $qinq) {
+			$members = explode(" ", $qinq['members']);
+			foreach ($members as $mem) {
+				$qentry = $qinq['vlanif'] . "." . $mem;
+				$portlist[$qentry] = $qentry;
+			}
+		}
+	}
+
 	foreach ($portlist as $ifn => $ifinfo) {
 		$string = "";
 		if (is_array($ifinfo)) {
@@ -7009,7 +7019,12 @@ function build_ppps_link_list() {
 	} else {
 		$iflist = get_interface_ports();
 
-		$viplist = get_configured_vip_list_with_descr('all', VIP_CARP);
+		$viplist = array();
+		$carplist = get_configured_vip_list_with_descr('all', VIP_CARP);
+		foreach ($carplist as $vid => $vaddr) {
+			$vip = get_configured_vip($vid);
+			$viplist[$vid] = "{$vaddr} (vhid: {$vip['vhid']})";
+		}
 
 		$linklist['list'] = array_merge($iflist, $viplist);
 


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9472
- [ ] Ready for review

After a QinQ interface has been created eg. vmx0.13.2 , this interface isn't available in the drop-down menu when selecting interfaces at Interfaces -> PPP -> Edit. Neither the vmx0.13 or vmx0.13.2 interface is available.

In Australia, we have some ISP's that run their PPPoE tagged as VLAN2 on their modem. For complex sites where vlan2 has already been used, QinQ is an excellent way to get a PPP session running. It works quite well if you edit the config file manually and put in the QinQ interface however it would be nice to be able to select the interfaces from the GUI drop down.

This PR adds QinQ to the list of Link Interface(s) on the Interfaces / PPPs / Edit page

It also adds “(vhid: x)” to the CARP description in this list, otherwise it simply shows the IP address of the CARP interface, which can confuse users.