### PR TITLE
ECL GPT partitions support. Fixes #9097

### DIFF
--- a/src/etc/ecl.php
+++ b/src/etc/ecl.php
@@ -40,7 +40,7 @@ function get_swap_disks() {
 
 function get_disk_slices($disk) {
 	global $g, $debug;
-	$slices = glob("/dev/" . $disk . "s*");
+	$slices = glob("/dev/" . $disk . "[ps]*");
 	$slices = str_replace("/dev/", "", $slices);
 	return $slices;
 }


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9097
- [X] Ready for review

GPT partitions show up as `da1p1`, not `da1s1`