### PR TITLE
Prevent over-matching the sysctl output. Issue 10963

### DIFF
--- a/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
+++ b/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
@@ -34,7 +34,7 @@ if (isset($_REQUEST["getThermalSensorsData"])) {
 		$_gb = exec("/sbin/sysctl -q dev.cpu | grep temperature | sort",
 		    $dfout);
 	} else {
-		$_gb = exec("/sbin/sysctl -aq | grep temperature", $dfout);
+		$_gb = exec("/sbin/sysctl -aq | grep temperature:", $dfout);
 	}
 	$dfout_filtered = array_filter($dfout, function($v) {
 		return strpos($negsign, ' -') === false;

--- a/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
+++ b/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
@@ -31,10 +31,10 @@ if (isset($_REQUEST["getThermalSensorsData"])) {
 
 	$specplatform = system_identify_specific_platform();
 	if ($specplatform['name'] == 'SG-5100') {
-		$_gb = exec("/sbin/sysctl -q dev.cpu | grep temperature | sort",
+		$_gb = exec("/sbin/sysctl -q dev.cpu | /usr/bin/grep temperature | sort",
 		    $dfout);
 	} else {
-		$_gb = exec("/sbin/sysctl -aq | grep temperature:", $dfout);
+		$_gb = exec("/sbin/sysctl -q hw.acpi.thermal dev.cpu | /usr/bin/grep 'temperature:'", $dfout);
 	}
 	$dfout_filtered = array_filter($dfout, function($v) {
 		return strpos($negsign, ' -') === false;

--- a/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
+++ b/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
@@ -31,8 +31,7 @@ if (isset($_REQUEST["getThermalSensorsData"])) {
 
 	$specplatform = system_identify_specific_platform();
 	if ($specplatform['name'] == 'SG-5100') {
-		$_gb = exec("/sbin/sysctl -q dev.cpu | /usr/bin/grep temperature | sort",
-		    $dfout);
+		$_gb = exec("/sbin/sysctl -q dev.cpu | /usr/bin/grep temperature | /usr/bin/sort", $dfout);
 	} else {
 		$_gb = exec("/sbin/sysctl -q hw.acpi.thermal dev.cpu | /usr/bin/grep 'temperature:'", $dfout);
 	}


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/10963
- [x] Ready for review

This more accurately matches only the coretemp and acpi sensor data sysctls.