### PR TITLE
Bridge interface Captive Portal validation. Issue #6528

### DIFF
--- a/src/usr/local/www/interfaces_bridge_edit.php
+++ b/src/usr/local/www/interfaces_bridge_edit.php
@@ -184,6 +184,18 @@ if ($_POST['save']) {
 		$input_errors[] = gettext("At least one member interface must be selected for a bridge.");
 	}
 
+	if (is_array($_POST['members']) && is_array($config['captiveportal'])) {
+		foreach ($_POST['members'] as $member) {
+			foreach ($config['captiveportal'] as $cp) {
+				if (in_array($member, explode(',', $cp['interface']))) {
+					$input_errors[] = sprintf(gettext('The interface (%s) is part of ' .
+						'the Captive Portal and cannot be part of the bridge. ' .
+						'Remove the interface to continue.'), $ifacelist[$cpint]);
+				}
+			}
+		}
+	}
+
 	if (is_array($_POST['static'])) {
 		foreach ($_POST['static'] as $ifstatic) {
 			if (is_array($_POST['members']) && !in_array($ifstatic, $_POST['members'])) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/6528
- [X] Ready for review

Captive Portal cannot be used on a bridge member interface and vise versa