### PR TITLE
IPsec mobile page minor fixes. Issue #8160

### DIFF
--- a/src/usr/local/www/vpn_ipsec_mobile.php
+++ b/src/usr/local/www/vpn_ipsec_mobile.php
@@ -239,6 +239,7 @@ if ($_POST['save']) {
 	if ($pconfig['radius_ip_priority_enable']) {
 		if (!(isset($mobileph1) && ($mobileph1['authentication_method'] == 'eap-radius'))) {
 			$input_errors[] = gettext("RADIUS IP may only take prioriy when using EAP-RADIUS for authentication on the Mobile IPsec VPN.");
+			$pconfig['user_source'] = implode(',', $pconfig['user_source']);
 		}
 	}
 
@@ -532,13 +533,6 @@ $group->add(new Form_Select(
 $section->add($group);
 
 $section->addInput(new Form_Checkbox(
-	'radius_ip_priority_enable',
-	'RADIUS IP address priority',
-	'IPv4 address pool is used if IP is not supplied by RADIUS server',
-	$pconfig['radius_ip_priority_enable']
-));
-
-$section->addInput(new Form_Checkbox(
 	'pool_enable_v6',
 	'Virtual IPv6 Address Pool',
 	'Provide a virtual IPv6 address to clients',
@@ -571,9 +565,16 @@ $group->add(new Form_Select(
 	'',
 	$pconfig['pool_netbits_v6'],
 	$netBitsv6
-))->setWidth(3);
+))->setWidth(2);
 
 $section->add($group);
+
+$section->addInput(new Form_Checkbox(
+	'radius_ip_priority_enable',
+	'RADIUS IP address priority',
+	'IPv4/IPv6 address pool is used if address is not supplied by RADIUS server',
+	$pconfig['radius_ip_priority_enable']
+));
 
 $section->addInput(new Form_Checkbox(
 	'net_list_enable',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/8160
- [ ] Ready for review

This PR changes RADIUS IP address priority description, because it's also used by IPv6 pool,
sets netmask fields to the same size,
and fixes error
> PHP Warning:  explode() expects parameter 2 to be string, array given in /usr/local/www/vpn_ipsec_mobile.php on line 467

when RADIUS IP address priority is checked, but Phase 1 auth != EAP-RADIUS
