### PR TITLE
addMask() netmask reset fix. Issue #10433

### DIFF
--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -467,7 +467,7 @@ $group->add(new Form_IpAddress(
 	'src',
 	null,
 	is_specialnet($pconfig['src']) ? '': $pconfig['src']
-))->addMask('srcmask', $pconfig['srcmask'], 31)->setHelp('Address/mask');
+))->addMask('srcmask', $pconfig['srcmask'], 31, 1, false)->setHelp('Address/mask');
 
 $group->setHelp('Enter the internal (LAN) subnet for the 1:1 mapping. ' .
 				'The subnet size specified for the internal subnet will be applied to the external subnet.');
@@ -495,7 +495,7 @@ $group->add(new Form_IpAddress(
 	null,
 	is_specialnet($pconfig['dst']) ? '': $pconfig['dst'],
 	'ALIASV4V6'
-))->addMask('dstmask', $pconfig['dstmask'], 31)->setHelp('Address/mask');
+))->addMask('dstmask', $pconfig['dstmask'], 31, 1, false)->setHelp('Address/mask');
 
 $group->setHelp('The 1:1 mapping will only be used for connections to or from the specified destination. Hint: this is usually "Any".');
 

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -791,7 +791,7 @@ $group->add(new Form_IpAddress(
 	null,
 	is_specialnet($pconfig['dst']) ? '': $pconfig['dst'],
 	'ALIASV4V6'
-))->addMask('dstmask', $pconfig['dstmask'], 31)->setHelp('Address/mask');
+))->addMask('dstmask', $pconfig['dstmask'], 31, 1, false)->setHelp('Address/mask');
 
 $section->add($group);
 

--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -586,7 +586,7 @@ if ($pconfig['type'] == 'pptp' || $pconfig['type'] == 'l2tp') {
 			'localip[' . $ifnm . ']',
 			null,
 			$pconfig['localip'][$ifnm]
-		))->addMask('subnet[' . $ifnm . ']', $pconfig['subnet'][$ifnm], 31)->setHelp('Local IP Address');
+		))->addMask('subnet[' . $ifnm . ']', $pconfig['subnet'][$ifnm], 31, 1, false)->setHelp('Local IP Address');
 
 		$group->add(new Form_Input(
 			'gateway[' . $ifnm . ']',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10433
- [ ] Ready for review

from https://github.com/pfsense/pfsense/pull/4200:
> if you are trying to use max netmask shorter that 128 for IPv6 or shorter that 32 for IPv4, js code resets netmask size to 128/32,
> this not allow to use /96 max size for dns64-prefix, or, you can see this issue on 1:1 NAT page - try to enter any IPv4 address to the destination network field, and you can that it allow you to select /32 range (but only /31 is allowed in code)
> IpAddress.class.php fixed

pages with this issue:
firewall_nat_1to1_edit.php
firewall_nat_edit.php
interfaces_ppps_edit.php

- netmask /31 can be reset to /32