### PR TITLE
Add option to disable NTP server. Issue #3567

### DIFF
--- a/src/etc/inc/rrd.inc
+++ b/src/etc/inc/rrd.inc
@@ -797,7 +797,7 @@ function enable_rrd_graphing() {
 		/* End Captive Portal statistics */
 
 		/* NTP, set up the ntpd rrd file */
-		if (isset($config['ntpd']['statsgraph'])) {
+		if (isset($config['ntpd']['statsgraph']) && ($config['ntpd']['enable'] != 'disabled')) {
 			/* set up the ntpd rrd file */
 			if (!file_exists("$rrddbpath$ntpd")) {
 				$rrdcreate = "$rrdtool create $rrddbpath$ntpd --step $rrdntpdinterval ";

--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -269,10 +269,12 @@ function get_services() {
 	$pconfig['description'] = gettext("PC/SC Smart Card Daemon");
 	$services[] = $pconfig;
 
-	$pconfig = array();
-	$pconfig['name'] = "ntpd";
-	$pconfig['description'] = gettext("NTP clock sync");
-	$services[] = $pconfig;
+	if (is_array($config['ntpd']) && ($config['ntpd']['enable'] != 'disabled')) {
+		$pconfig = array();
+		$pconfig['name'] = "ntpd";
+		$pconfig['description'] = gettext("NTP clock sync");
+		$services[] = $pconfig;
+	}
 
 	$pconfig = array();
 	$pconfig['name'] = "syslogd";

--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -1592,6 +1592,10 @@ function system_ntp_fixup_poll_value($type, $configvalue, $default) {
 function system_ntp_setup_gps($serialport) {
 	global $config, $g;
 
+	if (is_array($config['ntpd']) && ($config['ntpd']['enable'] == 'disabled')) {
+		return false;
+	}
+
 	init_config_arr(array('ntpd', 'gps', 'speed'));
 	$gps_device = '/dev/gps0';
 	$serialport = '/dev/'.$serialport;
@@ -1685,6 +1689,10 @@ function system_ntp_setup_pps($serialport) {
 	if (!file_exists($serialport)) {
 		return false;
 	}
+	// If ntpd is disabled, just return
+	if (is_array($config['ntpd']) && ($config['ntpd']['enable'] == 'disabled')) {
+		return false;
+	}
 
 	// Create symlink that ntpd requires
 	unlink_if_exists($pps_device);
@@ -1693,7 +1701,6 @@ function system_ntp_setup_pps($serialport) {
 
 	return true;
 }
-
 
 function system_ntp_configure() {
 	global $config, $g;
@@ -1709,6 +1716,20 @@ function system_ntp_configure() {
 
 	if (!is_array($config['ntpd'])) {
 		$config['ntpd'] = array();
+	}
+	// ntpd is disabled, just stop it and return
+	if ($config['ntpd']['enable'] == 'disabled') {
+		while (isvalidpid("{$g['varrun_path']}/ntpd.pid")) {
+			killbypid("{$g['varrun_path']}/ntpd.pid");
+		}
+		@unlink("{$g['varrun_path']}/ntpd.pid");
+		@unlink("{$g['varetc_path']}/ntpd.conf");
+		log_error("NTPD is disabled.");
+		return;
+	}
+
+	if (platform_booting()) {
+		echo gettext("Starting NTP Server...");
 	}
 
 	/* if ntpd is running, kill it */
@@ -2050,11 +2071,16 @@ function system_ntp_configure() {
 		mkdir("/var/empty", 0555, true);
 	}
 
-	/* start opentpd, set time now and use /var/etc/ntpd.conf */
+	/* start ntpd, set time now and use /var/etc/ntpd.conf */
 	mwexec("/usr/local/sbin/ntpd -g -c {$g['varetc_path']}/ntpd.conf -p {$g['varrun_path']}/ntpd.pid", false, true);
 
 	// Note that we are starting up
 	log_error("NTPD is starting up.");
+
+	if (platform_booting()) {
+		echo gettext("done.") . "\n";
+	}
+
 	return;
 }
 

--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -290,9 +290,7 @@ echo "done.\n";
 system_routing_enable();
 
 /* Enable ntpd */
-echo "Starting NTP time client...";
 system_ntp_configure();
-echo "done.\n";
 
 /* Configure console (and serial port - if necessary). */
 console_configure();

--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -93,6 +93,7 @@ if ($_POST) {
 	}
 
 	if (!$input_errors) {
+		$config['ntpd']['enable'] = isset($pconfig['enable']) ? 'enabled' : 'disabled';
 		if (is_array($_POST['interface'])) {
 			$config['ntpd']['interface'] = implode(",", $_POST['interface']);
 		} elseif (isset($config['ntpd']['interface'])) {
@@ -221,6 +222,7 @@ function build_interface_list() {
 
 init_config_arr(array('ntpd'));
 $pconfig = &$config['ntpd'];
+$config['ntpd']['enable'] = isset($pconfig['enable']) ? 'enabled' : 'disabled';
 if (empty($pconfig['interface'])) {
 	$pconfig['interface'] = array();
 } else {
@@ -250,6 +252,13 @@ $form = new Form;
 $form->setMultipartEncoding();	// Allow file uploads
 
 $section = new Form_Section('NTP Server Configuration');
+
+$section->addInput(new Form_Checkbox(
+	'enable',
+	'Enable',
+	'Enable NTP Server',
+	$pconfig['enable']
+))->setHelp('You may need to disable NTP if pfSense is running in a virtual machine and the host is responsible for the clock.');
 
 $iflist = build_interface_list();
 

--- a/src/usr/local/www/status_ntpd.php
+++ b/src/usr/local/www/status_ntpd.php
@@ -45,7 +45,7 @@ if (!empty($config['ntpd']['restrictions']['row']) && is_array($config['ntpd']['
 	}
 }
 
-if ($allow_query) {
+if ($allow_query && ($config['ntpd']['enable'] != 'disabled')) {
 	if (isset($config['system']['ipv6allow'])) {
 		$inet_version = "";
 	} else {
@@ -206,8 +206,13 @@ if ($_REQUEST['ajax']) {
 function print_status() {
 	global $config, $ntpq_servers, $allow_query;
 
-	if (!$allow_query):
-
+	if ($config['ntpd']['enable'] == 'disabled'):
+		print("<tr>\n");
+		print('<td class="warning" colspan="11">');
+		printf(gettext('NTP Server is disabled'));
+		print("</td>\n");
+		print("</tr>\n");
+	elseif (!$allow_query):
 		print("<tr>\n");
 		print('<td class="warning" colspan="11">');
 		printf(gettext('Statistics unavailable because ntpq and ntpdc queries are disabled in the %1$sNTP service settings%2$s'), '<a href="services_ntpd.php">', '</a>');

--- a/src/usr/local/www/widgets/widgets/ntp_status.widget.php
+++ b/src/usr/local/www/widgets/widgets/ntp_status.widget.php
@@ -30,7 +30,7 @@ require_once("/usr/local/www/widgets/include/ntp_status.inc");
 // to once per 60 seconds, not once per 10 seconds
 $widgetperiod = isset($config['widgets']['period']) ? $config['widgets']['period'] * 1000 * 6 : 60000;
 
-if ($_REQUEST['updateme']) {
+if ($_REQUEST['updateme'] && is_array($config['ntpd']) && ($config['ntpd']['enable'] != 'disabled')) {
 //this block displays only on ajax refresh
 	if (isset($config['system']['ipv6allow'])) {
 		$inet_version = "";
@@ -147,6 +147,7 @@ if ($_REQUEST['updateme']) {
 ?>
 
 <table id="ntp_status_widget" class="table table-striped table-hover">
+<?php if (is_array($config['ntpd']) && ($config['ntpd']['enable'] != 'disabled')): ?>
 	<tr>
 		<th><?=gettext('Server Time')?></th>
 		<td id="ClockTime">
@@ -188,6 +189,11 @@ if ($_REQUEST['updateme']) {
 			</tr>
 		<?php endif; ?>
 	<?php endif; ?>
+<?php else: ?>
+	<tr>
+		<td class="text-danger"><?=gettext('NTP Server is disabled')?></td>
+	</tr>
+<?php endif; ?>
 </table>
 
 <?php
@@ -225,9 +231,11 @@ setInterval(function() {
 <table id="ntpstatus" class="table table-striped table-hover">
 	<tbody>
 		<tr>
-			<td>
-				<?=gettext('Updating...')?>
-			</td>
+		<?php if (is_array($config['ntpd']) && ($config['ntpd']['enable'] != 'disabled')): ?>
+			<td><?=gettext('Updating...')?></td>
+		<?php else: ?>
+			<td class="text-danger"><?=gettext('NTP Server is disabled')?></td>
+		<?php endif; ?>
 		</tr>
 	</tbody>
 </table>


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/3567
- [ ] Ready for review

This is resolved copy of the original PR https://github.com/pfsense/pfsense/pull/3627 by @doktornotor 

It uses `<enable></enable>` to check that the service is enabled.
config version bump is used to add this value.