### PR TITLE
Allow to use IP Alias on PPP interfaces. Issue #7132

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3013,6 +3013,7 @@ function interfaces_vips_configure($interface = "") {
 function interface_ipalias_configure(&$vip) {
 	global $config;
 
+	$gateway = '';
 	if ($vip['mode'] != 'ipalias') {
 		return;
 	}
@@ -3023,6 +3024,13 @@ function interface_ipalias_configure(&$vip) {
 		if (!isset($config['interfaces'][$if]) ||
 		    !isset($config['interfaces'][$if]['enable'])) {
 			return;
+		}
+		if (is_pseudo_interface($realif)) {
+			if (is_ipaddrv4($vip['subnet'])) {
+				$gateway = get_interface_gateway($if);
+			} else {
+				$gateway = get_interface_gateway_v6($if);
+			}
 		}
 	}
 
@@ -3037,8 +3045,8 @@ function interface_ipalias_configure(&$vip) {
 		$iface = $carpvip['interface'];
 		$vhid = "vhid {$carpvip['vhid']}";
 	}
-	mwexec("/sbin/ifconfig " . escapeshellarg($realif) ." {$af} ". escapeshellarg($vip['subnet']) ."/" . escapeshellarg($vip['subnet_bits']) . " alias {$vhid}");
-	unset($iface, $af, $realif, $carpvip, $vhid);
+	mwexec("/sbin/ifconfig " . escapeshellarg($realif) ." {$af} ". escapeshellarg($vip['subnet']) ."/" . escapeshellarg($vip['subnet_bits']) . " alias {$gateway} {$vhid}");
+	unset($iface, $af, $realif, $carpvip, $vhid, $gateway);
 }
 
 function interface_carp_configure(&$vip, $maintenancemode_only = false) {

--- a/src/usr/local/www/firewall_virtual_ip_edit.php
+++ b/src/usr/local/www/firewall_virtual_ip_edit.php
@@ -97,8 +97,8 @@ if ($_POST['save']) {
 	}
 
 	if (is_pseudo_interface(convert_friendly_interface_to_real_interface_name($_POST['interface']))) {
-		if ($_POST['mode'] == 'ipalias') {
-			$input_errors[] = gettext("The interface chosen for the VIP does not support IP Alias mode.");
+		if ($_POST['mode'] == 'carp') {
+			$input_errors[] = gettext("The interface chosen for the VIP does not support CARP mode.");
 		} elseif ($_POST['mode'] == 'proxyarp') {
 			$input_errors[] = gettext("The interface chosen for the VIP does not support Proxy ARP mode.");
 		}


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/7132
- [X] Ready for review

It's possible to use IP Aliase on the PPP interface by adding the destination IP (gateway)