### PR TITLE
RED/GRED limiters do not have noecn option. Issue #10211

### DIFF
--- a/src/etc/inc/shaper.inc
+++ b/src/etc/inc/shaper.inc
@@ -4071,7 +4071,7 @@ class dnpipe_class extends dummynet_class {
 			if ($selectedAQM["ecn"]) {
 				if ($this->getECN() == 'on') {
 					$pfq_rule .= ' ecn';
-				} else {
+				} elseif (($this->getAQM() != 'red') && ($this->getAQM() != 'gred')) {
 					$pfq_rule .= ' noecn';
 				}
 			}
@@ -4689,7 +4689,7 @@ class dnqueue_class extends dummynet_class {
 			if ($selectedAQM["ecn"]) {
 				if ($this->getECN() == 'on') {
 					$pfq_rule .= ' ecn';
-				} else {
+				} elseif (($this->getAQM() != 'red') && ($this->getAQM() != 'gred')) {
 					$pfq_rule .= ' noecn';
 				}
 			}


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10211
- [ ] Ready for review

You create RED/GRED limiters with ECN.
Then you decide to remove ECN and so remove ECN checkbox.

Limiter should be updated but its not.
Syslog error:
`/rc.filter_configure_sync: The command '/sbin/ipfw /tmp/rules.limiter' returned exit code '65', the output was 'Line 4: unrecognised option ``noecn'''`

RED/GRED limiters do not have `noecn` option, https://www.freebsd.org/cgi/man.cgi?ipfw(8):
> red | gred	w_q/min_th/max_th/max_p
> 	   [ecn] Make use of the RED (Random Early Detection) queue management
> 	   algorithm.  w_q and max_p are floating point	numbers	between	0 and
> 	   1 (inclusive), while	min_th and max_th are integer numbers specify-
> 	   ing thresholds for queue management (thresholds are computed	in
> 	   bytes if the	queue has been defined in bytes, in slots otherwise).
> 	   The two parameters can also be of the same value if needed. The
> 	   dummynet also supports the gentle RED variant (gred)	and ECN	(Ex-
> 	   plicit Congestion Notification) as optional.	Three sysctl(8)	vari-
> 	   ables can be	used to	control	the RED	behaviour...