### PR TITLE
Bridge with GIF interface bootup fix. Issue #10524

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -677,30 +677,24 @@ function interfaces_bridge_configure($checkmember = 0, $realif = "") {
 			if (empty($bridge['bridgeif'])) {
 				$bridge['bridgeif'] = "bridge{$i}";
 			}
-			if (!empty($realif) && $realif != $bridge['bridgeif']) {
+			if (!empty($realif) && ($realif != $bridge['bridgeif'])) {
+				continue;
+			}
+			$ifname = false;
+			foreach ($config['interfaces'] as $intname => $intpar) {
+				if ($intpar['if'] == $bridge['bridgeif']) {
+					$ifname = $intname;
+					break;
+				}
+			}
+
+			if (($checkmember == 1) && $ifname &&
+			    ($config['interfaces'][$ifname]['ipaddrv6'] == "track6")) {
+				continue;
+			} elseif (($checkmember == 2) && !$ifname) {
 				continue;
 			}
 
-			if ($checkmember == 1) {
-				/* XXX: It should not be possible no? */
-				if (strstr($bridge['if'], '_vip')) {
-					continue;
-				}
-				$members = explode(',', $bridge['members']);
-				foreach ($members as $member) {
-					if (!empty($config['interfaces'][$bridge['if']]) && $config['interfaces'][$bridge['if']]['ipaddrv6'] == "track6") {
-						continue 2;
-					}
-				}
-			}
-			else if ($checkmember == 2) {
-				$members = explode(',', $bridge['members']);
-				foreach ($members as $member) {
-					if (empty($config['interfaces'][$bridge['if']]) || $config['interfaces'][$bridge['if']]['ipaddrv6'] != "track6") {
-						continue 2;
-					}
-				}
-			}
 			/* XXX: Maybe we should report any errors?! */
 			interface_bridge_configure($bridge, $checkmember);
 			$i++;


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10524
- [X] Ready for review

1) There is no need to check `$config['interfaces'][$bridge['if']]['ipaddrv6'] != "track6"` when `checkmember == 2`,- all needed interfaces are up before with `$track6_list` and `$delayed_list` foreach loops, and it's safe to exec `interface_bridge_configure($bridge, $checkmember);`

2) unused `foreach ($members as $member)` removed;

3) this code is not needed because the `<bridged>` does not have `<if>` attribute:
```
if (strstr($bridge['if'], '_vip')) {
	continue;
}
```