### PR TITLE
Do not deprecate prefix if AdvRASrcAddress is specified, refs: #11103

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -173,7 +173,7 @@ function services_radvd_configure($blacklist = array()) {
 				break;
 		}
 		$radvdconf .= "\tprefix {$subnetv6}/{$ifcfgsnv6} {\n";
-		if ($racarpif == true) {
+		if ($racarpif == true || $rasrcaddr) {
 			$radvdconf .= "\t\tDeprecatePrefix off;\n";
 		} else {
 			$radvdconf .= "\t\tDeprecatePrefix on;\n";


### PR DESCRIPTION
This is a small fix for #4487 When specifying `AdvRASrcAddress` we should set `DeprecatePrefix off`, otherwise clients will loose connectivity during failover.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/11103
- [x] Ready for review