### PR TITLE
Fw rule description input validation. Issue #10542

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -408,6 +408,10 @@ if ($_POST['save']) {
 		}
 	}
 
+	if (strpos($_POST['descr'], "\\") !== false) {
+		$input_errors[] = gettext("The '\' character is not allowed in the Description field.");
+	}
+
 	if (($_POST['proto'] != "tcp") && ($_POST['proto'] != "udp") && ($_POST['proto'] != "tcp/udp")) {
 		$_POST['srcbeginport'] = 0;
 		$_POST['srcendport'] = 0;


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10542
- [X] Ready for review

The '\\' character is not allowed in the Description field.

All other special characters are OK