### PR TITLE
Captive Portal MAC masking. Implements #2424

### DIFF
--- a/src/usr/local/www/services_captiveportal_mac_edit.php
+++ b/src/usr/local/www/services_captiveportal_mac_edit.php
@@ -90,7 +90,9 @@ if ($_POST['save']) {
 
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
-	$_POST['mac'] = strtolower(str_replace("-", ":", $_POST['mac']));
+	$macfull = explode('/', $_POST['mac']);
+	$macmask = $macfull[1] ? $macfull[1] : false; 
+	$_POST['mac'] = strtolower(str_replace("-", ":", $macfull[0]));
 
 	if ($_POST['mac']) {
 		if (is_macaddr($_POST['mac'])) {
@@ -117,6 +119,9 @@ if ($_POST['save']) {
 	if ($_POST['bw_down'] && ($_POST['bw_down'] > 999999 || $_POST['bw_down'] < 1)) {
 		$input_errors[] = gettext("Download speed must be between 1 and 999999");
 	}
+	if ($macmask && (($macmask > 48) || ($macmask < 1))) {
+		$input_errors[] = gettext("MAC address mask must be between 1 and 48");
+	}
 
 	foreach ($a_passthrumacs as $macent) {
 		if (isset($id) && ($a_passthrumacs[$id]) && ($a_passthrumacs[$id] === $macent)) {
@@ -133,6 +138,9 @@ if ($_POST['save']) {
 		$mac = array();
 		$mac['action'] = $_POST['action'];
 		$mac['mac'] = $_POST['mac'];
+		if ($macmask) {
+			$mac['mac'] .= '/' . $macmask;
+		}
 		if ($_POST['bw_up']) {
 			$mac['bw_up'] = $_POST['bw_up'];
 		}
@@ -219,7 +227,10 @@ $btnmymac->setAttribute('type','button')->removeClass('btn-primary')->addClass('
 $group = new Form_Group('*MAC Address');
 $group->add($macaddress);
 $group->add($btnmymac);
-$group->setHelp('6 hex octets separated by colons');
+$group->setHelp('6 hex octets separated by colons%1$s%2$s%3$s', '<div class="infoblock">',
+	sprint_info_box(gettext('It is also possible to add a mask value (like /24),
+	for example, to allow all phones of a certain manufacturer to bypass the portal'), 'info', false),
+	'</div>');
 $section->add($group);
 
 $section->addInput(new Form_Input(


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/2424
- [x] Ready for review

ipfw supports masking MACs, sort of like a CIDR, and this could be a useful feature to allow, for example, all phones from a certain manufacturer to bypass the portal.

From ipfw(8):
```
{ MAC | mac } dst-mac src-mac
	     Match packets with	a given	dst-mac	and src-mac addresses, speci-
	     fied as the any keyword (matching any MAC address), or six	groups
	     of	hex digits separated by	colons,	and optionally followed	by a
	     mask indicating the significant bits.  The	mask may be specified
	     using either of the following methods:

	     1.	     A slash (/) followed by the number	of significant bits.
		     For example, an address with 33 significant bits could be
		     specified as:

			   MAC 10:20:30:40:50:60/33 any

	     2.	     An	ampersand (&) followed by a bitmask specified as six
		     groups of hex digits separated by colons.	For example,
		     an	address	in which the last 16 bits are significant
		     could be specified	as:

			   MAC 10:20:30:40:50:60&00:00:00:00:ff:ff any

		     Note that the ampersand character has a special meaning
		     in	many shells and	should generally be escaped.
	     Note that the order of MAC	addresses (destination first, source
	     second) is	the same as on the wire, but the opposite of the one
	     used for IP addresses.
```