### PR TITLE
Ignore events on LAGG members. Issue #10365

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -6088,6 +6088,18 @@ function link_interface_to_bridge($int) {
 	}
 }
 
+function link_interface_to_lagg($int) {
+	global $config;
+
+	if (isset($config['laggs']['lagg']) && is_array($config['laggs']['lagg'])) {
+		foreach ($config['laggs']['lagg'] as $lagg) {
+			if (in_array($int, explode(',', $lagg['members']))) {
+				return "{$lagg['laggif']}";
+			}
+		}
+	}
+}
+
 function link_interface_to_group($int) {
 	global $config;
 

--- a/src/etc/rc.linkup
+++ b/src/etc/rc.linkup
@@ -79,6 +79,14 @@ function handle_argument_group($iface, $argument2) {
 		return;
 	}
 
+	/* Ignore events on LAGG members without IP address configuration */
+	$lagg_if = link_interface_to_lagg($iface);
+	if (!empty($lagg_if) && empty($ipaddr) && empty($ip6addr)) {
+		log_error("Ignoring link event for LAGG member without IP address configuration");
+
+		return;
+	}
+
 	if ($staticv4 === true && $staticv6 === true) {
 		$friendly = convert_friendly_interface_to_friendly_descr($iface);
 		log_error("Hotplug event detected for {$friendly}({$iface}) static IP ({$ipaddr} {$ip6addr})");

--- a/src/usr/local/www/status_interfaces.php
+++ b/src/usr/local/www/status_interfaces.php
@@ -162,6 +162,14 @@ foreach ($ifdescrs as $ifdescr => $ifname):
 				}
 			}
 
+			if ($ifinfo['laggport']) {
+				$laggp = array();
+				foreach ($ifinfo['laggport'] as $lgp) {
+					list($laggp[]) = explode(" ", $lgp);
+				}
+				$laggport = implode(", ", $laggp);
+			}
+
 			showDef($ifinfo['mtu'], gettext("MTU"), $ifinfo['mtu']);
 			showDef($ifinfo['media'], gettext("Media"), $ifinfo['media']);
 			showDef($ifinfo['laggproto'], gettext("LAGG Protocol"), $ifinfo['laggproto']);


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10365
- [ ] Ready for review

The LAGG interface member is cxl0 and cxl1,
if one of these interfaces is down, it triggers check_reload_status:
```
check_reload_status: Linkup starting cxl0
check_reload_status: Linkup starting cxl0
check_reload_status: Reloading filter
check_reload_status: Reloading filter
```

there is code to ignore such events on the BRIDGE interfaces:
https://github.com/pfsense/pfsense/blob/892d8a10810092f47bc417639a9d74346fe7bb28/src/etc/rc.linkup#L74

This PR adds the same code for LAGG members checking,
and fixes LAGG Ports field on the Status / Interfaces page.