### PR TITLE
Renew cert with IP Address SAN. Issue #10362

### DIFF
--- a/src/etc/inc/certs.inc
+++ b/src/etc/inc/certs.inc
@@ -1616,7 +1616,7 @@ function cert_renew(& $cert, $reusekey = true, $strictsecurity = false) {
 	}
 
 	/* Reuse SAN list, or, if empty, add CN as SAN. */
-	$sans = $cert_details['extensions']['subjectAltName'];
+	$sans = str_replace("IP Address", "IP", $cert_details['extensions']['subjectAltName']);
 	if (empty($sans)) {
 		$sans = cert_add_altname_type($dn['commonName']);
 	}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10362
- [ ] Ready for review

example SAN: DNS:tkWAN2, IP Address:10.123.123.4

If I try to renew it, I get the message 'Error renewing Certificate' and:
`openssl_csr_new(): Error loading extensions_section section server_san of /etc/ssl/openssl.cnf in /etc/inc/certs.inc on line 1682`

https://www.openssl.org/docs/manmaster/man5/x509v3_config.html#Subject-Alternative-Name:
> The subject alternative name extension allows various literal values to be included in the configuration file. These include email (an email address) URI a uniform resource indicator, DNS (a DNS domain name), RID (a registered ID: OBJECT IDENTIFIER), IP (an IP address), dirName (a distinguished name) and otherName

Correct SAN is `IP`, not `IP Address`
