### PR TITLE
Captive Portal keep Pass-through MAC Auto Entry. Issue #9933

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -1096,21 +1096,6 @@ function captiveportal_prune_old_automac() {
 				}
 				$tmpvoucherdb[$emac['username']] = $eid;
 			}
-			if (voucher_auth($emac['username']) <= 0) {
-				$pipeno = captiveportal_get_dn_passthru_ruleno($emac['mac']);
-				if ($pipeno) {
-					captiveportal_free_dn_ruleno($pipeno);
-					$macrules .= "table {$cpzone}_pipe_mac delete any,{$emac['mac']}\n";
-					$macrules .= "table {$cpzone}_pipe_mac delete {$emac['mac']},any\n";
-					$macrules .= "pipe delete {$pipeno}\n";
-					++$pipeno;
-					$macrules .= "pipe delete {$pipeno}\n";
-				}
-				$writecfg = true;
-				captiveportal_logportalauth($emac['username'], $emac['mac'],
-				    $emac['ip'], "EXPIRED {$emac['username']} LOGIN - TERMINATING SESSION");
-				unset($config['captiveportal'][$cpzone]['passthrumac'][$eid]);
-			}
 		}
 		unset($tmpvoucherdb);
 		if (!empty($macrules)) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9933
- [X] Ready for review

With Captive Portal, the "Enabled Pass-through MAC Auto Entry" should normally keep definitvly the MAC address into table. Regarding documentation there is only one way to delete it: manually.
But in version 2.4.4p3, the auto-added Mac is deleted in same time than Voucher expiration.

Correction find with Forum and Gertjan help.
https://forum.netgate.com/topic/148464/captive-portal-voucher-not-keeping-auto-added-pass-through-mac-auto-entry/4


It's safe to remove this code, as `captiveportal_prune_old()` already removes expired sessions in loop:
https://github.com/pfsense/pfsense/blob/d2abe7c919eaf0c40b911278b96f9bab4fa0be45/src/etc/inc/captiveportal.inc#L863

> logportalauth | 54817 | Zone: zone1 - SESSION TIMEOUT: 6d8xAhCm2yq, 0c:dd:ae:8c:e7:00, 192.168.1.33

