### PR TITLE
is_proccess_running empty proc fix. Issue #10540

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -45,9 +45,11 @@ function isvalidpid($pidfile) {
 
 function is_process_running($process) {
 	$output = "";
-	exec("/bin/pgrep -anx " . escapeshellarg($process), $output, $retval);
-
-	return (intval($retval) == 0);
+	if (!empty($process)) {
+		exec("/bin/pgrep -anx " . escapeshellarg($process), $output, $retval);
+		return (intval($retval) == 0);
+	}
+	return false;
 }
 
 function isvalidproc($proc) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10540
- [X] Ready for review

is_process_running generates an error when $process is "".

original patch by [Orion Poplawski](https://redmine.pfsense.org/users/4450)