### PR TITLE
Lagg Failover Mode Master Interface select. Issue #1019

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1034,6 +1034,12 @@ function interface_lagg_configure($lagg) {
 		$lagg_mtu = 1500;
 	}
 
+	// put failover master interface on top of list
+	if (isset($lagg['failovermaster']) && ($lagg['failovermaster'] != 'auto')) {
+		unset($members[array_search($lagg['failovermaster'], $members)]);
+		$members = array_merge(array($lagg['failovermaster']), $members);
+	}
+
 	foreach ($members as $member) {
 		if (!does_interface_exist($member)) {
 			continue;


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/1019
- [ ] Ready for review

when creating a lagg interface in failover mode I am not able to choose the master interface.
The first interface in the list becomes the master, which in my case is making
the lagg choosing a 100mbit interface over a 1gbit interface.
An additional drop down menu would be nice.