### PR TITLE
NTP maxpeers default value fix. Issue #10323

### DIFF
--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -61,9 +61,8 @@ if ($_POST) {
 	unset($input_errors);
 	$pconfig = $_POST;
 
-	if (!is_numericint($_POST['ntpmaxpeers']) ||
-	    ($_POST['ntpmaxpeers'] < $min_candidate_peers) ||
-	    ($_POST['ntpmaxpeers'] > $max_candidate_peers)) {
+	if (!empty($_POST['ntpmaxpeers']) && (!is_numericint($_POST['ntpmaxpeers']) ||
+	    ($_POST['ntpmaxpeers'] < $min_candidate_peers) || ($_POST['ntpmaxpeers'] > $max_candidate_peers))) {
 		$input_errors[] = sprintf(gettext("Max candidate pool peers must be a number between %d and %d"), $min_candidate_peers, $max_candidate_peers);
 	}
 	
@@ -130,7 +129,11 @@ if ($_POST) {
 		}
 		$config['system']['timeservers'] = trim($timeservers);
 
-		$config['ntpd']['ntpmaxpeers'] = $pconfig['ntpmaxpeers'];
+		if (!empty($pconfig['ntpmaxpeers'])) {
+			$config['ntpd']['ntpmaxpeers'] = $pconfig['ntpmaxpeers'];
+		} else {
+			unset($config['ntpd']['ntpmaxpeers']);
+		}
 		$config['ntpd']['orphan'] = trim($pconfig['ntporphan']);
 		$config['ntpd']['ntpminpoll'] = $pconfig['ntpminpoll'];
 		$config['ntpd']['ntpmaxpoll'] = $pconfig['ntpmaxpoll'];


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10323
- [ ] Ready for review

Fix for the https://github.com/pfsense/pfsense/pull/4224 

Input validation fix allowing to use empty(default value) 'Max Pool Peers' field 