### PR TITLE
Support dynamic interface address for 1:1 NAT. Implements #7705

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -1965,7 +1965,13 @@ function filter_nat_rules_generate() {
 
 			$sn = "";
 			$sn1 = "";
-			$target = alias_expand($rule['external']);
+			if (is_ipaddr($rule['external'])) {
+				$target = $rule['external'];
+			} else {
+				$tmprule = array();
+				$tmprule['external']['network'] = $rule['external'];
+				$target = filter_generate_address($tmprule, 'external');
+			}
 			if (!$target) {
 				$natrules .= "# Unresolvable alias {$rule['target']}\n";
 				continue;               /* unresolvable alias */

--- a/src/usr/local/www/firewall_nat_1to1.php
+++ b/src/usr/local/www/firewall_nat_1to1.php
@@ -40,6 +40,14 @@ require_once("shaper.inc");
 init_config_arr(array('nat', 'onetoone'));
 $a_1to1 = &$config['nat']['onetoone'];
 
+$specialsrcdst = explode(" ", "any pptp pppoe l2tp openvpn");
+$ifdisp = get_configured_interface_with_descr();
+
+foreach ($ifdisp as $kif => $kdescr) {
+	$specialsrcdst[] = "{$kif}";
+	$specialsrcdst[] = "{$kif}ip";
+}
+
 /* update rule order, POST[rule] is an array of ordered IDs */
 if (array_key_exists('order-store', $_POST)) {
 	if (is_array($_POST['rule']) && !empty($_POST['rule'])) {
@@ -196,8 +204,11 @@ display_top_tabs($tab_array);
 						<td>
 <?php
 					$source_net = pprint_address($natent['source']);
-					$source_cidr = strstr($source_net, '/');
-					echo $natent['external'] . $source_cidr;
+					if (is_specialnet($natent['external'])) {
+						echo $specialnets[$natent['external']];
+					} else {
+						echo $natent['external'] . strstr($source_net, '/');
+					}
 ?>
 						</td>
 						<td>


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/7705
- [X] Ready for review

Allows to use dynamic interface address (like 'WAN address') for 1:1 NAT
Currently IPv4-only