### PR TITLE
Support omitting Cloudflare Zone ID for dynamic DNS

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -235,6 +235,10 @@
 				break;
 			case "cloudflare-v6":
 			case "cloudflare":
+				if (!$dnsPass) $this->_error(4);
+				if (!$dnsHost) $this->_error(5);
+				if (!$dnsDomain) $this->_error(5);
+				break;
 			case "gratisdns":
 			case "hover":
 				if (!$dnsUser) $this->_error(3);
@@ -883,12 +887,19 @@
 
 					curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-					if (strpos($this->_dnsUser, '@') !== false) {
-						curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-							'X-Auth-Email: ' . $this->_dnsUser,
-							'X-Auth-Key: ' . $this->_dnsPass,
-							'Content-Type: application/json'
-						));
+					if ((!$this->_dnsUser) || (strpos($this->_dnsUser, '@') !== false)) {
+						if (strpos($this->_dnsUser, '@') !== false) {
+							curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+										'X-Auth-Email: ' . $this->_dnsUser,
+										'X-Auth-Key: ' . $this->_dnsPass,
+										'Content-Type: application/json'
+										));
+						} else {
+							curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+										'Authorization: Bearer ' . $this->_dnsPass,
+										'Content-Type: application/json'
+										));
+						}
 
 						// Get zone ID
 						$getZoneId = "https://{$dnsServer}/client/v4/zones/?name={$this->_dnsDomain}";

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -83,7 +83,7 @@ if ($_POST['save'] || $_POST['force']) {
 	unset($input_errors);
 	$pconfig = $_POST;
 
-	if (($pconfig['type'] == "freedns" || $pconfig['type'] == "freedns-v6" || $pconfig['type'] == "freedns2" || $pconfig['type'] == "freedns2-v6" || $pconfig['type'] == "namecheap" || $pconfig['type'] == "digitalocean" || $pconfig['type'] == "digitalocean-v6" || $pconfig['type'] == "linode" || $pconfig['type'] == "linode-v6" || $pconfig['type'] == "gandi-livedns")
+	if (($pconfig['type'] == "freedns" || $pconfig['type'] == "freedns-v6" || $pconfig['type'] == "freedns2" || $pconfig['type'] == "freedns2-v6" || $pconfig['type'] == "namecheap" || $pconfig['type'] == "digitalocean" || $pconfig['type'] == "digitalocean-v6" || $pconfig['type'] == "linode" || $pconfig['type'] == "linode-v6" || $pconfig['type'] == "gandi-livedns" || $pconfig['type'] == "cloudflare" || $pconfig['type'] == "cloudflare-v6")
 	    && $_POST['username'] == "") {
 		$_POST['username'] = "none";
 	}
@@ -394,7 +394,7 @@ $section->addInput(new Form_Input(
 	'text',
 	$pconfig['username'],
 	['autocomplete' => 'new-password']
-))->setHelp('Username is required for all types except Namecheap, FreeDNS (APIv1&2), FreeDNS-v6 (APIv1&2), DigitalOcean, Linode and Custom Entries.%1$s' .
+))->setHelp('Username is required for all types except Namecheap, FreeDNS (APIv1&2), FreeDNS-v6 (APIv1&2), DigitalOcean, Linode, Cloudflare and Custom Entries.%1$s' .
 			'Azure: Enter your Azure AD application ID%1$s' .
 			'DNS Made Easy: Dynamic DNS ID%1$s' .
 			'DNSimple: User account ID (In the URL after the \'/a/\')%1$s' .
@@ -403,7 +403,7 @@ $section->addInput(new Form_Input(
 			'Domeneshop: Enter the API token.%1$s' .
 			'Dreamhost: Enter a value to appear in the DNS record comment.%1$s' .
 			'Godaddy: Enter the API key.%1$s' .
-			'Cloudflare: Enter email for Global API Key or Zone ID for API token.%1$s' .
+			'Cloudflare: Enter email for Global API Key or (optionally) Zone ID for API token.%1$s' .
 			'For Custom Entries, Username and Password represent HTTP Authentication username and passwords.', '<br />');
 
 $section->addPassword(new Form_Input(


### PR DESCRIPTION
In May, Cloudflare
[improved their API](https://community.cloudflare.com/t/bug-zone-detail-by-name-requires-zone-list-permission/128042/14)
so that a token scoped to a particular zone now has permission to
`GET https://api.cloudflare.com/client/v4/zones/?name=<specific_zone_name_here>`.

As a result, the zone id can be queried without increasing permissions.
If the username is blank, query the zone id.

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10992
- [ ] Ready for review