### PR TITLE
Same gateway naming convention for console and WebGUI. Issue #10264

### DIFF
--- a/src/etc/rc.initial.setlanip
+++ b/src/etc/rc.initial.setlanip
@@ -177,9 +177,16 @@ if (!$interface) {
 
 $ifaceassigned = "";
 
-function next_unused_gateway_name($interface) {
+function next_unused_gateway_name($interface, $inet_type = 'inet') {
 	global $g, $config;
-	$new_name = "GW_" . strtoupper($interface);
+
+	if ($inet_type == 'inet') {
+		$name_suffix = "GW";
+	} else {
+		$name_suffix = "GWv6";
+	}
+
+	$new_name = strtoupper($interface) . $name_suffix;
 
 	if (!is_array($config['gateways']['gateway_item'])) {
 		return $new_name;
@@ -195,7 +202,7 @@ function next_unused_gateway_name($interface) {
 		}
 		if ($existing) {
 			$count += 1;
-			$new_name = "GW_" . strtoupper($interface) . "_" . $count;
+			$new_name = strtoupper($interface) . $name_suffix . "_" . $count;
 		}
 	} while ($existing);
 	return $new_name;
@@ -217,7 +224,7 @@ function add_gateway_to_config($interface, $gatewayip, $inet_type) {
 		}
 	}
 	if ($new_name == '') {
-		$new_name = next_unused_gateway_name($interface);
+		$new_name = next_unused_gateway_name($interface, $inet_type);
 		$item = array(
 			"interface" => $interface,
 			"gateway" => $gatewayip,


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10264
- [ ] Ready for review

When you create a gateway in the webgui by setting an interface as static and adding a new gateway it will, by default, create a gateway named 'WANGW' for example.

However if you do the same thing from the console menu the gateway created is named 'GW_WAN'.

That is not normally an issue if, for example, you are changing the WAN interface from DHCP to Static IP. If you are changing an existing static IP however you then create a second gateway.
If WANGW was set as default then the result is no default route as WANGW is now invalid.

Gateways created in the webgui and the console should use the same naming convention to avoid that.