### PR TITLE
IPsec VTI enable netmask. Issue #10418

### DIFF
--- a/src/usr/local/www/vpn_ipsec_phase2.php
+++ b/src/usr/local/www/vpn_ipsec_phase2.php
@@ -787,11 +787,11 @@ events.push(function() {
 			hideClass('opt_natid', true);
 			hideClass('opt_remoteid', false);
 			$('#localid_type').val('address');
-			disableInput('localid_type', true);
+			disableInput('localid_type', false);
 			typesel_change_local(30);
 			$('#remoteid_type').val('address');
-			disableInput('remoteid_type', true);
-			typesel_change_remote(32);
+			disableInput('remoteid_type', false);
+			typesel_change_remote(30);
 			$('#opt_localid_help').html("<?=$localid_help_vti?>");
 			$('#opt_remoteid_help').html("<?=$remoteid_help_vti?>");
 		} else {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10418
- [ ] Ready for review

It seems reasonable to revert back https://github.com/pfsense/pfsense/pull/4140 changes
to allow VTI netmask select