### PR TITLE
Replace double quote character in DHCP client ID. Issue #10295

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1118,6 +1118,7 @@ EOD;
 
 			$i = 0;
 			foreach ($dhcpifconf['staticmap'] as $sm) {
+				$cid = '';
 				$dhcpdconf .= "host s_{$dhcpif}_{$i} {\n";
 
 				if ($sm['mac']) {
@@ -1125,7 +1126,8 @@ EOD;
 				}
 
 				if ($sm['cid']) {
-					$dhcpdconf .= " option dhcp-client-identifier \"{$sm['cid']}\";\n";
+					$cid = str_replace('"', '\"', $sm['cid']);
+					$dhcpdconf .= "	option dhcp-client-identifier \"{$cid}\";\n";
 				}
 
 				if ($sm['ipaddr']) {
@@ -1207,8 +1209,8 @@ EOD;
 					// assuming ALL addresses are ethernet hardware type ("1:" prefix)
 					$dhcpdconf .= "subclass \"s_{$dhcpif}\" 1:{$sm['mac']};\n";
 				}
-				if (!empty($sm['cid'])) {
-					$dhcpdconf .= "subclass \"s_{$dhcpif}\" \"{$sm['cid']}\";\n";
+				if (!empty($cid)) {
+					$dhcpdconf .= "subclass \"s_{$dhcpif}\" \"{$cid}\";\n";
 				}
 
 


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10295
- [ ] Ready for review

The following is allowed by the webgui in a static mapping: Client Identifier: 32" Sony Trinitron
That creates a configuration that cannot be loaded:
```
host s_lan_0 {
        hardware ethernet 01:02:03:04:05:06;
        option dhcp-client-identifier "32" Sony Trinitron";
    option host-name "32-Sony";
    option domain-name-servers 172.25.228.1;
}
```

This fix replaces the double quote character with '&quot';
There is no issue with other special characters (',./!@#$%^&*()~)