### PR TITLE
Firewall rule states link and Require State Filter option fix. Issue #10359

### DIFF
--- a/src/usr/local/www/diag_dump_states.php
+++ b/src/usr/local/www/diag_dump_states.php
@@ -213,7 +213,8 @@ print $form;
 		$arr[] = array("filter" => $_POST['filter']);
 	}
 
-	if (isset($_POST['filter']) || !isset($config['system']['webgui']['requirestatefilter'])) {
+	if (isset($_POST['filter']) || isset($_REQUEST['ruleid']) ||
+	    !isset($config['system']['webgui']['requirestatefilter'])) {
 		if (count($arr) > 0) {
 			$res = pfSense_get_pf_states($arr);
 		} else {
@@ -273,7 +274,8 @@ print $form;
 if ($states == 0) {
 	if (isset($_POST['filter']) && !empty($_POST['filter'])) {
 		$errmsg = gettext('No states were found that match the current filter.');
-	} else if (!isset($_POST['filter']) && isset($config['system']['webgui']['requirestatefilter'])) {
+	} else if (!isset($_POST['filter']) && !isset($_REQUEST['ruleid']) &&
+	    isset($config['system']['webgui']['requirestatefilter'])) {
 		$errmsg = gettext('State display suppressed without filter submission. '.
 		'See System > General Setup, Require State Filter.');
 	} else {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10359
- [ ] Ready for review

If one configures

System > General Setup
- Require State Filter -> yes (enabled checkbox)

that's a great way to stop browsers (like firefox) to crash or load infinitely while opening "Diagnostics > State" on a busy firewall.
We had to set this as on our busy datacenter cluster there were so many state that most browsers were going down while trying to load the state table page unfiltered.

But: with the above option set, the cross-linking of states belonging to filter rules is no longer working:

- enable "Require State Filter"
- save
- go to "Firewall > Rules"
- click on the States in front of a busy firewall rule that you want to check
- you are redirected to diag_dump_states.php but the page thinks that your call is "unfiltered" therefore not showing anything


Firewall rules page uses `$_REQUEST['ruleid']`, but diag_dump_states.php checks only for $_POST['filter'] and `requirestatefilter` option.
This PR adds check for `$_REQUEST['ruleid']`