### PR TITLE
LDAP group search fix. Issue #10942

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -1569,20 +1569,21 @@ function ldap_backed($username, $passwd, $authcfg, &$attributes = array()) {
 			$ldapdn = $ldapsearchbasedn;
 		}
 		$search = @$ldapfunc($ldap, $ldapdn, $ldapfilter);
-		$info = ldap_get_entries($ldap, $search);
+		if (!$search) {
+			log_error(sprintf(gettext("Search resulted in error: %s"), ldap_error($ldap)));
+			continue;
+		}
 		if (isset($authcfg['ldap_rfc2307']) && isset($ldapgroupfilter)) {
 			if (isset($authcfg['ldap_rfc2307_userdn'])) {
+				$info = ldap_get_entries($ldap, $search);
 				$username = $info[0]['dn'];
 			}
 			$ldapgroupfilter = "(&({$ldapgroupattribute}={$username})({$ldapextendedquery}))";
+			$groupsearch = @$ldapfunc($ldap, $ldapdn, $ldapgroupfilter);
 		}
 
 		if (isset($ldapgroupfilter) && !$groupsearch) {
 			log_error(sprintf(gettext("Extended group search resulted in error: %s"), ldap_error($ldap)));
-			continue;
-		}
-		if (!$search) {
-			log_error(sprintf(gettext("Search resulted in error: %s"), ldap_error($ldap)));
 			continue;
 		}
 		if (isset($groupsearch)) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10942
- [X] Ready for review

`$groupsearch` is missed in https://github.com/pfsense/pfsense/pull/4458
and put `ldap_get_entries()` check only after successful `$search`
