### PR TITLE
Shaper root queue percent bw fix. Issue #10660

### DIFF
--- a/src/etc/inc/shaper.inc
+++ b/src/etc/inc/shaper.inc
@@ -517,7 +517,12 @@ function get_queue_bandwidth($obj) {
 
 	switch ($match[1]) {
 		case '%':
-			$objbw = ($bw / 100) * get_queue_bandwidth($obj->GetParent());
+			if (method_exists($obj, 'GetParent')) {
+				$getobjbw = get_queue_bandwidth($obj->GetParent());
+			} else {
+				$getobjbw = $obj->bandwidth;
+			}
+			$objbw = ($bw / 100) * $getobjbw;
 			break;
 		default:
 			$objbw = $bw * get_bandwidthtype_scale($scale);


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10660
- [X] Ready for review

class `altq_root_queue` has no method `GetParent()`,
this PR adds check for it

issue:
> Created a shaper on interface, did not apply, set bandwidth to "100%", clicked apply
> Cannot open firewall_shaper.php anymore, just shows error below on fullscreen.

`Fatal error: Uncaught Error: Call to undefined method altq_root_queue::GetParent() in /etc/inc/shaper.inc:518 Stack trace: #0 /etc/inc/shaper.inc(1302): get_queue_bandwidth(Object(altq_root_queue)) #1 /etc/inc/shaper.inc(1516): priq_queue->CheckBandwidth(NULL, NULL) ....