### PR TITLE
Do not halt on configuration file not found error. Implements #10556

### DIFF
--- a/src/etc/inc/config.lib.inc
+++ b/src/etc/inc/config.lib.inc
@@ -237,11 +237,12 @@ function parse_config_bootup() {
 			if (!file_exists("{$g['conf_path']}/config.xml")) {
 				echo sprintf(gettext("XML configuration file not found.  %s cannot continue booting."), $g['product_name']) . "\n";
 				unlock($lockkey);
-				mwexec("/sbin/halt");
-				exit;
+				log_error(gettext("Could not find a usable configuration file! Exiting...."));
+				exit(0);
+			} else {
+				log_error("Last known config found and restored.  Please double check the configuration file for accuracy.");
+				file_notice("config.xml", gettext("Last known config found and restored.  Please double check the configuration file for accuracy."), "pfSenseConfigurator", "");
 			}
-			log_error("Last known config found and restored.  Please double check the configuration file for accuracy.");
-			file_notice("config.xml", gettext("Last known config found and restored.  Please double check the configuration file for accuracy."), "pfSenseConfigurator", "");
 		} else {
 			unlock($lockkey);
 			log_error(gettext("Could not find a usable configuration file! Exiting...."));


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10556
- [X] Ready for review

After a shutdown/filesystem error I got on boot:

> XML configuration file not found. pfSense cannot continue booting.

then system halted
This is not a very useful behavior in this situation,
With this PR it goes forward and shows the console menu that allow you to make factory reset for example