### PR TITLE
Extra parameter SLAACuseIPv4iface. Issue #9324

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -5741,7 +5741,8 @@ function get_real_interface($interface = "wan", $family = "all", $realv6iface = 
 							case 'l2tp':
 							case 'pptp':
 								// Added catch for static v6 but using v4 link. Sets things to use pppoe link
-								if ((isset($cfg['dhcp6usev4iface']) && $realv6iface === false) || isset($cfg['ipv6usev4iface'])) {
+								if ((isset($cfg['dhcp6usev4iface']) && $realv6iface === false) || 
+								    isset($cfg['ipv6usev4iface']) || isset($cfg['slaacusev4iface'])) {
 									$wanif = $cfg['if'];
 								} else {
 									$parents = get_parent_interface($interface);
@@ -6402,7 +6403,8 @@ function get_interface_ipv6($interface = "wan", $flush = false, $linklocal_fallb
 			case 'l2tp':
 			case 'pptp':
 			case 'ppp':
-				if ($config['interfaces'][$interface]['ipaddrv6'] == 'dhcp6') {
+				if (($config['interfaces'][$interface]['ipaddrv6'] == 'dhcp6') ||
+				    ($config['interfaces'][$interface]['ipaddrv6'] == 'slaac')) {
 					$realif = get_real_interface($interface, 'inet6', false);
 				}
 				break;

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -283,7 +283,7 @@ switch ($wancfg['ipaddr']) {
 switch ($wancfg['ipaddrv6']) {
 	case "slaac":
 		$pconfig['type6'] = "slaac";
-		$pconfig['ipv6usev4iface'] = isset($wancfg['ipv6usev4iface']);
+		$pconfig['slaacusev4iface'] = isset($wancfg['slaacusev4iface']);
 		break;
 	case "dhcp6":
 		$pconfig['dhcp6-duid'] = $wancfg['dhcp6-duid'];
@@ -1087,6 +1087,7 @@ if ($_POST['apply']) {
 		unset($wancfg['dhcp6-ia-pd-send-hint']);
 		unset($wancfg['dhcp6prefixonly']);
 		unset($wancfg['dhcp6usev4iface']);
+		unset($wancfg['slaacusev4iface']);
 		unset($wancfg['ipv6usev4iface']);
 		unset($wancfg['dhcp6debug']);
 		unset($wancfg['track6-interface']);
@@ -1339,8 +1340,8 @@ if ($_POST['apply']) {
 				break;
 			case "slaac":
 				$wancfg['ipaddrv6'] = "slaac";
-				if ($_POST['ipv6usev4iface'] == "yes") {
-					$wancfg['ipv6usev4iface'] = true;
+				if ($_POST['slaacusev4iface'] == "yes") {
+					$wancfg['slaacusev4iface'] = true;
 				}
 				break;
 			case "dhcp6":
@@ -1972,10 +1973,10 @@ $section = new Form_Section('SLAAC IPv6 Configuration');
 $section->addClass('slaac');
 
 $section->addInput(new Form_Checkbox(
-	'ipv6usev4iface',
+	'slaacusev4iface',
 	'Use IPv4 connectivity as parent interface',
 	'IPv6 will use the IPv4 connectivity link (PPPoE)',
-	$pconfig['ipv6usev4iface']
+	$pconfig['slaacusev4iface']
 ));
 
 $form->add($section);


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9324
- [ ] Ready for review

Update for https://github.com/pfsense/pfsense/pull/4169
It adds $slaacusev4iface parameter, 
Otherwise using one parameter $ipv6usev4iface by both Static IPv6 and SLAAC confuse WebGUI