### PR TITLE
Do not remove route upon radvd shutdown if AdvRASrcAddress is specified

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -124,7 +124,11 @@ function does_vip_exist($vip) {
 	$ifacedata = pfSense_getall_interface_addresses($realif);
 
 	if (is_subnetv6("{$vip['subnet']}/{$vip['subnet_bits']}")) {
-		$comparevip = text_to_compressed_ip6("{$vip['subnet']}/{$vip['subnet_bits']}");
+		$comparevip = text_to_compressed_ip6($vip['subnet']);
+		if (is_linklocal($vip['subnet'])) {
+			$comparevip .= "%{$realif}";
+		}
+		$comparevip .= "/{$vip['subnet_bits']}";
 	} else {
 		$comparevip = "{$vip['subnet']}/{$vip['subnet_bits']}";
 	}

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -251,7 +251,13 @@ function services_radvd_configure($blacklist = array()) {
 				$radvdconf .= "\t\tAdvRoutePreference medium;\n";
 				break;
 		}
-		$radvdconf .= "\t\tRemoveRoute on;\n";
+
+		if ($rasrcaddr) {
+			$radvdconf .= "\t\tRemoveRoute off;\n";
+		}
+		else {
+			$radvdconf .= "\t\tRemoveRoute on;\n";
+		}
 		$radvdconf .= "\t};\n";
 
 		/* add DNS servers */


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/11103
- [x] Ready for review

This is (hopefully) the last follow-up PR to #4487

Also contains a fix very similar to #4172 which prevents linklocal vips from being removed from the interface on a secondary host during a hasync.