### PR TITLE
Password confirmation when exporting encrypted backup file. Issue #10301

### DIFF
--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -157,8 +157,8 @@ if ($_POST) {
 	if ($mode) {
 		if ($mode == "download") {
 			if ($_POST['encrypt']) {
-				if (!$_POST['encrypt_password']) {
-					$input_errors[] = gettext("A password for encryption must be supplied and confirmed.");
+				if (!$_POST['encrypt_password'] || ($_POST['encrypt_password'] != $_POST['encrypt_password_confirm'])) {
+					$input_errors[] = gettext("Supplied password and confirmation do not match.");
 				}
 			}
 
@@ -548,7 +548,7 @@ $section->addInput(new Form_Checkbox(
 	false
 ));
 
-$section->addInput(new Form_Input(
+$section->addPassword(new Form_Input(
 	'encrypt_password',
 	'Password',
 	'password',
@@ -666,9 +666,7 @@ events.push(function() {
 		decryptHide = !($('input[name="decrypt"]').is(':checked'));
 
 		hideInput('encrypt_password', encryptHide);
-		hideInput('encrypt_password_confirm', encryptHide);
 		hideInput('decrypt_password', decryptHide);
-		hideInput('decrypt_password_confirm', decryptHide);
 	}
 
 	// ---------- Click handlers ------------------------------------------------------------------


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10301
- [ ] Ready for review

redmine:

> I would highly recommend to implement password confirmation so you have to insert the password two times when exporting an encrypted pfsense backup file. Or alternatively the option to show the password before submitting it.
> It would be a mess in case I really needed to restore the config but got an invalid password because I did a mistake when creating it.

This PR adds password confirmation