### PR TITLE
Use gid from /etc/groups when creating a user group

### DIFF
--- a/src/usr/local/www/system_groupmanager.php
+++ b/src/usr/local/www/system_groupmanager.php
@@ -238,7 +238,14 @@ if (isset($_POST['save']) && !$read_only) {
 		if (isset($id) && $a_group[$id]) {
 			$a_group[$id] = $group;
 		} else {
-			$group['gid'] = $config['system']['nextgid']++;
+			/* Use gid from /etc/group if it exists */
+			$groups = posix_getgrnam($group['name']);
+			if ($groups) {
+				$group['gid'] = $groups["gid"];
+				$group['scope'] = "system";
+			} else {
+				$group['gid'] = $config['system']['nextgid']++;
+			}
 			$a_group[] = $group;
 		}
 


### PR DESCRIPTION
This solves group name collisions and also allows users to be placed in group operator to be able to read filesystem partitions.
Protect such groups from deletion.

- [ x] Redmine Issue: https://redmine.pfsense.org/issues/10544
- [ x] Ready for review