### PR TITLE
Toggle VLAN_HWTSO when TSO is toggled in the GUI. Fixes #10836

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -571,8 +571,10 @@ function hardware_offloading_applyflags($iface) {
 
 	if (isset($config['system']['disablesegmentationoffloading'])) {
 		$flags_off |= IFCAP_TSO;
+		$flags_off |= IFCAP_VLAN_HWTSO;
 	} else if (isset($options['caps']['tso']) || isset($options['caps']['tso4']) || isset($options['caps']['tso6'])) {
 		$flags_on |= IFCAP_TSO;
+		$flags_on |= IFCAP_VLAN_HWTSO;
 	}
 
 	if (isset($config['system']['disablelargereceiveoffloading'])) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10836
- [X] Ready for review

The VLAN_HWTSO flag is not toggled when TSO is toggled in the GUI.

This PR fixes it.


p.s. maybe add extra checkbox on the System / Advanced / Networking ?..