### PR TITLE
Remote OpenVPN server proto definition. Issue #10368

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1139,7 +1139,8 @@ function openvpn_reconfigure($mode, $settings) {
 		$conf .= "management {$g['openvpn_base']}/{$mode_id}/sock unix\n";
 
 		// The remote server
-		$conf .= "remote {$settings['server_addr']} {$settings['server_port']}\n";
+		$remoteproto = strtolower($settings['protocol']);
+		$conf .= "remote {$settings['server_addr']} {$settings['server_port']} {$remoteproto}\n";
 
 		if (!empty($settings['use_shaper'])) {
 			$conf .= "shaper {$settings['use_shaper']}\n";


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10368
- [ ] Ready for review

When implementing a OpenVPN server and selecting the protocol "udp on ipv4 only" i expect, that that is exaclty what is included in my client configuration file.
Since this is not what is being configured, clients which have ipv6 available will try to connect through ipv6 and since the server is not running on ipv6 they are unable to connect.

What actually is included:
remote example.org 1194 udp

What i expect to be included:
remote exmaple.org 1194 udp4

This PR adds protocol definition.

TODO: same for OpenVPN client export