### PR TITLE
Exclude unsupported interfaces from DHCP Relay. Issue #10341

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -7162,4 +7162,14 @@ function create_interface_list() {
 	return($iflist);
 }
 
+function is_pseudo_interface($inf) {
+	$psifs = array('ovpn', 'ipsec', 'l2tp', 'pptp', 'gif', 'gre', 'ppp', 'pppoe');
+	foreach ($psifs as $pif) {
+		if (substr($inf, 0, strlen($pif)) == $pif) {
+			return true;
+		}
+	}
+	return false;
+}
+
 ?>

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1798,12 +1798,11 @@ function services_dhcrelay_configure() {
 	$dhcrelayifs = array();
 	$dhcifaces = explode(",", $dhcrelaycfg['interface']);
 	foreach ($dhcifaces as $dhcrelayif) {
-		if (!isset($iflist[$dhcrelayif]) ||
-		    link_interface_to_bridge($dhcrelayif)) {
+		if (!isset($iflist[$dhcrelayif])) {
 			continue;
 		}
 
-		if (is_ipaddr(get_interface_ip($dhcrelayif))) {
+		if (get_interface_ip($dhcrelayif)) {
 			$dhcrelayifs[] = get_real_interface($dhcrelayif);
 		}
 	}
@@ -1821,7 +1820,7 @@ function services_dhcrelay_configure() {
 	$srvifaces = array();
 	foreach ($srvips as $srcidx => $srvip) {
 		$destif = guess_interface_from_ip($srvip);
-		if (!empty($destif)) {
+		if (!empty($destif) && !is_pseudo_interface($destif)) {
 			$srvifaces[] = $destif;
 		}
 	}
@@ -1884,12 +1883,11 @@ function services_dhcrelay6_configure() {
 
 	$dhcifaces = explode(",", $dhcrelaycfg['interface']);
 	foreach ($dhcifaces as $dhcrelayif) {
-		if (!isset($iflist[$dhcrelayif]) ||
-		    link_interface_to_bridge($dhcrelayif)) {
+		if (!isset($iflist[$dhcrelayif])) {
 			continue;
 		}
 
-		if (is_ipaddrv6(get_interface_ipv6($dhcrelayif))) {
+		if (get_interface_ipv6($dhcrelayif)) {
 			$dhcrelayifs[] = get_real_interface($dhcrelayif);
 		}
 	}
@@ -1903,7 +1901,7 @@ function services_dhcrelay6_configure() {
 	$srvifaces = array();
 	foreach ($srvips as $srcidx => $srvip) {
 		$destif = guess_interface_from_ip($srvip);
-		if (!empty($destif)) {
+		if (!empty($destif) && !is_pseudo_interface($destif)) {
 			$srvifaces[] = "{$srvip}%{$destif}";
 		}
 	}

--- a/src/usr/local/www/services_dhcp_relay.php
+++ b/src/usr/local/www/services_dhcp_relay.php
@@ -48,8 +48,8 @@ $iflist = array_intersect_key(
 		array_filter(
 			array_keys(get_configured_interface_with_descr()),
 			function($if) {
-				return (is_ipaddr(get_interface_ip($if)) &&
-				    (substr(convert_friendly_interface_to_real_interface_name($if), 0, 4) != 'ovpn'));
+				return (get_interface_ip($if) &&
+				    !is_pseudo_interface(convert_friendly_interface_to_real_interface_name($if)));
 			}
 		)
 	)

--- a/src/usr/local/www/services_dhcpv6_relay.php
+++ b/src/usr/local/www/services_dhcpv6_relay.php
@@ -49,7 +49,8 @@ $iflist = array_intersect_key(
 		array_filter(
 			array_keys(get_configured_interface_with_descr()),
 			function($if) {
-				return is_ipaddrv6(get_interface_ipv6($if));
+				return (get_interface_ipv6($if) &&
+				    !is_pseudo_interface(convert_friendly_interface_to_real_interface_name($if)));
 			}
 		)
 	)


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10341
- [ ] Ready for review

Such pseudo-interfaces as VTI, GIF, GRE, L2TP, PPTP, PPP, PPPoE and OpenVPN is unsupported by DHCP Relay:
```
Mar 13 09:03:40    dhcrelay    65228    Unsupported device type 131 for "ipsec2000" 
Mar 13 09:04:14    dhcrelay    32263    Unsupported device type 240 for "gif0" 
Mar 13 09:22:04    dhcrelay    53447    Unsupported device type 131 for "gre0" 
Mar 13 09:24:10    dhcrelay    10853    Unsupported device type 53 for "l2tp1" 
```

They must be excluded from interface selection list,
service must also avoid use them for auto-generated upstream interface list:
https://github.com/pfsense/pfsense/blob/d09e19adf4253251dc2aa6d9edc3043e69096d4f/src/etc/inc/services.inc#L1823