### PR TITLE
Fix separators moving when multiple filters deleted - Fix #9887

### DIFF
--- a/src/usr/local/www/firewall_nat.php
+++ b/src/usr/local/www/firewall_nat.php
@@ -138,11 +138,10 @@ if (isset($_POST['del_x']) && have_natpfruleint_access($natent['interface'])) {
 
 	/* delete selected rules */
 	if (is_array($_POST['rule']) && count($_POST['rule'])) {
+		$first_idx = 0;		
 		$num_deleted = 0;
 
 		foreach ($_POST['rule'] as $rulei) {
-			$target = $rule['target'];
-
 			// Check for filter rule associations
 			if (isset($a_nat[$rulei]['associated-rule-id'])) {
 				delete_id($a_nat[$rulei]['associated-rule-id'], $config['filter']['rule']);
@@ -151,16 +150,16 @@ if (isset($_POST['del_x']) && have_natpfruleint_access($natent['interface'])) {
 
 			unset($a_nat[$rulei]);
 
-			// Update the separators
-			// As rules are deleted, $ridx has to be decremented or separator position will break
-			$ridx = $rulei - $num_deleted;
-			$mvnrows = -1;
-			move_separators($a_separators, $ridx, $mvnrows);
+			// Capture first changed filter index for later separator shifting
+			if (!$first_idx) $first_idx = $rulei;
 			$num_deleted++;
 		}
 
-		if (write_config("NAT: Rule deleted")) {
-			mark_subsystem_dirty('natconf');
+		if ($num_deleted) {
+			move_separators($a_separators, $first_idx, -$num_deleted);
+			if (write_config("NAT: Rule deleted")) {
+				mark_subsystem_dirty('natconf');
+			}
 		}
 
 		header("Location: firewall_nat.php");

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -193,7 +193,6 @@ if (isset($_POST['del_x'])) {
 	if (is_array($_POST['rule']) && count($_POST['rule'])) {
 		init_config_arr(array('filter', 'separator', strtolower($if)));
 		$a_separators = &$config['filter']['separator'][strtolower($if)];
-		$num_deleted = 0;
 
 		foreach ($_POST['rule'] as $rulei) {
 			delete_nat_association($a_filter[$rulei]['associated-rule-id']);
@@ -201,11 +200,9 @@ if (isset($_POST['del_x'])) {
 			$deleted = true;
 
 			// Update the separators
-			// As rules are deleted, $ridx has to be decremented or separator position will break
-			$ridx = ifridx($if, $rulei) - $num_deleted;	// get rule index within interface
+			$ridx = ifridx($if, $rulei);	// get rule index within interface
 			$mvnrows = -1;
 			move_separators($a_separators, $ridx, $mvnrows);
-			$num_deleted++;
 		}
 
 		if ($deleted) {

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -187,25 +187,25 @@ if ($_REQUEST['savemsg']) {
 }
 
 if (isset($_POST['del_x'])) {
-	/* delete selected rules */
-	$deleted = false;
-
 	if (is_array($_POST['rule']) && count($_POST['rule'])) {
 		init_config_arr(array('filter', 'separator', strtolower($if)));
 		$a_separators = &$config['filter']['separator'][strtolower($if)];
 
+		$first_idx = 0;		
+		$num_deleted = 0;
 		foreach ($_POST['rule'] as $rulei) {
 			delete_nat_association($a_filter[$rulei]['associated-rule-id']);
 			unset($a_filter[$rulei]);
 			$deleted = true;
 
 			// Update the separators
-			$ridx = ifridx($if, $rulei);	// get rule index within interface
-			$mvnrows = -1;
-			move_separators($a_separators, $ridx, $mvnrows);
+			$ridx = ifridx($if, $rulei);	      // get rule index within interface
+			if (!$first_idx) $first_idx = $ridx;  // capture first changed filter index
+			$num_deleted++;
 		}
 
-		if ($deleted) {
+		if ($num_deleted) {
+			move_separators($a_separators, $first_idx, -$num_deleted);
 			if (write_config(gettext("Firewall: Rules - deleted selected firewall rules."))) {
 				mark_subsystem_dirty('filter');
 			}

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -196,7 +196,6 @@ if (isset($_POST['del_x'])) {
 		foreach ($_POST['rule'] as $rulei) {
 			delete_nat_association($a_filter[$rulei]['associated-rule-id']);
 			unset($a_filter[$rulei]);
-			$deleted = true;
 
 			// Update the separators
 			$ridx = ifridx($if, $rulei);	      // get rule index within interface

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -197,9 +197,8 @@ if (isset($_POST['del_x'])) {
 			delete_nat_association($a_filter[$rulei]['associated-rule-id']);
 			unset($a_filter[$rulei]);
 
-			// Update the separators
-			$ridx = ifridx($if, $rulei);	      // get rule index within interface
-			if (!$first_idx) $first_idx = $ridx;  // capture first changed filter index
+			// Capture first changed filter index for later separator shifting
+			if (!$first_idx) $first_idx = ifridx($if, $rulei);
 			$num_deleted++;
 		}
 


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9887
- [x] Ready for review

`$ridx` was being subtracted as each filter was deleted resulting in separators becoming logically under subsequent filters.
I can not see why this subtraction was required since adding a filter does not require an increase of `$ridx`.

History likely dictates why it was required so strike this pull request if I am way off the mark.

Local testing has identified no ill effects from this change.