### PR TITLE
OpenVPN RADIUS ACL enhancements. Issue #9206

### DIFF
--- a/src/etc/inc/openvpn.auth-user.php
+++ b/src/etc/inc/openvpn.auth-user.php
@@ -36,7 +36,7 @@ require_once("interfaces.inc");
 /* setup syslog logging */
 openlog("openvpn", LOG_ODELAY, LOG_AUTH);
 
-global $common_name, $username;
+global $common_name, $username, $dev, $untrusted_port;
 
 if (isset($_GET['username'])) {
 	$authmodes = explode(",", base64_decode($_GET['authcfg']));
@@ -46,11 +46,15 @@ if (isset($_GET['username'])) {
 	$common_name = $_GET['cn'];
 	$modeid = $_GET['modeid'];
 	$strictusercn = $_GET['strictcn'] == "false" ? false : true;
+	$dev = $_GET['dev'];
+	$untrusted_port = $_GET['untrusted_port'];
 } else {
 	/* read data from environment */
 	$username = getenv("username");
 	$password = getenv("password");
 	$common_name = getenv("common_name");
+	$dev = getenv("dev");
+	$untrusted_port = getenv("untrusted_port");
 }
 
 if (!$username) {

--- a/src/usr/local/sbin/openvpn.attributes.sh
+++ b/src/usr/local/sbin/openvpn.attributes.sh
@@ -20,16 +20,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+lockfile="/tmp/ovpn_${dev}_${username}_${trusted_port}.lock"
+rulesfile="/tmp/ovpn_${dev}_${username}_${trusted_port}.rules"
+anchorname="openvpn/${dev}_${username}_${trusted_port}"
+
 if [ "$script_type" = "client-connect" ]; then
+	i=1
+	while [ -f "${lockfile}" ]; do
+		if [ $i -ge 30 ]; then
+			/bin/echo "Timeout while waiting for lockfile"
+			exit 1
+		fi
+
+		/bin/sleep 1
+		i=$(( i + 1 ))
+	done
+	/usr/bin/touch "${lockfile}"
+
+	/bin/cat "${rulesfile}" | /usr/bin/sed "s/{clientip}/${ifconfig_pool_remote_ip}/g" > "${rulesfile}.tmp" && /bin/mv "${rulesfile}.tmp" "${rulesfile}"
+	/sbin/pfctl -a "openvpn/${dev}_${username}_${trusted_port}" -f "${rulesfile}"
+	/bin/rm "${rulesfile}"
+
 	if [ -f /tmp/$common_name ]; then
 		/bin/cat /tmp/$common_name > $1
 		/bin/rm /tmp/$common_name
 	fi
+
+	/bin/rm "${lockfile}"
 elif [ "$script_type" = "client-disconnect" ]; then
-	command="/sbin/pfctl -a 'openvpn/$common_name' -F rules"
+	i=1
+	while [ -f "${lockfile}" ]; do
+		if [ $i -ge 30 ]; then
+			/bin/echo "Timeout while waiting for lockfile"
+			exit 1
+		fi
+
+		/bin/sleep 1
+		i=$(( i + 1 ))
+	done
+	/usr/bin/touch "${lockfile}"
+
+	command="/sbin/pfctl -a '${anchorname}' -F rules"
 	eval $command
 	/sbin/pfctl -k $ifconfig_pool_remote_ip
 	/sbin/pfctl -K $ifconfig_pool_remote_ip
+
+	/bin/rm "${lockfile}"
 fi
 
 exit 0

--- a/src/usr/local/sbin/ovpn_auth_verify_async
+++ b/src/usr/local/sbin/ovpn_auth_verify_async
@@ -62,7 +62,7 @@ username=$(printf "%s" "${username}" | "${openssl}" enc -base64 | \
 # ---------- Perform Check
 auth_credentials="username=${username}&password=${password}"
 # Note that common_name is also assumed to be set by the environment
-auth_server_1="cn=${common_name}&strictcn=${strictcn}&authcfg=${authcfg}"
+auth_server_1="cn=${common_name}&strictcn=${strictcn}&authcfg=${authcfg}&dev=${dev}&untrusted_port=${untrusted_port}"
 auth_server_2="modeid=${modeid}&nas_port=${nas_port}"
 auth_args="${auth_credentials}&${auth_server_1}&${auth_server_2}"
 
@@ -72,7 +72,7 @@ result=$("${fcgicli}" -f "${auth_user_php}" -d "${auth_args}")
 
 auth_result="${auth_failure}"
 if [ "${result}" = "OK" ]; then
-    auth_result="${auth_success}"
+	auth_result="${auth_success}"
 fi
 
 # The output file path should be set in the environment


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9206
- [ ] Ready for review

* fixed a race condition where disconnecting and reconnecting a session when using AVPair ACLs would result in no rules being inserted.
* Updated the ACL parser to support IP and ICMP protocol options
* Updated the ACL parser to support port operators.
* Added a template variable "{clientip}" that is replaced with the connecting clients VPN IP.

This is squashed, resolved (@hatclub notes) and tested PR https://github.com/pfsense/pfsense/pull/4026

tested on pfSense 2.5.0.a.20200211.1811 with freeradius3 0.15.7_10
OpenVPN 2.4.7 client (Debian 10)