### PR TITLE
CDATA encode Squid LDAP options. Issue #7654

### DIFF
--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -220,9 +220,10 @@ function is_cdata_entity($ent) {
 	$cdata_fields = array(
 		'auth_pass', 'auth_prompt', 'auth_user', 'certca', 'certname', 'city', 'common_name',
 		'descr', 'detail', 'email', 'encryption_password', 'ldap_attr',
-		'ldap_authcn', 'ldap_basedn', 'ldap_bind',
-		'ldap_extended_query', 'login_banner', 'organization', 'password', 'rangedescr',
-		'state', 'text', 'username', 'varusersusername', 'varuserspassword'
+		'ldap_authcn', 'ldap_basedn', 'ldap_basedomain', 'ldap_bind', 'ldapbinddn',
+		'ldapbindpass', 'ldap_extended_query', 'ldap_filter', 'ldap_pass', 'ldap_user',
+		'login_banner', 'organization', 'password', 'rangedescr', 'state', 'text',
+		'username', 'varusersusername', 'varuserspassword'
 	);
 
 	/* Check if the entity name starts with any of the strings above */


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/7654
- [ ] Ready for review

This allows to use any unicode characters in Squid and squidGuard LDAP fields.

Squid LDAP auth fields:
`ldap_user, ldap_pass, ldap_basedomain, ldap_filter`

SquidGuard LDAP fields:
`ldapbinddn, ldapbindpass`