### PR TITLE
PPPoE Server secondary RADIUS server fixes. Issue #10926

### DIFF
--- a/src/etc/inc/vpn.inc
+++ b/src/etc/inc/vpn.inc
@@ -194,8 +194,20 @@ EOD;
 				if (isset($pppoecfg['radius']['server']['acctport'])) {
 					$radiusacctport = $pppoecfg['radius']['server']['acctport'];
 				}
+				$mpdconf .= "\tset radius server {$pppoecfg['radius']['server']['ip']} \"{$pppoecfg['radius']['server']['secret']}\" {$radiusport} {$radiusacctport}\n";
+				if (isset($pppoecfg['radius']['server2']['enable'])) {
+					$radiusport = "";
+					$radiusacctport = "";
+					if (isset($pppoecfg['radius']['server2']['port'])) {
+						$radiusport = $pppoecfg['radius']['server2']['port'];
+					}
+					if (isset($pppoecfg['radius']['server2']['acctport'])) {
+						$radiusacctport = $pppoecfg['radius']['server2']['acctport'];
+					}
+					$mpdconf .= "\tset radius server {$pppoecfg['radius']['server2']['ip']} \"{$pppoecfg['radius']['server2']['secret2']}\" {$radiusport} {$radiusacctport}\n";
+				}
+
 				$mpdconf .=<<<EOD
-	set radius server {$pppoecfg['radius']['server']['ip']} "{$pppoecfg['radius']['server']['secret']}" {$radiusport} {$radiusacctport}
 	set radius retries 3
 	set radius timeout 10
 	set auth enable radius-auth

--- a/src/usr/local/www/services_pppoe_edit.php
+++ b/src/usr/local/www/services_pppoe_edit.php
@@ -108,6 +108,11 @@ if ($_POST['save']) {
 			$reqdfieldsn = array_merge($reqdfieldsn,
 				array(gettext("RADIUS server address"), gettext("RADIUS shared secret")));
 		}
+		if ($_POST['radiussecenable']) {
+			$reqdfields = array_merge($reqdfields, explode(" ", "radiusserver2 radiussecret2"));
+			$reqdfieldsn = array_merge($reqdfieldsn,
+				array(gettext("Secondary RADIUS server address"), gettext("Secondary RADIUS server shared secret")));
+		}
 
 		do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
@@ -470,10 +475,11 @@ $section->addPassword(new Form_Input(
 $counter = 0;
 $numrows = count($item) -1;
 
-$usernames = $pconfig['username'];
-
-//DEBUG
-//$usernames = 'sbeaver:TXlQYXNzd2Q=:192.168.1.1 smith:TXlQYXNzd2Q=:192.168.2.1 sjones:TXlQYXNzd2Q=:192.168.3.1 salpha:TXlQYXNzd2Q=:192.168.4.1';
+if (!empty($pconfig['username'])) {
+	$usernames = $pconfig['username'];
+} else {
+	$usernames = $pppoecfg['username'];
+}
 
 if ($usernames == "") {
 	$usernames = '::';


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10926
- [X] Ready for review

* Fixes using Secondary RADIUS server;
* Fixes `secret2` -> `secret` renaming for the secondary RADIUS server;
* Additional input validation and filling of the `usernames` array - otherwise it will be cleared if the input validation fails;