### PR TITLE
IPsec VTI /30 netmask. Issue #10418

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -373,6 +373,8 @@ function ipsec_idinfo_to_cidr(& $idinfo, $addrbits = false, $mode = "") {
 			if ($addrbits) {
 				if ($mode == "tunnel6") {
 					return $idinfo['address']."/128";
+				} elseif (($mode == "vti") && is_ipaddrv4($idinfo['address'])) {
+					return $idinfo['address']."/30";
 				} elseif (($mode == "vti") && is_ipaddrv6($idinfo['address'])) {
 					return $idinfo['address']."/64";
 				} else {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10418
- [ ] Ready for review

Once the IPsec interface is assigned, it gets /32 subnet instead of /30.

Fix