### PR TITLE
DynDNS DNSExit URL fix. Issue #9632

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -664,7 +664,7 @@
 					break;
 				case 'dnsexit':
 					$needsIP = TRUE;
-					curl_setopt($ch, CURLOPT_URL, 'https://www.dnsexit.com/RemoteUpdate.sv?login=' . $this->_dnsUser . '&password=' . $this->_dnsPass . '&host=' . $this->_dnsHost . '&myip=' . $this->_dnsIP);
+					curl_setopt($ch, CURLOPT_URL, 'https://update.dnsexit.com/RemoteUpdate.sv?login=' . $this->_dnsUser . '&password=' . $this->_dnsPass . '&host=' . $this->_dnsHost . '&myip=' . $this->_dnsIP);
 					break;
 				case 'loopia':
 					$needsIP = TRUE;


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9632
- [X] Ready for review

When using the DNSExit dynamic DNS service, the IP address changes and the "Save & Force Update" button is clicked, the following appears in the system log:
Jul 15 10:29:15 php-fpm 381 /rc.newwanip: phpDynDNS (xxmurphy.linkpc.net): PAYLOAD: HTTP/1.1 200 OK 13=Error: www.dnsexit.com does not take IP updates. Please post IP updates to https://update.dnsexit.com/RemoteUpdate.svlogin=xxmurphy&password=xxxxxxx&host=xxmurphy.linkpc.net&myip=111.22.111.21

see https://update.dnsexit.com/apps/dynamic-dns-update-client.jsp