### PR TITLE
Change client endpoint update API for he.net tunnelbroker dynamic DNS

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -802,9 +802,9 @@
 					break;
 				case 'he-net-tunnelbroker':
 					$needsIP = FALSE;
-					$server = "https://ipv4.tunnelbroker.net/ipv4_end.php?";
+					$server = "https://ipv4.tunnelbroker.net/nic/update?";
 					curl_setopt($ch, CURLOPT_USERPWD, $this->_dnsUser . ':' . $this->_dnsPass);
-					curl_setopt($ch, CURLOPT_URL, $server . 'tid=' . $this->_dnsHost  . '&ip=' . $this->_dnsIP);
+					curl_setopt($ch, CURLOPT_URL, $server . 'hostname=' . $this->_dnsHost . '&myip=' . $this->_dnsIP);
 					break;
 				case 'selfhost':
 					$needsIP = FALSE;
@@ -2046,6 +2046,7 @@
 					break;
 				case 'he-net':
 				case 'he-net-v6':
+				case 'he-net-tunnelbroker':
 					if (preg_match("/badip/i", $data)) {
 						$status = $status_intro . $error_str . gettext("Bad Request - The IP provided was invalid.");
 					} else if (preg_match('/nohost/i', $data)) {
@@ -2056,33 +2057,6 @@
 						$status = $status_intro . $success_str . gettext("IP Address Updated Successfully!");
 						$successful_update = true;
 					} else if (preg_match('/nochg/i', $data)) {
-						$status = $status_intro . $success_str . gettext("No Change In IP Address.");
-						$successful_update = true;
-					} else {
-						$status = $status_intro . "(" . gettext("Unknown Response") . ")";
-						log_error($status_intro . gettext("PAYLOAD:") . " " . $data);
-						$this->_debug($data);
-					}
-					break;
-				case 'he-net-tunnelbroker':
-					/*
-					-ERROR: Missing parameter(s).
-					-ERROR: Invalid API key or password
-					-ERROR: Tunnel not found
-					-ERROR: Another tunnel exists for this IP.
-					-ERROR: This tunnel is already associated with this IP address
-					+OK: Tunnel endpoint updated to: x.x.x.x
-					*/
-					if (preg_match("/Missing parameter/i", $data)) {
-						$status = $status_intro . $error_str . gettext("Bad Request - Missing/Invalid Parameters.");
-					} else if (preg_match('/Tunnel not found/i', $data)) {
-						$status = $status_intro . $error_str . gettext("Bad Request - Invalid Tunnel ID.");
-					} else if (preg_match('/Invalid API key or password/i', $data)) {
-						$status = $status_intro . $error_str . gettext("Invalid username or password.");
-					} else if (preg_match('/OK:/i', $data)) {
-						$status = $status_intro . $success_str . gettext("IP Address Updated Successfully!");
-						$successful_update = true;
-					} else if (preg_match('/This tunnel is already associated with this IP address/i', $data)) {
 						$status = $status_intro . $success_str . gettext("No Change In IP Address.");
 						$successful_update = true;
 					} else {


### PR DESCRIPTION
- [ x ] Redmine Issue: https://redmine.pfsense.org/issues/11037
- [ x ] Ready for review

For he.net tunnelbroker dynamic DNS we are using a deprecated client update API.

_https://ipv4.tunnelbroker.net/ipv4_end.php (Deprecated)_

This PR changes to the current client update API.

_https://ipv4.tunnelbroker.net/nic/update (Preferred)_

This also allows re-use of the other he.net dynamic dns update error handling code.

[API docs](https://forums.he.net/index.php?topic=3153.msg18553#msg18553)