### PR TITLE
OpenVPN/IPsec IPv6 prefix in DNS Resolver access list. Issue #10460

### DIFF
--- a/src/etc/inc/unbound.inc
+++ b/src/etc/inc/unbound.inc
@@ -910,6 +910,23 @@ function unbound_acls_config($cfgsubdir = "") {
 			}
 		}
 
+		// OpenVPN IPv6 Tunnel Networks
+		foreach (array('openvpn-client', 'openvpn-server') as $ovpnentry) {
+			if (is_array($config['openvpn'][$ovpnentry])) {
+				foreach ($config['openvpn'][$ovpnentry] as $ovpnent) {
+					if (!isset($ovpnent['disable']) && !empty($ovpnent['tunnel_networkv6'])) {
+						$aclcfg .= "access-control: {$ovpnent['tunnel_networkv6']} allow\n";
+					}
+				}
+			}
+		}
+		// IPsec Mobile Virtual IPv6 Address Pool
+		if ((isset($config['ipsec']['client']['enable'])) &&
+		    (!empty($config['ipsec']['client']['pool_address_v6'])) &&
+		    (!empty($config['ipsec']['client']['pool_netbits_v6']))) {
+			$aclcfg .= "access-control: {$config['ipsec']['client']['pool_address_v6']}/{$config['ipsec']['client']['pool_netbits_v6']} allow\n";
+		}
+
 		// Generate IPv4 access-control entries using the same logic as automatic outbound NAT
 		if (empty($FilterIflist)) {
 			filter_generate_optcfg_array();


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10460
- [ ] Ready for review

add OpenVPN IPv6 Tunnel Networks and IPsec Mobile Virtual IPv6 Address Pool to the `/var/unbound/access_lists.conf`