### PR TITLE
Remove Zabbix 4.2 support

### DIFF
--- a/tools/conf/pfPorts/make.conf
+++ b/tools/conf/pfPorts/make.conf
@@ -125,11 +125,6 @@ net-mgmt_zabbix4-agent_SET_FORCE=IPV6
 net-mgmt_zabbix4-proxy_SET_FORCE=IPMI IPV6 LIBXML2 SQLITE SSH
 net-mgmt_zabbix4-proxy_UNSET_FORCE=MYSQL
 
-net-mgmt_zabbix42-agent_SET_FORCE=IPV6
-
-net-mgmt_zabbix42-proxy_SET_FORCE=IPMI IPV6 LIBXML2 SQLITE SSH
-net-mgmt_zabbix42-proxy_UNSET_FORCE=MYSQL
-
 net-mgmt_zabbix44-agent_SET_FORCE=IPV6
 
 net-mgmt_zabbix44-proxy_SET_FORCE=IPMI IPV6 LIBXML2 SQLITE SSH

--- a/tools/conf/pfPorts/poudriere_bulk
+++ b/tools/conf/pfPorts/poudriere_bulk
@@ -27,12 +27,10 @@ net-mgmt/%%PRODUCT_NAME%%-pkg-snmptt
 net-mgmt/%%PRODUCT_NAME%%-pkg-softflowd
 net-mgmt/%%PRODUCT_NAME%%-pkg-zabbix-agent
 net-mgmt/%%PRODUCT_NAME%%-pkg-zabbix-agent4
-net-mgmt/%%PRODUCT_NAME%%-pkg-zabbix-agent42
 net-mgmt/%%PRODUCT_NAME%%-pkg-zabbix-agent44
 net-mgmt/%%PRODUCT_NAME%%-pkg-zabbix-agent5
 net-mgmt/%%PRODUCT_NAME%%-pkg-zabbix-proxy
 net-mgmt/%%PRODUCT_NAME%%-pkg-zabbix-proxy4
-net-mgmt/%%PRODUCT_NAME%%-pkg-zabbix-proxy42
 net-mgmt/%%PRODUCT_NAME%%-pkg-zabbix-proxy44
 net-mgmt/%%PRODUCT_NAME%%-pkg-zabbix-proxy5
 net-mgmt/dhcp_probe


### PR DESCRIPTION
Zabbix 4.2 ports were removed from the FreeBSD ports tree (End of Life).

- [x] Redmine Issue: https://redmine.pfsense.org/issues/10688
- [x] Ready for review