### PR TITLE
PFTop filter hide for non-states views. Issue #10625

### DIFF
--- a/src/usr/local/www/diag_pftop.php
+++ b/src/usr/local/www/diag_pftop.php
@@ -205,9 +205,9 @@ print $form;
 events.push(function() {
 	$('#viewtype').on('change', function() {
 		if (['queue', 'label', 'rules'].indexOf($(this).val()) > -1) {
-			$("#sorttype, #sorttypediv, #statesdiv, #states").parents('.form-group').hide();
+			$("#filter, #sorttype, #sorttypediv, #statesdiv, #states").parents('.form-group').hide();
 		} else {
-			$("#sorttype, #sorttypediv, #statesdiv, #states").parents('.form-group').show();
+			$("#filter, #sorttype, #sorttypediv, #statesdiv, #states").parents('.form-group').show();
 		}
 	});
 	$('#filter').on('keypress keyup', function(event) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10625
- [X] Ready for review

As filter rule can be used only with states views,
it must be hidden for the 'queue', 'label' and 'rules' views.