### PR TITLE
Incorrect IPsec service status. Issue #10306

### DIFF
--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -481,7 +481,7 @@ function get_service_status($service) {
 			$running = is_pid_running("{$g['varrun_path']}/dhcrelay6.pid");
 			break;
 		case 'ipsec':
-			$running = is_pid_running("{$g['varrun_path']}/charon.pid");
+			$running = (is_pid_running("{$g['varrun_path']}/charon.pid") || is_process_running('charon'));
 			break;
 		default:
 			$running = is_service_running($service['name']);


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10306
- [ ] Ready for review

If you do some changes on the IPsec Mobile or IPsec Advanced tab and press apply,
Strongswan daemon restarted, but you can see 'start service' button in top right corner
although the service is actually running

It seems that `get_service_status()` tries to check charon daemon status by `is_pid_running()` with using outdated charon.pid file.

This PR adds extra charon process checking