### PR TITLE
Fix SMTP SSL/TLS disable validation. Issue #10317

### DIFF
--- a/src/etc/inc/notices.inc
+++ b/src/etc/inc/notices.inc
@@ -375,7 +375,11 @@ function send_smtp_message($message, $subject = "(no subject)", $force = false) 
 	);
 
 	if ($config['notifications']['smtp']['sslvalidate'] == "disabled") {
-		$params['socket_options'] = array('ssl' => array('verify_peer_name' => false));
+		$params['socket_options'] = array(
+			'ssl' => array(
+				'verify_peer_name' => false,
+				'verify_peer' => false
+		));
 	}
 
 	if ($config['notifications']['smtp']['fromaddress']) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10317
- [ ] Ready for review

The function send_smtp_message in etc/inc/notices.inc will try to verify the SSL certificate, even though the Validate SSL/TLS option is disabled in System -> Advanced -> Notifications.
This results in the error:

> [05-Mar-2020 22:04:06 America/Chicago] PHP Warning: stream_socket_client(): SSL operation failed with code 1. OpenSSL Error messages:
> error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed in /usr/local/share/pear/Net/Socket.php on line 159

And the notification is not sent.

The default php ssl context options are verify_peer = true and verify_peer_name = true.
When sslvalidate is disabled in the config, the send_smtp_message code only sets verify_peer_name to false. verify_peer is still true.
verify_peer is defined as "Require verification of SSL certificate used"
Adding verify_peer=false to the socket_options when sslvalidate is disabled resolves the error and the notification is sent.

from https://www.php.net/manual/en/context.ssl.php:
**verify_peer** boolean
Require verification of SSL certificate used.
Defaults to TRUE.

**verify_peer_name** boolean
Require verification of peer name.
Defaults to TRUE.