### PR TITLE
Not destroying VTI interfaces when booting before creating a new one. Fixes #10842

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1505,7 +1505,7 @@ function interface_ipsec_vti_configure($ph1ent) {
 			continue;
 		}
 		// Create IPsec interface
-		if (!platform_booting() && does_interface_exist($ipsecif)) {
+		if (does_interface_exist($ipsecif)) {
 			mwexec("/sbin/ifconfig " . escapeshellarg($ipsecif) . " destroy", false);
 		}
 		mwexec("/sbin/ifconfig " . escapeshellarg($ipsecif) . " create reqid " . escapeshellarg($ipsecifnum), false);


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10842
- [X] Ready for review

During the booting process, we call interface_ipsec_vti_configure() from interfaces.inc multiple times :
- From interfaces_configures() (once)
- From vpn_ipsec_configure() (up to twice)
When create the VTI interface we destroy it beforehand if it exists AND the system is not booting. That results in interface creation attempts when it already exists. An error ensues :

`rc.bootup: The command '/sbin/ifconfig 'ipsec1000' create reqid '1000'' returned exit code '1', the output was 'ifconfig: create: bad value'`

And this command takes around 20s to return this error on our hardware which is a long time, especially during the booting process.