### PR TITLE
L2TP duplicate outbound NAT fix. Issue 10247

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -1662,16 +1662,6 @@ function filter_nat_rules_automatic_tonathosts($with_descr = false) {
 		}
 	}
 
-	/* L2TP subnet */
-	if (isset($FilterIflist['l2tp']) && $FilterIflist['l2tp']['mode'] == "server") {
-		$l2tp_sa = $FilterIflist['l2tp']['sa'];
-		$l2tp_sn = $FilterIflist['l2tp']['sn'];
-		if (is_private_ip($l2tp_sa) && !empty($l2tp_sn)) {
-			$tonathosts[] = "{$l2tp_sa}/{$l2tp_sn}";
-			$descriptions[] = gettext("L2TP server");
-		}
-	}
-
 	/* add openvpn interfaces */
 	if (is_array($config['openvpn']['openvpn-server'])) {
 		foreach ($config['openvpn']['openvpn-server'] as $ovpnsrv) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10247
- [ ] Ready for review

$FilterIflist['l2tp'] is already added to `$tonathosts[]` by https://github.com/pfsense/pfsense/blob/ca676aa35482c4e4fd64bfdcee9afe6d33b6c5fe/src/etc/inc/filter.inc#L1619

it safe remove code https://github.com/pfsense/pfsense/blob/ca676aa35482c4e4fd64bfdcee9afe6d33b6c5fe/src/etc/inc/filter.inc#L1665
seems copy of https://github.com/pfsense/pfsense/blob/ca676aa35482c4e4fd64bfdcee9afe6d33b6c5fe/src/etc/inc/filter.inc#L1655

`$FilterIflist['pppoe']` is array, this is why we don't see duplicate outbound nat entries for PPPoE server networks,
but this may be causing another issue https://redmine.pfsense.org/issues/6598
