### PR TITLE
Aggressive NSEC option. Issue #10449

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -328,6 +328,7 @@ EOF;
 	$prefetch = isset($unboundcfg['prefetch']) ? "yes" : "no";
 	$prefetch_key = isset($unboundcfg['prefetchkey']) ? "yes" : "no";
 	$dns_record_cache = isset($unboundcfg['dnsrecordcache']) ? "yes" : "no";
+	$aggressivensec = isset($unboundcfg['aggressivensec']) ? "yes" : "no";
 	$outgoing_num_tcp = isset($unboundcfg['outgoing_num_tcp']) ? $unboundcfg['outgoing_num_tcp'] : "10";
 	$incoming_num_tcp = isset($unboundcfg['incoming_num_tcp']) ? $unboundcfg['incoming_num_tcp'] : "10";
 	if (empty($unboundcfg['edns_buffer_size']) || ($unboundcfg['edns_buffer_size'] == 'auto')) {
@@ -494,6 +495,7 @@ prefetch: {$prefetch}
 prefetch-key: {$prefetch_key}
 use-caps-for-id: {$use_caps}
 serve-expired: {$dns_record_cache}
+aggressive-nsec: {$aggressivensec}
 # Statistics
 {$statistics}
 # TLS Configuration

--- a/src/usr/local/www/services_unbound_advanced.php
+++ b/src/usr/local/www/services_unbound_advanced.php
@@ -78,6 +78,10 @@ if (isset($config['unbound']['dnsrecordcache'])) {
 	$pconfig['dnsrecordcache'] = true;
 }
 
+if (isset($config['unbound']['aggressivensec'])) {
+	$pconfig['aggressivensec'] = true;
+}
+
 $pconfig['msgcachesize'] = $config['unbound']['msgcachesize'];
 $pconfig['outgoing_num_tcp'] = isset($config['unbound']['outgoing_num_tcp']) ? $config['unbound']['outgoing_num_tcp'] : '10';
 $pconfig['incoming_num_tcp'] = isset($config['unbound']['incoming_num_tcp']) ? $config['unbound']['incoming_num_tcp'] : '10';
@@ -207,6 +211,11 @@ if ($_POST) {
 				$config['unbound']['dnsrecordcache'] = true;
 			} else {
 				unset($config['unbound']['dnsrecordcache']);
+			}
+			if (isset($_POST['aggressivensec'])) {
+				$config['unbound']['aggressivensec'] = true;
+			} else {
+				unset($config['unbound']['aggressivensec']);
 			}
 			$config['unbound']['msgcachesize'] = $_POST['msgcachesize'];
 			$config['unbound']['outgoing_num_tcp'] = $_POST['outgoing_num_tcp'];
@@ -340,6 +349,15 @@ $section->addInput(new Form_Checkbox(
 	'Serve cache records even with TTL of 0',
 	$pconfig['dnsrecordcache']
 ))->setHelp('When enabled, allows unbound to serve one query even with a TTL of 0, if TTL is 0 then new record will be requested in the background when the cache is served to ensure cache is updated without latency on service of the DNS request.');
+
+$section->addInput(new Form_Checkbox(
+	'aggressivensec',
+	'Aggressive NSEC',
+	'Aggressive Use of DNSSEC-Validated Cache',
+	$pconfig['aggressivensec']
+))->setHelp('When enabled, unbound uses the DNSSEC NSEC chain to synthesize NXDOMAIN and other denials, ' .
+	    'using information from previous NXDOMAINs answers. It helps to reduce the query rate towards ' .
+	    'targets that get a very high nonexistent name lookup rate.');
 
 $section->addInput(new Form_Select(
 	'msgcachesize',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10449
- [ ] Ready for review

Very nice feature for DNS optimization, which can reduce the number of queries to authoritative name servers.
See https://tools.ietf.org/html/rfc8198

unbound.conf(5):
```
aggressive-nsec: <yes or no>
              Aggressive  NSEC uses the DNSSEC NSEC chain to synthesize NXDOMAIN and other denials, using information from previous
              NXDOMAINs answers.  Default is no.  It helps to reduce the query rate towards targets that get a very  high  nonexis‐
              tent name lookup rate.
```