### PR TITLE
Adding DynDNS response logging

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -1325,6 +1325,12 @@
 				$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
 				$header = substr($response, 0, $header_size);
 				$data = substr($response, $header_size);
+				if($this->_dnsVerboseLog) {
+					foreach(explode(PHP_EOL,$header) as $hv) {
+						log_error(sprintf("Response Header: %s", rtrim($hv)));
+				  	}
+				  log_error(sprintf("Response Data: %s", $data));
+				}
 				$this->_checkStatus($ch, $data, $header);
 				@curl_close($ch);
 			}

--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -1329,7 +1329,7 @@
 					foreach(explode(PHP_EOL,$header) as $hv) {
 						log_error(sprintf("Response Header: %s", rtrim($hv)));
 				  	}
-				  log_error(sprintf("Response Data: %s", $data));
+					log_error(sprintf("Response Data: %s", $data));
 				}
 				$this->_checkStatus($ch, $data, $header);
 				@curl_close($ch);

--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -1325,8 +1325,8 @@
 				$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
 				$header = substr($response, 0, $header_size);
 				$data = substr($response, $header_size);
-				if($this->_dnsVerboseLog) {
-					foreach(explode(PHP_EOL,$header) as $hv) {
+				if ($this->_dnsVerboseLog) {
+					foreach (explode(PHP_EOL, $header) as $hv) {
 						log_error(sprintf("Response Header: %s", rtrim($hv)));
 				  	}
 					log_error(sprintf("Response Data: %s", $data));


### PR DESCRIPTION
When verbose logging is enabled for a dynamic DNS provider, the DynDNS code will now write the HTTP response to the system log. This is extremely useful when troubleshooting issues.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/10459
- [x] Ready for review