### PR TITLE
Improve gateways popup. Implements #885

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -778,13 +778,17 @@ foreach ($a_filter as $filteri => $filterent):
 							<?php endif; ?>
 						</td>
 						<td>
-							<?php if (isset($config['interfaces'][$filterent['gateway']]['descr'])):?>
-								<?=str_replace('_', '_<wbr>', htmlspecialchars($config['interfaces'][$filterent['gateway']]['descr']))?>
+							<?php if (isset($filterent['gateway'])): ?>
+								<span data-toggle="popover" data-trigger="hover focus" title="<?=gettext('Gateways details')?>" data-content="<?=gateway_info_popup($filterent['gateway'])?>" data-html="true">
 							<?php else: ?>
-							<span data-toggle="popover" data-trigger="hover focus" title="<?=gettext('Gateways details')?>" data-content="<?=gateway_info_popup($filterent['gateway'])?>" data-html="true">
-								<?=htmlspecialchars(pprint_port($filterent['gateway']))?>
-							</span>
+								<span>
 							<?php endif; ?>
+								<?php if (isset($config['interfaces'][$filterent['gateway']]['descr'])): ?>
+									<?=str_replace('_', '_<wbr>', htmlspecialchars($config['interfaces'][$filterent['gateway']]['descr']))?>
+								<?php else: ?>
+									<?=htmlspecialchars(pprint_port($filterent['gateway']))?>
+								<?php endif; ?>
+							</span>
 						</td>
 						<td>
 							<?php

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -1087,28 +1087,30 @@ function alias_info_popup($alias_id) {
 	return $content;
 }
 
-function gateway_info_popup($gateway) {
-	global $config;
-	init_config_arr(array('gateways', 'gateway_item'));
+function gateway_info_popup($showgw) {
+	global $config, $user_settings;
+
 	init_config_arr(array('gateways', 'gateway_group'));
+	$a_gateways = return_gateways_array();
+	$gateways_status = return_gateways_status(true);
 
 	$content = "";
-	$gateways = array();
+	$gws = array();
 	$bgdanger = array('force_down', 'down', 'highloss', 'highdelay');
 	$bgwarning = array('loss', 'delay');
 	$bgsuccess = array('none');
 	$bgcolor = "bg-info";
 
-	if (is_array($config['gateways']['gateway_item'])) {
-		foreach($config['gateways']['gateway_item'] as $i => $item) {
-			if ($item['name'] == $gateway) {
-				$gateways[] = $item['name'];
+	if (is_array($a_gateways)) {
+		foreach ($a_gateways as $i => $gateway) {
+			if ($gateway['name'] == $showgw) {
+				$gws[] = $gateway['name'];
 			}
 		}
 	}
 	if (is_array($config['gateways']['gateway_group'])) {
 		foreach($config['gateways']['gateway_group'] as $gwgroup) {
-			if ($gwgroup['name'] == $gateway) {
+			if ($gwgroup['name'] == $showgw) {
 				foreach ($gwgroup['item'] as $member) {
 					$membersplit = explode("|", $member);
 					$gateways[] = $membersplit[0];
@@ -1117,8 +1119,7 @@ function gateway_info_popup($gateway) {
 		}
 	}
 
-	if (!empty($gateways)) {
-		$gateways_status = return_gateways_status(true);
+	if (!empty($gws)) {
 		$content .= "<table>\n";
 		$content .= "<thead>\n";
 		$content .= "<tr>\n";
@@ -1126,7 +1127,7 @@ function gateway_info_popup($gateway) {
 		$content .= "<th style='padding-left: 10px;'>" . gettext("Gateway") . "</th></tr>\n";
 		$content .= "</thead>\n";
 		$content .= "<tbody>\n";
-		foreach ($gateways as $gw) {
+		foreach ($gws as $gw) {
 			foreach ($gateways_status as $gwstatus) {
 				if ($gwstatus['name'] == $gw) {
 					if (in_array($gwstatus['status'], $bgdanger)) {
@@ -1155,6 +1156,8 @@ function gateway_info_popup($gateway) {
 		}
 		$content .= "</tbody>\n";
 		$content .= "<table>\n";
+	} else {
+		return;
 	}
 
 	return $content;


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/885
- [X] Ready for review

Improved:
- Now uses `return_gateways_array()` to correctly show default gateway
- Does not show empty popup
- Uses `disablealiaspopupdetail` config option (maybe not needed?)