### PR TITLE
DHCPv6 update-static-leases. Issue #10412

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1720,6 +1720,7 @@ EOD;
 
 	if ($nsupdate) {
 		$dhcpdv6conf .= "ddns-update-style interim;\n";
+		$dhcpdv6conf .= "update-static-leases on;\n";
 	} else {
 		$dhcpdv6conf .= "ddns-update-style none;\n";
 	}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10412
- [ ] Ready for review

Since pfSense 2.4.5 the isc-dhcp-server is 4.4.1 which supports "update-static-leases" statment for DHCPv6, too.

https://ftp.isc.org/isc/dhcp/4.4.1/dhcp-4.4.1-RELNOTES:
> - The server now honors update-static-leases parameter for static DHCPv6
>   hosts.