### PR TITLE
Add build_mask_rules for scheduler

### DIFF
--- a/src/etc/inc/shaper.inc
+++ b/src/etc/inc/shaper.inc
@@ -4134,7 +4134,11 @@ class dnpipe_class extends dummynet_class {
 		}
 		$selectedScheduler = getSchedulers()[$this->getScheduler()];
 		if ($selectedScheduler) {
-			$pfq_rule .= "\nsched ". $this->GetNumber() . " config pipe " . $this->GetNumber() . " " . FormatParameters($selectedScheduler["parameter_format"], $this->GetSchedulerParameters());
+			//$pfq_rule .= "\nsched ". $this->GetNumber() . " config pipe " . $this->GetNumber() . " " . FormatParameters($selectedScheduler["parameter_format"], $this->GetSchedulerParameters());			
+			$pfq_rule .= "\nsched ". $this->GetNumber() . " config ";
+			$pfq_rule .= "pipe ". $this->GetNumber();
+			$this->build_mask_rules($pfq_rule);
+			$pfq_rule .= " " . FormatParameters($selectedScheduler["parameter_format"], $this->GetSchedulerParameters());			
 			if ($selectedScheduler["ecn"]) {
 				if ($this->getECN() == 'on') {
 					$pfq_rule .= ' ecn';


### PR DESCRIPTION
Using the GUI , the mask options didn't apply to the sched limiter.

from [ipfw man](https://www.freebsd.org/cgi/man.cgi?ipfw(8))

_The SCHED_MASK is used to assign flows to one or more scheduler instances, one for each value of the packet's 5-tuple after applying SCHED_MASK.
As an example, using `src  ip 0xffffff00` creates one instance for each / 24 destination subnet._

_The FLOW_MASK, together with the SCHED_MASK, is used to split packets
into flows.As an example, using `src  ip 0x000000ff` together with the
previous SCHED_MASK makes a flow for each individual source address.
Inturn, flows for each / 24 subnet will be sent to the same scheduler instance._


before:
`sched 7 config pipe 7 type fq_codel target 5ms interval 100ms quantum 300 limit 20480 flows 65535 noecn`

after:
`sched 7 config pipe 7 mask dst-ip6 /128 dst-ip 0xffffffff type fq_codel target 5ms interval 100ms quantum 300 limit 20480 flows 65535 noecn`

