### PR TITLE
Floating rules tab fix. Issue #4629

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -669,16 +669,12 @@ foreach ($a_filter as $filteri => $filterent):
 							if ($config['l2tp']['mode'] == 'server')
 								$selected_descs[] = 'L2TP VPN';
 							break;
-						case 'pptp':
-							if ($config['pptpd']['mode'] == 'server')
-								$selected_descs[] = 'PPTP VPN';
-							break;
 						case 'pppoe':
 							if (is_pppoe_server_enabled())
 								$selected_descs[] = 'PPPoE Server';
 							break;
 						case 'enc0':
-							if (isset($config['ipsec']['enable']) || isset($config['ipsec']['client']['enable']))
+							if (ipsec_enabled())
 								$selected_descs[] = 'IPsec';
 							break;
 						case 'openvpn':
@@ -691,7 +687,9 @@ foreach ($a_filter as $filteri => $filterent):
 						}
 					}
 				}
-				echo implode('<br/>', $selected_descs);
+				if (!empty($selected_descs)) {
+					echo implode('<br/>', $selected_descs);
+				}
 			}
 	?>
 			</td>


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/4629
- [ ] Ready for review

fixes for previous PR https://github.com/pfsense/pfsense/pull/4286:
1) if you enable PPPoE Server for example, then create floating rules with only PPPoE Server, and then remove/disable PPPoE Server service, you get `PHP Warning:  implode(): Invalid arguments passed in /usr/local/www/firewall_rules.php on line 694` error. This PR fixes it;
2) removes PPTP Server entry code;
3) uses `ipsec_enabled()` for IPsec checking;