### PR TITLE
Remove CA prv key fix. Issue #10509

### DIFF
--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -247,10 +247,8 @@ if ($_POST['save']) {
 			$ca['descr']  = $pconfig['descr'];
 			$ca['refid']  = $pconfig['refid'];
 			$ca['serial'] = $pconfig['serial'];
-			$ca['crt']	  = base64_encode($pconfig['cert']);
-			if (!empty($pconfig['key'])) {
-				$ca['prv']	  = base64_encode($pconfig['key']);
-			}
+			$ca['crt'] = base64_encode($pconfig['cert']);
+			$ca['prv'] = base64_encode($pconfig['key']);
 			$savemsg = sprintf(gettext("Updated Certificate Authority %s"), $ca['descr']);
 		} else {
 			$old_err_level = error_reporting(0); /* otherwise openssl_ functions throw warnings directly to a page screwing menu tab */


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10509
- [X] Ready for review

https://forum.netgate.com/topic/153020/removing-a-ca-key

If you edit CA and save, the key is still there.