### PR TITLE
Do not include disabled IPSec P2 entries to <vpn_networks>. Issue #7622

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -979,7 +979,8 @@ function filter_get_vpns_list() {
 		}
 		if (is_array($config['ipsec']['phase2'])) {
 			foreach ($config['ipsec']['phase2'] as $ph2ent) {
-				if ((!$ph2ent['mobile']) && ($ph2ent['mode'] != 'transport')) {
+				if ((!$ph2ent['mobile']) && ($ph2ent['mode'] != 'transport') &&
+				    !isset($ph2ent['disabled'])) {
 					if (!is_array($ph2ent['remoteid'])) {
 						continue;
 					}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/7622
- [ ] Ready for review

PF Table vpn_networks is populated with disabled Phase 2 entries.

This may lead to underperformance if
(a) You have IPSec MSS clamping turned on
(b) The disabled phase 2 network or a subnetwork is reachable by pfsense by other path (directly connected, other VPN)
(c) MSS on this path is > IPSec MSS clamping value