### PR TITLE
Reverse DDNS zone in DHCP server for non-octet-aligned subnet. Issue #8179

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -730,23 +730,13 @@ EOPP;
 
 			$revsubnet = array_reverse(explode('.',$subnet));
 
-			/* Take care of full classes first */
-			switch ($ifcfgsn) {
-				case 8:
-					$start_octet = 3;
-					break;
-				case 16:
-					$start_octet = 2;
-					break;
-				case 24:
-					$start_octet = 1;
-					break;
-				default:
-					$start_octet = 0;
-					/* Add subnet bitmask to first octet */
-					$revsubnet[0] .= '-' . $ifcfgsn;
-					break;
-
+			$subnet_mask_bits = 32 - $ifcfgsn;
+			$start_octet = $subnet_mask_bits >> 3;
+			$octet_mask_bits = $subnet_mask_bits & ($subnet_mask_bits % 8);
+			if ($octet_mask_bits) {
+			    $octet_mask = (1 << $octet_mask_bits) - 1;
+			    $octet_start = $revsubnet[$start_octet] & ~$octet_mask;
+			    $revsubnet[$start_octet] = $octet_start . "-" . ($octet_start + $octet_mask);
 			}
 
 			$ptr_domain = '';


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/8179
- [ ] Ready for review

I have a DHCP server running on pfSense 2.4.2 on an interface with subnet 172.24.208.0 and subnet mask 255.255.254.0. Upon configuring dynamic DNS, I saw that regular DNS records were being correctly inserted into my DNS server, but PTR records were not. Near the bottom of /var/dhcpd/etc/dhcpd.conf, I found the following:
```
zone 0-23.208.24.172.in-addr.arpa {
    primary 127.0.0.1;
}
```

This should have been:
```
zone 208-209.24.172.in-addr.arpa {
    primary 127.0.0.1;
}
```