### PR TITLE
Hide ARM32/64 network booting options. Issue #10374

### DIFF
--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -2017,6 +2017,8 @@ events.push(function() {
 		hideInput('filename', !showadvnwkboot);
 		hideInput('filename32', !showadvnwkboot);
 		hideInput('filename64', !showadvnwkboot);
+		hideInput('filename32arm', !showadvnwkboot);
+		hideInput('filename64arm', !showadvnwkboot);
 		hideInput('rootpath', !showadvnwkboot);
 
 		if (showadvnwkboot) {


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10374
- [ ] Ready for review

Show/hide ARM32/64 booting options on pressing "Display Advanced" button