### PR TITLE
DynDNS gateway group update fix. Issue #9435

### DIFF
--- a/src/etc/rc.dyndns.update
+++ b/src/etc/rc.dyndns.update
@@ -49,9 +49,12 @@ if (empty($argument) || $argument == "all") {
 
 	/* check if this interface is used by gateway groups,
 	 * see https://redmine.pfsense.org/issues/9435 */
-	foreach (gateway_is_gwgroup_member($argument) as $gw) {
-		services_dyndns_configure($gw);
-		services_dnsupdate_process($gw);
+	$gateways = gateway_is_gwgroup_member($argument);
+	if (is_array($gateways) && !empty($gateways)) {
+		foreach ($gateways as $gw) {
+			services_dyndns_configure($gw);
+			services_dnsupdate_process($gw);
+		}
 	}
 }
 


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9435
- [X] Ready for review

See https://forum.netgate.com/topic/154421/php-errors-after-latest-update-amd64-built-on-thu-jun-11-13-02-15-edt-2020:
> PHP Warning: Invalid argument supplied for foreach() in /etc/rc.dyndns.update on line 52

`gateway_is_gwgroup_member()` can return `false`:
https://github.com/pfsense/pfsense/blob/6b624e416835e3824d5f1036704eb3e6e5421277/src/etc/inc/gwlb.inc#L1612-L1619
