### PR TITLE
Special interfaces description length validation. Issue #9401

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -553,6 +553,16 @@ if ($_POST['apply']) {
 			$input_errors[] = gettext("The interface description cannot contain only numbers.");
 		}
 
+		if ((strlen(trim($_POST['descr'])) > 25) && ((substr($realifname, 0, 4) == 'ovpn') ||
+		    (substr($realifname, 0, 5) == 'ipsec'))) {
+			$input_errors[] = gettext("The OpenVPN and VTI interface description must be less than 26 characters long.");
+		}
+
+		if ((strlen(trim($_POST['descr'])) > 22) && ((substr($realifname, 0, 3) == 'gif') ||
+		    (substr($realifname, 0, 3) == 'gre'))) {
+			$input_errors[] = gettext("The GIF and GRE interface description must be less than 23 characters long.");
+		}
+
 		/*
 		 * Packages (e.g. tinc) create interface groups, reserve this
 		 * namespace pkg_ for them.


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9401
- [ ] Ready for review

If you make an OpenVPN interface name with 26 to 31 characters (in my case, I made them with exactly 26 and 31 characters), _VPNV4 and _VPNV6 are appended to them when making the gateways under System / Routing / Gateways. Trying to add a monitor IP is impossible because the 31 character limit is exceeded and attempting to change the gateway name to honor the limit is not allowed. Working around this requires picking shorter interface names.

This is caused by special suffixes added to some special interfaces:
_VPNV4 and _VPNV6 for OpenVPN and VTI interfaces
_TUNNELV4 and _TUNNELV6 for GIF and GRE interfaces