### PR TITLE
DHCPv6 RA show default values in certain fields. Issue #10448

### DIFF
--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -178,7 +178,7 @@ if ($_POST['save']) {
 		if (!is_numericint($_POST['raminrtradvinterval'])) {
 			$input_errors[] = gettext("Minimum advertisement interval must be an integer.");
 		}
-		if ($_POST['raminrtradvinterval'] < "3") {
+		if ($_POST['raminrtradvinterval'] < 3) {
 			$input_errors[] = gettext("Minimum advertisement interval must be no less than 3.");
 		}
 		if ($_POST['ramaxrtradvinterval'] && $_POST['raminrtradvinterval'] > (0.75 * $_POST['ramaxrtradvinterval'])) {
@@ -189,12 +189,12 @@ if ($_POST['save']) {
 		if (!is_numericint($_POST['ramaxrtradvinterval'])) {
 			$input_errors[] = gettext("Maximum advertisement interval must be an integer.");
 		}
-		if ($_POST['ramaxrtradvinterval'] < "4" || $_POST['ramaxrtradvinterval'] > "1800") {
+		if ($_POST['ramaxrtradvinterval'] < 4 || $_POST['ramaxrtradvinterval'] > 1800) {
 			$input_errors[] = gettext("Maximum advertisement interval must be no less than 4 and no greater than 1800.");
 		}
 	}
-	if ($_POST['raadvdefaultlifetime'] && !is_numericint($_POST['raadvdefaultlifetime'])) {
-		$input_errors[] = gettext("Router lifetime must be an integer between 0 and 9000.");
+	if ($_POST['raadvdefaultlifetime'] && (($_POST['raadvdefaultlifetime'] < 1) || ($_POST['raadvdefaultlifetime'] > 9000))) {
+		$input_errors[] = gettext("Router lifetime must be an integer between 1 and 9000.");
 	}
 
 	if (!$input_errors) {
@@ -352,7 +352,7 @@ $section->addInput(new Form_Input(
 	'Default valid lifetime',
 	'number',
 	$pconfig['ravalidlifetime'],
-	['min' => 1, 'max' => 655350]
+	['min' => 1, 'max' => 655350, 'placeholder' => 86400]
 ))->setHelp('The length of time in seconds (relative to the time the packet is sent) that the prefix is valid for the purpose of on-link determination.%1$s' .
 'The default is 86400 seconds.', '<br />');
 
@@ -360,7 +360,8 @@ $section->addInput(new Form_Input(
 	'rapreferredlifetime',
 	'Default preferred lifetime',
 	'text',
-	$pconfig['rapreferredlifetime']
+	$pconfig['rapreferredlifetime'],
+	['placeholder' => 14400]
 ))->setHelp('Seconds. The length of time in seconds (relative to the time the packet is sent) that addresses generated from the prefix via stateless address autoconfiguration remain preferred.%1$s' .
 			'The default is 14400 seconds.', '<br />');
 
@@ -369,24 +370,27 @@ $section->addInput(new Form_Input(
 	'Minimum RA interval',
 	'number',
 	$pconfig['raminrtradvinterval'],
-	['min' => 3, 'max' => 1350]
-))->setHelp('The minimum time allowed between sending unsolicited multicast router advertisements in seconds.');
+	['min' => 3, 'max' => 1350, 'placeholder' => 5]
+))->setHelp('The minimum time allowed between sending unsolicited multicast router advertisements in seconds.%1$s' .
+'The default is 5 seconds.', '<br />');
 
 $section->addInput(new Form_Input(
 	'ramaxrtradvinterval',
 	'Maximum RA interval',
 	'number',
 	$pconfig['ramaxrtradvinterval'],
-	['min' => 4, 'max' => 1800]
-))->setHelp('The maximum time allowed between sending unsolicited multicast router advertisements in seconds.');
+	['min' => 4, 'max' => 1800, 'placeholder' => 20]
+))->setHelp('The maximum time allowed between sending unsolicited multicast router advertisements in seconds.%1$s' .
+'The default is 20 seconds.', '<br />');
 
 $section->addInput(new Form_Input(
 	'raadvdefaultlifetime',
 	'Router lifetime',
 	'number',
 	$pconfig['raadvdefaultlifetime'],
-	['min' => 0, 'max' => 9000]
-))->setHelp('The lifetime associated with the default router in seconds.');
+	['min' => 1, 'max' => 9000]
+))->setHelp('The lifetime associated with the default router in seconds.%1$s' .
+'The default is 3 * Maximim RA interval seconds.', '<br />');
 
 $section->addInput(new Form_StaticText(
 	'RA Subnets',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10448
- [ ] Ready for review

In Services -> DHCPv6 Server & RA -> Router Advertisements there are some fields - Minimum RA interval, Maximum RA interval, Router lifetime - that have no values filled out by default.

It shows default values from `services.inc`
what about Router lifetime, from radvd.conf(5):
> AdvDefaultLifetime seconds
> The lifetime associated with the default router in units of seconds. The maximum value corresponds to 18.2 hours. A lifetime of 0 indicates that the router is not a default router and should not appear on the default router list. The router lifetime applies only to the router's usefulness as a default router; it does not apply to information contained in other message fields or options. Options that need time limits for their information include their own lifetime fields.
> 
> Must be either zero or between MaxRtrAdvInterval and 9000 seconds.
> 
> Default: 3 * MaxRtrAdvInterval (Minimum 1 second).