### PR TITLE
NTP disable clean config fix. Issue #3567

### DIFF
--- a/src/usr/local/www/services_ntpd.php
+++ b/src/usr/local/www/services_ntpd.php
@@ -229,6 +229,7 @@ function build_interface_list() {
 
 init_config_arr(array('ntpd'));
 $pconfig = &$config['ntpd'];
+$pconfig['enable'] = ($config['ntpd']['enable'] != 'disabled') ? 'enabled' : 'disabled';
 if (empty($pconfig['interface'])) {
 	$pconfig['interface'] = array();
 } else {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/3567
- [ ] Ready for review

fix for clean NTP configurations which don't have `$config['ntpd']['enable']`  entry