### PR TITLE
Add help text to Register DHCP Leases in Resolver

### DIFF
--- a/src/usr/local/www/services_unbound.php
+++ b/src/usr/local/www/services_unbound.php
@@ -440,6 +440,7 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['regdhcp']
 ))->setHelp('If this option is set, then machines that specify their hostname when requesting an IPv4 DHCP lease will be registered'.
 					' in the DNS Resolver so that their name can be resolved.'.
+	    				' Note that this will cause the Resolver to reload and flush its resolution cache whenever a DHCP lease is issued.'.
 					' The domain in %1$sSystem &gt; General Setup%2$s should also be set to the proper value.','<a href="system.php">','</a>');
 
 $section->addInput(new Form_Checkbox(


### PR DESCRIPTION
This change adds a sentence to the help text for the `Register DHCP Leases in the DNS Resolver` input field. 

Enabling this option has the non-obvious side effect of reloading Unbound each time a client obtains a DHCP lease. This reload flushes the resolution cache, which can mean long recursive lookups being required for even frequently used domains. 

A long term fix for this issue would be to modify the Unbound scripts so that the resolution cache is persisted somehow between reloads, but in the short term this addition should help users avoid this pitfall.

This issue comes up in the forums from time to time, and I know that personally I long avoided using Unbound in recursive mode because I couldn't figure out why performance was sometimes poor on frequently used domains. Turns out it was because I had this option turned on.

Some forum mentions:
https://forum.netgate.com/topic/146117/dns-resolver-not-caching-correct/56
https://forum.netgate.com/topic/154368/unbound-resolver-low-cache-hits

- [x] Redmine Issue: https://redmine.pfsense.org/issues/5413 This issue is related, but the PR does not _fix_ the issue. It merely helps users avoid the problem.
- [x] Ready for review