### PR TITLE
Disable "Hardware Checksum Offloading" if VTNET is detected. Implements #10723

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -541,7 +541,10 @@ function hardware_offloading_applyflags($iface) {
 	$flags_off = 0;
 	$options = pfSense_get_interface_addresses($iface);
 
-	if (isset($config['system']['disablechecksumoffloading'])) {
+	/* disable hardware checksum offloading for VirtIO network drivers,
+	 * see https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=165059 */
+	if (isset($config['system']['disablechecksumoffloading']) ||
+	    stristr($iface, "vtnet")) { 
 		if (isset($options['encaps']['txcsum'])) {
 			$flags_off |= IFCAP_TXCSUM;
 		}


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10723
- [X] Ready for review

It would be better to disable "Hardware Checksum Offloading" on first boot if a VM system is detected