### PR TITLE
Generate more complex IPsec PSK

### DIFF
--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -43,7 +43,12 @@ require_once("filter.inc");
 if ($_REQUEST['generatekey']) {
 	$keyoutput = "";
 	$keystatus = "";
+	$more_char = "!?()[]{}#+-";
 	exec("/bin/dd status=none if=/dev/random bs=4096 count=1 | /usr/bin/openssl sha224 | /usr/bin/cut -f2 -d' '", $keyoutput, $keystatus);
+	while (strlen($keyoutput[0]) < 64) {
+		$keyoutput[0] .= substr($more_char, rand(0, strlen($more_char) - 1), 1);
+		$keyoutput[0] = str_shuffle($keyoutput[0]);
+	}
 	print json_encode(['pskey' => $keyoutput[0]]);
 	exit;
 }


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [x] Ready for review

I'm always generating my own IPsec PSK seperately. This change adds more chars to the key. I never had any issues with these chars in place. Perhaps we could some more which are known to be safe across all sorts of devices?

(I think, redmine issue is not needed...?)