### PR TITLE
Limiter default bw type in Mbit/s. Implements #10727

### DIFF
--- a/src/etc/inc/shaper.inc
+++ b/src/etc/inc/shaper.inc
@@ -4251,7 +4251,7 @@ EOD;
 
 		// If there are no bandwidths defined, make a blank one for convenience
 		if (empty($bandwidth)) {
-			$bandwidth = array(0 => array('bw' => '', 'bwscale' => 'Kb', 'bwsched' => 'none'));
+			$bandwidth = array(0 => array('bw' => '', 'bwscale' => 'Mb', 'bwsched' => 'none'));
 		}
 
 		if (is_array($bandwidth)) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10727
- [X] Ready for review

https://forum.netgate.com/topic/154812/limiter-bandwidth-type-default:
> Just a suggestion, might make the default Mbits not kBits. Just took 300 customers down for a 1/2 hour when I implemented a limiter @ 600kbps instead of 600mbps which immediately locked up the GUI and took a truck roll to a remote site to reboot. I know it was bonehead, was in a hurry. I should have reviewed the limiter in Diagnostics before implementing the rule and I may have caught the error, but still...

It seems reasonable for today.