### PR TITLE
NTP status/widget long IPv6 address. Issue #10307

### DIFF
--- a/src/usr/local/www/status_ntpd.php
+++ b/src/usr/local/www/status_ntpd.php
@@ -52,7 +52,7 @@ if ($allow_query) {
 		$inet_version = " -4";
 	}
 
-	exec("/usr/local/sbin/ntpq -pn $inet_version | /usr/bin/tail +3", $ntpq_output);
+	exec('/usr/local/sbin/ntpq -pnw ' . $inet_version . ' | /usr/bin/tail +3 | /usr/bin/sed -E \'N;s/\n[[:blank:]]+/ /;P;D\'', $ntpq_output);
 
 	$ntpq_servers = array();
 	foreach ($ntpq_output as $line) {

--- a/src/usr/local/www/widgets/widgets/ntp_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/ntp_status.widget.php
@@ -38,7 +38,7 @@ if ($_REQUEST['updateme']) {
 		$inet_version = " -4";
 	}
 
-	exec("/usr/local/sbin/ntpq -pn -w $inet_version | /usr/bin/tail +3", $ntpq_output);
+	exec('/usr/local/sbin/ntpq -pnw ' . $inet_version . ' | /usr/bin/tail +3 | /usr/bin/sed -E \'N;s/\n[[:blank:]]+/ /;P;D\'', $ntpq_output);
 	$ntpq_counter = 0;
 	$stratum_text = gettext("stratum");
 	foreach ($ntpq_output as $line) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10307
- [ ] Ready for review

if I have a) an IPv6 NTP server, and b) the NTP status widget on the dashboard, the widget doesn't display the stratum correctly:
```
NTP Status 
Server Time    10:08:58 CST
Sync Source    2620:19:4000:100::86 (stratum )
```

Also NTP status page shows truncated IPv6 address 

from ntpq(1):
>      -w, --wide
>              Display the full 'remote' value.
> 
>              Display the full value of the 'remote' value.  
>              If this requires more than 15 characters, display the full value, emit
>              a newline, and continue the data display properly indented on the next line.

This PR fixes both issues