### PR TITLE
rc.initial: handle -c command with arguments

### DIFF
--- a/src/etc/rc.initial
+++ b/src/etc/rc.initial
@@ -49,7 +49,7 @@ fi
 while [ $# -gt 0 ]; do
 	case $1 in
 		-c )	shift
-			/bin/sh -c $1
+			/bin/sh -c "$@"
 			exit
 			;;
 		* )


### PR DESCRIPTION
before this change rc.initial only passes the first -c parameter.
instead passing every parameter allows you to run complex commands
over ssh even if the shell is set to /etc/rc.initial

implements #10603

- [X] https://redmine.pfsense.org/issues/10603?next_issue_id=10602
- [X] Ready for review