### PR TITLE
Add qlxgb to ALTQ-capable list. Issue #10594

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -6671,10 +6671,10 @@ function is_altq_capable($int) {
 			"bfe", "bge", "bridge", "cas", "cpsw", "cxl", "dc", "de",
 			"ed", "em", "ep", "epair", "et", "fxp", "gem", "hme", "hn",
 			"igb", "jme", "l2tp", "le", "lem", "msk", "mxge", "my",
-			"ndis", "nfe", "ng", "nge", "npe", "nve", "ovpnc", "ovpns",
-			"ppp", "pppoe", "pptp", "re", "rl", "sf", "sge", "sis", "sk",
-			"ste", "stge", "ti", "tun", "txp", "udav", "ural", "vge",
-			"vlan", "vmx", "vr", "vte", "vtnet", "xl");
+			"ndis", "nfe", "ng", "nge", "npe", "nve", "qlxgb", "ovpnc", 
+			"ovpns", "ppp", "pppoe", "pptp", "re", "rl", "sf", "sge",
+			"sis", "sk", "ste", "stge", "ti", "tun", "txp", "udav",
+			"ural", "vge", "vlan", "vmx", "vr", "vte", "vtnet", "xl");
 
 	$int_family = remove_ifindex($int);
 


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10594
- [X] Ready for review

according to:
https://www.freebsd.org/cgi/man.cgi?query=altq&apropos=0&sektion=4&manpath=FreeBSD+11.3-RELEASE&arch=default&format=html
https://www.freebsd.org/cgi/man.cgi?query=qlxgb&sektion=4&apropos=0&manpath=FreeBSD+11.3-RELEASE

10 Gigabit Ethernet driver (qlxgb) supports ALTQ