### PR TITLE
L2TP VPN shared secret. Issue #10527

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -389,6 +389,13 @@ l2tps:
 	set link enable incoming
 
 EOD;
+			if (isset($l2tpcfg['secret'])) {
+				$secret = str_replace('"', '\"', base64_decode($l2tpcfg['secret']));
+				$mpdconf .=<<<EOD
+	set l2tp secret "{$secret}"
+
+EOD;
+			}
 
 
 			if (isset ($l2tpcfg['radius']['enable'])) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10527
- [ ] Ready for review

Shared secret on vpn_l2tp.php page is never used,
This PR fixes it

http://mpd.sourceforge.net/doc5/mpd48.html#48:
> set l2tp secret secret
>  Sets the L2TP tunnel secret. Used to authenticate tunnel connection and encrypt important control packets avpairs. For server side, 
>  only one unique secret supported for every pair of listening IP (set l2tp self ...) and peer ip (set l2tp peer ...). If several 
>  secrets defined, only the first matching will be used for all incoming connections.
> 
>  NOTE: This options is not related with usual PPP authentication. Windows client does not support tunnel authentication.