### PR TITLE
NTP: do not add noserve to restrict source. Issue #9830

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1867,7 +1867,7 @@ function system_ntp_configure() {
 		$ntpcfg .= ' notrap';
 	}
 
-	/* Pools require "restrict source" and cannot contain "nopeer". */
+	/* Pools require "restrict source" and cannot contain "nopeer" and "noserve". */
 	if ($have_pools) {
 		$ntpcfg .= "\nrestrict source";
 		if (empty($config['ntpd']['kod'])) { /*note: this one works backwards */
@@ -1878,9 +1878,6 @@ function system_ntp_configure() {
 		}
 		if (!empty($config['ntpd']['noquery'])) {
 			$ntpcfg .= ' noquery';
-		}
-		if (!empty($config['ntpd']['noserve'])) {
-			$ntpcfg .= ' noserve';
 		}
 		if (empty($config['ntpd']['notrap'])) { /*note: this one works backwards */
 			$ntpcfg .= ' notrap';


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9830
- [ ] Ready for review

When I uncheck Service (noserve) in Service/NTP/ACLs Default Access Restrictions, the web GUI script adds noserve to "restrict source" ACL in /var/etc/ntpd.conf:

```
    restrict default kod limited nomodify noquery nopeer notrap noserve
    restrict -6 default kod limited nomodify noquery nopeer noserve notrap
    restrict source kod limited nomodify noquery noserve notrap
```
and now no peers from defined pools can be connectet

noserve restriction should never be insterted to "restrict source" ACL (same as nopeer)