### PR TITLE
Accomodate both RADIUS and pool IP addresses in IPsec. Issue #8160

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -1341,7 +1341,6 @@ function ipsec_setup_strongswan() {
 	$ssconf[] = "# Automatically generated config file - DO NOT MODIFY. Changes will be overwritten.";
 	$ssconf['starter'] = array();
 	$ssconf['starter']['load_warning'] = "no";
-	$ssconf['starter']['config_file'] = "{$g['varetc_path']}/ipsec/ipsec.conf";
 
 	$ssconf['charon'] = array();
 	$ssconf['charon'][] = '# number of worker threads in charon';
@@ -1419,6 +1418,7 @@ function ipsec_setup_strongswan() {
 	/* Generate an eap-radius config section if appropriate */
 	if (count($radius_servers) && ($mobile_ipsec_auth === "eap-radius")) {
 		$ssconf['charon']['plugins']['eap-radius'] = array();
+		$ssconf['charon']['plugins']['eap-radius']['load'] = "2";
 		$ssconf['charon']['plugins']['eap-radius']['class_group'] = "yes";
 		$ssconf['charon']['plugins']['eap-radius']['eap_start'] = "no";
 		/* Activate RADIUS accounting only if it was selected on the IPsec Mobile Clients tab */
@@ -1461,6 +1461,10 @@ function ipsec_setup_pools() {
 	if (!is_array($a_client) || !isset($a_client['enable'])) {
 		return;
 	}
+	if (($mobile_ipsec_auth == "eap-radius") && empty($a_client['pool_address']) &&
+	    empty($a_client['pool_address_v6'])) {
+		return;
+	}
 	$scconf['pools']['mobile-pool'] = array();
 
 	$pool_addrs = array();
@@ -1469,9 +1473,6 @@ function ipsec_setup_pools() {
 	}
 	if (!empty($a_client['pool_address_v6'])) {
 		$pool_addrs[] = "{$a_client['pool_address_v6']}/{$a_client['pool_netbits_v6']}";
-	}
-	if ($mobile_ipsec_auth == "eap-radius" && !count($pool_addrs)) {
-		$pool_addrs[] = "%radius";
 	}
 	if (count($pool_addrs)) {
 		$scconf['pools']['mobile-pool']['addrs'] = implode(',', $pool_addrs);
@@ -2263,7 +2264,15 @@ function ipsec_setup_tunnels() {
 		$conn['remote_addrs'] = $remote_spec;
 
 		if (isset($ph1ent['mobile'])) {
-			$conn['pools'] = "mobile-pool";
+			if (($ph1ent['authentication_method'] == 'eap-radius') && 
+			    empty($a_client['pool_address']) && empty($a_client['pool_address_v6'])) {
+				$conn['pools'] = "radius";
+			} else {
+				$conn['pools'] = "mobile-pool";
+				if (isset($a_client['radius_ip_priority_enable'])) {
+					$conn['pools'] .= ", radius";
+				}
+			}
 		}
 
 		/* For IKEv2 without Split Connections, setup combined sets of

--- a/src/usr/local/www/vpn_ipsec_mobile.php
+++ b/src/usr/local/www/vpn_ipsec_mobile.php
@@ -69,18 +69,23 @@ if (count($a_client)) {
 	$pconfig['wins_server2'] = $a_client['wins_server2'];
 	$pconfig['pfs_group'] = $a_client['pfs_group'];
 	$pconfig['login_banner'] = $a_client['login_banner'];
-
+	$pconfig['radius_ip_priority_enable'] = $a_client['radius_ip_priority_enable'];
+	
 	if (isset($pconfig['enable'])) {
 		$pconfig['enable'] = true;
 	}
 
-	if ($pconfig['pool_address']&&$pconfig['pool_netbits']) {
+	if ($pconfig['pool_address'] && $pconfig['pool_netbits']) {
 		$pconfig['pool_enable'] = true;
 	} else {
 		$pconfig['pool_netbits'] = 24;
 	}
 
-	if ($pconfig['pool_address_v6']&&$pconfig['pool_netbits_v6']) {
+	if (isset($pconfig['radius_ip_priority_enable'])) {
+		$pconfig['radius_ip_priority_enable'] = true;
+	}
+
+	if ($pconfig['pool_address_v6'] && $pconfig['pool_netbits_v6']) {
 		$pconfig['pool_enable_v6'] = true;
 	} else {
 		$pconfig['pool_netbits_v6'] = 120;
@@ -102,11 +107,11 @@ if (count($a_client)) {
 		$pconfig['dns_split_enable'] = true;
 	}
 
-	if ($pconfig['dns_server1']||$pconfig['dns_server2']||$pconfig['dns_server3']||$pconfig['dns_server4']) {
+	if ($pconfig['dns_server1'] || $pconfig['dns_server2'] || $pconfig['dns_server3'] || $pconfig['dns_server4']) {
 		$pconfig['dns_server_enable'] = true;
 	}
 
-	if ($pconfig['wins_server1']||$pconfig['wins_server2']) {
+	if ($pconfig['wins_server1'] || $pconfig['wins_server2']) {
 		$pconfig['wins_server_enable'] = true;
 	}
 
@@ -231,6 +236,12 @@ if ($_POST['save']) {
 		}
 	}
 
+	if ($pconfig['radius_ip_priority_enable']) {
+		if (!(isset($mobileph1) && ($mobileph1['authentication_method'] == 'eap-radius'))) {
+			$input_errors[] = gettext("RADIUS IP may only take prioriy when using EAP-RADIUS for authentication on the Mobile IPsec VPN.");
+		}
+	}
+
 	if (!$input_errors) {
 		$client = array();
 
@@ -250,6 +261,10 @@ if ($_POST['save']) {
 		if ($pconfig['pool_enable']) {
 			$client['pool_address'] = $pconfig['pool_address'];
 			$client['pool_netbits'] = $pconfig['pool_netbits'];
+		}
+
+		if ($pconfig['radius_ip_priority_enable']) {
+			$client['radius_ip_priority_enable'] = true;
 		}
 
 		if ($pconfig['pool_enable_v6']) {
@@ -515,6 +530,13 @@ $group->add(new Form_Select(
 ))->setWidth(2);
 
 $section->add($group);
+
+$section->addInput(new Form_Checkbox(
+	'radius_ip_priority_enable',
+	'RADIUS IP address priority',
+	'IPv4 address pool is used if IP is not supplied by RADIUS server',
+	$pconfig['radius_ip_priority_enable']
+));
 
 $section->addInput(new Form_Checkbox(
 	'pool_enable_v6',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/8160
- [ ] Ready for review

fixed and tested copy of https://github.com/pfsense/pfsense/pull/3976: by @Amith211

> I have a requirement to be able to have IPSec VPN clients receive their IP addresses via RADIUS for some groups and others from a simple pool. I decided to have a stab at implementing the solution mentioned in Redmine issue 8160.

What done:
* Adopted to swanctl.conf https://redmine.pfsense.org/issues/9603,
From https://wiki.strongswan.org/projects/strongswan/wiki/VirtualIp#RADIUS-backend:

> the order in which they are queried for virtual IPs depends on the plugin load order (in-memory pools are provided by the stroke and vici plugins, respectively). The order in rightsourceip or pools is irrelevant unless multiple in-memory pools from the same backend are defined.

this is why we need increase the priority of eap-radius plugin by `$ssconf['charon']['plugins']['eap-radius']['load'] = "2";`
see https://wiki.strongswan.org/projects/strongswan/wiki/PluginLoad:

> Besides simply enabling/disabling plugins the load setting accepts a numeric priority
> value, which the plugin loader uses to decide in which order plugins are loaded. Plugins with the same priority are loaded
> according to the default load order, unknown plugins with the same priority are loaded first and in alphabetical order.
> The default priority is 1, and can also be negative to simplify moving a plugin to the end of the list.

* removed line 
`$ssconf['starter']['config_file'] = "{$g['varetc_path']}/ipsec/ipsec.conf";`
no such file

* Fixed creating correct config file when using EAP-RADIUS without pool ( ipsec_setup_pools() used the ipsec.conf-style %radius)

p.s. as I found you can't see mobile clients that get their IP via RADIUS on the Status / IPsec/ Leases page (only under child sa), and their IPs are not added to the tonatsubnets table