### PR TITLE
NTP Time Server input validation. Issue #10386

### DIFF
--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -83,6 +83,10 @@ if ($_POST) {
 		    (substr_compare($pconfig["server{$i}"], $auto_pool_suffix, strlen($pconfig["server{$i}"]) - strlen($auto_pool_suffix), strlen($auto_pool_suffix)) === 0))) {
 			$input_errors[] = gettext("It is not possible to use 'No Select' for pools.");
 		}
+		if (!empty($pconfig["server{$i}"]) && !is_domain($pconfig["server{$i}"]) &&
+		    !is_ipaddr($pconfig["server{$i}"])) {
+			$input_errors[] = gettext("NTP Time Server names must be valid domain names, IPv4 addresses, or IPv6 addresses");
+		}
 	}
 
 	if (is_numericint($pconfig['ntpminpoll']) &&


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10386
- [ ] Ready for review

A NTP Time Server name must be valid domain name or IPv4/IPv6 address