### PR TITLE
DHCPv6 do not announce Router Address. Issue #9710

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -158,12 +158,7 @@ function services_radvd_configure($blacklist = array()) {
 				$radvdconf .= "\tAdvOtherConfigFlag on;\n";
 				break;
 		}
-		if ($dhcpv6ifconf['ramode'] == "unmanaged") {
-			$prefixnet = $ifcfgipv6;
-		} else {
-			$prefixnet = $subnetv6;
-		}
-		$radvdconf .= "\tprefix {$prefixnet}/{$ifcfgsnv6} {\n";
+		$radvdconf .= "\tprefix {$subnetv6}/{$ifcfgsnv6} {\n";
 		if ($racarpif == true) {
 			$radvdconf .= "\t\tDeprecatePrefix off;\n";
 		} else {
@@ -186,7 +181,6 @@ function services_radvd_configure($blacklist = array()) {
 			case "unmanaged":
 				$radvdconf .= "\t\tAdvOnLink on;\n";
 				$radvdconf .= "\t\tAdvAutonomous on;\n";
-				$radvdconf .= "\t\tAdvRouterAddr on;\n";
 				break;
 		}
 


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9710
- [X] Ready for review

The 'AdvRouterAddr' flag should only be set if the router implements ipv6 mobility. As far as I can tell pfSense does not implement ipv6 mobility or if it does it provides no facility to configure it. If it did provide this facility it is not related to whether it is "Unmanaged" or any of the other radvd settings.

https://tools.ietf.org/html/rfc6275#page-65:
```
   Mobile IPv6 extends Neighbor Discovery to allow a router to advertise
   its global address, by the addition of a single flag bit in the
   format of a Prefix Information option for use in Router Advertisement
   messages.
```