### PR TITLE
Allow to select EoIP protocol. Implements #10698

### DIFF
--- a/src/usr/local/www/firewall_rules_edit.php
+++ b/src/usr/local/www/firewall_rules_edit.php
@@ -1356,6 +1356,7 @@ $section->addInput(new Form_Select(
 		'esp' => 'ESP',
 		'ah' => 'AH',
 		'gre' => 'GRE',
+		'etherip' => 'EoIP',
 		'ipv6' => 'IPV6',
 		'igmp' => 'IGMP',
 		'pim' => 'PIM',


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10698
- [X] Ready for review

Allow to select EoIP (97 or etherip in FreeBSD) protocol in the Protocol drop-down menu
It's used by many wireless controllers.

See https://tools.ietf.org/html/rfc3378