### PR TITLE
thermal sensors widget typo fix

### DIFF
--- a/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
+++ b/src/usr/local/www/widgets/widgets/thermal_sensors.widget.php
@@ -36,7 +36,7 @@ if (isset($_REQUEST["getThermalSensorsData"])) {
 		$_gb = exec("/sbin/sysctl -q hw.acpi.thermal dev.cpu dev.t5nex dev.armada_thermal dev.cordbuc | /usr/bin/grep 'temperature:'", $dfout);
 	}
 	$dfout_filtered = array_filter($dfout, function($v) {
-		return strpos($negsign, ' -') === false;
+		return strpos($v, ' -') === false;
 	});
 
 	print(join("|", $dfout_filtered));


### PR DESCRIPTION
Minor typo fix for thermal sensors widget that results in negative temperature readings not actually being filtered out as intended

Didn't raise a redmine as I think this qualifies as a very minor typo fix under the contributing guidelines (edit: my bad it does need one)

- [x]  Redmine Issue: https://redmine.pfsense.org/issues/12470
- [x]  Ready for review