### PR TITLE
Allow to use 6RD/6to4 interfaces for DynDNS. Fixes #9641

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -7219,4 +7219,16 @@ function is_pseudo_interface($inf) {
 	return false;
 }
 
+function is_stf_interface($inf) {
+	global $config;
+
+	if (is_array($config['interfaces'][$inf]) &&
+	    (($config['interfaces'][$inf]['ipaddrv6'] == '6rd') ||
+	    ($config['interfaces'][$inf]['ipaddrv6'] == '6to4'))) {
+	    return true;
+	}
+
+	return false;
+}
+
 ?>

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2759,7 +2759,11 @@ function services_dnsupdate_process($int = "", $updatehost = "", $forced = false
 			$wanip = get_interface_ip($if);
 			$bindipv4 = $wanip;
 		}
-		$wanipv6 = get_interface_ipv6($if);
+		if (is_stf_interface($dnsupdate['interface'])) { 
+			$wanipv6 = get_interface_ipv6($dnsupdate['interface'] . '_stf');
+		} else {
+			$wanipv6 = get_interface_ipv6($if);
+		}
 		$bindipv6 = $wanipv6;
 
 		/* Handle non-default interface bindings */
@@ -2770,7 +2774,11 @@ function services_dnsupdate_process($int = "", $updatehost = "", $forced = false
 		} elseif (!empty($dnsupdate['updatesource'])) {
 			/* Find the alternate binding address */
 			$bindipv4 = get_interface_ip($dnsupdate['updatesource']);
-			$bindipv6 = get_interface_ipv6($dnsupdate['updatesource']);
+			if (is_stf_interface($dnsupdate['interface'])) { 
+				$bindipv6 = get_interface_ipv6($dnsupdate['updatesource'] . '_stf');
+			} else {
+				$bindipv6 = get_interface_ipv6($dnsupdate['updatesource']);
+			}
 		}
 
 		/* Handle IPv4/IPv6 selection for the update source interface/VIP */

--- a/src/usr/local/www/services_dyndns.php
+++ b/src/usr/local/www/services_dyndns.php
@@ -111,7 +111,7 @@ foreach ($a_dyndns as $dyndns):
 <?php
 	$iflist = get_configured_interface_with_descr();
 	foreach ($iflist as $if => $ifdesc) {
-		if ($dyndns['interface'] == $if) {
+		if (str_replace('_stf', '', $dyndns['interface']) == $if) {
 			print($ifdesc);
 
 			break;

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -64,7 +64,7 @@ if (isset($id) && isset($a_dyndns[$id])) {
 	$pconfig['mx'] = $a_dyndns[$id]['mx'];
 	$pconfig['type'] = $a_dyndns[$id]['type'];
 	$pconfig['enable'] = !isset($a_dyndns[$id]['enable']);
-	$pconfig['interface'] = $a_dyndns[$id]['interface'];
+	$pconfig['interface'] = str_replace('_stf', '', $a_dyndns[$id]['interface']);
 	$pconfig['wildcard'] = isset($a_dyndns[$id]['wildcard']);
 	$pconfig['proxied'] = isset($a_dyndns[$id]['proxied']);
 	$pconfig['verboselog'] = isset($a_dyndns[$id]['verboselog']);
@@ -74,7 +74,7 @@ if (isset($id) && isset($a_dyndns[$id])) {
 	$pconfig['ttl'] = $a_dyndns[$id]['ttl'];
 	$pconfig['updateurl'] = $a_dyndns[$id]['updateurl'];
 	$pconfig['resultmatch'] = $a_dyndns[$id]['resultmatch'];
-	$pconfig['requestif'] = $a_dyndns[$id]['requestif'];
+	$pconfig['requestif'] = str_replace('_stf', '', $a_dyndns[$id]['requestif']);
 	$pconfig['descr'] = $a_dyndns[$id]['descr'];
 }
 
@@ -195,13 +195,22 @@ if ($_POST['save'] || $_POST['force']) {
 		} else {
 			$dyndns['enable'] = true;
 		}
-		$dyndns['interface'] = $_POST['interface'];
+		if (preg_match('/.+-v6/', $_POST['type']) && is_stf_interface($_POST['interface'])) { 
+			$dyndns['interface'] = $_POST['interface'] . '_stf';
+		} else {
+			$dyndns['interface'] = $_POST['interface'];
+		}
 		$dyndns['zoneid'] = $_POST['zoneid'];
 		$dyndns['ttl'] = $_POST['ttl'];
 		$dyndns['updateurl'] = $_POST['updateurl'];
 		// Trim hard-to-type but sometimes returned characters
 		$dyndns['resultmatch'] = trim($_POST['resultmatch'], "\t\n\r");
-		($dyndns['type'] == "custom" || $dyndns['type'] == "custom-v6") ? $dyndns['requestif'] = $_POST['requestif'] : $dyndns['requestif'] = $_POST['interface'];
+		($dyndns['type'] == "custom") ? $dyndns['requestif'] = $_POST['requestif'] : $dyndns['requestif'] = $_POST['interface'];
+		if (($dyndns['type'] == "custom-v6") && is_stf_interface($_POST['requestif'])) { 
+			$dyndns['requestif'] = $_POST['requestif'] . '_stf';
+		} else {
+			$dyndns['requestif'] = $_POST['requestif'];
+		}
 		$dyndns['descr'] = $_POST['descr'];
 		$dyndns['force'] = isset($_POST['force']);
 


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9641
- [X] Ready for review

Allow to use 6RD/6to4 (`$int_stf`) interface for DynDNS / RFC2136 update