### PR TITLE
HE.net Tunnelbroker dynamic dns not supplying IP address parameter

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -804,7 +804,7 @@
 					$needsIP = FALSE;
 					$server = "https://ipv4.tunnelbroker.net/ipv4_end.php?";
 					curl_setopt($ch, CURLOPT_USERPWD, $this->_dnsUser . ':' . $this->_dnsPass);
-					curl_setopt($ch, CURLOPT_URL, $server . 'tid=' . $this->_dnsHost);
+					curl_setopt($ch, CURLOPT_URL, $server . 'tid=' . $this->_dnsHost  . '&ip=' . $this->_dnsIP);
 					break;
 				case 'selfhost':
 					$needsIP = FALSE;


### PR DESCRIPTION
- [ x ] Redmine Issue: https://redmine.pfsense.org/issues/11024
- [ x ] Ready for review

Tunnel client IP address is being set to the IP address of the default WAN interface, as it is the requesting IP address, rather than the actual dynamic DNS IP address.

This PR adds the "ip" parameter to the request.

I also noticed that we are using a deprecated API, but will change separately and create a new PR after testing.