### PR TITLE
openssl list digest algorithm parameter changed in /etc/inc/openvpn.inc

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -494,7 +494,7 @@ function openvpn_validate_curve($curve) {
 /* Obtain the list of digest algorithms supported by openssl and their alternate names */
 function openvpn_get_openssldigestmappings() {
 	$digests = array();
-	$digest_out = shell_exec('/usr/bin/openssl list-message-digest-algorithms | /usr/bin/grep "=>"');
+	$digest_out = shell_exec('/usr/bin/openssl list -digest-algorithms | /usr/bin/grep "=>"');
 	$digest_lines = explode("\n", trim($digest_out));
 	sort($digest_lines);
 	foreach ($digest_lines as $line) {


### PR DESCRIPTION
At least in OpenSSL version 1.1.1i-freebsd, used by pfsense 2.5, there is no longer a "list-message-digest-algorithms" parameter. It has been replaced by "list -digest-algorithms".
The old parameter results in an error <Invalid command 'list-message-digest-algorithms'; type "help" for a list> and may even cause an endless loop on startup/migration.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/11500
- [x] Ready for review