### PR TITLE
Remove fe80::1:1 from interface. Issue #10661

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3936,6 +3936,8 @@ function interface_configure($interface = "wan", $reloadall = false, $linkupeven
 					if (!is_linklocal($tmpiface)) {
 						mwexec("/sbin/ifconfig " . escapeshellarg($realif) . " inet6 {$tmpiface} delete");
 					}
+				} elseif (strstr($tmpiface, "fe80::1:1")) {
+					mwexec("/sbin/ifconfig " . escapeshellarg($realif) . " inet6 fe80::1:1 -alias");
 				} else {
 					if (is_subnetv4($tmpiface)) {
 						$tmpip = explode('/', $tmpiface);


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10661
- [X] Ready for review

Remove `fe80::1:1` alias from interface in `interface_configure()` "remove all IPv4 and IPv6 addresses" loop