### PR TITLE
Add ARM32/64 netboot file support to dhcpd. Feature #10374

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -987,8 +987,18 @@ EOPP;
 				    ($poolconf['filename64'] != $dhcpifconf['filename64']))) {
 					$filename64 = $poolconf['filename64'];
 				}
+				if (!empty($poolconf['filename32arm']) &&
+				    (!isset($dhcpifconf['filename32arm']) ||
+				    ($poolconf['filename32arm'] != $dhcpifconf['filename32arm']))) {
+					$filename32arm = $poolconf['filename32arm'];
+				}
+				if (!empty($poolconf['filename64arm']) &&
+				    (!isset($dhcpifconf['filename64arm']) ||
+				    ($poolconf['filename64arm'] != $dhcpifconf['filename64arm']))) {
+					$filename64arm = $poolconf['filename64arm'];
+				}
 
-				if (!empty($filename32) || !empty($filename64)) {
+				if (!empty($filename32) || !empty($filename64) || !empty($filename32arm) || !empty($filename64arm)) {
 					if (empty($filename) && !empty($dhcpifconf['filename'])) {
 						$filename = $dhcpifconf['filename'];
 					}
@@ -998,22 +1008,32 @@ EOPP;
 					if (empty($filename64) && !empty($dhcpifconf['filename64'])) {
 						$filename64 = $dhcpifconf['filename64'];
 					}
+					if (empty($filename32arm) && !empty($dhcpifconf['filename32arm'])) {
+						$filename32arm = $dhcpifconf['filename32arm'];
+					}
+					if (empty($filename64arm) && !empty($dhcpifconf['filename64arm'])) {
+						$filename64arm = $dhcpifconf['filename64arm'];
+					}
 				}
 
-				if (!empty($filename) && !empty($filename32) && !empty($filename64)) {
+				if (!empty($filename) && !empty($filename32) && !empty($filename64) && !empty($filename32arm) && !empty($filename64arm)) {
 					$dhcpdconf .= "		if option arch = 00:06 {\n";
 					$dhcpdconf .= "			filename \"{$filename32}\";\n";
 					$dhcpdconf .= "		} else if option arch = 00:07 {\n";
 					$dhcpdconf .= "			filename \"{$filename64}\";\n";
 					$dhcpdconf .= "		} else if option arch = 00:09 {\n";
 					$dhcpdconf .= "			filename \"{$filename64}\";\n";
+					$dhcpdconf .= "		} else if option arch = 00:0a {\n";
+					$dhcpdconf .= "			filename \"{$filename32arm}\";\n";
+					$dhcpdconf .= "		} else if option arch = 00:0b {\n";
+					$dhcpdconf .= "			filename \"{$filename64arm}\";\n";
 					$dhcpdconf .= "		} else {\n";
 					$dhcpdconf .= "			filename \"{$filename}\";\n";
 					$dhcpdconf .= "		}\n\n";
 				} elseif (!empty($filename)) {
 					$dhcpdconf .= "		filename \"{$filename}\";\n";
 				}
-				unset($filename, $filename32, $filename64);
+				unset($filename, $filename32, $filename64, $filename32arm, $filename64arm);
 
 				if (!empty($poolconf['rootpath']) && ($poolconf['rootpath'] != $dhcpifconf['rootpath'])) {
 					$dhcpdconf .= "		option root-path \"{$poolconf['rootpath']}\";\n";

--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -190,6 +190,8 @@ if (is_array($dhcpdconf)) {
 	$pconfig['filename'] = $dhcpdconf['filename'];
 	$pconfig['filename32'] = $dhcpdconf['filename32'];
 	$pconfig['filename64'] = $dhcpdconf['filename64'];
+	$pconfig['filename32arm'] = $dhcpdconf['filename32arm'];
+	$pconfig['filename64arm'] = $dhcpdconf['filename64arm'];
 	$pconfig['rootpath'] = $dhcpdconf['rootpath'];
 	$pconfig['netmask'] = $dhcpdconf['netmask'];
 	$pconfig['numberoptions'] = $dhcpdconf['numberoptions'];
@@ -718,6 +720,8 @@ if (isset($_POST['save'])) {
 		$dhcpdconf['filename'] = $_POST['filename'];
 		$dhcpdconf['filename32'] = $_POST['filename32'];
 		$dhcpdconf['filename64'] = $_POST['filename64'];
+		$dhcpdconf['filename32arm'] = $_POST['filename32arm'];
+		$dhcpdconf['filename64arm'] = $_POST['filename64arm'];
 		$dhcpdconf['rootpath'] = $_POST['rootpath'];
 		unset($dhcpdconf['statsgraph']);
 		if ($_POST['statsgraph']) {
@@ -1509,8 +1513,22 @@ $section->addInput(new Form_Input(
 	'UEFI 64 bit file name',
 	'text',
 	$pconfig['filename64']
+));
+
+$section->addInput(new Form_Input(
+	'filename32arm',
+	'ARM 32 bit file name',
+	'text',
+	$pconfig['filename32arm']
+));
+
+$section->addInput(new Form_Input(
+	'filename64arm',
+	'ARM 64 bit file name',
+	'text',
+	$pconfig['filename64arm']
 ))->setHelp('Both a filename and a boot server must be configured for this to work! ' .
-			'All three filenames and a configured boot server are necessary for UEFI to work! ');
+			'All five filenames and a configured boot server are necessary for UEFI & ARM to work! ');
 
 $section->addInput(new Form_Input(
 	'rootpath',

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -100,6 +100,8 @@ if (isset($id) && $a_maps[$id]) {
 	$pconfig['filename'] = $a_maps[$id]['filename'];
 	$pconfig['filename32'] = $a_maps[$id]['filename32'];
 	$pconfig['filename64'] = $a_maps[$id]['filename64'];
+	$pconfig['filename32arm'] = $dhcpdconf['filename32arm'];
+	$pconfig['filename64arm'] = $dhcpdconf['filename64arm'];
 	$pconfig['rootpath'] = $a_maps[$id]['rootpath'];
 	$pconfig['netmask'] = $a_maps[$id]['netmask'];
 	$pconfig['numberoptions'] = $a_maps[$id]['numberoptions'];
@@ -138,6 +140,8 @@ if (isset($id) && $a_maps[$id]) {
 	$pconfig['filename'] = $_REQUEST['filename'];
 	$pconfig['filename32'] = $_REQUEST['filename32'];
 	$pconfig['filename64'] = $_REQUEST['filename64'];
+	$pconfig['filename32arm'] = $dhcpdconf['filename32arm'];
+	$pconfig['filename64arm'] = $dhcpdconf['filename64arm'];
 	$pconfig['rootpath'] = $_REQUEST['rootpath'];
 	$pconfig['netmask'] = $_REQUEST['netmask'];
 	$pconfig['numberoptions'] = $_REQUEST['numberoptions'];
@@ -385,6 +389,8 @@ if ($_POST['save']) {
 		$mapent['filename'] = $_POST['filename'];
 		$mapent['filename32'] = $_POST['filename32'];
 		$mapent['filename64'] = $_POST['filename64'];
+		$mapent['filename32arm'] = $_POST['filename32arm'];
+		$mapent['filename64arm'] = $_POST['filename64arm'];
 		$mapent['numberoptions'] = $pconfig['numberoptions'];
 
 		if (isset($id) && $a_maps[$id]) {
@@ -803,8 +809,22 @@ $section->addInput(new Form_Input(
 	'UEFI 64 bit file name',
 	'text',
 	$pconfig['filename64']
+));
+
+$section->addInput(new Form_Input(
+	'filename32arm',
+	'ARM 32 bit file name',
+	'text',
+	$pconfig['filename32arm']
+));
+
+$section->addInput(new Form_Input(
+	'filename64arm',
+	'ARM 64 bit file name',
+	'text',
+	$pconfig['filename64arm']
 ))->setHelp('Both a filename and a boot server must be configured for this to work! ' .
-			'All three filenames and a configured boot server are necessary for UEFI to work! ');
+			'All five filenames and a configured boot server are necessary for UEFI & ARM to work! ');
 
 $section->addInput(new Form_Input(
 	'rootpath',
@@ -1117,6 +1137,8 @@ events.push(function() {
 		hideInput('filename', !showadvnwkboot);
 		hideInput('filename32', !showadvnwkboot);
 		hideInput('filename64', !showadvnwkboot);
+		hideInput('filename32arm', !showadvnwkboot);
+		hideInput('filename64arm', !showadvnwkboot);
 		hideInput('rootpath', !showadvnwkboot);
 
 		if (showadvnwkboot) {


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/10374
- [x] Ready for review

Extends the exiting DHCPd UEFI 32 & 64 bit support with 2 additional fields for ARM CPU support. 