### PR TITLE
Cisco-AVPair ACL rule: port range operator change

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -3487,9 +3487,7 @@ function parse_cisco_acl_rule($rule, $devname, $dir, $proto) {
 	} else if (trim($rule[$index]) == "range") {
 		$port = array($rule[++$index], $rule[++$index]);
 		if (is_port($port[0]) && is_port($port[1])) {
-			$port[0]--;
-			$port[1]++;
-			$tmprule .= "port {$port[0]} >< {$port[1]} ";
+			$tmprule .= "port {$port[0]}:{$port[1]} ";
 		} else {
 			syslog(LOG_WARNING, "Error parsing rule {$rule_orig}: Invalid source ports: '$port[0]' & '$port[1]' one or both are not a numeric value between 0 and 65535.");
 			return;
@@ -3562,9 +3560,7 @@ function parse_cisco_acl_rule($rule, $devname, $dir, $proto) {
 	} else if (trim($rule[$index]) == "range") {
 		$port = array($rule[++$index], $rule[++$index]);
 		if (is_port($port[0]) && is_port($port[1])) {
-			$port[0]--;
-			$port[1]++;
-			$tmprule .= "port {$port[0]} >< {$port[1]} ";
+			$tmprule .= "port {$port[0]}:{$port[1]} ";
 		} else {
 			syslog(LOG_WARNING, "Error parsing rule {$rule_orig}: Invalid destination ports: '$port[0]' '$port[1]' one or both are not a numeric value between 0 and 65535.");
 			return;


### PR DESCRIPTION
Previous operator ( `><` ) prevented inserting port range with min/max port.
Ex.
`ip:inacl#1=permit tcp host {clientip} host 1.1.1.1 range 10000 65535`
produced the following invalid rule:
`pass in quick on ovpns1 inet proto tcp from 192.168.1.2 to 1.1.1.1 port 9999 >< 65536`

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [x] Ready for review