### PR TITLE
RA lifetime input validation. Fixes #10709

### DIFF
--- a/src/usr/local/www/services_router_advertisements.php
+++ b/src/usr/local/www/services_router_advertisements.php
@@ -196,6 +196,13 @@ if ($_POST['save']) {
 	if ($_POST['raadvdefaultlifetime'] && (($_POST['raadvdefaultlifetime'] < 1) || ($_POST['raadvdefaultlifetime'] > 9000))) {
 		$input_errors[] = gettext("Router lifetime must be an integer between 1 and 9000.");
 	}
+	if (($_POST['ravalidlifetime'] && $_POST['rapreferredlifetime'] &&
+	    ($_POST['ravalidlifetime'] < $_POST['rapreferredlifetime'])) ||
+	    ($_POST['ravalidlifetime'] && empty($_POST['rapreffedlifetime']) &&
+	    ($_POST['ravalidlifetime'] < 14400)) || (empty($_POST['ravalidlifetime']) &&
+	    $_POST['rapreferredlifetime'] && ($_POST['rapreferredlifetime'] > 86400))) { 
+		$input_errors[] = gettext("Default valid lifetime must be greater than Default preferred lifetime.");
+	}
 
 	if (!$input_errors) {
 		if (!is_array($config['dhcpdv6'])) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10709
- [X] Ready for review

the user interface allows the `Default valid lifetime` field to be set to a lower value than `Default preferred lifetime` field. When this is done, radvd will not start, due to
`AdvValidLifeTime must be greater than AdvPreferredLifetime in /var/etc/radvd.conf, line 18`