### PR TITLE
DNS64 support. Issue #10274

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -175,6 +175,17 @@ function unbound_generate_config_text($unboundcfg = NULL, $cfgsubdir = "") {
 		$module_config .= 'python ';
 	}
 
+	// Setup DNS64 support
+	if (isset($unboundcfg['dns64'])) {
+		$module_config .= 'dns64 ';
+		$dns64_conf = 'dns64-prefix: ';
+		if (is_subnetv6($unboundcfg['dns64prefix'] . '/' . $unboundcfg['dns64netbits'])) {
+			$dns64_conf .= $unboundcfg['dns64prefix'] . '/' . $unboundcfg['dns64netbits'];
+		} else {
+			$dns64_conf .= '64:ff9b::/96';
+		}
+	}
+
 	// Setup DNSSEC support
 	if (isset($unboundcfg['dnssec'])) {
 		$module_config .= 'validator ';
@@ -487,6 +498,7 @@ serve-expired: {$dns_record_cache}
 # DNS Rebinding
 {$private_addr}
 {$private_domains}
+{$dns64_conf}
 
 # Access lists
 include: {$g['unbound_chroot_path']}{$cfgsubdir}/access_lists.conf

--- a/src/usr/local/www/classes/Form/IpAddress.class.php
+++ b/src/usr/local/www/classes/Form/IpAddress.class.php
@@ -70,7 +70,7 @@ class Form_IpAddress extends Form_Input
 	}
 
 	// $min is provided to allow for VPN masks in which '0' is valid
-	public function addMask($name, $value, $max = 128, $min = 1)
+	public function addMask($name, $value, $max = 128, $min = 1, $auto = true)
 	{
 		$this->_mask = new Form_Select(
 			$name,
@@ -80,6 +80,9 @@ class Form_IpAddress extends Form_Input
 		);
 
 		$this->_mask->addClass("pfIpMask");
+
+		if ($auto)
+			$this->_auto = true;
 
 		return $this;
 	}
@@ -99,10 +102,13 @@ class Form_IpAddress extends Form_Input
 		if (!isset($this->_mask))
 			return $input;
 
+		if (isset($this->_auto))
+			$pfipmask = " pfIpMask";
+
 		return <<<EOT
 		<div class="input-group">
 			$input
-			<span class="input-group-addon input-group-inbetween pfIpMask">/</span>
+			<span class="input-group-addon input-group-inbetween$pfipmask">/</span>
 			{$this->_mask}
 		</div>
 EOT;


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10274
- [ ] Ready for review

Add DNS64 configuration to DNS Resolver WebGUI

from https://github.com/monero-project/unbound/blob/master/doc/README.DNS64:

> To enable DNS64 functionality in Unbound, two directives in unbound.conf must
> be edited:
> 
> 1. The "module-config" directive must start with "dns64". For example:
> 
>     module-config: "dns64 validator iterator" 
> 
> 2. The "dns64-prefix" directive indicates your DNS64 prefix. For example:
> 
>     dns64-prefix: 64:FF9B::/96
> 
> The prefix must be a /96 or shorter.

if there is no 'dns64-prefix: xxx' option, default 64:FF9B::/96 prefix is used

During this coding this PR, I also found issue with addMask() -
if you are trying to use max netmask shorter that 128 for IPv6 or shorter that 32 for IPv4, js code resets netmask size to 128/32, 
this not allow to use /96 max size for dns64-prefix, or, you can see this issue on 1:1 NAT page - try to enter any IPv4 address to the destination network field, and you can that it allow you to select /32 range (but only /31 is allowed in code)
IpAddress.class.php fixed