### PR TITLE
URL/URL Table alias with IDN hostnames. Issue #10321

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2383,7 +2383,7 @@ function parse_aliases_file($filename, $type = "url", $max_items = -1, $kflc = f
 	$comments = array();
 	/* NOTE: fgetss() is not a typo RTFM before being smart */
 	while (($fc = fgetss($fd)) !== FALSE) {
-		$tmp = trim($fc, " \t\n\r");
+		$tmp = idn_to_ascii(trim($fc, " \t\n\r"));
 		if (empty($tmp)) {
 			continue;
 		}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10321
- [ ] Ready for review

Add ability to use IDN hostnames ('täst.de') in URL/URL Tables files

idn_to_ascii() is used to convert IDN to punnycode