### PR TITLE
Strip IPsec PH2 hash for AEAD ciphers. Issue #9726

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -1918,7 +1918,8 @@ function ipsec_setup_proposal_entry(& $ph2ent, & $algo_arr, $ealg_id, $keylen) {
 	$proposal = array();
 
 	/* If multiple hash algorithms are present, loop through and add them all. */
-	if (!empty($ph2ent['hash-algorithm-option']) && is_array($ph2ent['hash-algorithm-option'])) {
+	if (!empty($ph2ent['hash-algorithm-option']) && is_array($ph2ent['hash-algorithm-option']) 
+	    && !strpos($ealg_id, "gcm")) {
 		foreach ($ph2ent['hash-algorithm-option'] as $halgo) {
 			$proposal[] = ipsec_setup_proposal_algo($ealg_id, $keylen, $halgo, false, $ph2ent['pfsgroup']);
 		}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9726
- [ ] Ready for review

This small fix is still needed for cases where both AEAD and non-AEAD ciphers are selected at the same time.