### PR TITLE
L2TP username containing @ (realm separator). Issue #9828

### DIFF
--- a/src/usr/local/www/vpn_l2tp_users_edit.php
+++ b/src/usr/local/www/vpn_l2tp_users_edit.php
@@ -81,7 +81,7 @@ if ($_POST['save']) {
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
-	if (preg_match("/[^a-zA-Z0-9\.\-_]/", $_POST['usernamefld'])) {
+	if (preg_match("/[^a-zA-Z0-9\.\@\-_]/", $_POST['usernamefld'])) {
 		$input_errors[] = gettext("The username contains invalid characters.");
 	}
 	if (preg_match("/^!/", trim($_POST['passwordfld']))) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9828
- [ ] Ready for review

from the redmine page:
> I’m trying to use pfSense as LNS via L2TP. However my LAC always includes a realm in the username.
> 
> For L2TP it’s not uncommon to use usernames containing a realm, in my case (the LAC is a mobile gateway) this results in a username like 31612345678@internet.mvno.mobi (this is a real world example that I currently use on Cisco, Juniper and FreeBSD/mpd5 with success.
> 
> This is currently not working with pfSende as special characters are not accepted as username.

This PR allows you to use the `@` character in username