### PR TITLE
Allow concurrent logins when using vouchers. Implements #2146

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -2362,9 +2362,11 @@ function portal_allow($clientip, $clientmac, $username, $password = null, $attri
 				$remaining_time = 0;
 			}
 
-			/* This user was already logged in so we disconnect the old one */
-			captiveportal_disconnect($cpentry, 13);
-			captiveportal_logportalauth($cpentry[4], $cpentry[3], $cpentry[2], "CONCURRENT LOGIN - TERMINATING OLD SESSION");
+			if (isset($config['captiveportal'][$cpzone]['noconcurrentlogins'])) {
+				/* This user was already logged in so we disconnect the old one */
+				captiveportal_disconnect($cpentry, 13);
+				captiveportal_logportalauth($cpentry[4], $cpentry[3], $cpentry[2], "CONCURRENT LOGIN - TERMINATING OLD SESSION");
+			}
 			$unsetindexes[] = $cpentry[5];
 			break;
 		} elseif ((isset($config['captiveportal'][$cpzone]['noconcurrentlogins'])) && ($username != 'unauthenticated')) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/2146
- [X] Ready for review

When using vouchers it is not possible to use them more then once, even when enabling 'allow concurrent logins'. Using one vouchers more than once is sometimes required. For example when you rent meetingrooms and want to give them access by giving a voucher to the meetingholder.