### PR TITLE
DHCP Domain trailing dot validation. Issue #8054

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -998,8 +998,11 @@ function is_hostname($hostname, $allow_wildcard=false) {
 }
 
 /* returns true if $domain is a valid domain name */
-function is_domain($domain, $allow_wildcard=false) {
+function is_domain($domain, $allow_wildcard=false, $trailing_dot=true) {
 	if (!is_string($domain)) {
+		return false;
+	}
+	if (!$trailing_dot && ($domain[strlen($domain)-1] == ".")) {
 		return false;
 	}
 	if ($allow_wildcard) {

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -418,7 +418,7 @@ if (isset($_POST['save'])) {
 	    ($_POST['ntp3'] && (!is_ipaddrv4($_POST['ntp3']) && !is_hostname($_POST['ntp3'])))) {
 		$input_errors[] = gettext("A valid IP address or hostname must be specified for the primary/secondary NTP servers.");
 	}
-	if (($_POST['domain'] && !is_domain($_POST['domain']))) {
+	if ($_POST['domain'] && (!is_domain($_POST['domain'], false, false))) {
 		$input_errors[] = gettext("A valid domain name must be specified for the DNS domain.");
 	}
 	if ($_POST['tftp'] && !is_ipaddrv4($_POST['tftp']) && !is_domain($_POST['tftp']) && !filter_var($_POST['tftp'], FILTER_VALIDATE_URL)) {

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -296,6 +296,9 @@ if ($_POST['save']) {
 	    ($_POST['ntp3'] && (!is_ipaddrv4($_POST['ntp3']) && !is_hostname($_POST['ntp3'])))) {
 		$input_errors[] = gettext("A valid IP address or hostname must be specified for the primary/secondary NTP servers.");
 	}
+	if ($_POST['domain'] && (!is_domain($_POST['domain'], false, false))) {
+		$input_errors[] = gettext("A valid domain name must be specified for the DNS domain.");
+	}
 	if ($_POST['tftp'] && !is_ipaddrv4($_POST['tftp']) && !is_domain($_POST['tftp']) && !filter_var($_POST['tftp'], FILTER_VALIDATE_URL)) {
 		$input_errors[] = gettext("A valid IPv4 address, hostname or URL must be specified for the TFTP server.");
 	}

--- a/src/usr/local/www/system.php
+++ b/src/usr/local/www/system.php
@@ -182,7 +182,7 @@ if ($_POST) {
 			}
 		}
 	}
-	if ($_POST['domain'] && !is_domain($_POST['domain'])) {
+	if ($_POST['domain'] && (!is_domain($_POST['domain'], false, false))) {
 		$input_errors[] = gettext("The domain may only contain the characters a-z, 0-9, '-' and '.'.");
 	}
 	validate_webguicss_field($input_errors, $_POST['webguicss']);


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/8054
- [ ] Ready for review

If you add a trailing dot on the domain name in the DHCP static mapping "domain name" or System / General / Domain, this is accepted. The DNS Resolver retrieves this domain name from a lease and adds a dot: the configuration file ends up with 2 trailing dots and unbound fails to parse its config file if "DHCP Registration" or "Static DHCP" is enabled.