### PR TITLE
Ticket #11159. Allow wildcard DNS record of type A in DynDNS client for DNS provider Gandi.

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -1387,9 +1387,9 @@
 			case 'gandi-livedns':
 				// NOTE: quite similar to digitalocean case but with json content like azure case
 				// Get record href
-				$server = 'https://dns.api.gandi.net/api/v5/domains/';
+				$server = 'https://api.gandi.net/v5/livedns/domains/';
 				$url = $server . $this->_dnsDomain . '/records';
-				curl_setopt($ch, CURLOPT_HTTPHEADER, array("X-Api-Key: {$this->_dnsPass}"));
+				curl_setopt($ch, CURLOPT_HTTPHEADER, array("Authorization: Apikey {$this->_dnsPass}"));
 				curl_setopt($ch, CURLOPT_URL, $url);
 				$output = json_decode(curl_exec($ch));
 				if (!is_array($output)) {
@@ -1404,7 +1404,7 @@
 				}
 				$request_headers = array();
 				//$request_headers[] = 'Accept: application/json';
-				$request_headers[] = 'X-Api-Key: ' . $this->_dnsPass;
+				$request_headers[] = 'Authorization: Apikey ' . $this->_dnsPass;
 				$request_headers[] = 'Content-Type: application/json';
 				//create or update record
 				if ($recordHref == null) {

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -120,14 +120,14 @@ if ($_POST['save'] || $_POST['force']) {
 	if (isset($_POST['host']) && in_array("host", $reqdfields)) {
 		$allow_wildcard = false;
 		/* Namecheap can have a @. and *. in hostname */
-		if ($pconfig['type'] == "namecheap" && ($_POST['host'] == '*.' || $_POST['host'] == '*' || $_POST['host'] == '@.' || $_POST['host'] == '@')) {
+		if (($pconfig['type'] == "namecheap" || $pconfig['type'] == "gandi-livedns") && ($_POST['host'] == '*.' || $_POST['host'] == '*' || $_POST['host'] == '@.' || $_POST['host'] == '@')) {
 			$host_to_check = $_POST['domainname'];
 		} elseif (($pconfig['type'] == "cloudflare") || ($pconfig['type'] == "cloudflare-v6")) {
 			$host_to_check = $_POST['host'] == '@' ? $_POST['domainname'] : ( $_POST['host'] . '.' . $_POST['domainname'] );
 			$allow_wildcard = true;
 		} elseif ((($pconfig['type'] == "godaddy") || ($pconfig['type'] == "godaddy-v6")) && ($_POST['host'] == '@.' || $_POST['host'] == '@')) {
 			$host_to_check = $_POST['domainname'];
-		} elseif (($pconfig['type'] == "digitalocean" || $pconfig['type'] == "digitalocean-v6" || $pconfig['type'] == "gandi-livedns") && ($_POST['host'] == '@.' || $_POST['host'] == '@')) {
+		} elseif (($pconfig['type'] == "digitalocean" || $pconfig['type'] == "digitalocean-v6") && ($_POST['host'] == '@.' || $_POST['host'] == '@')) {
 			$host_to_check = $_POST['domainname'];
 		} elseif (($pconfig['type'] == "linode") || ($pconfig['type'] == "linode-v6")) {
 			$host_to_check = $_POST['host'] == '@' ? $_POST['domainname'] : ( $_POST['host'] . '.' . $_POST['domainname'] );


### PR DESCRIPTION


- [x] Redmine Issue: https://redmine.pfsense.org/issues/11159 ;
- [x] Ready for review.

Allow the use of wildcard DNS record in hostname for the DNS provider Gandi.
Change the URL and the authorization header to the new API for the DNS provider Gandi.

I have tested the commit using the System Patches Package as described in the documentation on `pfSense-CE-2.5.0-DEVELOPMENT-amd64-20201212-0250.iso.gz` (Patch applied successfully) and also on pfSense `2.4.5-p1`.