### PR TITLE
Add option to set max cache age for the custom dynamic DNS provider

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -197,7 +197,7 @@
 		function __construct($dnsService = '', $dnsHost = '', $dnsDomain = '', $dnsUser = '', $dnsPass = '',
 					$dnsWildcard = 'OFF', $dnsProxied = false, $dnsMX = '', $dnsIf = '', $dnsBackMX = '',
 					$dnsServer = '', $dnsPort = '', $dnsUpdateURL = '', $forceUpdate = false,
-					$dnsZoneID ='', $dnsTTL='', $dnsResultMatch = '', $dnsRequestIf = '',
+					$dnsZoneID ='', $dnsTTL='', $dnsResultMatch = '', $dnsRequestIf = '', $dnsMaxCacheAge = '',
 					$dnsID = '', $dnsVerboseLog = false, $curlIpresolveV4 = false, $curlSslVerifypeer = true) {
 
 			global $config, $g, $dyndns_split_domain_types;
@@ -338,11 +338,15 @@
 			$this->_dnsUpdateURL = $dnsUpdateURL;
 			$this->_dnsResultMatch = $dnsResultMatch;
 			$this->_dnsRequestIf = get_failover_interface($dnsRequestIf);
+			if ($dnsMaxCacheAge !== "") {
+				$this->_dnsMaxCacheAgeDays = (int)$dnsMaxCacheAge;
+			} else {
+				$this->_dnsMaxCacheAgeDays = 25;
+			}
 			if ($this->_dnsVerboseLog) {
 				log_error(sprintf(gettext('Dynamic DNS (%1$s): running get_failover_interface for %2$s. found %3$s'), $this->_FQDN, $dnsRequestIf, $this->_dnsRequestIf));
 			}
 			$this->_dnsRequestIfIP = get_interface_ip($dnsRequestIf);
-			$this->_dnsMaxCacheAgeDays = 25;
 			$this->_dnsDummyUpdateDone = false;
 			$this->_forceUpdateNeeded = $forceUpdate;
 

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -2105,6 +2105,7 @@ function services_dyndns_configure_client($conf) {
 		$dnsTTL = $conf['ttl'],
 		$dnsResultMatch = "{$conf['resultmatch']}",
 		$dnsRequestIf = "{$conf['requestif']}",
+		$dnsMaxCacheAge = $conf['maxcacheage'],
 		$dnsID = "{$conf['id']}",
 		$dnsVerboseLog = $conf['verboselog'],
 		$curlIpresolveV4 = $conf['curl_ipresolve_v4'],

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -72,6 +72,7 @@ if (isset($id) && isset($a_dyndns[$id])) {
 	$pconfig['curl_ssl_verifypeer'] = isset($a_dyndns[$id]['curl_ssl_verifypeer']);
 	$pconfig['zoneid'] = $a_dyndns[$id]['zoneid'];
 	$pconfig['ttl'] = $a_dyndns[$id]['ttl'];
+	$pconfig['maxcacheage'] = $a_dyndns[$id]['maxcacheage'];
 	$pconfig['updateurl'] = $a_dyndns[$id]['updateurl'];
 	$pconfig['resultmatch'] = $a_dyndns[$id]['resultmatch'];
 	$pconfig['requestif'] = str_replace('_stf', '', $a_dyndns[$id]['requestif']);
@@ -170,6 +171,9 @@ if ($_POST['save'] || $_POST['force']) {
 	if ((in_array("username", $reqdfields) && $_POST['username'] && !is_dyndns_username($_POST['username'])) || ((in_array("username", $reqdfields)) && ($_POST['username'] == ""))) {
 		$input_errors[] = gettext("The username contains invalid characters.");
 	}
+	if (isset($_POST['maxcacheage']) && $_POST['maxcacheage'] !== "" && (!is_numericint($_POST['maxcacheage']) || (int)$_POST['maxcacheage'] < 1)) {
+		$input_errors[] = gettext("The max cache age must be an integer and greater than 0 (or empty for the default).");
+	}
 
 	if (!$input_errors) {
 		$dyndns = array();
@@ -201,6 +205,7 @@ if ($_POST['save'] || $_POST['force']) {
 		}
 		$dyndns['zoneid'] = $_POST['zoneid'];
 		$dyndns['ttl'] = $_POST['ttl'];
+		$dyndns['maxcacheage'] = $_POST['maxcacheage'];
 		$dyndns['updateurl'] = $_POST['updateurl'];
 		// Trim hard-to-type but sometimes returned characters
 		$dyndns['resultmatch'] = trim($_POST['resultmatch'], "\t\n\r");
@@ -459,6 +464,13 @@ $section->addInput(new Form_Input(
 ))->setHelp('Choose TTL for the dns record.');
 
 $section->addInput(new Form_Input(
+	'maxcacheage',
+	'Max Cache Age',
+	'number',
+	$pconfig['maxcacheage']
+))->setHelp('The number of days after which the DNS record is always updated. The DNS record is updated when: update is forced, WAN address changes or this number of days has passed.');
+
+$section->addInput(new Form_Input(
 	'descr',
 	'Description',
 	'text',
@@ -508,6 +520,7 @@ events.push(function() {
 		hideCheckbox('proxied', true);
 		hideInput('zoneid', true);
 		hideInput('ttl', true);
+		hideInput('maxcacheage', true);
 
 		switch (service) {
 			case "custom" :
@@ -520,6 +533,7 @@ events.push(function() {
 				hideInput('host', true);
 				hideInput('mx', true);
 				hideCheckbox('wildcard', true);
+				hideInput('maxcacheage', false);
 				break;
 			// providers in an alphabetical order (based on the first provider in a group of cases)
 			case "azure":


### PR DESCRIPTION
Add ability to manually set an integer for the max cache age, i.e, set a duration (in days) for how often the Dynamic DNS entry is always updated. This is required for some providers or setting really huge number here, would kind of disable the force update.

Currently, the field is visible only for the custom provider (v4 and v6).

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9092
- [x] Ready for review