### PR TITLE
Delete Captive Portal Zone related files. Fixes #10891

### DIFF
--- a/src/usr/local/www/services_captiveportal_zones.php
+++ b/src/usr/local/www/services_captiveportal_zones.php
@@ -50,6 +50,9 @@ if ($_POST['act'] == "del" && !empty($_POST['zone'])) {
 		if (isset($config['voucher'][$cpzone])) {
 			unset($config['voucher'][$cpzone]);
 		}
+		unlink_if_exists("/var/db/captiveportal{$cpzone}.db");
+		unlink_if_exists("/var/db/captiveportal_usedmacs_{$cpzone}.db");
+		unlink_if_exists("/var/db/voucher_{$cpzone}_*.db");
 		write_config();
 	}
 	header("Location: services_captiveportal_zones.php");


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10891
- [X] Ready for review

Remove Captive Portal Zone related files on deleting it in WebGUI:
```
/var/db/captiveportal<zone>.db
/var/db/captiveportal_usedmacs_<zone>.db
/var/db/voucher_<zone>_active_X.db
/var/db/voucher_<zone>_used_X.db
```