### PR TITLE
DHCPv6 service Dynamic DNS fix. Issue #10346

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1278,7 +1278,7 @@ EOD;
 		$dhcpdifs[] = get_real_interface($dhcpif);
 		if ($newzone['domain-name']) {
 			if ($need_ddns_updates) {
-				$newzone['dns-servers'] = array($dhcpifconf['ddnsdomainprimary']);
+				$newzone['dns-servers'] = array($dhcpifconf['ddnsdomainprimary'], $dhcpifconf['ddnsdomainsecondary']);
 				$newzone['ddnsdomainkeyname'] = $dhcpifconf['ddnsdomainkeyname'];
 				$newzone['ddnsdomainkeyalgorithm'] = $dhcpifconf['ddnsdomainkeyalgorithm'];
 				$newzone['ddnsdomainkey'] = $dhcpifconf['ddnsdomainkey'];
@@ -1350,9 +1350,9 @@ function dhcpdzones($ddns_zones) {
 			$primary = $zone['dns-servers'][0];
 			$secondary = empty($zone['dns-servers'][1]) ? "" : $zone['dns-servers'][1];
 
-			// Make sure we aren't using any invalid or IPv6 DNS servers.
-			if (!is_ipaddrv4($primary)) {
-				if (is_ipaddrv4($secondary)) {
+			// Make sure we aren't using any invalid servers.
+			if (!is_ipaddr($primary)) {
+				if (is_ipaddr($secondary)) {
 					$primary = $secondary;
 					$secondary = "";
 				} else {
@@ -1363,9 +1363,15 @@ function dhcpdzones($ddns_zones) {
 			// We don't need to add zones multiple times.
 			if ($zone['domain-name'] && !in_array($zone['domain-name'], $added_zones)) {
 				$dhcpdconf .= "zone {$zone['domain-name']}. {\n";
-				$dhcpdconf .= "	primary {$primary};\n";
+				if (is_ipaddrv4($primary)) {
+					$dhcpdconf .= "	primary {$primary};\n";
+				} else {
+					$dhcpdconf .= "	primary6 {$primary};\n";
+				}
 				if (is_ipaddrv4($secondary)) {
 					$dhcpdconf .= "	secondary {$secondary};\n";
+				} elseif (is_ipaddrv6($secondary)) {
+					$dhcpdconf .= "	secondary6 {$secondary};\n";
 				}
 				if ($zone['ddnsdomainkeyname'] <> "" && $zone['ddnsdomainkey'] <> "") {
 					$dhcpdconf .= "	key {$zone['ddnsdomainkeyname']};\n";
@@ -1375,9 +1381,15 @@ function dhcpdzones($ddns_zones) {
 			}
 			if ($zone['ptr-domain'] && !in_array($zone['ptr-domain'], $added_zones)) {
 				$dhcpdconf .= "zone {$zone['ptr-domain']} {\n";
-				$dhcpdconf .= "	primary {$primary};\n";
+				if (is_ipaddrv4($primary)) {
+					$dhcpdconf .= "	primary {$primary};\n";
+				} else {
+					$dhcpdconf .= "	primary6 {$primary};\n";
+				}
 				if (is_ipaddrv4($secondary)) {
 					$dhcpdconf .= "	secondary {$secondary};\n";
+				} elseif (is_ipaddrv6($secondary)) {
+					$dhcpdconf .= "	secondary6 {$secondary};\n";
 				}
 				if ($zone['ddnsdomainkeyname'] <> "" && $zone['ddnsdomainkey'] <> "") {
 					$dhcpdconf .= "	key {$zone['ddnsdomainkeyname']};\n";
@@ -1550,7 +1562,7 @@ EOD;
 		    !empty($dhcpv6ifconf['ddnsdomain'])) {
 			$newzone = array();
 			$newzone['domain-name'] = $dhcpv6ifconf['ddnsdomain'];
-			$newzone['dns-servers'][] = $dhcpv6ifconf['ddnsdomainprimary'];
+			$newzone['dns-servers'] = array($dhcpv6ifconf['ddnsdomainprimary'], $dhcpv6ifconf['ddnsdomainsecondary']);
 			$newzone['ddnsdomainkeyname'] = $dhcpv6ifconf['ddnsdomainkeyname'];
 			$newzone['ddnsdomainkey'] = $dhcpv6ifconf['ddnsdomainkey'];
 			$ddns_zones[] = $newzone;
@@ -1559,7 +1571,7 @@ EOD;
 				foreach ($ptr_zones as $ptr_zone) {
 					$reversezone = array();
 					$reversezone['ptr-domain'] = $ptr_zone;
-					$reversezone['dns-servers'][] = $dhcpv6ifconf['ddnsdomainprimary'];
+					$reversezone['dns-servers'] = array($dhcpv6ifconf['ddnsdomainprimary'], $dhcpv6ifconf['ddnsdomainsecondary']);
 					$reversezone['ddnsdomainkeyname'] = $dhcpv6ifconf['ddnsdomainkeyname'];
 					$reversezone['ddnsdomainkey'] = $dhcpv6ifconf['ddnsdomainkey'];
 					$ddns_zones[] = $reversezone;

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -274,12 +274,22 @@ if ($_POST['save']) {
 	if (($_POST['ddnsdomain'] && !is_domain($_POST['ddnsdomain']))) {
 		$input_errors[] = gettext("A valid domain name must be specified for the dynamic DNS registration.");
 	}
-	if (($_POST['ddnsdomain'] && !is_ipaddrv4($_POST['ddnsdomainprimary']))) {
-		$input_errors[] = gettext("A valid primary domain name server IPv4 address must be specified for the dynamic domain name.");
+	if (($_POST['ddnsdomain'] && !is_ipaddr($_POST['ddnsdomainprimary']))) {
+		$input_errors[] = gettext("A valid primary domain name server IP address must be specified for the dynamic domain name.");
 	}
-	if (($_POST['ddnsdomainkey'] && !$_POST['ddnsdomainkeyname']) ||
-	    ($_POST['ddnsdomainkeyname'] && !$_POST['ddnsdomainkey'])) {
-		$input_errors[] = gettext("Both a valid domain key and key name must be specified.");
+	if ($_POST['ddnsupdate']) {
+		if (!is_domain($_POST['ddnsdomain'])) {
+			$input_errors[] = gettext("A valid domain name must be specified for the dynamic DNS registration.");
+		}
+		if (!is_ipaddr($_POST['ddnsdomainprimary'])) {
+			$input_errors[] = gettext("A valid primary domain name server IP address must be specified for the dynamic domain name.");
+		}
+		if (preg_match('/[^A-Za-z0-9\-_]/', $_POST['ddnsdomainkeyname'])) {
+			$input_errors[] = gettext("The domain key name may only contain the characters a-z, A-Z, 0-9, '-' and '_'");
+		}
+		if ($_POST['ddnsdomainkey'] && !base64_decode($_POST['ddnsdomainkey'], true)) {
+			$input_errors[] = gettext("The domain key secret must be a Base64 encoded value.");
+		}
 	}
 	if ($_POST['domainsearchlist']) {
 		$domain_array=preg_split("/[ ;]+/", $_POST['domainsearchlist']);
@@ -641,7 +651,7 @@ $section->addInput(new Form_IpAddress(
 	'ddnsdomainprimary',
 	'DDNS Server IP',
 	$pconfig['ddnsdomainprimary'],
-	'V4'
+	'BOTH'
 ))->setHelp('Enter the primary domain name server IP address for the dynamic domain name.');
 
 $section->addInput(new Form_Input(

--- a/src/usr/local/www/services_dhcpv6.php
+++ b/src/usr/local/www/services_dhcpv6.php
@@ -145,6 +145,7 @@ if (is_array($config['dhcpdv6'][$if])) {
 	$pconfig['enable'] = isset($config['dhcpdv6'][$if]['enable']);
 	$pconfig['ddnsdomain'] = $config['dhcpdv6'][$if]['ddnsdomain'];
 	$pconfig['ddnsdomainprimary'] = $config['dhcpdv6'][$if]['ddnsdomainprimary'];
+	$pconfig['ddnsdomainsecondary'] = $config['dhcpdv6'][$if]['ddnsdomainsecondary'];
 	$pconfig['ddnsdomainkeyname'] = $config['dhcpdv6'][$if]['ddnsdomainkeyname'];
 	$pconfig['ddnsdomainkeyalgorithm'] = $config['dhcpdv6'][$if]['ddnsdomainkeyalgorithm'];
 	$pconfig['ddnsdomainkey'] = $config['dhcpdv6'][$if]['ddnsdomainkey'];
@@ -310,14 +311,25 @@ if (isset($_POST['apply'])) {
 	if ($_POST['maxtime'] && (!is_numeric($_POST['maxtime']) || ($_POST['maxtime'] < 60) || ($_POST['maxtime'] <= $_POST['deftime']))) {
 		$input_errors[] = gettext("The maximum lease time must be at least 60 seconds and higher than the default lease time.");
 	}
-	if ($_POST['ddnsupdate'] && !is_domain($_POST['ddnsdomain'])) {
-		$input_errors[] = gettext("A valid domain name must be specified for the dynamic DNS registration.");
-	}
-	if ($_POST['ddnsupdate'] && !is_ipaddrv4($_POST['ddnsdomainprimary'])) {
-		$input_errors[] = gettext("A valid primary domain name server IPv4 address must be specified for the dynamic domain name.");
-	}
-	if ($_POST['ddnsupdate'] && (!$_POST['ddnsdomainkeyname'] || !$_POST['ddnsdomainkeyalgorithm'] || !$_POST['ddnsdomainkey'])) {
-		$input_errors[] = gettext("A valid domain key name, algorithm and secret must be specified.");
+	if ($_POST['ddnsupdate']) {
+		if (!is_domain($_POST['ddnsdomain'])) {
+			$input_errors[] = gettext("A valid domain name must be specified for the dynamic DNS registration.");
+		}
+		if (!is_ipaddr($_POST['ddnsdomainprimary'])) {
+			$input_errors[] = gettext("A valid primary domain name server IP address must be specified for the dynamic domain name.");
+		}
+		if (!empty($_POST['ddnsdomainsecondary']) && !is_ipaddr($_POST['ddnsdomainsecondary'])) {
+			$input_errors[] = gettext("A valid secondary domain name server IP address must be specified for the dynamic domain name.");
+		}
+		if (!$_POST['ddnsdomainkeyname'] || !$_POST['ddnsdomainkeyalgorithm'] || !$_POST['ddnsdomainkey']) {
+			$input_errors[] = gettext("A valid domain key name, algorithm and secret must be specified.");
+		}
+		if (preg_match('/[^A-Za-z0-9\-_]/', $_POST['ddnsdomainkeyname'])) {
+			$input_errors[] = gettext("The domain key name may only contain the characters a-z, A-Z, 0-9, '-' and '_'");
+		}
+		if ($_POST['ddnsdomainkey'] && !base64_decode($_POST['ddnsdomainkey'], true)) {
+			$input_errors[] = gettext("The domain key secret must be a Base64 encoded value.");
+		}
 	}
 	if ($_POST['domainsearchlist']) {
 		$domain_array = preg_split("/[ ;]+/", $_POST['domainsearchlist']);
@@ -450,6 +462,7 @@ if (isset($_POST['apply'])) {
 		$config['dhcpdv6'][$if]['enable'] = ($_POST['enable']) ? true : false;
 		$config['dhcpdv6'][$if]['ddnsdomain'] = $_POST['ddnsdomain'];
 		$config['dhcpdv6'][$if]['ddnsdomainprimary'] = $_POST['ddnsdomainprimary'];
+		$config['dhcpdv6'][$if]['ddnsdomainsecondary'] = (!empty($_POST['ddnsdomainsecondary'])) ? $_POST['ddnsdomainsecondary'] : ''; 
 		$config['dhcpdv6'][$if]['ddnsdomainkeyname'] = $_POST['ddnsdomainkeyname'];
 		$config['dhcpdv6'][$if]['ddnsdomainkeyalgorithm'] = $_POST['ddnsdomainkeyalgorithm'];
 		$config['dhcpdv6'][$if]['ddnsdomainkey'] = $_POST['ddnsdomainkey'];
@@ -798,10 +811,17 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_IpAddress(
 	'ddnsdomainprimary',
-	'DDNS Server IP',
+	'Primary DDNS address',
 	$pconfig['ddnsdomainprimary'],
-	'V4'
-))->setHelp('Enter the primary domain name server IPv4 address for the dynamic domain name.');
+	'BOTH'
+))->setHelp('Enter the primary domain name server IP address for the dynamic domain name.');
+
+$section->addInput(new Form_IpAddress(
+	'ddnsdomainsecondary',
+	'Secondary DDNS address',
+	$pconfig['ddnsdomainsecondary'],
+	'BOTH'
+))->setHelp('Enter the secondary domain name server IP address for the dynamic domain name.');
 
 $section->addInput(new Form_Input(
 	'ddnsdomainkeyname',
@@ -829,7 +849,8 @@ $section->addInput(new Form_Input(
 	'DDNS Domain Key secret',
 	'text',
 	$pconfig['ddnsdomainkey']
-))->setHelp('Enter the dynamic DNS domain key secret which will be used to register client names in the DNS server.');
+))->setAttribute('placeholder', 'Base64 encoded string')
+->setHelp('Enter the dynamic DNS domain key secret which will be used to register client names in the DNS server.');
 
 $section->addInput(new Form_Select(
 	'ddnsclientupdates',
@@ -1122,6 +1143,7 @@ events.push(function() {
 			    !$pconfig['ddnsforcehostname'] &&
 			    empty($pconfig['ddnsdomain']) &&
 			    empty($pconfig['ddnsdomainprimary']) &&
+			    empty($pconfig['ddnsdomainsecondary']) &&
 			    empty($pconfig['ddnsdomainkeyname']) &&
 			    (empty($pconfig['ddnsdomainkeyalgorithm'])  || ($pconfig['ddnsdomainkeyalgorithm'] == "hmac-md5")) &&
 			    empty($pconfig['ddnsdomainkey']) &&
@@ -1142,6 +1164,7 @@ events.push(function() {
 		hideInput('ddnsdomain', !showadvdns);
 		hideCheckbox('ddnsforcehostname', !showadvdns);
 		hideInput('ddnsdomainprimary', !showadvdns);
+		hideInput('ddnsdomainsecondary', !showadvdns);
 		hideInput('ddnsdomainkeyname', !showadvdns);
 		hideInput('ddnsdomainkeyalgorithm', !showadvdns);
 		hideInput('ddnsdomainkey', !showadvdns);


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10346
- [ ] Ready for review

1) The DHCPv6 Server & RA page is not allow to enter IPv6 address in DDNS Server IP field (IPv4?)
2) The DHCPv6 Server & RA page DDNS Domain Key name may only contain the characters a-z, A-Z 0-9, '-' and '_'
'=', '@', '.', '^', etc. are special characters and dhcpd doesn't start if config contains it
3) The DynDNS secret must be enclosed in quotes (“secret”), otherwise you will get error message:
```
/services_dhcpv6.php: The command '/usr/local/sbin/dhcpd -6 -user dhcpd -group _dhcp -chroot 
/var/dhcpd -cf /etc/dhcpdv6.conf -pf /var/run/dhcpdv6.pid vtnet2' returned exit code '1', the output 
was 'Internet Systems Consortium DHCP Server 4.4.1 Copyright 2004-2018 Internet Systems 
Consortium. All rights reserved. For info, please visit https://www.isc.org/software/dhcp/ 
/etc/dhcpdv6.conf line 27: partial base64 value left over: 3. \x09secret 123; ^ Configuration file 
errors encountered -- exiting If you think you have received this message due to a bug rather than a 
configuration issue please read the section on submitting bugs on either our web page at 
www.isc.org or in the README file before submitting a bug. These pages explain the proper 
process and the information we find helpful for debugging. exiting.'

```