### PR TITLE
Allow to submit voucher via URL. Implements #1984

### DIFF
--- a/src/etc/inc/captiveportal.inc
+++ b/src/etc/inc/captiveportal.inc
@@ -141,7 +141,7 @@ EOD;
 			$translated_text = gettext("Voucher Code");
 			$htmltext .= <<<EOD
 				<br  /><br  />
-				<input name="auth_voucher" type="text" placeholder="{$translated_text}">
+				<input name="auth_voucher" type="text" placeholder="{$translated_text}" value="#VOUCHER#">
 EOD;
 		}
 	}
@@ -2201,7 +2201,7 @@ function portal_hostname_from_client_ip($cliip) {
 
 /* functions move from index.php */
 
-function portal_reply_page($redirurl, $type = null, $message = null, $clientmac = null, $clientip = null, $username = null, $password = null) {
+function portal_reply_page($redirurl, $type = null, $message = null, $clientmac = null, $clientip = null, $username = null, $password = null, $voucher = null) {
 	global $g, $config, $cpzone;
 
 	/* Get captive portal layout */
@@ -2244,6 +2244,7 @@ function portal_reply_page($redirurl, $type = null, $message = null, $clientmac 
 	$htmltext = str_replace("#CLIENT_IP#", htmlspecialchars($clientip), $htmltext);
 	$htmltext = str_replace("#USERNAME#", htmlspecialchars($username), $htmltext);
 	$htmltext = str_replace("#PASSWORD#", htmlspecialchars($password), $htmltext);
+	$htmltext = str_replace("#VOUCHER#", htmlspecialchars($voucher), $htmltext);
 
 	echo $htmltext;
 }

--- a/src/usr/local/captiveportal/index.php
+++ b/src/usr/local/captiveportal/index.php
@@ -82,7 +82,12 @@ if ((!empty($cpsession)) && (! $_POST['logout_id']) && (!empty($cpcfg['page']['l
 } elseif (!empty($cpsession) && (!isset($_POST['logout_id']) || !isset($config['captiveportal'][$cpzone]['logoutwin_enable']))) {
 	/* If client try to access captive portal page while already connected, 
 		but no custom logout page does exist and logout popup is disabled */	
-	echo gettext("You are connected.");
+	echo gettext("You are connected.<br/>");
+	if ($_GET['redirurl'] || $_POST['redirurl']) {
+		$redirurl = $_GET['redirurl'] ? $_GET['redirurl'] : $_POST['redirurl'];
+		$redirurl = htmlspecialchars($redirurl);
+		echo ("You can proceed to: <a href='{$redirurl}'>{$redirurl}</a>");
+	} 
 	ob_flush();
 	return;
 } elseif ($orig_host != $ourhostname) {
@@ -157,8 +162,15 @@ EOD;
 	captiveportal_logportalauth("unauthenticated", $clientmac, $clientip, "ACCEPT");
 	portal_allow($clientip, $clientmac, "unauthenticated");
 
-} elseif (isset($config['voucher'][$cpzone]['enable']) && $_POST['accept'] && $_POST['auth_voucher']) {
-	$voucher = trim($_POST['auth_voucher']);
+} elseif (isset($config['voucher'][$cpzone]['enable']) && ($_POST['accept'] && $_POST['auth_voucher']) || $_GET['voucher']) {
+	if (isset($_POST['auth_voucher'])) {
+		$voucher = trim($_POST['auth_voucher']);
+	} else {
+		/* submit voucher via URL, see https://redmine.pfsense.org/issues/1984 */
+		$voucher = trim($_GET['voucher']);
+		portal_reply_page($redirurl, "login", null, null, null, null, null, $voucher);
+		return;
+	}
 	$errormsg = gettext("Invalid credentials specified.");
 	$timecredit = voucher_auth($voucher);
 	// $timecredit contains either a credit in minutes or an error message


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/1984
- [X] Ready for review

In addition to the web form, allow the submission of voucher via URL e.g.

`http://pfsenseip:8002/index.php?zone=zone_name&redirurl=redir_url&voucher=voucher_code`

Considering the numerous forum posts about shortening pfsense vouchers and the proliferation of handheld devices with bar-code scanning apps, it'd be cool to be able to distribute vouchers as a URL stored in QR code.