### PR TITLE
Skip floating rules with all interfaces disabled. Issue #11688

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -2974,7 +2974,11 @@ function filter_generate_user_rule($rule) {
 			if (!empty($ifliste)) {
 				$aline['interface'] = " on { {$ifliste} } ";
 			} else {
-				$aline['interface'] = "";
+				/* This rule specifies interface(s), but none of those were
+				 * found in the enabled list, so just ignore the rule.
+				 * See https://redmine.pfsense.org/issues/11688.
+				 */
+				return "# rule " . $rule['descr'] . " has no enabled interfaces";
 			}
 		} else {
 			$aline['interface'] = "";


### PR DESCRIPTION
Prior to this change, if a floating rule had associated interfaces, but they were all disabled, the rule would be generated without any interface specification, causing it to erroneously be applied to *all interfaces*.

For example, a rule that looked like this:
```
block  out  on {  vtnet1  } inet from any to any tracker 1615945995  label "USER_RULE: FLOATER"
```

If the interface for `vtnet1` was disabled (in the webcfg), then the rule would be generated like this:
```
block  out inet from any to any tacker 1615945995  label "USER_RULE: FLOATER"
```

This fixes that problem by instead skipping that floating rule, since it has no active interfaces to which to apply.

(This was written and tested against v2.4.5 but clearly applies to master as well.)

See https://redmine.pfsense.org/issues/11688

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/11688
- [ ] Ready for review