### PR TITLE
Restart choparp on VIP change. Fixes #7379

### DIFF
--- a/src/usr/local/www/firewall_virtual_ip.php
+++ b/src/usr/local/www/firewall_virtual_ip.php
@@ -64,6 +64,16 @@ if ($_POST['apply']) {
 					default:
 						break;
 				}
+				/* restart choparp on VIP change, see #7379 */
+				if ($a_vip[$vid]['mode'] != 'proxyarp') {
+					foreach ($a_vip as $avip) { 
+						if (($avip['interface'] == $a_vip[$vid]['interface']) &&
+						    ($avip['mode'] == 'proxyarp')) {
+							interface_proxyarp_configure($a_vip[$vid]['interface']);
+							break;
+						}
+					}
+				}
 			}
 		}
 		@unlink("{$g['tmp_path']}/.firewall_virtual_ip.apply");


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/7379
- [X] Ready for review

Issue:
> There are several PoxyARP VIPs. Open one of them to edit and change the type to an Alias or Another (CARP not checked). choparp is dying, but not starting again.

This PR fixes it