### PR TITLE
Synchronize admin accounts. Issue #9622

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -447,7 +447,9 @@ function local_sync_accounts($u2add, $u2del, $g2add, $g2del) {
 	}
 
 	foreach($u2del as $user) {
-		if ($user['uid'] < 2000 || $user['uid'] > 65000) {
+		if ($user['uid'] > 65000) {
+			continue;
+		} else if ($user['uid'] < 2000 && !in_array($user, $u2add)) {
 			continue;
 		}
 
@@ -774,9 +776,15 @@ function local_user_del($user) {
 }
 
 function local_user_set_password(&$user, $password) {
+	global $config;
+
 	unset($user['password']);
 	unset($user['md5-hash']);
 	$user['bcrypt-hash'] = password_hash($password, PASSWORD_BCRYPT);
+	if (($user['name'] == $config['hasync']['username']) &&
+	    ($config['hasync']['adminsync'] == 'on')) {
+		$config['hasync']['new_password'] = $password;
+	}
 }
 
 function local_user_get_groups($user, $all = false) {
@@ -1641,7 +1649,7 @@ function radius_backed($username, $password, $authcfg, &$attributes = array()) {
 		}
 		if (!is_ipaddr($nasip)) {
 			$nasip = get_interface_ip($nasip);
-			
+
 			if (!is_ipaddr($nasip)) {
 				$nasip = get_interface_ip();//We use wan interface IP as fallback for NAS-IP-Address
 			}
@@ -1650,7 +1658,7 @@ function radius_backed($username, $password, $authcfg, &$attributes = array()) {
 
 		$rauth->putAttribute(RADIUS_NAS_IP_ADDRESS, $nasip, "addr");
 		$rauth->putAttribute(RADIUS_NAS_IDENTIFIER, $nasid);
-		
+
 		if(!empty($attributes['calling_station_id'])) {
 			$rauth->putAttribute(RADIUS_CALLING_STATION_ID, $attributes['calling_station_id']);
 		}
@@ -1661,7 +1669,7 @@ function radius_backed($username, $password, $authcfg, &$attributes = array()) {
 		}
 		if(!empty($attributes['nas_port_type'])) {
 			$rauth->putAttribute(RADIUS_NAS_PORT_TYPE, $attributes['nas_port_type']);
-		}		
+		}
 		if(!empty($attributes['nas_port'])) {
 			$rauth->putAttribute(RADIUS_NAS_PORT, intval($attributes['nas_port']), 'integer');
 		}
@@ -1684,7 +1692,7 @@ function radius_backed($username, $password, $authcfg, &$attributes = array()) {
 		$ret = false;
 	}
 
-	
+
 	// Get attributes, even if auth failed.
 	if ($rauth->getAttributes()) {
 	$attributes = array_merge($attributes,$rauth->listAttributes());
@@ -1695,7 +1703,7 @@ function radius_backed($username, $password, $authcfg, &$attributes = array()) {
 			$stt = strtotime(preg_replace("/\+(\d+):(\d+)$/", " +\${1}\${2}", preg_replace("/(\d+)T(\d+)/", "\${1} \${2}",$stt)));
 		}
 	}
-	
+
 	// close OO RADIUS_AUTHENTICATION
 	$rauth->close();
 
@@ -1888,7 +1896,7 @@ function getUserGroups($username, $authcfg, &$attributes = array()) {
 }
 
 /*
-Possible return values : 
+Possible return values :
 true : authentication worked
 false : authentication failed (invalid login/password, not enought permission, etc...)
 null : error during authentication process (unable to reach remote server, etc...)

--- a/src/etc/rc.filter_synchronize
+++ b/src/etc/rc.filter_synchronize
@@ -214,11 +214,21 @@ function carp_sync_xml($sections) {
 		}
 	}
 
+	if (isset($config_copy['hasync']['adminsync'])) {
+		$xml['hasync']['adminsync'] = $config_copy['hasync']['adminsync'];
+	}
+
 	$rpc_client = new pfsense_xmlrpc_client();
 	$resp = $rpc_client->xmlrpc_method('restore_config_section', $xml, 900);
 	if ($resp != null) {
 		$url = $rpc_client->getUrl();
 		update_filter_reload_status("XMLRPC sync successfully completed with {$url}.");
+		if (isset($config['hasync']['new_password'])) {
+			update_filter_reload_status("Updating XMLRPC sync password.");
+			$config['hasync']['password'] = $config['hasync']['new_password'];
+			unset($config['hasync']['new_password']);
+			write_config("Update XMLRPC sync password.");
+		}
 		return true;
 	}
 	return false;

--- a/src/usr/local/www/system_hasync.php
+++ b/src/usr/local/www/system_hasync.php
@@ -33,6 +33,7 @@ $a_hasync = &$config['hasync'];
 
 $checkbox_names = array(
 	'pfsyncenabled',
+	'adminsync',
 	'synchronizeusers',
 	'synchronizeauthservers',
 	'synchronizecerts',
@@ -172,6 +173,16 @@ $section->addPassword(new Form_Input(
 	$pconfig['passwordfld']
 ))->setHelp('Enter the webConfigurator password of the system entered above for synchronizing the configuration.%1$s' .
 			'Do not use the Synchronize Config to IP and password option on backup cluster members!', '<br />');
+
+$section->addInput(new Form_Checkbox(
+	'adminsync',
+	'Synchronize admin',
+	'synchronize admin accounts and autoupdate sync password.',
+	($pconfig['adminsync'] === 'on'),
+	'on'
+))->setHelp('By default, the admin account does not synchronize, and each node may have a different admin password.%1$s' .
+			'This option automatically updates XMLRPC Remote System Password when the password is changed on 
+			the Remote System Username account.', '<br />');
 
 $group = new Form_MultiCheckboxGroup('Select options to sync');
 

--- a/src/usr/local/www/xmlrpc.php
+++ b/src/usr/local/www/xmlrpc.php
@@ -299,7 +299,7 @@ class pfsense_xmlrpc_server {
 
 					if ($idx === false) {
 						$u2add[] = $user;
-					} else if ($user['uid'] < 2000) {
+					} else if (($user['uid'] < 2000) && ($sections['hasync']['adminsync'] != 'on')) {
 						$u2keep[] = $idx;
 					} else if ($user != $local_users[$idx]) {
 						$u2add[] = $user;
@@ -661,9 +661,7 @@ class pfsense_xmlrpc_server {
 	 *
 	 * @return bool
 	 */
-	public function filter_configure($reset_accounts = true) {
-		$this->auth();
-
+	private function filter_configure($reset_accounts = true) {
 		global $g, $config;
 
 		filter_configure();


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9622
- [ ] Ready for review

This is copy of the original PR https://github.com/pfsense/pfsense/pull/4068 by @jwsi 
with checkbox on the System \ High Availability Sync to turn on/off this feature

from original PR:

These changes allow for the ability for the admin account to be synced between HA pairs.

**The following functionality is introduced**:
1. All admin account changes are synced to a partner.
2. When the admin password is changed on the primary node, the secondary is updated accordingly and the primary HA sync password is also updated to prevent future auth errors occuring during sync.

**Important Notes**:
* When an admin account password is changed, the config.xml file will be updated accordingly on the secondary. In xmlrpc.php there is a function called auth which authenticates the entity making changes to the device. Obviously this cannot be called if the config.xml file has been updated with the new credentials, but the PHP session is still using the old credentials. Therefore, I have made filter_configure a private function to remove this possibility.
James.