### PR TITLE
Fix flock and fclose null parameter php warning in util.inc

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -163,8 +163,10 @@ function try_lock($lock, $timeout = 5) {
 /* unlock configuration file */
 function unlock($cfglckkey = 0) {
 	global $g;
-	flock($cfglckkey, LOCK_UN);
-	fclose($cfglckkey);
+	if (!is_null($cfglckkey)) {
+		@flock($cfglckkey, LOCK_UN);
+		@fclose($cfglckkey);
+	}
 	return;
 }
 


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/12111
- [x] Ready for review