### PR TITLE
Allow dashed DUID to be entered in a DHCPv6 Mapping. Issue #2568

### DIFF
--- a/src/usr/local/www/services_dhcpv6_edit.php
+++ b/src/usr/local/www/services_dhcpv6_edit.php
@@ -146,7 +146,7 @@ if ($_POST['save']) {
 
 	if (!$input_errors) {
 		$mapent = array();
-		$mapent['duid'] = $_POST['duid'];
+		$mapent['duid'] = str_replace("-", ":", $_POST['duid']);
 		$mapent['ipaddrv6'] = $_POST['ipaddrv6'];
 		$mapent['hostname'] = $_POST['hostname'];
 		$mapent['descr'] = $_POST['descr'];
@@ -206,7 +206,8 @@ $section->addInput(new Form_Input(
 	['placeholder' => 'DUID-LLT - ETH -- TIME --- ---- address ---- xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx']
 ))->setHelp('Enter a DUID in the following format: %1$s %2$s', '<br />',
 			'DUID-LLT - ETH -- TIME --- ---- address ---- ' .
-			'xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx');
+			'xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx ---- ' .
+			'xx-xx-xx-xx-xx-xx-xx-xx-xx-xx-xx-xx-xx-xx');
 
 $section->addInput(new Form_Input(
 	'ipaddrv6',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/2568
- [ ] Ready for review

The DHCPv4 service allows the Windows MAC address format (xx-xx-xx-xx-xx) to be entered in a DHCP reservation mapping which will automatically be converted to the colon format used by pfSense (xx:xx:xx:xx:xx). This allows for easy copy and pasting from Windows clients. 

This PR allows to use dashed DUID