### PR TITLE
Special characters in Schedules descr and rangedescr fields. Issue #10305

### DIFF
--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -218,11 +218,11 @@ function parse_xml_config_raw($cffile, $rootobj, $isstring = "false") {
 /* Return true if a field should be cdata encoded */
 function is_cdata_entity($ent) {
 	$cdata_fields = array(
-		'auth_prompt', 'certca', 'certname', 'city', 'common_name',
+		'auth_pass', 'auth_prompt', 'auth_user', 'certca', 'certname', 'city', 'common_name',
 		'descr', 'detail', 'email', 'encryption_password', 'ldap_attr',
 		'ldap_authcn', 'ldap_basedn', 'ldap_bind',
-		'ldap_extended_query', 'login_banner', 'organization', 'state',
-		'text', 'username', 'password', 'auth_user', 'auth_pass'
+		'ldap_extended_query', 'login_banner', 'organization', 'password', 'rangedescr',
+		'state', 'text', 'username' 
 	);
 
 	/* Check if the entity name starts with any of the strings above */

--- a/src/usr/local/www/firewall_schedule_edit.php
+++ b/src/usr/local/www/firewall_schedule_edit.php
@@ -107,7 +107,7 @@ if ($_POST['save']) {
 	$schedule = array();
 
 	$schedule['name'] = $_POST['name'];
-	$schedule['descr'] = htmlentities($_POST['descr'], ENT_QUOTES, 'UTF-8');
+	$schedule['descr'] = $_POST['descr'];
 
 	$timerangeFound = false;
 
@@ -130,7 +130,7 @@ if ($_POST['save']) {
 			$timehourstr = $_POST['starttime' . $x];
 			$timehourstr .= "-";
 			$timehourstr .= $_POST['stoptime' . $x];
-			$timedescrstr = htmlentities($_POST['timedescr' . $x], ENT_QUOTES, 'UTF-8');
+			$timedescrstr = $_POST['timedescr' . $x];
 			$dashpos = strpos($timestr, '-');
 
 			if ($dashpos === false) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10305
- [ ] Ready for review

> When using special characters in Schedules and timeranges description fields
> firewall_schedule.php page shows escaping symbols, i.e.
> `G&uuml;nter` instead of Günter

This PR removes `htmlentities($_POST['descr'], ENT_QUOTES, 'UTF-8');` (legacy code?)
from firewall_schedule_edit.php
and adds `rangedescr` to $cdata_fields array
It also sort $cdata_fields array alphabetically 