### PR TITLE
XML parser: stop using CDATA with invalid XML entities, fixes #10765

### DIFF
--- a/src/etc/inc/xmlparse.inc
+++ b/src/etc/inc/xmlparse.inc
@@ -128,10 +128,10 @@ function cData($parser, $data) {
 		}
 
 		if (is_string($ptr)) {
-			$ptr .= html_entity_decode($data);
+			$ptr .= htmlspecialchars_decode($data);
 		} else {
 			if (trim($data, " ") != "") {
-				$ptr = html_entity_decode($data);
+				$ptr = htmlspecialchars_decode($data);
 				$havedata++;
 			}
 		}
@@ -215,21 +215,6 @@ function parse_xml_config_raw($cffile, $rootobj, $isstring = "false") {
 	}
 }
 
-/* Return true if a field should be cdata encoded */
-function is_cdata_entity($ent) {
-	$cdata_fields = array(
-		'aclname', 'auth_pass', 'auth_prompt', 'auth_user', 'certca', 'certname', 'city', 'common_name',
-		'descr', 'detail', 'email', 'encryption_password', 'ldap_attr',
-		'ldap_authcn', 'ldap_basedn', 'ldap_basedomain', 'ldap_bind', 'ldapbinddn',
-		'ldapbindpass', 'ldap_extended_query', 'ldap_filter', 'ldap_pass', 'ldap_user',
-		'login_banner', 'organization', 'password', 'rangedescr', 'state', 'text',
-		'username', 'varusersusername', 'varuserspassword'
-	);
-
-	/* Check if the entity name starts with any of the strings above */
-	return preg_match('/(^' . implode('|^', $cdata_fields) . ')/', $ent) === 1;
-}
-
 function dump_xml_config_sub($arr, $indent) {
 
 	global $listtags;
@@ -263,10 +248,8 @@ function dump_xml_config_sub($arr, $indent) {
 						$xmlconfig .= str_repeat("\t", $indent);
 						if ((is_bool($cval) && $cval == true) || ($cval === "")) {
 							$xmlconfig .= "<$ent></$ent>\n";
-						} else if (is_cdata_entity($ent)) {
-							$xmlconfig .= "<$ent><![CDATA[" . htmlentities($cval) . "]]></$ent>\n";
 						} else {
-							$xmlconfig .= "<$ent>" . htmlentities($cval) . "</$ent>\n";
+							$xmlconfig .= "<$ent>" . htmlspecialchars($cval) . "</$ent>\n";
 						}
 					}
 				}
@@ -287,11 +270,7 @@ function dump_xml_config_sub($arr, $indent) {
 				$xmlconfig .= "<$ent></$ent>\n";
 			} else if (!is_bool($val)) {
 				$xmlconfig .= str_repeat("\t", $indent);
-				if (is_cdata_entity($ent)) {
-					$xmlconfig .= "<$ent><![CDATA[" . htmlentities($val) . "]]></$ent>\n";
-				} else {
-					$xmlconfig .= "<$ent>" . htmlentities($val) . "</$ent>\n";
-				}
+				$xmlconfig .= "<$ent>" . htmlspecialchars($val) . "</$ent>\n";
 			}
 		}
 	}


### PR DESCRIPTION
Hi @jim-p,

I have been looking further into this double-escaped ampersand issue and I propose the following patch.

It removes an old workaround, added in 2e6a43a13c449ae0c486989cb60fd47e9fe541f1, which resulted in invalid XML files where CDATA sections contained _HTML_ entities, some of which were invalid _XML_ entities (such as `ü` which was translated to `&uuml;`).

This was only a problem because the `htmlentities` function was used (which attempts to escape all characters that have matching _HTML_ entities) instead of `htmlspecialchars` (which only converts the 5 characters that have valid _XML_ entities).

 By switching to `htmlspecialchars`, we ensure that the resulting XML will be valid no matter what special characters are used inside any tag, removing the need to maintain a list of special tags.


I initially meant to only remove the double escaping because text inside CDATA doesn't need to be escaped so I wrote https://github.com/sbraz/pfsense/commit/95d37e77ca42a1aab49ad3e1878e25991b860e45. But after understanding why CDATA was used in the first place, I thought it best to completely get rid of it and simplify the code while making it future-proof (no need to maintain a list of tags containing special characters).

- [X] Redmine Issue: https://redmine.pfsense.org/issues/10765
- [X] Ready for review