### PR TITLE
Add localhost to NTP Interfaces. Issue #10348

### DIFF
--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -47,7 +47,7 @@ if (empty($config['ntpd']['interface'])) {
 	    is_array($config['installedpackages']['openntpd']['config'][0]) && !empty($config['installedpackages']['openntpd']['config'][0]['interface'])) {
 		$pconfig['interface'] = explode(",", $config['installedpackages']['openntpd']['config'][0]['interface']);
 		unset($config['installedpackages']['openntpd']);
-		write_config(gettext("Upgraded settings from openttpd"));
+		write_config(gettext("Upgraded settings from openntpd"));
 	} else {
 		$pconfig['interface'] = array();
 	}
@@ -192,6 +192,8 @@ function build_interface_list() {
 	$iflist = array('options' => array(), 'selected' => array());
 
 	$interfaces = get_configured_interface_with_descr();
+	$interfaces['lo0'] = "Localhost";
+
 	foreach ($interfaces as $iface => $ifacename) {
 		if (!is_ipaddr(get_interface_ip($iface)) &&
 		    !is_ipaddrv6(get_interface_ipv6($iface))) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10348
- [ ] Ready for review

> When selecting interfaces its not possible to select localhost unless deselecting all interfaces and enabling the use of a wildcard.
> Intended behavior is to be able to enable a select few interfaces AND localhost to enable NAT redirection back to pfSense for clients where NTP settings cant be changed.
> Intended behavior can be seen in the DNS Resolver that provides the ability to select interfaces + localhost.

NTPD listens for 127.0.0.1:123 and :: 1: 123 anyway, but this PR allows you to select _only_ Loopback as the listening interface, for cases when you need to do port-forward to loopback and not listen to any other interface.
