### PR TITLE
Fix disabling IPv6 for PPPoE. Issue #7386

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -2302,6 +2302,9 @@ function interface_ppps_configure($interface) {
 	if (isset($ppp['mrru'])) {
 		$mrrus = explode(',', $ppp['mrru']);
 	}
+	if (!empty($ifcfg['ipaddrv6'])) {
+		$ipv6cp = "set bundle enable ipv6cp";
+	}
 
 	// Construct the mpd.conf file
 	$mpdconf = <<<EOD
@@ -2314,7 +2317,7 @@ startup:
 default:
 {$ppp['type']}client:
 	create bundle static {$interface}
-	set bundle enable ipv6cp
+	{$ipv6cp}
 	set iface name {$pppif}
 
 EOD;


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/7386
- [ ] Ready for review

continuing from:
https://forum.pfsense.org/index.php?topic=126849.0

When my ISP (Fairpoint) apparently added some IPv6 support, my connectivity broke, even though IPv6 was proactively disabled in my PPPoE config.

Commenting out:

`set bundle enable ipv6cp`
in mpd_wan.conf and running mpd5 by hand fixed the problem.


patch by Bill McGonigle