### PR TITLE
Correct QLogic interface name in ALTQ-capable list. Issue #10594

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -6715,7 +6715,7 @@ function is_altq_capable($int) {
 			"bfe", "bge", "bnxt", "bridge", "cas", "cpsw", "cxl", "dc", "de",
 			"ed", "em", "ep", "epair", "et", "fxp", "gem", "hme", "hn",
 			"igb", "ix", "jme", "l2tp", "le", "lem", "msk", "mxge", "my",
-			"ndis", "nfe", "ng", "nge", "npe", "nve", "qlxgb", "ovpnc", 
+			"ndis", "nfe", "ng", "nge", "npe", "nve", "ql", "ovpnc", 
 			"ovpns", "ppp", "pppoe", "pptp", "re", "rl", "sf", "sge",
 			"sis", "sk", "ste", "stge", "ti", "tun", "txp", "udav",
 			"ural", "vge", "vlan", "vmx", "vr", "vte", "vtnet", "xl");


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10594
- [X] Ready for review

Correct interface name is `qlX`,
see https://forum.netgate.com/topic/155582/hp-qlogic-nc523sfp-not-functional-by-default for example