### PR TITLE
Add vxlans

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1342,12 +1342,14 @@ function interface_vxlan_configure(&$vxlan, $vxlankey = "") {
 		log_error(gettext("could not bring parentif up -- variable not defined -- interface_vxlan_configure()"));
 	}
 
-	if (platform_booting() || !(empty($vxlan['vxlanif']))) {
-		pfSense_interface_destroy($vxlan['vxlanif']);
-		pfSense_interface_create($vxlan['vxlanif']);
+	if (!(empty($vxlan['vxlanif']))) {				//Interface us defined.
+		if (!platform_booting()) {
+			pfSense_interface_destroy($vxlan['vxlanif']);	//Calling this after boot implies we are editing an existing interface so destroy it first.
+		}
+		pfSense_interface_create($vxlan['vxlanif']);		//Create the interfaces at boot.
 		$vxlanif = $vxlan['vxlanif'];
 	} else {
-		$vxlanif = pfSense_interface_create("vxlan");
+		$vxlanif = pfSense_interface_create("vxlan");		//The interface is undefined, we are creating a new one. Next interface name is returned.
 	}
 
 	$ifconfigcmd = "/sbin/ifconfig " . escapeshellarg($vxlanif) . " vxlanid " .

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1351,10 +1351,10 @@ function interface_vxlan_configure(&$vxlan, $vxlankey = "") {
 	}
 
 	$ifconfigcmd = "/sbin/ifconfig " . escapeshellarg($vxlanif) . " vxlanid " .
-	    escapeshellarg($vxlan['vxlanid']) . " vxlandev " . escapeshellarg($realif);
+	    escapeshellarg($vxlan['vxlanid']);
 
 	if (is_mcast($vxlan['remote-addr'])) {
-		$ifconfigcmd .= " vxlangroup " . escapeshellarg($vxlan['remote-addr']);
+		$ifconfigcmd .= " vxlangroup " . escapeshellarg($vxlan['remote-addr']) . " vxlandev " . escapeshellarg($realif);
 	} else {
 		$ifconfigcmd .= " vxlanremote " . escapeshellarg($vxlan['remote-addr']);
 	}

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1342,7 +1342,7 @@ function interface_vxlan_configure(&$vxlan, $vxlankey = "") {
 		log_error(gettext("could not bring parentif up -- variable not defined -- interface_vxlan_configure()"));
 	}
 
-	if (!(empty($vxlan['vxlanif']))) {				//Interface us defined.
+	if (!(empty($vxlan['vxlanif']))) {				//Interface is defined.
 		if (!platform_booting()) {
 			pfSense_interface_destroy($vxlan['vxlanif']);	//Calling this after boot implies we are editing an existing interface so destroy it first.
 		}

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1342,7 +1342,7 @@ function interface_vxlan_configure(&$vxlan, $vxlankey = "") {
 		log_error(gettext("could not bring parentif up -- variable not defined -- interface_vxlan_configure()"));
 	}
 
-	if (!platform_booting() && !(empty($vxlan['vxlanif']))) {
+	if (platform_booting() || !(empty($vxlan['vxlanif']))) {
 		pfSense_interface_destroy($vxlan['vxlanif']);
 		pfSense_interface_create($vxlan['vxlanif']);
 		$vxlanif = $vxlan['vxlanif'];

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2338,7 +2338,7 @@ function is_interface_mismatch() {
 		foreach ($config['interfaces'] as $ifname => $ifcfg) {
 			if (interface_is_vlan($ifcfg['if']) != NULL ||
 			    interface_is_qinq($ifcfg['if']) != NULL ||
-			    preg_match("/^enc|^cua|^tun|^tap|^l2tp|^pptp|^ppp|^ovpn|^ipsec|^gif|^gre|^lagg|^bridge|vlan|_wlan|_\d{0,4}_\d{0,4}$/i", $ifcfg['if'])) {
+			    preg_match("/^enc|^cua|^tun|^tap|^l2tp|^pptp|^ppp|^ovpn|^ipsec|^gif|^gre|^lagg|^bridge|^vxlan|vlan|_wlan|_\d{0,4}_\d{0,4}$/i", $ifcfg['if'])) {
 				// Do not check these interfaces.
 				$i++;
 				continue;


### PR DESCRIPTION
Exclude vxlan interfaces from the interface mismatch check at boot.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/10898
- [x] Ready for review