### PR TITLE
Fix IPsec issue if no PH2 hashes selected. Issue #9309

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -1915,7 +1915,7 @@ function ipsec_setup_proposal_entry(& $ph2ent, & $algo_arr, $ealg_id, $keylen) {
 			$proposal[] = ipsec_setup_proposal_algo($ealg_id, $keylen, $halgo, $ph2ent['pfsgroup']);
 		}
 	} else {
-		$proposal[] = ipsec_setup_proposal_algo($ealg_id, $keylen, '', $ph2ent['pfsgroup']);
+		$proposal[] = ipsec_setup_proposal_algo($ealg_id, $keylen, false, false, $ph2ent['pfsgroup']);
 	}
 
 	/* Add to master list */


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9309
- [ ] Ready for review

If no IPsec PH2 hashes selected (i.e. AES-GCM) after pressing 'apply' you got:

> Fatal error: Uncaught ArgumentCountError: Too few arguments to function ipsec_setup_proposal_algo(), 4 passed in /etc/inc/ipsec.inc on line 1922 and exactly 5 expected in /etc/inc/ipsec.inc:1862 

see https://forum.netgate.com/topic/150353/ipsec-php-fatal-error-uncaught-argumentcounterror-too-few-arguments-to-function-ipsec_setup_proposal_algo-4-passed/2

This PR fix this issue