### PR TITLE
Add interface description to OS interface description. Issue #1557

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4183,6 +4183,10 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 		}
 	}
 
+	if (!empty($wancfg['descr'])) {
+		mwexec("/sbin/ifconfig " . escapeshellarg($wancfg['if']) . " description " . escapeshellarg($wancfg['descr']));
+	};
+
 	interfaces_staticarp_configure($interface);
 	return 0;
 }


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/1557
- [ ] Ready for review

When configuring an interface we can specify a "description" of the interface.
Unfortunately this description is not saved into the os interface level.
Example:
```
# ifconfig vtnet2 description INTLAN
# ifconfig vtnet2
vtnet2: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1350
        description: INTLAN
        options=80028<VLAN_MTU,JUMBO_MTU,LINKSTATE>
        ether 0c:ea:fd:26:64:02
        inet6 fe80::eea:fdff:fe26:6402%vtnet2 prefixlen 64 scopeid 0x3 
        inet 10.40.40.1 netmask 0xffffff00 broadcast 10.40.40.255 
        media: Ethernet 10Gbase-T <full-duplex>
        status: active
        nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>

```
It would be perfect when the description is also saved into the interface in os level.
So you can use this with SNMP Tools to see the interface descriptions.

bsnmpd uses this value in ifAlias starting from 10.3:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=206217

It can be used by various NMS software (Zabbix).

tested with GIF, GRE, LAGG, BRIDGE, OpenVPN, VTI interfaces