### PR TITLE
Use user DN for RFC2307 membership search. Issue #9527

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -1271,11 +1271,6 @@ function ldap_get_groups($username, $authcfg) {
 		$ldapauthcont = $authcfg['ldap_authcn'];
 		$ldapnameattribute = strtolower($authcfg['ldap_attr_user']);
 		$ldapgroupattribute = strtolower($authcfg['ldap_attr_member']);
-		if (isset($authcfg['ldap_rfc2307'])) {
-			$ldapfilter         = "(&(objectClass={$authcfg['ldap_attr_groupobj']})({$ldapgroupattribute}={$username}))";
-		} else {
-			$ldapfilter         = "({$ldapnameattribute}={$username})";
-		}
 		$ldaptype = "";
 		$ldapver = $authcfg['ldap_protver'];
 		if (empty($ldapbindun) || empty($ldapbindpw)) {
@@ -1354,7 +1349,29 @@ function ldap_get_groups($username, $authcfg) {
 		$ldapfunc = "ldap_search";
 	}
 
-	$search = @$ldapfunc($ldap, $ldapdn, $ldapfilter, array($ldapgroupattribute));
+	if (isset($authcfg['ldap_rfc2307'])) {
+		if (isset($authcfg['ldap_rfc2307_userdn'])) {
+			$ldac_splits = explode(";", $ldapauthcont);
+			foreach ($ldac_splits as $i => $ldac_split) {
+				$ldac_split = isset($authcfg['ldap_utf8']) ? utf8_encode($ldac_split) : $ldac_split;
+				$ldapsearchbasedn = isset($authcfg['ldap_utf8']) ? utf8_encode("{$ldac_split},{$ldapbasedn}") : "{$ldac_split},{$ldapbasedn}";
+				$ldapfilter = "({$ldapnameattribute}={$username})";
+				if (stristr($ldac_split, "DC=") || empty($ldapbasedn)) {
+					$ldapdn = $ldac_split;
+				} else {
+					$ldapdn = $ldapsearchbasedn;
+				}
+				$usersearch = @$ldapfunc($ldap, $ldapdn, $ldapfilter);
+				$userinfo = @ldap_get_entries($ldap, $usersearch);
+			}
+			$username = $userinfo[0]['dn'];
+		}
+		$ldapgroupfilter         = "(&(objectClass={$authcfg['ldap_attr_groupobj']})({$ldapgroupattribute}={$username}))";
+	} else {
+		$ldapgroupfilter         = "({$ldapnameattribute}={$username})";
+	}
+
+	$search = @$ldapfunc($ldap, $ldapdn, $ldapgroupfilter, array($ldapgroupattribute));
 	$info = @ldap_get_entries($ldap, $search);
 
 	$gresults = isset($authcfg['ldap_rfc2307']) ? $info : $info[0][$ldapgroupattribute];
@@ -1546,15 +1563,21 @@ function ldap_backed($username, $passwd, $authcfg, &$attributes = array()) {
 		}
 		/* Support legacy auth container specification. */
 		if (stristr($ldac_split, "DC=") || empty($ldapbasedn)) {
-			$search = @$ldapfunc($ldap, $ldac_split, $ldapfilter);
-			if (isset($ldapgroupfilter)) {
-				$groupsearch = @$ldapfunc($ldap, $ldac_split, $ldapgroupfilter);
-			}
+			$ldapdn = $ldac_split;
 		} else {
-			$search = @$ldapfunc($ldap, $ldapsearchbasedn, $ldapfilter);
-			if (isset($ldapgroupfilter)) {
-				$groupsearch = @$ldapfunc($ldap, $ldapsearchbasedn, $ldapgroupfilter);
+			$ldapdn = $ldapsearchbasedn;
+		}
+		$search = @$ldapfunc($ldap, $ldapdn, $ldapfilter);
+		$info = ldap_get_entries($ldap, $search);
+		if (isset($authcfg['ldap_rfc2307'])) {
+			if (isset($authcfg['ldap_rfc2307_userdn'])) {
+				$username = $info[0]['dn'];
 			}
+			$ldapgroupfilter = "(&({$ldapgroupattribute}={$username})({$ldapextendedquery}))";
+		}
+
+		if (isset($ldapgroupfilter)) {
+			$groupsearch = @$ldapfunc($ldap, $ldapdn, $ldapgroupfilter);
 		}
 
 		if (isset($ldapgroupfilter) && !$groupsearch) {
@@ -1571,7 +1594,6 @@ function ldap_backed($username, $passwd, $authcfg, &$attributes = array()) {
 				log_auth(sprintf(gettext("LDAP group search: %s results."), $validgroup));
 			}
 		}
-		$info = ldap_get_entries($ldap, $search);
 		$matches = $info['count'];
 		if ($matches == 1) {
 			$userdn = $_SESSION['ldapdn'] = $info[0]['dn'];

--- a/src/usr/local/www/system_authservers.php
+++ b/src/usr/local/www/system_authservers.php
@@ -163,6 +163,7 @@ if ($act == "edit") {
 			$pconfig['ldap_nostrip_at'] = isset($a_server[$id]['ldap_nostrip_at']);
 			$pconfig['ldap_allow_unauthenticated'] = isset($a_server[$id]['ldap_allow_unauthenticated']);
 			$pconfig['ldap_rfc2307'] = isset($a_server[$id]['ldap_rfc2307']);
+			$pconfig['ldap_rfc2307_userdn'] = isset($a_server[$id]['ldap_rfc2307_userdn']);
 
 			if (!$pconfig['ldap_binddn'] || !$pconfig['ldap_bindpw']) {
 				$pconfig['ldap_anon'] = true;
@@ -346,6 +347,11 @@ if ($_POST['save']) {
 				$server['ldap_rfc2307'] = true;
 			} else {
 				unset($server['ldap_rfc2307']);
+			}
+			if ($pconfig['ldap_rfc2307_userdn'] == "yes") {
+				$server['ldap_rfc2307_userdn'] = true;
+			} else {
+				unset($server['ldap_rfc2307_userdn']);
 			}
 
 
@@ -747,6 +753,18 @@ $section->addInput(new Form_Checkbox(
 	'object rather than using groups listed on user object. Leave unchecked '.
 	'for Active Directory style group membership (RFC 2307bis).');
 
+$group = new Form_Group('RFC 2307 User DN');
+$group->addClass('ldap_rfc2307_userdn');
+
+$group->add(new Form_Checkbox(
+	'ldap_rfc2307_userdn',
+	'RFC 2307 user DN',
+	'RFC 2307 Use DN for username search.',
+	$pconfig['ldap_rfc2307_userdn']
+))->setHelp('Use DN for username search, i.e. "(member=CN=Username,CN=Users,DC=example,DC=com)".');
+
+$section->add($group);
+
 $section->addInput(new Form_Input(
 	'ldap_attr_groupobj',
 	'Group Object Class',
@@ -1011,6 +1029,7 @@ events.push(function() {
 
 	hideClass('ldapanon', $('#ldap_anon').prop('checked'));
 	hideClass('extended', !$('#ldap_extended_enabled').prop('checked'));
+	hideClass('ldap_rfc2307_userdn', !$('#ldap_rfc2307').prop('checked'));
 	set_required_port_fields();
 
 	if ($('#ldap_port').val() == "")
@@ -1051,6 +1070,10 @@ events.push(function() {
 
 	$('#ldap_extended_enabled').click(function () {
 		hideClass('extended', !this.checked);
+	});
+
+	$('#ldap_rfc2307').click(function () {
+		hideClass('ldap_rfc2307_userdn', !this.checked);
 	});
 
 	$('#radius_srvcs').on('change', function() {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9527
- [X] Ready for review

Adds checkbox to use full user DN for group membership search, i.e.
`(member=CN=Username,CN=Users,DC=example,DC=com)`
instead of 
`(member=Username)`