### PR TITLE
Delay configuring vxlans at boot. Issue #10960

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -1763,6 +1763,8 @@ function interfaces_configure() {
 			$delayed_list[$if] = $ifname;
 		} else if (strstr($realif, "gif")) {
 			$delayed_list[$if] = $ifname;
+		} else if (strstr($realif, "vxlan")) {
+			$delayed_list[$if] = $ifname;
 		} else if (strstr($realif, "ovpn")) {
 			//echo "Delaying OpenVPN interface configuration...done.\n";
 			continue;


### PR DESCRIPTION
Configure VXLAN interfaces after the parent interfaces are configured. Add them to the delayed list with GRE and GIF.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/10960
- [ ] Ready for review