### PR TITLE
Restart syslogd on interface change. Issue #9660

### DIFF
--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -494,6 +494,11 @@ if ($_POST['apply']) {
 		if (is_subsystem_dirty('staticroutes') && (system_routing_configure() == 0)) {
 			clear_subsystem_dirty('staticroutes');
 		}
+
+		init_config_arr(array('syslog'));
+		if (isset($config['syslog']['enable']) && ($ifapply == $config['syslog']['sourceip'])) {
+			system_syslogd_start();
+		}
 	}
 	@unlink("{$g['tmp_path']}/.interfaces.apply");
 } else if ($_POST['save']) {


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9660
- [X] Ready for review

Syslogd keeps using old IP address after interface IP address change

in this case syslogd must be restarted on the bind interface change
