### PR TITLE
EDNS buffer size configuration. Issue #10293

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -30,6 +30,8 @@ require_once("config.inc");
 require_once("functions.inc");
 require_once("filter.inc");
 require_once("shaper.inc");
+require_once("interfaces.inc");
+require_once("util.inc");
 
 function create_unbound_chroot_path($cfgsubdir = "") {
 	global $config, $g;
@@ -317,7 +319,11 @@ EOF;
 	$dns_record_cache = isset($unboundcfg['dnsrecordcache']) ? "yes" : "no";
 	$outgoing_num_tcp = isset($unboundcfg['outgoing_num_tcp']) ? $unboundcfg['outgoing_num_tcp'] : "10";
 	$incoming_num_tcp = isset($unboundcfg['incoming_num_tcp']) ? $unboundcfg['incoming_num_tcp'] : "10";
-	$edns_buffer_size = (!empty($unboundcfg['edns_buffer_size'])) ? $unboundcfg['edns_buffer_size'] : "4096";
+	if (empty($unboundcfg['edns_buffer_size']) || ($unboundcfg['edns_buffer_size'] == 'auto')) {
+		$edns_buffer_size = unbound_auto_ednsbufsize();
+	} else {
+		$edns_buffer_size = $unboundcfg['edns_buffer_size'];
+	}
 	$num_queries_per_thread = (!empty($unboundcfg['num_queries_per_thread'])) ? $unboundcfg['num_queries_per_thread'] : "4096";
 	$jostle_timeout = (!empty($unboundcfg['jostle_timeout'])) ? $unboundcfg['jostle_timeout'] : "200";
 	$cache_max_ttl = (!empty($unboundcfg['cache_max_ttl'])) ? $unboundcfg['cache_max_ttl'] : "86400";
@@ -945,6 +951,40 @@ function unbound_local_zone_types() {
 		"inform_deny" => gettext("Inform Deny"),
 		"nodefault" => gettext("No Default")
 	);
+}
+
+// Autoconfig EDNS buffer size
+function unbound_auto_ednsbufsize() {
+	global $config;
+
+	$active_ipv6_inf = false;
+	if ($config['unbound']['active_interface'] != 'all') {
+		$active_interfaces = explode(",", $config['unbound']['active_interface']);
+	} else {
+		$active_interfaces = get_configured_interface_list();
+	}
+
+	$min_mtu = get_interface_mtu(get_real_interface($active_interfaces[0]));
+	foreach ($active_interfaces as $ubif) {
+		$ubif_mtu = get_interface_mtu(get_real_interface($ubif));
+		if (get_interface_ipv6($ubif)) {
+			$active_ipv6_inf = true;
+		}
+		if ($ubif_mtu < $min_mtu) {
+			$min_mtu = $ubif_mtu;
+		}
+	}
+
+	// maximum IPv4 + UDP header = 68 bytes
+	$min_mtu = $min_mtu - 68;
+
+	if (($min_mtu < 1232) && $active_ipv6_inf) {
+		$min_mtu = 1232;
+	} elseif ($min_mtu < 512) {
+		$min_mtu = 512;
+	}	
+
+	return $min_mtu;
 }
 
 ?>


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10293
- [ ] Ready for review

https://dnsflagday.net/2020/:

> Message Size Considerations
> 
> The optimum DNS message size to avoid IP fragmentation while minimizaing the use of TCP will depend on the Maximum Transmission Unit (MTU) of the physical network links connecting two network endpoints. Unfortunately, there is not yet a standard mechanism for DNS server implementors to access this information. Until such a standard exists, we recommend that the EDNS buffer size should, by default, be set to a value small enough to avoid fragmentation on the majority of network links in use today.
> 
> An EDNS buffer size of 1232 bytes will avoid fragmentation on nearly all current networks. This is based on an MTU of 1280, which is required by the IPv6 specification, minus 48 bytes for the IPv6 and UDP headers.
> 
> Note that this recomendation is for a default value, to be used when better information is not available. Operators may still configure larger values if their networks support larger data frames and they are certain there is no risk of IP fragmentation. DNS server vendors may use higher (or lower) packet sizes if better information about the MTU is available from the kernel.