### PR TITLE
Increase DHCP/DHCPv6 NTP server options to three. Issue #9661

### DIFF
--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -181,7 +181,7 @@ if (is_array($dhcpdconf)) {
 	$pconfig['ddnsforcehostname'] = isset($dhcpdconf['ddnsforcehostname']);
 	$pconfig['mac_allow'] = $dhcpdconf['mac_allow'];
 	$pconfig['mac_deny'] = $dhcpdconf['mac_deny'];
-	list($pconfig['ntp1'], $pconfig['ntp2']) = $dhcpdconf['ntpserver'];
+	list($pconfig['ntp1'], $pconfig['ntp2'], $pconfig['ntp3'] ) = $dhcpdconf['ntpserver'];
 	$pconfig['tftp'] = $dhcpdconf['tftp'];
 	$pconfig['ldap'] = $dhcpdconf['ldap'];
 	$pconfig['netboot'] = isset($dhcpdconf['netboot']);
@@ -413,7 +413,9 @@ if (isset($_POST['save'])) {
 		$input_errors[] = gettext("If a mac deny list is specified, it must contain only valid partial MAC addresses.");
 	}
 
-	if (($_POST['ntp1'] && (!is_ipaddrv4($_POST['ntp1']) && !is_hostname($_POST['ntp1']))) || ($_POST['ntp2'] && (!is_ipaddrv4($_POST['ntp2']) && !is_hostname($_POST['ntp2'])))) {
+	if (($_POST['ntp1'] && (!is_ipaddrv4($_POST['ntp1']) && !is_hostname($_POST['ntp1']))) || 
+	    ($_POST['ntp2'] && (!is_ipaddrv4($_POST['ntp2']) && !is_hostname($_POST['ntp2']))) || 
+	    ($_POST['ntp3'] && (!is_ipaddrv4($_POST['ntp3']) && !is_hostname($_POST['ntp3'])))) {
 		$input_errors[] = gettext("A valid IP address or hostname must be specified for the primary/secondary NTP servers.");
 	}
 	if (($_POST['domain'] && !is_domain($_POST['domain']))) {
@@ -691,6 +693,9 @@ if (isset($_POST['save'])) {
 		}
 		if ($_POST['ntp2']) {
 			$dhcpdconf['ntpserver'][] = $_POST['ntp2'];
+		}
+		if ($_POST['ntp3']) {
+			$dhcpdconf['ntpserver'][] = $_POST['ntp3'];
 		}
 
 		$dhcpdconf['tftp'] = $_POST['tftp'];
@@ -1384,6 +1389,13 @@ $section->addInput(new Form_IpAddress(
 	'HOSTV4'
 ));
 
+$section->addInput(new Form_IpAddress(
+	'ntp3',
+	'NTP Server 3',
+	$pconfig['ntp3'],
+	'HOSTV4'
+));
+
 // Advanced TFTP
 $btnadv = new Form_Button(
 	'btnadvtftp',
@@ -1801,7 +1813,7 @@ events.push(function() {
 		// On page load decide the initial state based on the data.
 		if (ispageload) {
 <?php
-			if (empty($pconfig['ntp1']) && empty($pconfig['ntp2'])) {
+			if (empty($pconfig['ntp1']) && empty($pconfig['ntp2']) && empty($pconfig['ntp3']) ) {
 				$showadv = false;
 			} else {
 				$showadv = true;
@@ -1815,6 +1827,7 @@ events.push(function() {
 
 		hideInput('ntp1', !showadvntp);
 		hideInput('ntp2', !showadvntp);
+		hideInput('ntp3', !showadvntp);
 
 		if (showadvntp) {
 			text = "<?=gettext('Hide Advanced');?>";

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -152,7 +152,7 @@ if (is_array($config['dhcpdv6'][$if])) {
 	$pconfig['ddnsforcehostname'] = isset($config['dhcpdv6'][$if]['ddnsforcehostname']);
 	$pconfig['ddnsreverse'] = isset($config['dhcpdv6'][$if]['ddnsreverse']);
 	$pconfig['ddnsclientupdates'] = $config['dhcpdv6'][$if]['ddnsclientupdates'];
-	list($pconfig['ntp1'], $pconfig['ntp2']) = $config['dhcpdv6'][$if]['ntpserver'];
+	list($pconfig['ntp1'], $pconfig['ntp2'], $pconfig['ntp3'] ) = $config['dhcpdv6'][$if]['ntpserver'];
 	$pconfig['tftp'] = $config['dhcpdv6'][$if]['tftp'];
 	$pconfig['ldap'] = $config['dhcpdv6'][$if]['ldap'];
 	$pconfig['netboot'] = isset($config['dhcpdv6'][$if]['netboot']);
@@ -329,7 +329,9 @@ if (isset($_POST['apply'])) {
 		}
 	}
 
-	if (($_POST['ntp1'] && !is_ipaddrv6($_POST['ntp1'])) || ($_POST['ntp2'] && !is_ipaddrv6($_POST['ntp2']))) {
+	if (($_POST['ntp1'] && !is_ipaddrv6($_POST['ntp1'])) || 
+	    ($_POST['ntp2'] && !is_ipaddrv6($_POST['ntp2'])) || 
+	    ($_POST['ntp3'] && !is_ipaddrv6($_POST['ntp3']))) {
 		$input_errors[] = gettext("A valid IPv6 address must be specified for the primary/secondary NTP servers.");
 	}
 	if (($_POST['domain'] && !is_domain($_POST['domain']))) {
@@ -462,6 +464,9 @@ if (isset($_POST['apply'])) {
 		}
 		if ($_POST['ntp2']) {
 			$config['dhcpdv6'][$if]['ntpserver'][] = $_POST['ntp2'];
+		}
+		if ($_POST['ntp3']) {
+			$config['dhcpdv6'][$if]['ntpserver'][] = $_POST['ntp3'];
 		}
 
 		$config['dhcpdv6'][$if]['tftp'] = $_POST['tftp'];
@@ -878,6 +883,14 @@ $group->add(new Form_Input(
 	['placeholder' => 'NTP 2']
 ));
 
+$group->add(new Form_Input(
+	'ntp3',
+	'NTP Server 3',
+	'text',
+	$pconfig['ntp3'],
+	['placeholder' => 'NTP 3']
+));
+
 $group->addClass('ntpclass');
 
 $section->add($group);
@@ -1155,7 +1168,7 @@ events.push(function() {
 		// On page load decide the initial state based on the data.
 		if (ispageload) {
 <?php
-			if (empty($pconfig['ntp1']) && empty($pconfig['ntp2'])) {
+			if (empty($pconfig['ntp1']) && empty($pconfig['ntp2']) && empty($pconfig['ntp3'])) {
 				$showadv = false;
 			} else {
 				$showadv = true;
@@ -1169,6 +1182,7 @@ events.push(function() {
 
 		hideInput('ntp1', !showadvntp);
 		hideInput('ntp2', !showadvntp);
+		hideInput('ntp3', !showadvntp);
 
 		if (showadvntp) {
 			text = "<?=gettext('Hide Advanced');?>";


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9661
- [ ] Ready for review

This is squashed and tested PR https://github.com/pfsense/pfsense/pull/4078

It is considered a general best practice to use at least three NTP servers to help identify "falsetickers" (bad clock sources). Unfortunately the pfSense DHCP/DHCPv6 web UI (v2.4.4-RELEASE-p3 at the time of writing) doesn't allow you to specify more than two NTP servers in the "Other Options".