### PR TITLE
Show LAGG Members info. Issue #9187

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2999,4 +2999,22 @@ function is_supported_image($image_filename) {
 	}
 }
 
+function get_lagg_ports ($laggport) {
+	$laggp = array();
+	foreach ($laggport as $lgp) {
+		list($lpname, $lpinfo) = explode(" ", $lgp);
+		preg_match('~<(.+)>~', $lpinfo, $lgportmode);
+		if ($lgportmode[1]) {
+			$laggp[] = $lpname . " (" . $lgportmode[1] . ")";
+		} else {
+			$laggp[] = $lpname;
+		}
+	}
+	if ($laggp) {
+		return implode(", ", $laggp);
+	} else {
+		return false;
+	}
+}
+
 ?>

--- a/src/usr/local/www/status_interfaces.php
+++ b/src/usr/local/www/status_interfaces.php
@@ -163,11 +163,7 @@ foreach ($ifdescrs as $ifdescr => $ifname):
 			}
 
 			if ($ifinfo['laggport']) {
-				$laggp = array();
-				foreach ($ifinfo['laggport'] as $lgp) {
-					list($laggp[]) = explode(" ", $lgp);
-				}
-				$laggport = implode(", ", $laggp);
+				$laggport = get_lagg_ports($ifinfo['laggport']);
 			}
 
 			showDef($ifinfo['mtu'], gettext("MTU"), $ifinfo['mtu']);

--- a/src/usr/local/www/widgets/widgets/interfaces.widget.php
+++ b/src/usr/local/www/widgets/widgets/interfaces.widget.php
@@ -119,6 +119,8 @@ foreach ($ifdescrs as $ifdescr => $ifname):
 		<td>
 			<?php if ($ifinfo['pppoelink'] == "up" || $ifinfo['pptplink'] == "up" || $ifinfo['l2tplink'] == "up" || $ifinfo['ppplink'] == "up"):?>
 				<?=sprintf(gettext("Uptime: %s"), htmlspecialchars($ifinfo['ppp_uptime']));?>
+			<?php elseif (isset($ifinfo['laggproto'])):?>
+				<?=sprintf(gettext("LAGG Ports: %s"), htmlspecialchars(get_lagg_ports($ifinfo['laggport'])));?>
 			<?php else: ?>
 				<?=htmlspecialchars($ifinfo['media']);?>
 			<?php endif; ?>


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9187
- [ ] Ready for review

Show LAGG Member info on the status_interfaces.php page and interfaces widget
It also shows member status - ACTIVE or MASTER for the Failover mode,

i.e.: 
LAGG Ports: vtnet4 (MASTER), vtnet5, vtnet6 (ACTIVE)


TODO: same for the BRIDGE interfaces