### PR TITLE
NAT Reflection timeout set fix. Issue #10591

### DIFF
--- a/src/usr/local/www/system_advanced_firewall.php
+++ b/src/usr/local/www/system_advanced_firewall.php
@@ -352,7 +352,7 @@ if ($_POST) {
 			unset($config['system']['enablenatreflectionhelper']);
 		}
 
-		$config['system']['reflectiontimeout'] = $_POST['reflection-timeout'];
+		$config['system']['reflectiontimeout'] = $_POST['reflectiontimeout'];
 
 		if ($_POST['bypassstaticroutes'] == "yes") {
 			$config['filter']['bypassstaticroutes'] = $_POST['bypassstaticroutes'];


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10591
- [X] Ready for review

It's not possible to set a value for 'Reflection Timeout' in the Network Address Translation section of System > Advanced > Firewall & NAT.

Doing so adds the tags <reflectiontimeout></reflectiontimeout> in the config but with no value present.

The webgui returns a page with no value set.

This PR fixes this