### PR TITLE
Suppress dns_get_record() errors. Issue #9405

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1958,16 +1958,18 @@ function resolve_retry($hostname, $protocol = 'inet', $retries = 5, $numrecords 
 		if ($checkproto($hostname)) {
 			return $hostname;
 		}
-		$dnsresult = dns_get_record($hostname, $dnsproto);
-		foreach ($dnsresult as $dnsrec => $ip) {
-			if (is_array($ip)) {
-				if (in_array($ip['type'], $dnstype)) {
-				    if ($checkproto($ip['ip'])) { 
-					    $recresult[] = $ip['ip'];
-				    }
-				    if ($checkproto($ip['ipv6'])) { 
-					    $recresult[] = $ip['ipv6'];
-				    }
+		$dnsresult = @dns_get_record($hostname, $dnsproto);
+		if (!empty($dnsresult)) {
+			foreach ($dnsresult as $dnsrec => $ip) {
+				if (is_array($ip)) {
+					if (in_array($ip['type'], $dnstype)) {
+					    if ($checkproto($ip['ip'])) { 
+						    $recresult[] = $ip['ip'];
+					    }
+					    if ($checkproto($ip['ipv6'])) { 
+						    $recresult[] = $ip['ipv6'];
+					    }
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9405
- [ ] Ready for review

This PR suppress dns_get_record() PHP errors

like:

> PHP Errors:
[08-Feb-2020 14:06:19 Europe/Moscow] PHP Warning:  dns_get_record(): DNS Query failed in /etc/inc/util.inc on line 1961
[08-Feb-2020 14:06:19 Europe/Moscow] PHP Warning:  Invalid argument supplied for foreach() in /etc/inc/util.inc on line 1962