### PR TITLE
LAGG VLAN MTU fix. Issue #8585

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3999,7 +3999,7 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 	if ($wantedmtu == 0) {
 		$wantedmtu = interface_mtu_wanted_for_pppoe($mtuif);
 	}
-	if (($wantedmtu == 0) && interface_is_vlan($mtuif) != NULL && interface_isppp_type($interface)) {
+	if (($wantedmtu == 0) && (interface_is_vlan($mtuif) != NULL) && interface_isppp_type($interface)) {
 		$wantedmtu = interface_mtu_wanted_for_pppoe($mtuhwif);
 	}
 	if (($wantedmtu == 0) && interface_is_type($mtuif, 'gre')) {
@@ -6754,7 +6754,8 @@ function get_wireless_channel_info($interface) {
 function set_interface_mtu($interface, $mtu) {
 
 	/* LAGG interface must be destroyed and re-created to change MTU */
-	if (substr($interface, 0, 4) == 'lagg') {
+	if ((substr($interface, 0, 4) == 'lagg') &&
+	    (!strstr($interface, "."))) {
 		if (isset($config['laggs']['lagg']) &&
 		    is_array($config['laggs']['lagg'])) {
 			foreach ($config['laggs']['lagg'] as $lagg) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/8585
- [ ] Ready for review

If a port channel is configured with an MTU of 9000, but one of the VLAN interfaces on that port channel is configured with 1500, the port channel configuration is applied to the port, not the correct one from the logical configuration.

This PR adds additional checking for lagg vlan interface (lagg with dot) to set_interface_mtu()