### PR TITLE
Fixed bug parsing netmask cisco acl

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -3396,7 +3396,7 @@ function parse_cisco_acl_rule($rule, $devname, $dir, $proto) {
 				syslog(LOG_WARNING, "Error parsing rule {$rule_orig}: Invalid source netmask '$netmask'.");
 				return;
 			}
-			$tmprule .= "from {$network}/{$netmask}";
+			$tmprule .= "from {$network}/{$netmask} ";
 		} else {
 			syslog(LOG_WARNING, "Error parsing rule {$rule_orig}: Invalid source network '$network'.");
 			return;
@@ -3471,7 +3471,7 @@ function parse_cisco_acl_rule($rule, $devname, $dir, $proto) {
 				syslog(LOG_WARNING, "Error parsing rule {$rule_orig}: Invalid destination network '$network'.");
 				return;
 			}
-			$tmprule .= "to {$network}/{$netmask}";
+			$tmprule .= "to {$network}/{$netmask} ";
 		} else {
 			syslog(LOG_WARNING, "Error parsing rule {$rule_orig}: Invalid destination network '$network'.");
 			return;


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/11569
- [x] Ready for review

test case

```php
<?php

function assertSame($expected, $actual, $message)
{
    if ($expected === $actual) {
	echo "$message\t ok\n";
	return;
    }

    echo "$message:\nFailed asserting that \n - - - \n'$expected'\n is identical to\n - - - \n'$actual'.\n";
    exit(1);
}

//test case #10469
$rules = parse_cisco_acl([
    'ciscoavpair' => [
	'ip:outacl#1=permit udp host 4.4.4.4 host 7.7.7.7 range 3110 5000',
	'ip:outacl#2=permit tcp any host 7.7.7.7 gt 333',
	'ip:inacl#3=permit udp host 3.3.3.3 host 7.7.7.7 lt 566',
	'ip:inacl#4=permit udp host 3.3.3.3 host 7.7.7.7 neq 899',
	'ip:inacl#6=permit icmp host 2.2.2.2 host 5.5.5.5',
	'ipv6:outacl#1=permit udp host 2001:DB8::4444 host 2001:DB8::7777 range 3110 5000',
	'ipv6:outacl#2=permit tcp any host 2001:DB8::7777 gt 333',
	'ipv6:inacl#3=permit udp host 2001:DB8::3333 host 2001:DB8::7777 lt 566',
	'ipv6:inacl#4=permit udp host 2001:DB8::3333 host 2001:DB8::7777 neq 899',
	'ipv6:inacl#5=permit tcp host 2001:DB8::2222 host 2001:DB8::5555 eq 999',
	'ipv6:inacl#6=deny udp 2001:DB8:1234::/64 2001:DB8:6789::/48',
	'ipv6:inacl#7=deny icmp 2001:DB8:1234::/64 2001:DB8:9999::/56'
    ]
], 'ovpns1');

assertSame(<<<EXPECTED
pass in quick on ovpns1 inet proto udp from 3.3.3.3 to 7.7.7.7 port < 566 no state
pass in quick on ovpns1 inet proto udp from 3.3.3.3 to 7.7.7.7 port != 899 no state
pass in quick on ovpns1 inet proto icmp from 2.2.2.2 to 5.5.5.5 no state
pass out quick on ovpns1 inet proto udp from 4.4.4.4 to 7.7.7.7 port 3109 >< 5001 no state
pass out quick on ovpns1 inet proto tcp from any to 7.7.7.7 port > 333 no state
pass in quick on ovpns1 inet6 proto udp from 2001:DB8::3333 to 2001:DB8::7777 port < 566 no state
pass in quick on ovpns1 inet6 proto udp from 2001:DB8::3333 to 2001:DB8::7777 port != 899 no state
pass in quick on ovpns1 inet6 proto tcp from 2001:DB8::2222 to 2001:DB8::5555 port = 999 no state
block in quick on ovpns1 inet6 proto udp from 2001:DB8:1234::/64 to 2001:DB8:6789::/48 no state
block in quick on ovpns1 inet6 proto ipv6-icmp from 2001:DB8:1234::/64 to 2001:DB8:9999::/56 no state
pass out quick on ovpns1 inet6 proto udp from 2001:DB8::4444 to 2001:DB8::7777 port 3109 >< 5001 no state
pass out quick on ovpns1 inet6 proto tcp from any to 2001:DB8::7777 port > 333 no state

EXPECTED
, $rules, 'test case #9206');


//broken test
$rules = parse_cisco_acl([
    'ciscoavpair' => [
	'ip:inacl#1=permit tcp 192.168.1.2 0.0.0.0 any',
	'ip:inacl#2=permit tcp 192.168.1.1 0.0.0.0 10.10.128.151 0.0.0.0 eq 80'
    ]
], 'ovpns1');


assertSame(
    <<<EXPECTED
pass in quick on ovpns1 inet proto tcp from 192.168.1.2/32 to any
pass in quick on ovpns1 inet proto tcp from 192.168.1.1/32 to 10.10.128.151/32 port = 80

EXPECTED,
    $rules,
    'broken test v2.5.0'
);


```