### PR TITLE
Add Google Stadia ports to traffic shaper wizard

### DIFF
--- a/src/etc/inc/wizardapp.inc
+++ b/src/etc/inc/wizardapp.inc
@@ -94,6 +94,11 @@ $gamesplist['gamesforwindowslive'] = array();
 	$gamesplist['gamesforwindowslive'][] = array('Games4WinLive-2', 'udp', '3074', '3074', 'both');
 	$gamesplist['gamesforwindowslive'][] = array('Games4WinLive-3', 'tcp', '3074', '3074', 'both');
 
+$gamesplist['googlestadia'] = array();
+	/* Google Stadia */
+	$gamesplist['googlestadia'][] = array('google-stadia-UDP-1', 'udp', '44700', '44899', 'both');
+	$gamesplist['googlestadia'][] = array('google-stadia-TCP-1', 'tcp', '44700', '44899', 'both');
+
 /* Games */
 
 $gamesplist['arma2'] = array();

--- a/src/usr/local/www/wizards/traffic_shaper_wizard_dedicated.xml
+++ b/src/usr/local/www/wizards/traffic_shaper_wizard_dedicated.xml
@@ -474,6 +474,12 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;xboxconsoles</bindstofield>
 			</field>
 			<field>
+				<name>GoogleStadia</name>
+				<type>checkbox</type>
+				<typehint>Google Stadia</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;googlestadia</bindstofield>
+			</field>
+			<field>
 				<name>Enable/Disable specific games</name>
 				<type>listtopic</type>
 			</field>

--- a/src/usr/local/www/wizards/traffic_shaper_wizard_multi_all.xml
+++ b/src/usr/local/www/wizards/traffic_shaper_wizard_multi_all.xml
@@ -480,6 +480,12 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;xboxconsoles</bindstofield>
 			</field>
 			<field>
+				<name>GoogleStadia</name>
+				<type>checkbox</type>
+				<typehint>Google Stadia</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;googlestadia</bindstofield>
+			</field>
+			<field>
 				<name>Enable/Disable specific games</name>
 				<type>listtopic</type>
 			</field>


### PR DESCRIPTION
 - According to https://support.google.com/stadia/answer/9595943?hl=en-CA Google Stadia uses "traffic on ports in the range 44700–44899 (TCP and UDP)"
 - https://redmine.pfsense.org/issues/10743

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10743
- [ ] Ready for review