### PR TITLE
Complete IPv6 router address in radvd.conf prefix. Issue #9710

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -158,7 +158,12 @@ function services_radvd_configure($blacklist = array()) {
 				$radvdconf .= "\tAdvOtherConfigFlag on;\n";
 				break;
 		}
-		$radvdconf .= "\tprefix {$subnetv6}/{$ifcfgsnv6} {\n";
+		if ($dhcpv6ifconf['ramode'] == "unmanaged") {
+			$prefixnet = $ifcfgipv6;
+		} else {
+			$prefixnet = $subnetv6;
+		}
+		$radvdconf .= "\tprefix {$prefixnet}/{$ifcfgsnv6} {\n";
 		if ($racarpif == true) {
 			$radvdconf .= "\t\tDeprecatePrefix off;\n";
 		} else {
@@ -168,18 +173,15 @@ function services_radvd_configure($blacklist = array()) {
 			case "managed":
 				$radvdconf .= "\t\tAdvOnLink on;\n";
 				$radvdconf .= "\t\tAdvAutonomous off;\n";
-				$radvdconf .= "\t\tAdvRouterAddr on;\n";
 				break;
 			case "router":
 				$radvdconf .= "\t\tAdvOnLink off;\n";
 				$radvdconf .= "\t\tAdvAutonomous off;\n";
-				$radvdconf .= "\t\tAdvRouterAddr on;\n";
 				break;
 			case "stateless_dhcp":
 			case "assist":
 				$radvdconf .= "\t\tAdvOnLink on;\n";
 				$radvdconf .= "\t\tAdvAutonomous on;\n";
-				$radvdconf .= "\t\tAdvRouterAddr on;\n";
 				break;
 			case "unmanaged":
 				$radvdconf .= "\t\tAdvOnLink on;\n";
@@ -211,22 +213,18 @@ function services_radvd_configure($blacklist = array()) {
 						case "managed":
 							$radvdconf .= "\t\tAdvOnLink on;\n";
 							$radvdconf .= "\t\tAdvAutonomous off;\n";
-							$radvdconf .= "\t\tAdvRouterAddr on;\n";
 							break;
 						case "router":
 							$radvdconf .= "\t\tAdvOnLink off;\n";
 							$radvdconf .= "\t\tAdvAutonomous off;\n";
-							$radvdconf .= "\t\tAdvRouterAddr on;\n";
 							break;
 						case "assist":
 							$radvdconf .= "\t\tAdvOnLink on;\n";
 							$radvdconf .= "\t\tAdvAutonomous on;\n";
-							$radvdconf .= "\t\tAdvRouterAddr on;\n";
 							break;
 						case "unmanaged":
 							$radvdconf .= "\t\tAdvOnLink on;\n";
 							$radvdconf .= "\t\tAdvAutonomous on;\n";
-							$radvdconf .= "\t\tAdvRouterAddr on;\n";
 							break;
 					}
 					$radvdconf .= "\t};\n";
@@ -367,7 +365,6 @@ function services_radvd_configure($blacklist = array()) {
 		$radvdconf .= "\tprefix {$subnetv6}/{$ifcfgsnv6} {\n";
 		$radvdconf .= "\t\tAdvOnLink on;\n";
 		$radvdconf .= "\t\tAdvAutonomous on;\n";
-		$radvdconf .= "\t\tAdvRouterAddr on;\n";
 		$radvdconf .= "\t};\n";
 
 		/* add DNS servers */


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9710
- [x] Ready for review

When setting router mode to "unmanaged" and not specifying any prefix, pfSense does not send the advertising interface's address in the RA's prefix option even though the "R" flag is being set. Instead it only announces the prefix, with all host bits set to zero. This is in violation of RFC 6275, which states on page 65 regarding the "R" flag: "When set, indicates that the Prefix field contains a complete IP address assigned to the sending router."

see https://tools.ietf.org/html/rfc6275#page-65:

This fix set full IPv6 router address in prefix field, and removes 'AdvRouterAddr on' for subnets, because (radvd.conf(5)):

> AdvRouterAddr on|off
> When set, indicates that the address of interface is sent instead of network prefix, as is required by Mobile IPv6. When set, minimum limits specified by Mobile IPv6 are used for MinRtrAdvInterval and MaxRtrAdvInterval.

> Default: off


tested with Cisco IOS 15.5(3) client: