### PR TITLE
Make disabled firewall rules red instead of grey in dark theme

### DIFF
--- a/src/usr/local/www/css/pfSense-dark.css
+++ b/src/usr/local/www/css/pfSense-dark.css
@@ -284,12 +284,12 @@ caption {
 
 .table-striped>tbody>tr.disabled:nth-of-type(odd) {
     background-color: rgba(48, 48, 48, .5);
-    color: rgba(255,255,255,.5);
+    color: rgba(255,55,55,1);
 }
 
 .table-striped>tbody>tr.disabled:nth-of-type(even) {
     background-color: rgba(66, 66, 66, .5);
-    color: rgba(255,255,255,.5);
+    color: rgba(255,55,55,1);
 }
 
 .table-hover>tbody>tr.disabled:hover, .table-striped>tbody>tr.disabled:nth-of-type(odd):hover, .table-striped>tbody>tr.disabled:nth-of-type(even):hover {


### PR DESCRIPTION
With this change, in the dark theme, firewall rules are marked with red text instead of light grey. The light grey text had very little contrast to the slightly darker grey background, so it was hard to see. The red text is much more noticeable.

I spent hours yesterday debugging an issue with my network. Turned out that I had disabled some firewall rules, and forgot to turn them back on again. I checked the rules multiple times just to make sure they made sense, but the very slight difference in contrast made me not register that some rules were disabled. I've got perfectly good eye-sight with no color blindness or anything, it was just that the contrast difference was not clear enough for me to register.

I don't think it looks too bad either:
**Old style:**
![Old style](https://user-images.githubusercontent.com/7773090/73592508-8c53be80-44fb-11ea-9b30-0d23437b84be.png)
**New style:**
![New style](https://user-images.githubusercontent.com/7773090/73592507-8c53be80-44fb-11ea-9430-232486dca4e4.png)



- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [x] Ready for review