### PR TITLE
L2TP empty secret fix. Issue #10710

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -389,7 +389,7 @@ l2tps:
 	set link enable incoming
 
 EOD;
-			if (isset($l2tpcfg['secret'])) {
+			if (!empty($l2tpcfg['secret'])) {
 				$secret = str_replace('"', '\"', $l2tpcfg['secret']);
 				$mpdconf .=<<<EOD
 	set l2tp secret "{$secret}"


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10710
- [X] Ready for review

If you set the L2TP shared secret and then remove it,
an empty value will still be used in mpd.conf:
```
# grep secret var/etc/l2tp-vpn/mpd.conf 
    set l2tp secret "" 
```