### PR TITLE
Alzeebum 10980 - Restores standard /etc/rc.local functionality

### DIFF
--- a/src/etc/pfSense-rc
+++ b/src/etc/pfSense-rc
@@ -514,4 +514,9 @@ echo "Bootup complete" | /usr/bin/logger
 # Reset the cache.  read-only requires this.
 /bin/rm -f /tmp/config.cache
 
+# Run /etc/rc.local
+if [ -x /etc/rc.local ]; then
+        /etc/rc.local
+fi
+
 exit 0

--- a/src/etc/rc.initial
+++ b/src/etc/rc.initial
@@ -31,19 +31,6 @@ trap : 3
 trap : 4
 
 unset do_sleep
-if [ -f /etc/rc.local ]; then
-	if ! ps auxwww | egrep -q '[r]c.local$'; then
-		echo ">>> Launching rc.local in background..."
-		sh /etc/rc.local &
-		do_sleep=1
-	fi
-	if [ -f /etc/rc.local.running ] && \
-	    ! ps auxwww | egrep -q '[r]c.local.running$'; then
-		[ -n "${do_sleep}" ] && sleep 1
-		echo ">>> Launching rc.local.running in background..."
-		sh /etc/rc.local.running &
-	fi
-fi
 
 # Parse command line parameters
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/10980
- [x] Ready for review

Tested this on 2.5.0, but it's a simple enough sledgehammer that it doesn't seem like it can introduce any issues other than potential backwards compatibility.  I can't imagine there are that many people out there using the broken existing rc.local invocation setup though, so IMO the potential for damage is low.