### PR TITLE
fix for missing 0 subnet when cloning address entry with mask

### DIFF
--- a/src/usr/local/www/js/pfSenseHelpers.js
+++ b/src/usr/local/www/js/pfSenseHelpers.js
@@ -337,7 +337,7 @@ function bump_input_id(newGroup) {
 		// and no items selected, so that automatic v4/v6 selection still works
 		if ($(this).is('[id^=address_subnet]')) {
 			$(this).empty();
-			for (idx=128; idx>0; idx--) {
+			for (idx=128; idx>=0; idx--) {
 				$(this).append($('<option>', {
 					value: idx,
 					text: idx


### PR DESCRIPTION
needed for vpn's that need two 0 subnets one for ipv4 and ipv6. When the min mask is set to 0. The first address would have a 0 selectable mask, but subsequent clones of that row would not, because of this bug. 

- [x] Redmine Issue: https://redmine.pfsense.org/issues/11880
- [x] Ready for review