### PR TITLE
IPsec Mobile RADIUS Group authentication. Implements #10748

### DIFF
--- a/src/etc/inc/ipsec.auth-user.php
+++ b/src/etc/inc/ipsec.auth-user.php
@@ -34,6 +34,7 @@ require_once("config.inc");
 require_once("auth.inc");
 require_once("interfaces.inc");
 
+global $config;
 
 /* setup syslog logging */
 openlog("charon", LOG_ODELAY, LOG_AUTH);
@@ -78,6 +79,12 @@ if (($strictusercn === true) && ($common_name != $username)) {
 }
 
 $attributes = array("nas_identifier" => "xauthIPsec");
+if (($config['ipsec']['client']['group_source'] == 'enabled') &&
+    !empty($config['ipsec']['client']['auth_groups'])) {
+	$ipsec_groups = explode(",", ($config['ipsec']['client']['auth_groups']));
+} else { 
+	$ipsec_groups = '';
+}
 foreach ($authmodes as $authmode) {
 	$authcfg = auth_get_authserver($authmode);
 	if (!$authcfg && $authmode != "Local Database") {
@@ -86,9 +93,11 @@ foreach ($authmodes as $authmode) {
 
 	$authenticated = authenticate_user($username, $password, $authcfg, $attributes);
 	if ($authenticated == true) {
+		$userGroups = getUserGroups($username, $authcfg, array());
 		if ($authmode == "Local Database") {
 			$user = getUserEntry($username);
-			if (!is_array($user) || !userHasPrivilege($user, "user-ipsec-xauth-dialin")) {
+			if (!is_array($user) || !userHasPrivilege($user, "user-ipsec-xauth-dialin") ||
+			    (!empty($ipsec_groups) && (count(array_intersect($userGroups, $ipsec_groups)) == 0))) {
 				$authenticated = false;
 				syslog(LOG_WARNING, "user '{$username}' cannot authenticate through IPsec since the required privileges are missing.");
 				continue;

--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -1758,7 +1758,7 @@ function ipsec_setup_routes($interface, $family, $sourcehost, $duplicates) {
  *   details.
  ******/
 function ipsec_setup_authentication(& $ph1ent, & $conn) {
-	global $rgmap, $ipsec_swanctl_dirs;
+	global $rgmap, $ipsec_swanctl_dirs, $config;
 	$local = array();
 	$remote = array();
 	$remote2 = array();
@@ -1812,6 +1812,10 @@ function ipsec_setup_authentication(& $ph1ent, & $conn) {
 				$remote['eap_id'] = "%any";
 			} else {
 				$local['auth'] = "eap-radius";
+			}
+			if (($config['ipsec']['client']['group_source'] == 'enabled') &&
+			    !empty($config['ipsec']['client']['auth_groups'])) {
+				$remote['groups'] = $config['ipsec']['client']['auth_groups'];
 			}
 			$remote['auth'] = "eap-radius";
 			break;


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10748
- [X] Ready for review

Allows to limit which users have VPN access via groups (RADIUS `Class` attribute) in the WebGUI
see https://wiki.strongswan.org/projects/strongswan/wiki/EAPRadius#Group-selection
and https://wiki.strongswan.org/projects/strongswan/wiki/Fromipsecconf:
ipsec.conf format | swanctl.conf format
-- | --
rightgroups=`<group list>` | connections.<conn>.remote<suffix>.groups=`<group list>`




