### PR TITLE
Active voucher restore from backup. Implements #3128

### DIFF
--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -50,7 +50,7 @@ function listtags() {
 		'pages', 'pipe', 'radnsserver', 'roll', 'route', 'row', 'rrddatafile', 'rule',
 		'schedule', 'service', 'servernat', 'servers',
 		'serversdisabled', 'shellcmd', 'staticmap', 'subqueue', 'switch', 'swport',
-		'timerange', 'tunnel', 'user', 'vip', 'virtual_server', 'vlan', 'vlangroup',
+		'timerange', 'tunnel', 'user', 'vip', 'virtual_server', 'vlan', 'vlangroup', 'voucherdbfile',
 		'winsserver', 'wolentry', 'widget'
 	);
 	return array_flip($ret);

--- a/src/etc/inc/xmlreader.inc
+++ b/src/etc/inc/xmlreader.inc
@@ -50,7 +50,7 @@ function listtags() {
 		'pages', 'pipe', 'radnsserver', 'roll', 'route', 'row', 'rrddatafile', 'rule',
 		'schedule', 'service', 'servernat', 'servers',
 		'serversdisabled', 'shellcmd', 'staticmap', 'subqueue', 'switch', 'swport',
-		'timerange', 'tunnel', 'user', 'vip', 'virtual_server', 'vlan', 'vlangroup',
+		'timerange', 'tunnel', 'user', 'vip', 'virtual_server', 'vlan', 'vlangroup', 'voucherdbfile',
 		'winsserver', 'wolentry', 'widget'
 	);
 	return array_flip($ret);


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/3128
- [X] Ready for review

Backup/restore `voucher_{$cpzone}_used_$roll.db` and `voucher_{$cpzone}_active_$roll.db` files (zipped and base64 encoded)
`rrd_data_xml()` and `restore_rrddata()` were used as templates


TODO:
same for `captiveportal{$cpzone}.db` and `captiveportal_usedmacs_{$cpzone}.db`