### PR TITLE
Setup Wizard DNS IPv6 support. Fixes #10720

### DIFF
--- a/src/usr/local/www/wizards/setup_wizard.xml
+++ b/src/usr/local/www/wizards/setup_wizard.xml
@@ -108,7 +108,7 @@
 			<!-- we must unset the fields because this is an array. -->
 			<unsetfield>yes</unsetfield>
 			<arraynum>0</arraynum>
-			<validate>^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$</validate>
+			<validate>^(?:((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))|([0-9a-f:]{3,39}|[0-9a-f:]{2,30}[0-9.]{7,15}))$</validate>
 			<message>Primary DNS Server field is invalid</message>
 		</field>
 		<field>
@@ -116,7 +116,7 @@
 			<type>input</type>
 			<bindstofield>system->dnsserver</bindstofield>
 			<arraynum>1</arraynum>
-			<validate>^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$</validate>
+			<validate>^(?:((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))|([0-9a-f:]{3,39}|[0-9a-f:]{2,30}[0-9.]{7,15}))$</validate>
 			<message>Secondary DNS Server field is invalid</message>
 		</field>
 		<field>


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10720
- [X] Ready for review

Allows to use DNS IPv6 addresses in Setup Wizard
it also supports RFC4291 par 2.2.2 IPv6 address format (i.e. `64:ff9b::10.11.12.1`)