### PR TITLE
Revert addMask() max /31 netmask. Issue #10433

### DIFF
--- a/src/usr/local/www/firewall_nat_1to1_edit.php
+++ b/src/usr/local/www/firewall_nat_1to1_edit.php
@@ -467,7 +467,7 @@ $group->add(new Form_IpAddress(
 	'src',
 	null,
 	is_specialnet($pconfig['src']) ? '': $pconfig['src']
-))->addMask('srcmask', $pconfig['srcmask'], 31, 1, false)->setHelp('Address/mask');
+))->addMask('srcmask', $pconfig['srcmask'], 31)->setHelp('Address/mask');
 
 $group->setHelp('Enter the internal (LAN) subnet for the 1:1 mapping. ' .
 				'The subnet size specified for the internal subnet will be applied to the external subnet.');
@@ -495,7 +495,7 @@ $group->add(new Form_IpAddress(
 	null,
 	is_specialnet($pconfig['dst']) ? '': $pconfig['dst'],
 	'ALIASV4V6'
-))->addMask('dstmask', $pconfig['dstmask'], 31, 1, false)->setHelp('Address/mask');
+))->addMask('dstmask', $pconfig['dstmask'], 31)->setHelp('Address/mask');
 
 $group->setHelp('The 1:1 mapping will only be used for connections to or from the specified destination. Hint: this is usually "Any".');
 

--- a/src/usr/local/www/firewall_nat_edit.php
+++ b/src/usr/local/www/firewall_nat_edit.php
@@ -797,7 +797,7 @@ $group->add(new Form_IpAddress(
 	null,
 	is_specialnet($pconfig['dst']) ? '': $pconfig['dst'],
 	'ALIASV4V6'
-))->addMask('dstmask', $pconfig['dstmask'], 31, 1, false)->setHelp('Address/mask');
+))->addMask('dstmask', $pconfig['dstmask'], 31)->setHelp('Address/mask');
 
 $section->add($group);
 

--- a/src/usr/local/www/interfaces_ppps_edit.php
+++ b/src/usr/local/www/interfaces_ppps_edit.php
@@ -586,7 +586,7 @@ if ($pconfig['type'] == 'pptp' || $pconfig['type'] == 'l2tp') {
 			'localip[' . $ifnm . ']',
 			null,
 			$pconfig['localip'][$ifnm]
-		))->addMask('subnet[' . $ifnm . ']', $pconfig['subnet'][$ifnm], 31, 1, false)->setHelp('Local IP Address');
+		))->addMask('subnet[' . $ifnm . ']', $pconfig['subnet'][$ifnm], 31)->setHelp('Local IP Address');
 
 		$group->add(new Form_Input(
 			'gateway[' . $ifnm . ']',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10433
- [ ] Ready for review

After PR https://github.com/pfsense/pfsense/pull/4264 is not possible to select > /31 netmask (IPv6),
see https://redmine.pfsense.org/issues/10433#note-5

revert it