### PR TITLE
[IPsec] Multiple phase 1 for mobile clients

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -80,10 +80,10 @@ $ipsec_log_cats = array(
 
 global $ipsec_identifier_list;
 $ipsec_identifier_list = array(
+	'none' => array('desc' => '', 'mobile' => true),
 	// 'ipv4' => array('desc' => gettext('IPv4 address'), 'mobile' => true),
 	// 'ipv6' => array('desc' => gettext('IPv6 address'), 'mobile' => true),
-	// 'rfc822' => array('desc' => gettext('RFC822'), 'mobile' => true),
-	'none' => array('desc' => '', 'mobile' => true),
+	'rfc822' => array('desc' => gettext('RFC822'), 'mobile' => true),
 	'email' => array('desc' => gettext('E-mail address'), 'mobile' => true),
 	'userfqdn' => array('desc' => gettext('User Fully Qualified Domain Name'), 'mobile' => true)
 	// 'fqdn' => array('desc' => gettext('Fully Qualified Domain Name'), 'mobile' => true),
@@ -204,7 +204,8 @@ $p1_authentication_methods = array(
 global $ipsec_preshared_key_type;
 $ipsec_preshared_key_type = array(
 	'PSK' => 'PSK',
-	'EAP' => 'EAP'
+	'EAP' => 'EAP',
+	'RSA' => 'RSA'
 );
 
 global $ipsec_closeactions;
@@ -1603,7 +1604,7 @@ function ipsec_setup_userpools() {
 		$upbase = "mobile-userpool-{$suffix}";
 		/* The full connection name including a reference to the primary
 		 * mobile connection */
-		$upconn = "con-{$upbase} : con-mobile-defaults";
+		$upconn = "con{$mkent['ikeid']}000-{$upbase} : con-mobile-defaults";
 		/* The full pool name including a reference to the primary
 		 * mobile pool */
 		$upname = "{$upbase} : mobile-pool";
@@ -1611,13 +1612,34 @@ function ipsec_setup_userpools() {
 		$scconf['connections'][$upconn] = array();
 		$scconf['pools'][$upname] = array();
 
-		$clientid = ($mkent['ident_type'] == "none") ? "\"{$mkent['ident']}\"" : "{$mkent['ident_type']}:{$mkent['ident']}";
+		switch ($mkent['ident_type']) {
+			case 'email':
+			case 'rfc822':
+			case 'userfqdn':
+				$clientid = "{$mkent['ident_type']}:{$mkent['ident']}";
+				break;
+			default:
+				$clientid = "\"{$mkent['ident']}\"";
+				break;
+		}
+
 		$clienteapid = ($ph1ent['authentication_method'] == "eap-mschapv2") ? $clientid : '%any';
 
 		/* Craft a cloned connection with the ID information to match */
 		$scconf['connections'][$upconn]['remote'] = array();
-		$scconf['connections'][$upconn]['remote']['id'] = $clientid;
-		$scconf['connections'][$upconn]['remote']['eap_id'] = $clienteapid;
+
+		switch ($mkent['type']) {
+			case 'EAP':
+				$scconf['connections'][$upconn]['remote']['id'] = $clientid;
+				$scconf['connections'][$upconn]['remote']['eap_id'] = $clienteapid;
+				break;
+			case 'RSA':
+				$scconf['connections'][$upconn]['remote']['id'] = '"/CN=' . $mkent['ident'] . '/"';
+				break;
+			default:
+				break;
+		}
+
 		$scconf['connections'][$upconn]['pools'] = $upbase;
 
 		/* Craft a cloned pool with pool settings to override for this user */
@@ -1997,12 +2019,13 @@ function ipsec_setup_tunnels() {
 		/* Determine the name of this connection, either con-mobile for
 		 * mobile clients, or a name based on the IKE ID otherwise. */
 		if (isset($ph1ent['mobile'])) {
-			$cname = "con-mobile";
+			$cdefaults = "con-mobile";
+			$cname = "con{$ph1ent['ikeid']}000-mobile";
 			/* Start with common default values */
-			$scconf["{$cname}-defaults"] = $conn_defaults;
+			$scconf["{$cdefaults}-defaults"] = $conn_defaults;
 			/* Array reference to make things easier */
-			$conn =& $scconf["{$cname}-defaults"];
-			$scconf['connections']["{$cname} : {$cname}-defaults"] = array("# Stub to load con-mobile-defaults");
+			$conn =& $scconf["{$cdefaults}-defaults"];
+			$scconf['connections']["{$cname} : {$cdefaults}-defaults"] = array("# Stub to load con-mobile-defaults");
 		} else {
 			$cname = "con{$ph1ent['ikeid']}000";
 			/* Start with common default values */

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -43,7 +43,12 @@ require_once("filter.inc");
 if ($_REQUEST['generatekey']) {
 	$keyoutput = "";
 	$keystatus = "";
+	$more_char = "!?()[]{}#+-";
 	exec("/bin/dd status=none if=/dev/random bs=4096 count=1 | /usr/bin/openssl sha224 | /usr/bin/cut -f2 -d' '", $keyoutput, $keystatus);
+	while (strlen($keyoutput[0]) < 64) {
+		$keyoutput[0] .= substr($more_char, rand(0, strlen($more_char) - 1), 1);
+		$keyoutput[0] = str_shuffle($keyoutput[0]);
+	}
 	print json_encode(['pskey' => $keyoutput[0]]);
 	exit;
 }

--- a/src/usr/local/www/vpn_ipsec_phase1.php
+++ b/src/usr/local/www/vpn_ipsec_phase1.php
@@ -43,12 +43,7 @@ require_once("filter.inc");
 if ($_REQUEST['generatekey']) {
 	$keyoutput = "";
 	$keystatus = "";
-	$more_char = "!?()[]{}#+-";
 	exec("/bin/dd status=none if=/dev/random bs=4096 count=1 | /usr/bin/openssl sha224 | /usr/bin/cut -f2 -d' '", $keyoutput, $keystatus);
-	while (strlen($keyoutput[0]) < 64) {
-		$keyoutput[0] .= substr($more_char, rand(0, strlen($more_char) - 1), 1);
-		$keyoutput[0] = str_shuffle($keyoutput[0]);
-	}
 	print json_encode(['pskey' => $keyoutput[0]]);
 	exit;
 }

--- a/src/usr/local/www/vpn_ipsec_phase2.php
+++ b/src/usr/local/www/vpn_ipsec_phase2.php
@@ -255,9 +255,9 @@ if ($_POST['save']) {
 				}
 
 				$entered_localid_data = ipsec_idinfo_to_cidr($entered, false, $pconfig['mode']);
-				if ($localid_data == $entered_localid_data) {
+				if ($localid_data == $entered_localid_data && $pconfig['ikeid'] == $name['ikeid']) {
 					/* adding new p2 entry */
-					$input_errors[] = gettext("Phase2 with this Local Network is already defined for mobile clients.");
+					$input_errors[] = gettext("Phase2 with this Local Network is already defined for these mobile clients.");
 					break;
 				}
 			}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review

This is the first attempt to allow multiple phase 1 for mobile clients. I first made the changes to 2.4.5 and tested on my pfsense. Need to get another instance for testing with new code structure.
strongswan itself is handling these changes fine.

Before closing this early stage: Any suggestions for code sections to look at would be nice. I really think this could bring great benefit to pfSense.

Things I'm thinking of:
- **VPN->IPsec->Pre-Shared Keys** should be renamed, because users are now attached to the corresponding phase 1 (mobile).
- GUI needs some more changes to create multiple phase 1 for mobile (currently I just made a duplicate of the first one in the config.xml)

Will create redmine issue on the weekend.