### PR TITLE
OpenVPN client userpass is mandatory. Issue #10409

### DIFF
--- a/src/usr/local/www/vpn_openvpn_client.php
+++ b/src/usr/local/www/vpn_openvpn_client.php
@@ -709,7 +709,11 @@ if ($act=="new" || $act=="edit"):
 		'Authentication Retry',
 		'Do not retry connection when authentication fails',
 		$pconfig['auth-retry-none']
-	))->setHelp('When enabled, the OpenVPN process will exit if it receives an authentication failure message. The default behavior is to retry.');
+	))->setHelp('When enabled, the OpenVPN process will exit if it receives an authentication failure message. ' .
+		    'The default behavior is to retry.%1$s%2$s%3$s', '<div class="infoblock">',
+		    sprint_info_box(gettext('WARNING: If the remote server requires both a username and a password, ' .
+		    'but only one is filled in, the system will hang on reboot prompting for OpenVPN Client credentials unless ' .
+		    'Authentication Retry is checked.'), 'info', false), '</div>');
 
 	$form->add($section);
 


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/10409
- [ ] Ready for review

If you create OpenVPN client connection with user authentication,
but don’t enter the password
System hangs on startup with prompt:
`
Syncing OpenVPN settings...Enter Auth Password:
`