### PR TITLE
DHCPv6 range is not mandatory for Stateless DHCP. Issue #9596

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1517,11 +1517,11 @@ EOD;
 			$range_to = merge_ipv6_delegated_prefix($ifcfgipv6, $range_to, $pdlen);
 		}
 
-		$dhcpdv6conf .= <<<EOD
-	range6 {$range_from} {$range_to};
-$dnscfgv6
+		if (!empty($dhcpv6ifconf['range']['from']) && !empty($dhcpv6ifconf['range']['to'])) {
+			$dhcpdv6conf .= "	range6 {$range_from} {$range_to};\n";
+		}
 
-EOD;
+		$dhcpdv6conf .= $dnscfgv6;
 
 		if (is_ipaddrv6($dhcpv6ifconf['prefixrange']['from']) && is_ipaddrv6($dhcpv6ifconf['prefixrange']['to'])) {
 			$dhcpdv6conf .= "	prefix6 {$dhcpv6ifconf['prefixrange']['from']} {$dhcpv6ifconf['prefixrange']['to']} /{$dhcpv6ifconf['prefixrange']['prefixlength']};\n";

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -227,10 +227,10 @@ if (isset($_POST['apply'])) {
 
 	// Note: if DHCPv6 Server is not enabled, then it is OK to adjust other parameters without specifying range from-to.
 	if ($_POST['enable']) {
-		$reqdfields = explode(" ", "range_from range_to");
-		$reqdfieldsn = array(gettext("Range begin"), gettext("Range end"));
-
-		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
+		if ((empty($_POST['range_from']) || empty($_POST['range_to'])) &&
+		    ($config['dhcpdv6'][$if]['ramode'] != 'stateless_dhcp')) {
+			$input_errors[] = gettext("A valid range must be specified for any mode except Stateless DHCP.");
+		}
 	}
 
 	if (($_POST['prefixrange_from'] && !is_ipaddrv6($_POST['prefixrange_from']))) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9596
- [ ] Ready for review

"The firewall will send out RA packets and addresses can be assigned to clients by SLAAC while providing additional information such as DNS and NTP from DHCPv6."

I think, in this case, DHCPv6 range should not be a mandatory field in DHCPv6 Server tab.
The DHCPv6 should only pass additional info to clients, not the IP address.