### PR TITLE
Update wizardapp.inc

### DIFF
--- a/src/etc/inc/wizardapp.inc
+++ b/src/etc/inc/wizardapp.inc
@@ -40,22 +40,21 @@ $gamesplist['playstationconsoles'] = array();
 	$gamesplist['playstationconsoles'][] = array('PS-RemotePlay', 'tcp', '9293', '9293', 'both');
 
 $gamesplist['wiiconsoles'] = array();
-	/* XBox Consoles */
+	/* Wii Consoles */
 	$gamesplist['wiiconsoles'][] = array('Wii-Consoles-TCP-1', 'tcp', '6667', '6667', 'both');
 	$gamesplist['wiiconsoles'][] = array('Wii-Consoles-TCP-2', 'tcp', '12400', '12400', 'both');
 	$gamesplist['wiiconsoles'][] = array('Wii-Consoles-TCP-3', 'tcp', '28910', '28910', 'both');
 	$gamesplist['wiiconsoles'][] = array('Wii-Consoles-TCP-4', 'tcp', '29900', '29901', 'both');
 	$gamesplist['wiiconsoles'][] = array('Wii-Consoles-TCP-5', 'tcp', '29920', '29920', 'both');
 
-$gamesplist['xboxconsoles'] = array();
-	/* XBox Consoles */
-	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-UDP-1', 'udp', '88', '88', 'both');
-	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-UDP-2', 'udp', '3074', '3074', 'both');
-	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-TCP-1', 'tcp', '3074', '3074', 'both');
-	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-TCP-2', 'tcp', '3659', '3659', 'both');
-	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-TCP-3', 'tcp', '500', '500', 'both');
-	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-TCP-4', 'tcp', '3544', '3544', 'both');
-	$gamesplist['xboxconsoles'][] = array('xbox-Consoles-TCP-5', 'tcp', '4500', '4500', 'both');
+$gamesplist['xboxlive'] = array();
+	/* XBOX Live */
+	$gamesplist['xboxlive'][] = array('XBOX-Live-UDP-1', 'udp', '88', '88', 'both');
+	$gamesplist['xboxlive'][] = array('XBOX-Live-UDP-2', 'udp', '3074', '3074', 'both');
+	$gamesplist['xboxlive'][] = array('XBOX-Live-TCP-2', 'tcp', '3074', '3074', 'both');
+	$gamesplist['xboxlive'][] = array('XBOX-Live-UDP-3', 'udp', '500', '500', 'both');
+	$gamesplist['xboxlive'][] = array('XBOX-Live-UDP-4', 'udp', '3544', '3544', 'both');
+	$gamesplist['xboxlive'][] = array('XBOX-Live-UDP-5', 'udp', '4500', '4500', 'both');
 
 $gamesplist['battlenet'] = array();
 	/* Blizzard Publishing games */
@@ -87,12 +86,6 @@ $gamesplist['steam'] = array();
 	$gamesplist['steam'][] = array('Steam-1', 'udp', '4380', '4380', 'both');
 	$gamesplist['steam'][] = array('Steam-2', 'udp', '1200', '1200', 'both');
 	$gamesplist['steam'][] = array('Steam-voice', 'udp', '3478', '3480', 'both');
-
-$gamesplist['gamesforwindowslive'] = array();
-	/* Games for Windows Live */
-	$gamesplist['gamesforwindowslive'][] = array('Games4WinLive-1', 'udp', '88', '88', 'both');
-	$gamesplist['gamesforwindowslive'][] = array('Games4WinLive-2', 'udp', '3074', '3074', 'both');
-	$gamesplist['gamesforwindowslive'][] = array('Games4WinLive-3', 'tcp', '3074', '3074', 'both');
 
 $gamesplist['googlestadia'] = array();
 	/* Google Stadia */

--- a/src/usr/local/www/wizards/traffic_shaper_wizard_dedicated.xml
+++ b/src/usr/local/www/wizards/traffic_shaper_wizard_dedicated.xml
@@ -423,7 +423,7 @@
 				<type>checkbox</type>
 				<typehint>Prioritize network gaming traffic</typehint>
 				<description>This will raise the priority of gaming traffic to higher than most traffic.</description>
-				<enablefields>BattleNET,EAOrigin,GameForWindowsLive,PlayStationConsoles,Steam,WiiConsoles,XboxConsoles,ARMA2,ARMA3,Battlefield2,Battlefield3,BattlefieldBC2,Borderlands,CallOfDuty,Counterstrike,Crysis2,Crysis3,DeltaForce,DeadSpace2,DeadSpace3,Dirt3,DOOM3,DragonAge2,EmpireEarth,EveOnline,Everquest,Everquest2,FarCry,FarCry2,FarCry3,GunZOnline,HalfLife,LeagueofLegends,Lineage2,MassEffect3,MechwarriorOnline,Minecraft,OperationFlashpointDR,PlanetSide,PlanetSide2,QuakeIII,QuakeIV,StarWarsTOR,TigerWoods2004PS2,TribesAscend,UnrealTournament,WolfensteinEnemyTerritory,WorldOfWarcraft</enablefields>
+				<enablefields>BattleNET,EAOrigin,PlayStationConsoles,Steam,WiiConsoles,XboxLive,ARMA2,ARMA3,Battlefield2,Battlefield3,BattlefieldBC2,Borderlands,CallOfDuty,Counterstrike,Crysis2,Crysis3,DeltaForce,DeadSpace2,DeadSpace3,Dirt3,DOOM3,DragonAge2,EmpireEarth,EveOnline,Everquest,Everquest2,FarCry,FarCry2,FarCry3,GunZOnline,HalfLife,LeagueofLegends,Lineage2,MassEffect3,MechwarriorOnline,Minecraft,OperationFlashpointDR,PlanetSide,PlanetSide2,QuakeIII,QuakeIV,StarWarsTOR,TigerWoods2004PS2,TribesAscend,UnrealTournament,WolfensteinEnemyTerritory,WorldOfWarcraft</enablefields>
 				<donotdisable>true</donotdisable>
 				<bindstofield>ezshaper-&gt;step6-&gt;enable</bindstofield>
 			</field>
@@ -442,12 +442,6 @@
 				<type>checkbox</type>
 				<typehint>EA Origin Client - Some PC games by EA use this.</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;eaorigin</bindstofield>
-			</field>
-				<field>
-				<name>GameForWindowsLive</name>
-				<type>checkbox</type>
-				<typehint>Games for Windows Live</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;gamesforwindowslive</bindstofield>
 			</field>
 			<field>
 				<name>PlayStationConsoles</name>
@@ -468,10 +462,10 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;wiiconsoles</bindstofield>
 			</field>
 			<field>
-				<name>XboxConsoles</name>
+				<name>XboxLive</name>
 				<type>checkbox</type>
-				<typehint>Xbox Consoles - Xbox 360 and Xbox One</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;xboxconsoles</bindstofield>
+				<typehint>Xbox Live Services - Xbox 360, Xbox One, Windows 10 Store Games</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;xboxlive</bindstofield>
 			</field>
 			<field>
 				<name>GoogleStadia</name>

--- a/src/usr/local/www/wizards/traffic_shaper_wizard_multi_all.xml
+++ b/src/usr/local/www/wizards/traffic_shaper_wizard_multi_all.xml
@@ -429,7 +429,7 @@
 				<type>checkbox</type>
 				<typehint>Prioritize network gaming traffic</typehint>
 				<description>This will raise the priority of gaming traffic to higher than most traffic.</description>
-				<enablefields>BattleNET,EAOrigin,GameForWindowsLive,PlayStationConsoles,Steam,WiiConsoles,XboxConsoles,ARMA2,ARMA3,Battlefield2,Battlefield3,BattlefieldBC2,Borderlands,CallOfDuty,Counterstrike,Crysis2,Crysis3,DeltaForce,DeadSpace2,DeadSpace3,Dirt3,DOOM3,DragonAge2,EmpireEarth,EveOnline,Everquest,Everquest2,FarCry,FarCry2,FarCry3,GunZOnline,HalfLife,LeagueofLegends,Lineage2,MassEffect3,MechwarriorOnline,Minecraft,OperationFlashpointDR,PlanetSide,PlanetSide2,QuakeIII,QuakeIV,StarWarsTOR,TigerWoods2004PS2,TribesAscend,UnrealTournament,WolfensteinEnemyTerritory,WorldOfWarcraft</enablefields>
+				<enablefields>BattleNET,EAOrigin,PlayStationConsoles,Steam,WiiConsoles,XboxLive,ARMA2,ARMA3,Battlefield2,Battlefield3,BattlefieldBC2,Borderlands,CallOfDuty,Counterstrike,Crysis2,Crysis3,DeltaForce,DeadSpace2,DeadSpace3,Dirt3,DOOM3,DragonAge2,EmpireEarth,EveOnline,Everquest,Everquest2,FarCry,FarCry2,FarCry3,GunZOnline,HalfLife,LeagueofLegends,Lineage2,MassEffect3,MechwarriorOnline,Minecraft,OperationFlashpointDR,PlanetSide,PlanetSide2,QuakeIII,QuakeIV,StarWarsTOR,TigerWoods2004PS2,TribesAscend,UnrealTournament,WolfensteinEnemyTerritory,WorldOfWarcraft</enablefields>
 				<donotdisable>true</donotdisable>
 				<bindstofield>ezshaper-&gt;step6-&gt;enable</bindstofield>
 			</field>
@@ -448,12 +448,6 @@
 				<type>checkbox</type>
 				<typehint>EA Origin Client - Some PC games by EA use this.</typehint>
 				<bindstofield>ezshaper-&gt;step6-&gt;eaorigin</bindstofield>
-			</field>
-				<field>
-				<name>GameForWindowsLive</name>
-				<type>checkbox</type>
-				<typehint>Games for Windows Live</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;gamesforwindowslive</bindstofield>
 			</field>
 			<field>
 				<name>PlayStationConsoles</name>
@@ -474,10 +468,10 @@
 				<bindstofield>ezshaper-&gt;step6-&gt;wiiconsoles</bindstofield>
 			</field>
 			<field>
-				<name>XboxConsoles</name>
+				<name>XboxLive</name>
 				<type>checkbox</type>
-				<typehint>Xbox Consoles - Xbox 360 and Xbox One</typehint>
-				<bindstofield>ezshaper-&gt;step6-&gt;xboxconsoles</bindstofield>
+				<typehint>Xbox Live Services - Xbox 360, Xbox One, Windows 10 Store Games</typehint>
+				<bindstofield>ezshaper-&gt;step6-&gt;xboxlive</bindstofield>
 			</field>
 			<field>
 				<name>GoogleStadia</name>


### PR DESCRIPTION
These are the ports needed for any xbox live platform. 
https://support.microsoft.com/en-us/help/4026770/xbox-open-these-network-ports-for-xbox-one

Fixed some ports using improper protocol
Fixed naming comment for Wii
removed ports that werent specific to xbox at all
removed gamesforwindowslive since it is covered by xbox live and afaik uses same servers and pretty much dead

- [x] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [x] Ready for review