### PR TITLE
DHCP Relay send/listen on same interface. Issue #10381

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1883,8 +1883,11 @@ function services_dhcrelay_configure() {
 	}
 	$srvifaces = array_unique($srvifaces);
 
-	/* The server interface(s) should not be in this list */
-	$dhcrelayifs = array_diff($dhcrelayifs, $srvifaces);
+	/* see https://redmine.pfsense.org/issues/10381 */
+	if ((count($dhcrelayifs) > 1) || (count($srvifaces) > 1)) {
+		/* The server interface(s) should not be in this list */
+		$dhcrelayifs = array_diff($dhcrelayifs, $srvifaces);
+	}
 
 	/* fire up dhcrelay */
 	if (empty($dhcrelayifs)) {


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/10381
- [x] Ready for review

Required to OpenVPN clients to get DHCP address from internal DHCP server across the bridge.