### PR TITLE
Sanitize ACME passwords. Issue #10569

### DIFF
--- a/src/usr/local/www/status.php
+++ b/src/usr/local/www/status.php
@@ -76,8 +76,10 @@ $filtered_tags = array(
 	'varclientpasswordinput', 'varclientsharedsecret', 'varsqlconfpassword',
 	'varsqlconf2password', 'varsyncpassword', 'varmodulesldappassword', 
 	'varmodulesldap2password', 'varusersmotpinitsecret', 'varusersmotppin', 
-	'varuserspassword'
+	'varuserspassword', 'webrootftppassword'
 );
+
+$acme_filtered_tags = array('key', 'password', 'secret', 'token', 'pwd', 'pw');
 
 if ($_POST['submit'] == "DOWNLOAD" && file_exists($output_file)) {
 	session_cache_limiter('public');
@@ -92,7 +94,7 @@ unlink_if_exists($output_file);
 mkdir($output_path);
 
 function doCmdT($title, $command, $method) {
-	global $output_path, $output_file, $filtered_tags, $show_output;
+	global $output_path, $output_file, $filtered_tags, $acme_filtered_tags, $show_output;
 	/* Fixup output directory */
 
 	if ($show_output) {
@@ -113,6 +115,10 @@ function doCmdT($title, $command, $method) {
 				/* remove sensitive contents */
 				foreach ($filtered_tags as $tag) {
 					$line = preg_replace("/<{$tag}>.*?<\\/{$tag}>/", "<{$tag}>xxxxx</{$tag}>", $line);
+				}
+				/* remove ACME pkg sensitive contents */
+				foreach ($acme_filtered_tags as $tag) {
+					$line = preg_replace("/<dns_(.+){$tag}>.*?<\\/dns_(.+){$tag}>/", "<dns_$1{$tag}>xxxxx</dns_$1{$tag}>", $line);
 				}
 				if ($show_output) {
 					echo htmlspecialchars(str_replace("\t", "    ", $line), ENT_NOQUOTES);


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10569
- [X] Ready for review

All `<dns_***_key>, <dns_***_password>, <dns_***_secret>, <dns_***_token>, <dns_***_pwd> and <dns_***_pw>` fields must be sanitized

+
`<webrootftppassword>` field