### PR TITLE
Check IPv6 interface aliases for firewall rules. Issue #8256

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2560,16 +2560,27 @@ function filter_address_add_vips_subnets(&$subnets, $if, $not) {
 	global $FilterIflist;
 
 	$if_subnets = array($subnets);
+	$vips = array();
+	$vips6 = array();
 
 	if ($not == true) {
 		$subnets = "!{$subnets}";
 	}
 
-	if (!isset($FilterIflist[$if]['vips']) || !is_array($FilterIflist[$if]['vips'])) {
+	if ((!isset($FilterIflist[$if]['vips']) || !is_array($FilterIflist[$if]['vips'])) &&
+	    (!isset($FilterIflist[$if]['vips6']) || !is_array($FilterIflist[$if]['vips6']))) {
 		return;
 	}
 
-	foreach ($FilterIflist[$if]['vips'] as $vip) {
+	if (isset($FilterIflist[$if]['vips']) && is_array($FilterIflist[$if]['vips'])) {
+		$vips = $FilterIflist[$if]['vips'];
+	}
+
+	if (isset($FilterIflist[$if]['vips6']) && is_array($FilterIflist[$if]['vips6'])) {
+		$vips6 = $FilterIflist[$if]['vips6'];
+	}
+
+	foreach (array_merge($vips, $vips6) as $vip) {
 		foreach ($if_subnets as $subnet) {
 			if (ip_in_subnet($vip['ip'], $subnet)) {
 				continue 2;


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/8256
- [ ] Ready for review

cite:
> I have VLAN network interface called V1050 and I also have in and out rules to allow everything IPv4+IPv6, for IPv4 this works fine what ever CARP VIP alias you add it's defined in V1050 net but not for IPv6 if you add any IPv6 IP Alias to that interface you have to also add a firewall rules to allow the traffic for that IP Alias.

This issue is caused by `filter_address_add_vips_subnets()`, which does not check the array of IPv6 aliases (`vips6`)

This PR fixes it