### PR TITLE
Include wildcard setting in dyndns refresh

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2152,6 +2152,7 @@ function services_dyndns_configure($int = "") {
 				$dyndns['curl_ipresolve_v4'] = isset($dyndns['curl_ipresolve_v4']);
 				$dyndns['curl_ssl_verifypeer'] = isset($dyndns['curl_ssl_verifypeer']);
 				$dyndns['proxied'] = isset($dyndns['proxied']);
+				$dyndns['wildcard'] = isset($dyndns['wildcard']);
 				services_dyndns_configure_client($dyndns);
 				sleep(1);
 			}


### PR DESCRIPTION
Every 25th day, my dyndns forcibly updates, and the wildcard entry is gone.
Updating it manually brings it back.

This should fix that, as far as I can tell. Though I must admit I have not tested it live for 25 days.

- [X] Redmine Issue: https://redmine.pfsense.org/issues/11667
- [X] Ready for review