### PR TITLE
Add some leeway to dynamic DNS cache expiration time check

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -2835,7 +2835,10 @@
 			}
 
 			// Convert seconds = days * hr/day * min/hr * sec/min
-			$maxCacheAgeSecs = $this->_dnsMaxCacheAgeDays * 24 * 60 * 60;
+			// We subtract 1 hour, so that when this code is executed few seconds
+			// before _dnsMaxCacheAgeDays has passed, then we still consider that
+			// a required number of days has passed.
+			$maxCacheAgeSecs = $this->_dnsMaxCacheAgeDays * 24 * 60 * 60 - 60 * 60;
 
 			$needs_updating = FALSE;
 			/* lets determine if the item needs updating */


### PR DESCRIPTION
This leeway is needed to ensure that the cache is invalidated after N days and not N+1 days. The latter could happen, e.g., when the update happens few seconds earlier on expected expiration day, than on the previous update day. This could be due to a different number of providers on different days or some providers took longer on the first day. As a result, the cache would not
be considered expired on the correct day, but on the day after. Note that this is not required for the summer saving time, as `time()` always returns time in UTC.

As this is not based on a found bug, but instead on a speculation based on the code, I don't have good reasoning for it. However, I'm pretty scared that if the problem happens for a provider with a strict update schedule, then that provider could drop the host from the DNS. For example, dy.fi drops DNS definition, if there is no updated for 7 days. Additionally, dy.fi doesn't accept updates more often than every 5 days. Hence, the most optimal update schedule would be every 6 days (see #4514 for dy.fi implemantation). But, if the code is executed 5 days, 23 hours and 59 minutes after the previous, then the code wouldn't consider the cache expired and would wait until day 7 to actually update the provider. At that point, the host could be dropped already.

I would love to get some feedback and comments about this. It's totally possible that I'm wrong.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/12007
- [x] Ready for review