### PR TITLE
DHCP group known clients by interface. Issue #1605

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -789,6 +789,9 @@ EOPP;
 			}
 		}
 
+		// instantiate class before pool definition
+		$dhcpdconf .= "class \"s_{$dhcpif}\" {\n	match pick-first-value (option dhcp-client-identifier, hardware);\n}\n";
+
 		$dhcpdconf .= "subnet {$subnet} netmask {$subnetmask} {\n";
 
 		// Setup pool options
@@ -860,8 +863,16 @@ EOPP;
 				$dhcpdconf .= "		$deny_action dynamic bootp clients;\n";
 			}
 
+			// set pool MAC limitations
 			if (isset($poolconf['denyunknown'])) {
-				$dhcpdconf .= "		$deny_action unknown-clients;\n";
+				if ($poolconf['denyunknown'] == "class") {
+					$dhcpdconf .= "		allow members of \"s_{$dhcpif}\";\n";
+					$dhcpdconf .= "		$deny_action unknown-clients;\n";
+				} else if ($poolconf['denyunknown'] == "disabled") {
+					// add nothing to $dhcpdconf; condition added to prevent next condition applying if ever engine changes such that: isset("disabled") == true
+				} else {	// "catch-all" covering "enabled" value post-PR#4066, and covering non-upgraded boolean option (i.e. literal value "enabled")
+					$dhcpdconf .= "		$deny_action unknown-clients;\n";
+				}
 			}
 
 			if ($poolconf['gateway'] && $poolconf['gateway'] != "none" && ($poolconf['gateway'] != $dhcpifconf['gateway'])) {
@@ -1110,11 +1121,11 @@ EOD;
 				$dhcpdconf .= "host s_{$dhcpif}_{$i} {\n";
 
 				if ($sm['mac']) {
-					$dhcpdconf .= "        hardware ethernet {$sm['mac']};\n";
+					$dhcpdconf .= "	hardware ethernet {$sm['mac']};\n";
 				}
 
 				if ($sm['cid']) {
-					$dhcpdconf .= "        option dhcp-client-identifier \"{$sm['cid']}\";\n";
+					$dhcpdconf .= " option dhcp-client-identifier \"{$sm['cid']}\";\n";
 				}
 
 				if ($sm['ipaddr']) {
@@ -1190,6 +1201,17 @@ EOD;
 				}
 
 				$dhcpdconf .= "}\n";
+
+				// subclass for DHCP limiting
+				if (!empty($sm['mac'])) {
+					// assuming ALL addresses are ethernet hardware type ("1:" prefix)
+					$dhcpdconf .= "subclass \"s_{$dhcpif}\" 1:{$sm['mac']};\n";
+				}
+				if (!empty($sm['cid'])) {
+					$dhcpdconf .= "subclass \"s_{$dhcpif}\" \"{$sm['cid']}\";\n";
+				}
+
+
 				$i++;
 			}
 		}

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -163,7 +163,13 @@ if (is_array($dhcpdconf)) {
 	list($pconfig['wins1'], $pconfig['wins2']) = $dhcpdconf['winsserver'];
 	list($pconfig['dns1'], $pconfig['dns2'], $pconfig['dns3'], $pconfig['dns4']) = $dhcpdconf['dnsserver'];
 	$pconfig['ignorebootp'] = isset($dhcpdconf['ignorebootp']);
-	$pconfig['denyunknown'] = isset($dhcpdconf['denyunknown']);
+
+	if (isset($dhcpdconf['denyunknown'])) {
+		$pconfig['denyunknown'] = empty($dhcpdconf['denyunknown']) ? "enabled" : $dhcpdconf['denyunknown'];
+	} else {
+		$pconfig['denyunknown'] = "disabled";
+	}
+
 	$pconfig['ignoreclientuids'] = isset($dhcpdconf['ignoreclientuids']);
 	$pconfig['nonak'] = isset($dhcpdconf['nonak']);
 	$pconfig['ddnsdomain'] = $dhcpdconf['ddnsdomain'];
@@ -659,7 +665,13 @@ if (isset($_POST['save'])) {
 		$dhcpdconf['domain'] = $_POST['domain'];
 		$dhcpdconf['domainsearchlist'] = $_POST['domainsearchlist'];
 		$dhcpdconf['ignorebootp'] = ($_POST['ignorebootp']) ? true : false;
-		$dhcpdconf['denyunknown'] = ($_POST['denyunknown']) ? true : false;
+
+		if (in_array($_POST['denyunknown'], array("enabled", "class"))) {
+			$dhcpdconf['denyunknown'] = $_POST['denyunknown'];
+		} else {
+			unset($dhcpdconf['denyunknown']);
+		}
+
 		$dhcpdconf['ignoreclientuids'] = ($_POST['ignoreclientuids']) ? true : false;
 		$dhcpdconf['nonak'] = ($_POST['nonak']) ? true : false;
 		$dhcpdconf['ddnsdomain'] = $_POST['ddnsdomain'];
@@ -965,12 +977,19 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['ignorebootp']
 ));
 
-$section->addInput(new Form_Checkbox(
+$section->addInput(new Form_Select(
 	'denyunknown',
 	'Deny unknown clients',
-	'Only the clients defined below will get DHCP leases from this server.',
-	$pconfig['denyunknown']
-));
+	$pconfig['denyunknown'],
+	array(
+		"disabled" => "Allow all clients",
+		"enabled" => "Allow known clients from any interface",
+		"class" => "Allow known clients from only this interface",
+	)
+))->setHelp('When set to %3$sAllow all clients%4$s, any DHCP client will get an IP address within this scope/range on this interface. '.
+	'If set to %3$sAllow known clients from any interface%4$s, any DHCP client with a MAC address listed on %1$s%3$sany%4$s%2$s scope(s)/interface(s) will get an IP address. ' .
+	'If set to %3$sAllow known clients from only this interface%4$s, only MAC addresses listed below (i.e. for this interface) will get an IP address within this scope/range.',
+	'<i>', '</i>', '<b>', '</b>');
 
 $section->addInput(new Form_Checkbox(
 	'nonak',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/1605
- [ ] Ready for review

 When set to 'Allow all clients', any DHCP client will get an IP address within this scope/range on this interface. 
 If set to 'Allow known clients from any interface', any DHCP client with a MAC address listed on 'any' scope(s)/interface(s) will get an IP address. 
 If set to 'Allow known clients from only this interface', only MAC addresses listed below (i.e. for this interface) will get an IP address within this scope/range

This is squashed & tested PR https://github.com/pfsense/pfsense/pull/4066
Tested on pfSense 2.5.0.a.20200206.2005