### PR TITLE
Virtual IPs interface type/mode check. Issue #7132

### DIFF
--- a/src/usr/local/www/firewall_virtual_ip_edit.php
+++ b/src/usr/local/www/firewall_virtual_ip_edit.php
@@ -96,6 +96,14 @@ if ($_POST['save']) {
 		$_POST['subnet'] = trim($_POST['subnet']);
 	}
 
+	if (is_pseudo_interface(convert_friendly_interface_to_real_interface_name($_POST['interface']))) {
+		if ($_POST['mode'] == 'ipalias') {
+			$input_errors[] = gettext("The interface chosen for the VIP does not support IP Alias mode.");
+		} elseif ($_POST['mode'] == 'proxyarp') {
+			$input_errors[] = gettext("The interface chosen for the VIP does not support Proxy ARP mode.");
+		}
+	}
+
 	if ($_POST['subnet']) {
 		if (!is_ipaddr($_POST['subnet'])) {
 			$input_errors[] = gettext("A valid IP address must be specified.");


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/7132
- [X] Ready for review

All pseudo interfaces (ppp/pppoe/l2tp/ipsec/ovpn/pptp) need a destination IP address for alias creation, i.e.:
```
# ifconfig ipsec1000 inet 10.89.89.89/32 alias 
ifconfig: ioctl (SIOCAIFADDR): Destination address required
```

And it's not supported by `choparp` daemon, as it requires interface with a MAC address:
```
choparp ovpns1 auto 10.89.89.89/32
ovpns1: not found
```

