### PR TITLE
Add a comment about CARP in generated rules

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -4344,6 +4344,7 @@ function filter_process_carp_rules($log) {
 	$lines = "";
 	/* return if there are no carp configured items */
 	if (!empty($config['hasync']) or !empty($config['virtualip']['vip'])) {
+		$lines .= "\n# CARP rules\n";
 		$lines .= "block in {$log['block']} quick proto carp from (self) to any tracker {$increment_tracker()}\n";
 		$lines .= "pass {$log['pass']} quick proto carp tracker {$increment_tracker()} no state\n";
 	}


### PR DESCRIPTION
Currently the rules.debug file looks like this:
```
# Snort package
block log quick from <snort2c> to any tracker 1000000109 label "Block snort2c hosts"
block log quick from any to <snort2c> tracker 1000000110 label "Block snort2c hosts"
block in log quick proto carp from (self) to any tracker 1000000201
pass  quick proto carp tracker 1000000202 no state
```

This made me wonder which weird things snort is doing there. Turns out it was not snort.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/11061
- [x] Ready for review