### PR TITLE
Update MBT-4420/2220 Platform id string

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2530,7 +2530,7 @@ function system_identify_specific_platform() {
 		case 'SG-5100':
 			return (array('name' => 'SG-5100', 'descr' => 'Netgate SG-5100'));
 			break;
-		case 'Minnowboard Turbot D0 PLATFORM':
+		case 'Minnowboard Turbot D0 PLATFORM' || 'Minnowboard Turbot D0/D1 PLATFORM':
 			$result = array();
 			$result['name'] = 'Turbot Dual-E';
 			/* Detect specific model */


### PR DESCRIPTION
With 1.0 bios Intel changed indentifications tring for Turbot
That patch fixes Minnowboard detection on system level

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9242
- [x] Ready for review

To fix that issue 100% installer script need to be updated (factory.sh) but i din't found it in this repo