### PR TITLE
Fix array pass by reference in ipsec.auth-user.php

### DIFF
--- a/src/etc/inc/ipsec.auth-user.php
+++ b/src/etc/inc/ipsec.auth-user.php
@@ -93,7 +93,7 @@ foreach ($authmodes as $authmode) {
 
 	$authenticated = authenticate_user($username, $password, $authcfg, $attributes);
 	if ($authenticated == true) {
-		$userGroups = getUserGroups($username, $authcfg, array());
+		$userGroups = getUserGroups($username, $authcfg, $attributes = array());
 		if ($authmode == "Local Database") {
 			$user = getUserEntry($username);
 			if (!is_array($user) || !userHasPrivilege($user, "user-ipsec-xauth-dialin") ||


### PR DESCRIPTION
Fixes error: PHP Fatal error:  Uncaught Error: Cannot pass parameter 3 by reference in /etc/inc/ipsec.auth-user.php:95 on IPSec Xauth.

My first ever pull request, hopefully all is correct!