### PR TITLE
IPsec IPv4/IPv6 pools parameters. Issue #10296

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -1466,7 +1466,17 @@ function ipsec_setup_pools() {
 		return;
 	}
 	$scconf['pools']['mobile-pool'] = array();
+	$pool_addrs = array();
 	$pool_common =& $scconf['pools']['mobile-pool'];
+	if (!empty($a_client['pool_address'])) {
+		$pool_addrs[] = "{$a_client['pool_address']}/{$a_client['pool_netbits']}";
+	}
+	if (!empty($a_client['pool_address_v6'])) {
+		$pool_addrs[] = "{$a_client['pool_address_v6']}/{$a_client['pool_netbits_v6']}";
+	}
+	if (!empty($pool_addrs)) {
+		$pool_common['addrs'] = implode(',', $pool_addrs);
+	}
 
 	$rightdnsservers = array();
 	if (!empty($a_client['dns_server1'])) {

--- a/src/usr/local/www/vpn_ipsec_mobile.php
+++ b/src/usr/local/www/vpn_ipsec_mobile.php
@@ -532,13 +532,6 @@ $group->add(new Form_Select(
 $section->add($group);
 
 $section->addInput(new Form_Checkbox(
-	'radius_ip_priority_enable',
-	'RADIUS IP address priority',
-	'IPv4 address pool is used if IP is not supplied by RADIUS server',
-	$pconfig['radius_ip_priority_enable']
-));
-
-$section->addInput(new Form_Checkbox(
 	'pool_enable_v6',
 	'Virtual IPv6 Address Pool',
 	'Provide a virtual IPv6 address to clients',
@@ -571,9 +564,16 @@ $group->add(new Form_Select(
 	'',
 	$pconfig['pool_netbits_v6'],
 	$netBitsv6
-))->setWidth(3);
+))->setWidth(2);
 
 $section->add($group);
+
+$section->addInput(new Form_Checkbox(
+	'radius_ip_priority_enable',
+	'RADIUS IP address priority',
+	'IPv4/IPv6 address pool is used if address is not supplied by RADIUS server',
+	$pconfig['radius_ip_priority_enable']
+));
 
 $section->addInput(new Form_Checkbox(
 	'net_list_enable',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10296
- [ ] Ready for review

After last commit https://redmine.pfsense.org/projects/pfsense/repository/revisions/407a5c28093d46cb39cc1bba75740523a1ee97e6
The mobile-pool-v4 and mobile-pool-v6 pools are created as expected.
But seems that "addrs" is required for each pool, so the mobile-pool is not created (or referenced in connections).
Maybe the commons attrs should be included in the v4 pool or both for now?

This PR adds common attrs to each pool + description fix for vpn_ipsec_mobile.php, because RADIUS IP address priority applies to both ipv4 and ipv6