### PR TITLE
Fix iftop experimental traffic fetcher, unify and improve output style

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3653,11 +3653,11 @@ EOD;
 						$eappass = base64_decode($wlcfg['wpa']['wpa_eap_inner_password']);
 						$wpa .= "password=\"{$eappass}\"\n";
 					}
-					if (strstr($wlcfg['wpa']['wpa_eap_client_mode'], 'TLS')) { 
+					if (strstr($wlcfg['wpa']['wpa_eap_client_mode'], 'TLS')) {
 						$cert = lookup_cert($wlcfg['wpa']['wpa_eap_cert']);
 						@file_put_contents($wpa_supplicant_file . "crt", base64_decode($cert['crt']) . "\n" .
-						    ca_chain($cert)); 
-						@file_put_contents($wpa_supplicant_file . "key", base64_decode($cert['prv'])); 
+						    ca_chain($cert));
+						@file_put_contents($wpa_supplicant_file . "key", base64_decode($cert['prv']));
 						@chmod($wpa_supplicant_crt, 0600);
 						@chmod($wpa_supplicant_key, 0600);
 						$wpa .= "client_cert=\"{$wpa_supplicant_crt}\"\n";
@@ -3665,7 +3665,7 @@ EOD;
 					}
 					$ca = lookup_ca($wlcfg['wpa']['wpa_eap_ca']);
 					@file_put_contents($wpa_supplicant_file . "ca", base64_decode($ca['crt']) . "\n" .
-					    ca_chain($ca)); 
+					    ca_chain($ca));
 					$wpa .= "ca_cert=\"{$wpa_supplicant_ca}\"\n";
 					$wpa .= "eap={$wlcfg['wpa']['wpa_eap_client_mode']}\n";
 				} else {
@@ -7684,6 +7684,19 @@ function is_stf_interface($inf) {
 	}
 
 	return false;
+}
+
+function is_dhcp_server_enabled_on_interface($if) {
+	global $config;
+
+	if (!isset($config['dhcpd'][$if])) {
+		return false;
+	}
+	$dhcpifconf = $config['dhcpd'][$if];
+	if (!isset($dhcpifconf['enable']) || empty($config['interfaces'][$if])) {
+		return false;
+	}
+	return true;
 }
 
 ?>

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2100,7 +2100,7 @@ function format_number($num, $precision = 3) {
 		$num /= 1000;
 		$i++;
 	}
-	$num = round($num, $precision);
+	$num = number_format($num, $precision);
 
 	return ("$num {$units[$i]}");
 }

--- a/src/usr/local/bin/iftop_hidedestination.conf
+++ b/src/usr/local/bin/iftop_hidedestination.conf
@@ -1,0 +1,1 @@
+hide-destination: yes

--- a/src/usr/local/bin/iftop_hidesource.conf
+++ b/src/usr/local/bin/iftop_hidesource.conf
@@ -1,0 +1,1 @@
+hide-source: yes

--- a/src/usr/local/bin/iftop_parser.sh
+++ b/src/usr/local/bin/iftop_parser.sh
@@ -46,7 +46,7 @@ if [ -f $pid_file ]; then
         fi
 else
         echo -n $$ > $pid_file
-        $IFTOP -nNb -i $1 -s 3 -o 2s -t 2>> /dev/null | $AWK -f $awk_script > ${cache_file}.tmp
+        $IFTOP -nNb -i $1 -s 2 -o 2s -t 2>> /dev/null | $AWK -f $awk_script > ${cache_file}.tmp
         $CAT ${cache_file}.tmp > $cache_file
         $CAT $cache_file
         $RM $pid_file

--- a/src/usr/local/bin/iftop_parser.sh
+++ b/src/usr/local/bin/iftop_parser.sh
@@ -1,15 +1,21 @@
 #!/bin/sh
 
 # Usage
-if [ $# -ne 1 -a $# -ne 2 ]; then
-        echo "Usage : $0 iface"
+if [ $# -ne 2 ]; then
+        echo "Usage : $0 iface {all|hidesource|hidedestination}"
+        exit
+fi
+
+if [ "$2" != "all" ] && [ "$2" != "hidesource" ] && [ "$2" != "hidedestination" ]; then
+        echo "Usage : $0 iface {all|hidesource|hidedestination}"
         exit
 fi
 
 # files paths
-pid_file=/var/run/iftop_${1}.pid
-cache_file=/var/db/iftop_${1}.log
+pid_file=/var/run/iftop_${1}_${2}.pid
+cache_file=/var/db/iftop_${1}_${2}.log
 awk_script=/usr/local/bin/iftop_parse.awk
+iftop_config=/usr/local/bin/iftop_${2}.conf
 
 # Binaries paths
 DATE=/bin/date
@@ -46,7 +52,7 @@ if [ -f $pid_file ]; then
         fi
 else
         echo -n $$ > $pid_file
-        $IFTOP -nNb -i $1 -s 2 -o 2s -t 2>> /dev/null | $AWK -f $awk_script > ${cache_file}.tmp
+        $IFTOP -nNb -i $1 -s 2 -o 2s -t -c $iftop_config 2>> /dev/null | $AWK -f $awk_script > ${cache_file}.tmp
         $CAT ${cache_file}.tmp > $cache_file
         $CAT $cache_file
         $RM $pid_file

--- a/src/usr/local/www/css/pfSense.css
+++ b/src/usr/local/www/css/pfSense.css
@@ -1065,3 +1065,11 @@ text underline, but text-color, background, font etc. could also be used */
 .peerbg_color {
     background-color: #ccf2ff;"
 }
+
+.traffic-hosts .numeric {
+    text-align: right;
+}
+
+.traffic-hosts .speed-G .number, .traffic-hosts .speed-M .number {
+    font-weight: bold;
+}

--- a/src/usr/local/www/status_graph.php
+++ b/src/usr/local/www/status_graph.php
@@ -307,11 +307,12 @@ function updateBandwidth() {
 				for (var y=0; y<10; y++) {
 					if ((y < hosts_split.length) && (hosts_split[y] != "") && (hosts_split[y] != "no info")) {
 						hostinfo = hosts_split[y].split(";");
-
-						$('#top10-hosts').append('<tr>'+
-							'<td>'+ hostinfo[0] +'</td>'+
-							'<td>'+ hostinfo[1] +' <?=gettext("Bits/sec");?></td>'+
-							'<td>'+ hostinfo[2] +' <?=gettext("Bits/sec");?></td>'+
+						hostinfo[1] = hostinfo[1].split(" ");
+						hostinfo[2] = hostinfo[2].split(" ");
+						$('#top10-hosts').append('<tr>' +
+							'<td>' + hostinfo[0] + '</td>'+
+							'<td class="numeric speed-' + hostinfo[1][1] + '"><span class="number">' + hostinfo[1][0] + '</span> ' + hostinfo[1][1] + '<?= gettext("bits/s"); ?></td>' +
+							'<td class="numeric speed-' + hostinfo[2][1] + '"><span class="number">' + hostinfo[2][0] + '</span> ' + hostinfo[2][1] + '<?= gettext("bits/s"); ?></td>' +
 						'</tr>');
 					}
 				}
@@ -349,12 +350,12 @@ if (ipsec_enabled()) {
 			</div>
 		</div>
 		<div class="col-sm-6">
-			<table class="table table-striped table-condensed">
+			<table class="table table-striped table-condensed traffic-hosts">
 				<thead>
 					<tr>
 						<th><?=(($curhostipformat == "") ? gettext("Host IP") : gettext("Host Name or IP")); ?></th>
-						<th><?=gettext("Bandwidth In"); ?></th>
-						<th><?=gettext("Bandwidth Out"); ?></th>
+						<th class="numeric"><?=gettext("Bandwidth In"); ?></th>
+						<th class="numeric"><?=gettext("Bandwidth Out"); ?></th>
 					</tr>
 				</thead>
 				<tbody id="top10-hosts">


### PR DESCRIPTION
I've made a series of changes to the iftop experimental traffic fetcher.

Changes overview:
- multiple requests were sent to browser and they were pending, because script execution was blocking responses - now it is launched in the background and response is taken from file
- formatting was unified with output from rate (k letter size, rounding to two decimals)
- output view is better readable, aligned right and Megabits and Gigabits have their number in bold font
- the second commit improves accuracy. Iftop returns only entries that fit to console screen making results inaccurate if you have 15 connections from the same IP. Now source or destination is grouped and counted internally by iftop. This logic is applied only for cases you watch LAN interface (any interface with DHCP server enabled).

- [x] Ready for review