### PR TITLE
Add the default values of the TCP and UDP Timeouts on the WebUI. Issue #7362

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -330,6 +330,9 @@ function filter_configure_sync($delete_states_if_needed = true) {
 	if (isset($config['system']['tcpclosedtimeout']) && is_numericint($config['system']['tcpclosedtimeout'])) {
 		$timeoutlist .= " tcp.closed {$config['system']['tcpclosedtimeout']} ";
 	}
+	if (isset($config['system']['tcptsdifftimeout']) && is_numericint($config['system']['tcptsdifftimeout'])) {
+		$timeoutlist .= " tcp.tsdiff {$config['system']['tcptsdifftimeout']} ";
+	}
 	if (isset($config['system']['udpfirsttimeout']) && is_numericint($config['system']['udpfirsttimeout'])) {
 		$timeoutlist .= " udp.first {$config['system']['udpfirsttimeout']} ";
 	}

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3574,4 +3574,31 @@ function is_url_hostname_resolvable($url) {
 	return $resolvable;
 }
 
+function get_pf_timeouts () {
+	$pftimeout = array();
+	exec("/sbin/pfctl -st", $pfctlst, $retval);
+	if ($retval == 0) {
+		foreach ($pfctlst as $i => $pfst) {
+			preg_match('/([a-z]+)\.([a-z]+)\s+([0-9]+)/', $pfst, $timeout);
+			if ($timeout[1] == "other") {
+				$proto = "Other";
+			} else {
+				$proto = strtoupper($timeout[1]);
+			}
+			if ($timeout[2] == "finwait") {
+				$type = "FIN Wait";
+			} else {
+				$type = ucfirst($timeout[2]);
+			}
+			$pftimeout[$proto][$type]['name'] = $proto . " " . $type;
+			$pftimeout[$proto][$type]['keyname'] = $timeout[1] . $timeout[2] . "timeout";
+			$pftimeout[$proto][$type]['value'] = $timeout[3];
+			if ($i == 14) {
+				break;
+			}
+		}
+	}
+	return $pftimeout;
+}
+
 ?>


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/7362
- [ ] Ready for review

when you go to System --> Advanced --> Firewall & NAT then you have the possibility to modify the different timeouts but you do not know which timeouts are set by default. So it would be usefull to see the default values within the text fields and they should change when you change the "Firewall Optimization Options" - but should not override user specific modifications.

At least it could be helpfull to have a button like "show timeouts" which shows the output of "pfctl -st" or something else which is helpfull for the user/administrator.