### PR TITLE
OpenVPN TCP client fix. Issue #10650

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -1140,6 +1140,9 @@ function openvpn_reconfigure($mode, $settings) {
 
 		// The remote server
 		$remoteproto = strtolower($settings['protocol']);
+		if (substr($remoteproto, 0, 3) == "tcp") {
+			$remoteproto .= "-{$mode}";
+		}
 		$conf .= "remote {$settings['server_addr']} {$settings['server_port']} {$remoteproto}\n";
 
 		if (!empty($settings['use_shaper'])) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10650
- [X] Ready for review

`Options error: --proto tcp is ambiguous in this context. Please specify --proto tcp-server or --proto tcp-client`
Correct remote proto definition is `tcp4-client`/`tcp6-client` for TCP