### PR TITLE
Do not show stf(6RD/6to4) interface as parent physical. Issue #

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1613,7 +1613,8 @@ function get_interface_list($mode = "active", $keyby = "physical", $vfaces = "")
 		if (!in_array(array_shift(preg_split('/\d/', $ifname)), $vfaces) &&
 		    interface_is_vlan($ifname) == NULL &&
 		    interface_is_qinq($ifname) == NULL &&
-		    !stristr($ifname, "_wlan")) {
+		    !stristr($ifname, "_wlan") &&
+		    !stristr($ifname, "_stf")) {
 			$toput = array(
 					"mac" => trim($alink[1]),
 					"up" => in_array($ifname, $upints)


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10626
- [X] Ready for review

get_interface_list() shows _stf (6RD/6to4) interfaces as parent,
this is not correct since this function must not return virtual interfaces

otherwise `$int_stf` interfaces are shown on the Interfaces / VLANs/PPPs/QinQs/LAGGs pages in the parent interface list