### PR TITLE
Delete Captive Portal related files on HA node. Fixes #10891

### DIFF
--- a/src/usr/local/www/xmlrpc.php
+++ b/src/usr/local/www/xmlrpc.php
@@ -245,6 +245,9 @@ class pfsense_xmlrpc_server {
 					if (isset($config['voucher'][$cpzone])) {
 						unset($config['voucher'][$cpzone]);
 					}
+					unlink_if_exists("/var/db/captiveportal{$cpzone}.db");
+					unlink_if_exists("/var/db/captiveportal_usedmacs_{$cpzone}.db");
+					unlink_if_exists("/var/db/voucher_{$cpzone}_*.db");
 				}
 			}
 		}


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10891
- [X] Ready for review

Remove Captive Portal Zone related files on deleting it in WebGUI on HA node:
```
/var/db/captiveportal<zone>.db
/var/db/captiveportal_usedmacs_<zone>.db
/var/db/voucher_<zone>_active_X.db
/var/db/voucher_<zone>_used_X.db
```