### PR TITLE
IPsec PH1 creation fix. Issue #9592

### DIFF
--- a/src/etc/inc/ipsec.inc
+++ b/src/etc/inc/ipsec.inc
@@ -2035,7 +2035,11 @@ function ipsec_setup_tunnels() {
 			$conn =& $scconf["{$cname}-defaults"];
 			$scconf['connections']["{$cname} : {$cname}-defaults"] = array("# Stub to load con-mobile-defaults");
 		} else {
-			$cname = "con" . get_ipsecifnum($ph1ent['ikeid'], 0);
+			if (get_ipsecifnum($ph1ent['ikeid'], 0)) {
+				$cname = "con" . get_ipsecifnum($ph1ent['ikeid'], 0);
+			} else {
+				$cname = "con{$ph1ent['ikeid']}00000";
+			}
 			/* Start with common default values */
 			$scconf['connections'][$cname] = $conn_defaults;
 			/* Array reference to make things easier */


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9592
- [X] Ready for review

Fixes regression of https://github.com/pfsense/pfsense/pull/4190 -
if PH1 is created without VTI, it always uses the empty name `con`,
i.e. `/var/etc/ipsec/swanctl.conf`:
```
# This file is automatically generated. Do not edit
connections {
	...
	con {
```
leaving only the last non-VTI PH1 entry in `swanctl.conf`

This PR uses "safe" >32768 (x00000) numbers for non-VTI connections