### PR TITLE
Sanitize FreeRADIUS passwords. Fixes #10568

### DIFF
--- a/src/usr/local/www/status.php
+++ b/src/usr/local/www/status.php
@@ -73,8 +73,10 @@ $filtered_tags = array(
 	'proxypass', 'proxy_passwd', 'proxyuser', 'proxy_user', 'prv',
 	'radius_secret', 'redis_password', 'redis_passwordagain', 'rocommunity',
 	'secret', 'shared_key', 'tls', 'tlspskidentity', 'tlspskfile',
-	'varclientpasswordinput', 'varclientsharedsecret', 'varsyncpassword',
-	'varusersmotpinitsecret', 'varusersmotppin'
+	'varclientpasswordinput', 'varclientsharedsecret', 'varsqlconfpassword',
+	'varsqlconf2password', 'varsyncpassword', 'varmodulesldappassword', 
+	'varmodulesldap2password', 'varusersmotpinitsecret', 'varusersmotppin', 
+	'varuserspassword'
 );
 
 if ($_POST['submit'] == "DOWNLOAD" && file_exists($output_file)) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10568
- [X] Ready for review

fields to sanitize:
```
<varuserspassword>
<varsqlconfpassword>
<varsqlconf2password>
<varmodulesldappassword>
<varmodulesldap2password>
```
