### PR TITLE
Update interfaces_staticarp_configure()

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -6931,21 +6931,23 @@ function interfaces_staticarp_configure($if) {
 	if (isset($config['dhcpd'][$if]['staticarp'])) {
 		mwexec("/sbin/ifconfig " . escapeshellarg($ifcfg['if']) . " staticarp ");
 		mwexec("/usr/sbin/arp -d -i " . escapeshellarg($ifcfg['if']) . " -a > /dev/null 2>&1 ");
-		if (is_array($config['dhcpd'][$if]['staticmap'])) {
-			foreach ($config['dhcpd'][$if]['staticmap'] as $arpent) {
-				if (!empty($arpent['ipaddr']) && !empty($arpent['mac'])) {
-					mwexec("/usr/sbin/arp -s " . escapeshellarg($arpent['ipaddr']) . " " . escapeshellarg($arpent['mac']));
-				}
-			}
-		}
 	} else {
-		mwexec("/sbin/ifconfig " . escapeshellarg($ifcfg['if']) . " -staticarp ");
-		mwexec("/usr/sbin/arp -d -i " . escapeshellarg($ifcfg['if']) . " -a > /dev/null 2>&1 ");
-		if (is_array($config['dhcpd'][$if]) && is_array($config['dhcpd'][$if]['staticmap'])) {
-			foreach ($config['dhcpd'][$if]['staticmap'] as $arpent) {
-				if (isset($arpent['arp_table_static_entry']) && !empty($arpent['ipaddr']) && !empty($arpent['mac'])) {
-					mwexec("/usr/sbin/arp -s " . escapeshellarg($arpent['ipaddr']) . " " . escapeshellarg($arpent['mac']));
-				}
+		//Interfaces do not have staticarp enabled by default
+		//Let's not disable staticarp on freshly created interfaces
+		if (!platform_booting()) {
+			mwexec("/sbin/ifconfig " . escapeshellarg($ifcfg['if']) . " -staticarp ");
+			mwexec("/usr/sbin/arp -d -i " . escapeshellarg($ifcfg['if']) . " -a > /dev/null 2>&1 ");
+		}
+	}
+	
+	/* Enable static arp entries */
+	if (is_array($config['dhcpd'][$if]) && is_array($config['dhcpd'][$if]['staticmap'])) {
+		foreach ($config['dhcpd'][$if]['staticmap'] as $arpent) {
+			if (empty($arpent['ipaddr']) || empty($arpent['mac'])) {
+				continue;
+			}
+			if (isset($config['dhcpd'][$if]['staticarp']) || isset($arpent['arp_table_static_entry'])) {
+				mwexec("/usr/sbin/arp -s " . escapeshellarg($arpent['ipaddr']) . " " . escapeshellarg($arpent['mac']));
 			}
 		}
 	}


### PR DESCRIPTION
This commit implements code to skip disabling staticarp on boot.
We do this because interfaces created on boot are created without staticarp enabled, therefore we dont need to disable it on interfaces on boot.
This fixes issue #10589

This greatly improves boot times on systems with many interfaces.

Also implemented is a simplification of code to handle static ARP entries.

- [x ] Redmine Issue: https://redmine.pfsense.org/issues/10589
- [x ] Ready for review