### PR TITLE
Do not restart L2TP server after adding/modifying users. Issue #4866

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -407,29 +407,7 @@ EOD;
 			fclose($fd);
 			unset($mpdconf);
 
-			/* write mpd.secret */
-			$fd = fopen("{$g['varetc_path']}/l2tp-vpn/mpd.secret", "w");
-			if (!$fd) {
-				printf(gettext("Error: cannot open mpd.secret in vpn_l2tp_configure().") . "\n");
-				return 1;
-			}
-
-			$mpdsecret = "\n\n";
-
-			if (is_array($l2tpcfg['user'])) {
-				foreach ($l2tpcfg['user'] as $user) {
-					/* Escape double quotes, do not allow password to start with '!'
-					 * https://redmine.pfsense.org/issues/10275 */
-					$pass = str_replace('"', '\"', ltrim($user['password'], '!'));
-					$mpdsecret .= "{$user['name']} \"{$pass}\" {$user['ip']}\n";
-				}
-			}
-
-			fwrite($fd, $mpdsecret);
-			fclose($fd);
-			unset($mpdsecret);
-			chmod("{$g['varetc_path']}/l2tp-vpn/mpd.secret", 0600);
-
+			vpn_l2tp_updatesecret();
 			vpn_netgraph_support();
 
 			/* fire up mpd */
@@ -444,6 +422,35 @@ EOD;
 	if (platform_booting()) {
 		echo "done\n";
 	}
+
+	return 0;
+}
+
+function vpn_l2tp_updatesecret() {
+	global $config, $g;
+	$l2tpcfg = $config['l2tp'];
+
+	$fd = fopen("{$g['varetc_path']}/l2tp-vpn/mpd.secret", "w");
+	if (!$fd) {
+		printf(gettext("Error: cannot open mpd.secret in vpn_l2tp_updatesecret().") . "\n");
+		return 1;
+	}
+
+	$mpdsecret = "\n\n";
+
+	if (is_array($l2tpcfg['user'])) {
+		foreach ($l2tpcfg['user'] as $user) {
+			/* Escape double quotes, do not allow password to start with '!'
+			 * https://redmine.pfsense.org/issues/10275 */
+			$pass = str_replace('"', '\"', ltrim($user['password'], '!'));
+			$mpdsecret .= "{$user['name']} \"{$pass}\" {$user['ip']}\n";
+		}
+	}
+
+	fwrite($fd, $mpdsecret);
+	fclose($fd);
+	unset($mpdsecret);
+	chmod("{$g['varetc_path']}/l2tp-vpn/mpd.secret", 0600);
 
 	return 0;
 }

--- a/src/usr/local/www/vpn_l2tp_users_edit.php
+++ b/src/usr/local/www/vpn_l2tp_users_edit.php
@@ -126,7 +126,7 @@ if ($_POST['save']) {
 
 		write_config(gettext("Configured a L2TP VPN user."));
 
-		$retval = vpn_l2tp_configure();
+		$retval = vpn_l2tp_updatesecret();
 
 		pfSenseHeader("vpn_l2tp_users.php");
 


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/4866
- [ ] Ready for review

Full daemon restart drops L2TP clients sessions and may cause issues with other packages (see the redmine link)
This is useless since mpd reads mpd.secret on the fly.

This PR moves creation of the mpd.secret file to a separate function that does not restart mpd daemon.