### PR TITLE
Make LACP timeout PDU transmission speed configurable. Issue #10504

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1040,6 +1040,12 @@ function interface_lagg_configure($lagg) {
 		$members = array_merge(array($lagg['failovermaster']), $members);
 	}
 
+	if (isset($lagg['lacptimeout']) && ($lagg['lacptimeout'] != 'slow')) {
+		$lacptimeout = 'lacp_fast_timeout';
+	} else {
+		$lacptimeout = '';
+	}
+
 	foreach ($members as $member) {
 		if (!does_interface_exist($member)) {
 			continue;
@@ -1056,7 +1062,7 @@ function interface_lagg_configure($lagg) {
 		mwexec("/sbin/ifconfig " . escapeshellarg($laggif) . " laggport " . escapeshellarg($member));
 	}
 
-	mwexec("/sbin/ifconfig {$laggif} laggproto " . escapeshellarg($lagg['proto']));
+	mwexec("/sbin/ifconfig {$laggif} laggproto " . escapeshellarg($lagg['proto']) . " {$lacptimeout}");
 
 	interfaces_bring_up($laggif);
 

--- a/src/usr/local/www/interfaces_lagg_edit.php
+++ b/src/usr/local/www/interfaces_lagg_edit.php
@@ -112,6 +112,9 @@ if (isset($id) && $a_laggs[$id]) {
 	if (isset($a_laggs[$id]['failovermaster'])) {
 		$pconfig['failovermaster'] = $a_laggs[$id]['failovermaster'];
 	}
+	if (isset($a_laggs[$id]['lacptimeout'])) {
+		$pconfig['lacptimeout'] = $a_laggs[$id]['lacptimeout'];
+	}
 	$pconfig['descr'] = $a_laggs[$id]['descr'];
 }
 
@@ -158,6 +161,11 @@ if ($_POST['save']) {
 			$lagg['failovermaster'] = $_POST['failovermaster'];
 		} else {
 			unset($lagg['failovermaster']);
+		}
+		if (($_POST['proto'] == 'lacp') && isset($_POST['lacptimeout'])) {
+			$lagg['lacptimeout'] = $_POST['lacptimeout'];
+		} else {
+			unset($lagg['lacptimeout']);
 		}
 		if (isset($id) && $a_laggs[$id]) {
 			$lagg['laggif'] = $a_laggs[$id]['laggif'];
@@ -263,6 +271,20 @@ $group->add(new Form_Select(
 ))->setHelp('Master interface for the <b>FAILOVER</b> mode. If auto is selected, then the first interface added is the master port; any interfaces added after that are used as failover devices.');
 $section->add($group);
 
+$group = new Form_Group('LACP Timeout Mode');
+$group->addClass('lacptimeout');
+$group->add(new Form_Select(
+	'lacptimeout',
+	'LACP Timeout',
+	$pconfig['lacptimeout'],
+	array('slow' => 'Slow (default)', 'fast' => 'Fast')
+))->setHelp('In a <b>Slow</b> timeout, PDUs are sent every 30 seconds and in a <b>Fast</b> timeout, ' .
+	    'PDUs are sent every second. LACP timeout occurs when 3 consecutive PDUs are missed. ' .
+	    'If LACP timeout is a slow timeout, the time taken when 3 consecutive PDUs are missed ' .
+	    'is 90 seconds (3x30 seconds). If LACP timeout is a fast timeout, the time taken is 3 ' .
+	    'seconds (3x1 second).');
+$section->add($group);
+
 $section->addInput(new Form_Input(
 	'descr',
 	'Description',
@@ -295,6 +317,7 @@ print($form);
 events.push(function() {
 	function change_proto() {
 		hideClass('fomaster', ($('#proto').val() != 'failover'));
+		hideClass('lacptimeout', ($('#proto').val() != 'lacp'));
 	}
 
 	$('#proto').change(function () {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10504
- [ ] Ready for review

Allow to set "lacp_fast_timeout" option from the WebGUI
see redmine issue for details