### PR TITLE
rtsold: run script if MANAGED bit set

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -5151,6 +5151,7 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 		sleep(2);
 		mwexec("/usr/sbin/rtsold -1 " .
 		    "-p {$g['varrun_path']}/rtsold_{$wanif}.pid " .
+		    "-M {$g['varetc_path']}/rtsold_{$wanif}_script.sh " .
 		    "-O {$g['varetc_path']}/rtsold_{$wanif}_script.sh " .
 		    $wanif);
 	}


### PR DESCRIPTION
- [ x ] Redmine Issue: https://redmine.pfsense.org/issues/10965
- [ x ] Ready for review

In FreeBSD 12.2-STABLE rtsold was changed to allow for a script to run when the router advertisement has the MANAGED flag set.

From rfc4861:
```
M              1-bit "Managed address configuration" flag.  When
                      set, it indicates that addresses are available via
                      Dynamic Host Configuration Protocol [DHCPv6].
 
                      If the M flag is set, the O flag is redundant and
                      can be ignored because DHCPv6 will return all
                      available configuration information.
```
 
If the managed bit is set then the script specified with the -O option is *not* executed.  The -M option is (currently) processed before the -O option. The {$g['varetc_path']}/rtsold_{$wanif}_script.sh never runs and therefore no DHCPv6 client is started.

I probably could have just changed the O option to M, but seemed safer and possibly more resistant to future rtsold changes to include both since only one will execute.

rtsold.c changes:

https://github.com/freebsd/freebsd/commit/8ffcd478e5d5d60654e92ee952d7f50192577917

https://reviews.freebsd.org/D26099

I also noticed that the {$g['varetc_path']}/rtsold_{$wanif}_script.sh is using $2 when the input to the script is only the name of the interface, but did not address that.