### PR TITLE
Cisco-AVPair + Framed-IP-Address: correcting clientip

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -3427,9 +3427,8 @@ function parse_cisco_acl_rule($rule, $devname, $dir, $proto) {
 		$index++;
 		if ((($proto == 'inet') && (is_ipaddrv4(trim($rule[$index])) || (trim($rule[$index]) == "{clientip}"))) ||
 		    (($proto == 'inet6') && (is_ipaddrv6(trim($rule[$index])) || (trim($rule[$index]) == "{clientipv6}")))) {
-			if($GLOBALS['attributes']['framed_ip']) {
-				$framed_ip = $GLOBALS['attributes']['framed_ip'];
-				$tmprule .= "from {$framed_ip} ";
+			if ($GLOBALS['attributes']['framed_ip']) {
+				$tmprule .= "from {$GLOBALS['attributes']['framed_ip']} ";
 			} else {
 				$tmprule .= "from {$rule[$index]} ";
 			}

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -3427,7 +3427,12 @@ function parse_cisco_acl_rule($rule, $devname, $dir, $proto) {
 		$index++;
 		if ((($proto == 'inet') && (is_ipaddrv4(trim($rule[$index])) || (trim($rule[$index]) == "{clientip}"))) ||
 		    (($proto == 'inet6') && (is_ipaddrv6(trim($rule[$index])) || (trim($rule[$index]) == "{clientipv6}")))) {
-			$tmprule .= "from {$rule[$index]} ";
+			if($GLOBALS['attributes']['framed_ip']) {
+				$framed_ip = $GLOBALS['attributes']['framed_ip'];
+				$tmprule .= "from {$framed_ip} ";
+			} else {
+				$tmprule .= "from {$rule[$index]} ";
+			}
 			$index++;
 		} else {
 			syslog(LOG_WARNING, "Error parsing rule {$rule_orig}: Invalid source host '{$rule[$index]}'.");


### PR DESCRIPTION
Workaround to substitute Framed-IP-Address value in Cisco-AVPair ACL's where {clientip} is used

- [x] Redmine Issue: https://redmine.pfsense.org/issues/12076
- [x] Ready for review