### PR TITLE
Add Interfaces column to Floating Rules. Issue #4629

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -358,6 +358,13 @@ $columns_in_table = 13;
 						<th><input type="checkbox" id="selectAll" name="selectAll" /></th>
 						<th><!-- status icons --></th>
 						<th><?=gettext("States")?></th>
+				<?php
+					if ('FloatingRules' == $if) {
+				?>
+						<th><?=gettext("Interfaces")?></th>
+				<?php
+					}
+				?>
 						<th><?=gettext("Protocol")?></th>
 						<th><?=gettext("Source")?></th>
 						<th><?=gettext("Port")?></th>
@@ -645,7 +652,53 @@ foreach ($a_filter as $filteri => $filterent):
 		}
 	?>
 				<td><?php print_states(intval($filterent['tracker'])); ?></td>
-				<td>
+	<?php
+		if ($if == 'FloatingRules') {
+	?>
+			<td onclick="fr_toggle(<?=$nrules;?>)" id="frd<?=$nrules;?>" ondblclick="document.location='firewall_rules_edit.php?id=<?=$i;?>';">
+	<?php
+			if (isset($filterent['interface'])) {
+				$selected_interfaces = explode(',', $filterent['interface']);
+				unset($selected_descs);
+				foreach ($selected_interfaces as $interface) {
+					if (isset($ifdescs[$interface])) {
+						$selected_descs[] = $ifdescs[$interface];
+					} else {
+						switch ($interface) {
+						case 'l2tp':
+							if ($config['l2tp']['mode'] == 'server')
+								$selected_descs[] = 'L2TP VPN';
+							break;
+						case 'pptp':
+							if ($config['pptpd']['mode'] == 'server')
+								$selected_descs[] = 'PPTP VPN';
+							break;
+						case 'pppoe':
+							if (is_pppoe_server_enabled())
+								$selected_descs[] = 'PPPoE Server';
+							break;
+						case 'enc0':
+							if (isset($config['ipsec']['enable']) || isset($config['ipsec']['client']['enable']))
+								$selected_descs[] = 'IPsec';
+							break;
+						case 'openvpn':
+							if  ($config['openvpn']['openvpn-server'] || $config['openvpn']['openvpn-client'])
+								$selected_descs[] = 'OpenVPN';
+							break;
+						default:
+							$selected_descs[] = $interface;
+							break;
+						}
+					}
+				}
+				echo implode('<br/>', $selected_descs);
+			}
+	?>
+			</td>
+	<?php
+		}
+	?>
+			<td>
 	<?php
 		if (isset($filterent['ipprotocol'])) {
 			switch ($filterent['ipprotocol']) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/4629
- [ ] Ready for review

The floating rules apply to multiple interfaces unlike the other tabs. This change displays an Interfaces column on the Floating tab.

This is updated copy of the original PR https://github.com/pfsense/pfsense/pull/1616 by @Robert-Nelson