### PR TITLE
Add units in ntp status page. Issue #2850

### DIFF
--- a/src/usr/local/www/status_ntpd.php
+++ b/src/usr/local/www/status_ntpd.php
@@ -310,11 +310,11 @@ include("head.inc");
 					<th><?=gettext("Stratum")?></th>
 					<th><?=gettext("Type")?></th>
 					<th><?=gettext("When")?></th>
-					<th><?=gettext("Poll")?></th>
+					<th><?=gettext("Poll (s)")?></th>
 					<th><?=gettext("Reach")?></th>
-					<th><?=gettext("Delay")?></th>
-					<th><?=gettext("Offset")?></th>
-					<th><?=gettext("Jitter")?></th>
+					<th><?=gettext("Delay (ms)")?></th>
+					<th><?=gettext("Offset (ms)")?></th>
+					<th><?=gettext("Jitter (ms)")?></th>
 				</tr>
 			</thead>
 			<tbody id="ntpbody">


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/2850
- [ ] Ready for review

Hi, I am trying to set up a stratum 1 ntp server with a serial gps (if that is what it is called)
and when I am checking the ntp status page, there is no units behind the numbers.

after figuring out that most of the page is the output of ntpq -p, and looking
up the man page online, I see that the polling interval is in seconds,
and delay, offset, jitter is in milliseconds.

It would be great if there was units behind the numbers (s,ms) for simplicity.

man ntpq(1):
...
poll       poll interval (s)

Other values in milliseconds