### PR TITLE
Bug #12174 - cache gateway_info_popup results for firewall_rules.php page loads

### DIFF
--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -823,25 +823,25 @@ foreach ($a_filter as $filteri => $filterent):
 							<?php endif; ?>
 						</td>
 						<td>
-							<?php 
-								/* Cache gateway info for this page load.
-								 * See https://redmine.pfsense.org/issues/12174 */
-								if (isset($filterent['gateway'])) {
+							<?php if (isset($filterent['gateway'])): ?>
+								<?php
+									/* Cache gateway status for this page load.
+									 * See https://redmine.pfsense.org/issues/12174 */
 									if (!is_array($gw_info)) {
 										$gw_info = array();
 									}
 									if (empty($gw_info[$filterent['gateway']])) {
 										$gw_info[$filterent['gateway']] = gateway_info_popup($filterent['gateway']);
 									}
-									if (!empty($gw_info[$filterent['gateway']])) {
-										echo sprintf('<span data-toggle="popover" data-trigger="hover focus" title="%s" data-content="%s" data-html="true">', gettext('Gateway details'), $gw_info[$filterent['gateway']]);
-									} else {
-										echo "<span>";
-									}
-								} else {
-									echo "<span>";
-								}
-							?>
+								?>
+								<?php if (!empty($gw_info[$filterent['gateway']])): ?>
+									<span data-toggle="popover" data-trigger="hover focus" title="<?=gettext('Gateway details')?>" data-content="<?=$gw_info[$filterent['gateway']]?>" data-html="true">
+								<?php else: ?>
+									<span>
+								<?php endif; ?>
+							<?php else: ?>
+								<span>
+							<?php endif; ?>
 								<?php if (isset($config['interfaces'][$filterent['gateway']]['descr'])): ?>
 									<?=str_replace('_', '_<wbr>', htmlspecialchars($config['interfaces'][$filterent['gateway']]['descr']))?>
 								<?php else: ?>

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -823,11 +823,25 @@ foreach ($a_filter as $filteri => $filterent):
 							<?php endif; ?>
 						</td>
 						<td>
-							<?php if (isset($filterent['gateway'])): ?>
-								<span data-toggle="popover" data-trigger="hover focus" title="<?=gettext('Gateways details')?>" data-content="<?=gateway_info_popup($filterent['gateway'], $gateways_status)?>" data-html="true">
-							<?php else: ?>
-								<span>
-							<?php endif; ?>
+							<?php 
+								/* Cache gateway info for this page load.
+								 * See https://redmine.pfsense.org/issues/12174 */
+								if (isset($filterent['gateway'])) {
+									if (!is_array($gw_table)) {
+										$gw_table = array();
+									}
+									if (empty($gw_table[$filterent['gateway']])) {
+										$gw_table[$filterent['gateway']] = gateway_info_popup($filterent['gateway']);
+									}
+									if (!empty($gw_table[$filterent['gateway']])) {
+										echo sprintf('<span data-toggle="popover" data-trigger="hover focus" title="%s" data-content="%s" data-html="true">', gettext('Gateway details'), $gw_table[$filterent['gateway']]);
+									} else {
+										echo "<span>";
+									}
+								} else {
+									echo "<span>";
+								}
+							?>
 								<?php if (isset($config['interfaces'][$filterent['gateway']]['descr'])): ?>
 									<?=str_replace('_', '_<wbr>', htmlspecialchars($config['interfaces'][$filterent['gateway']]['descr']))?>
 								<?php else: ?>

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -831,7 +831,7 @@ foreach ($a_filter as $filteri => $filterent):
 										$gw_info = array();
 									}
 									if (empty($gw_info[$filterent['gateway']])) {
-										$gw_info[$filterent['gateway']] = gateway_info_popup($filterent['gateway'],$gateways_status);
+										$gw_info[$filterent['gateway']] = gateway_info_popup($filterent['gateway'], $gateways_status);
 									}
 								?>
 								<?php if (!empty($gw_info[$filterent['gateway']])): ?>

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -831,7 +831,7 @@ foreach ($a_filter as $filteri => $filterent):
 										$gw_info = array();
 									}
 									if (empty($gw_info[$filterent['gateway']])) {
-										$gw_info[$filterent['gateway']] = gateway_info_popup($filterent['gateway']);
+										$gw_info[$filterent['gateway']] = gateway_info_popup($filterent['gateway'],$gateways_status);
 									}
 								?>
 								<?php if (!empty($gw_info[$filterent['gateway']])): ?>

--- a/src/usr/local/www/firewall_rules.php
+++ b/src/usr/local/www/firewall_rules.php
@@ -827,14 +827,14 @@ foreach ($a_filter as $filteri => $filterent):
 								/* Cache gateway info for this page load.
 								 * See https://redmine.pfsense.org/issues/12174 */
 								if (isset($filterent['gateway'])) {
-									if (!is_array($gw_table)) {
-										$gw_table = array();
+									if (!is_array($gw_info)) {
+										$gw_info = array();
 									}
-									if (empty($gw_table[$filterent['gateway']])) {
-										$gw_table[$filterent['gateway']] = gateway_info_popup($filterent['gateway']);
+									if (empty($gw_info[$filterent['gateway']])) {
+										$gw_info[$filterent['gateway']] = gateway_info_popup($filterent['gateway']);
 									}
-									if (!empty($gw_table[$filterent['gateway']])) {
-										echo sprintf('<span data-toggle="popover" data-trigger="hover focus" title="%s" data-content="%s" data-html="true">', gettext('Gateway details'), $gw_table[$filterent['gateway']]);
+									if (!empty($gw_info[$filterent['gateway']])) {
+										echo sprintf('<span data-toggle="popover" data-trigger="hover focus" title="%s" data-content="%s" data-html="true">', gettext('Gateway details'), $gw_info[$filterent['gateway']]);
 									} else {
 										echo "<span>";
 									}


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/12174
- [x] Ready for review

Calling gateway_info_popup for each rule with 'gateway' set caused long page loads for rule-sets that make extensive use of policy-based routing.  

This change would cause `firewall_rules.php` to first check an array, `gw_info`, for cached gateway info before resorting to calling the `gateway_info_popup` function.  The full content from each `gateway_info_popup` call is added to the cache.