### PR TITLE
DynDNS: make simultaneous update of IP and LegacyIP possible

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -172,6 +172,7 @@
 		var $_dnsDomain;
 		var $_FQDN;
 		var $_dnsIP;
+		var $_dnsLegacyIP;
 		var $_dnsWildcard;
 		var $_dnsProxied;
 		var $_dnsMX;
@@ -194,6 +195,7 @@
 		var $_dnsDummyUpdateDone;
 		var $_forceUpdateNeeded;
 		var $_useIPv6;
+		var $_useIPv4Andv6;
 		var $_existingRecords;
 		var $_curlProxy;
 
@@ -345,6 +347,12 @@
 				default:
 					$this->_useIPv6 = false;
 			}
+
+			switch ($dnsService) {
+				default:
+					$this->_useIPv4Andv6 = false;
+			}
+
 			$this->_dnsService = strtolower($dnsService);
 			$this->_dnsUser = $dnsUser;
 			$this->_dnsPass = base64_decode($dnsPass);
@@ -3126,33 +3134,53 @@
 				log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): _checkIP() starting.'), $this->_dnsService, $this->_FQDN));
 			}
 
-			if ($this->_useIPv6 == true) {
+			if ($this->_useIPv6 == true || $this->_useIPv4Andv6 == true) {
 				$ip_address = get_interface_ipv6($this->_if);
 				if (!is_ipaddrv6($ip_address)) {
 					return 0;
 				}
-			} else {
-				$ip_address = dyndnsCheckIP($this->_if);
-				if (!is_ipaddr($ip_address)) {
+			}
+			if ($this->_useIPv6 == false || $this->_useIPv4Andv6 == true) {
+				$legacy_ip_address = dyndnsCheckIP($this->_if);
+				if (!is_ipaddr($legacy_ip_address)) {
 					log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): IP address could not be extracted from Check IP Service'), $this->_dnsService, $this->_FQDN));
 					return 0;
-				} elseif (is_private_ip($ip_address)) {
+				} elseif (is_private_ip($legacy_ip_address)) {
 					log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): Public IP address could not be extracted from Check IP Service'), $this->_dnsService, $this->_FQDN));
 					return 0;
 				}
 			}
-			if ($this->_useIPv6 == false && is_private_ip(get_interface_ip($this->_if))) {
-				if ($this->_dnsVerboseLog) {
-					log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): %3$s extracted from Check IP Service'), $this->_dnsService, $this->_FQDN, $ip_address));
+			if (($this->_useIPv6 == false || $this->_useIPv4Andv6 == true) && is_private_ip(get_interface_ip($this->_if))) {
+				if (is_ipaddr($legacy_ip_address)) {
+					if ($this->_dnsVerboseLog) {
+						log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): %3$s extracted from Check IP Service'), $this->_dnsService, $this->_FQDN, $legacy_ip_address));
+					}
+				} else {
+					log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): IP address could not be extracted from Check IP Service'), $this->_dnsService, $this->_FQDN));
+					return 0;
 				}
-			} else {
+			}
+			if ($this->_useIPv6 == true || $this->_useIPv4Andv6 == true) {
 				if ($this->_dnsVerboseLog) {
 					log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): %3$s extracted from local system.'), $this->_dnsService, $this->_FQDN, $ip_address));
 				}
 			}
-			$this->_dnsIP = $ip_address;
 
-			return $ip_address;
+			if ($this->_useIPv6 == true || $this->_useIPv4Andv6 == true) {
+				$this->_dnsIP = $ip_address;
+			} else {
+				$this->_dnsIP = $legacy_ip_address;
+			}
+
+			if ($this->_useIPv4Andv6 == true) {
+				$this->_dnsLegacyIP = $legacy_ip_address;
+			}
+
+			if ($this->_useIPv6 == true) {
+				return $ip_address;
+			} else {
+				return $legacy_ip_address;
+			}
 		}
 
 	}


### PR DESCRIPTION
The `_checkIP()` method is only obtaining either the legacyIP as default
or the IP if the flag is set for it.  
For services that would override one entry with the newest on each
update it would not be possible to create entries with both, as this
requires them to be sent in the same request.

For this purpose this adds a new flag to signal a service needs both,
legacyIP and IP, available at the same time and a new field
`_dnsLegacyIP`.  
If the new flag isn't set (which is the default) the `_checkIP()` works
like before. If the new flag is set, the `_dnsIP` field will hold the IP
and the `_dnsLegacyIP` the legacyIP.

To not break the cached-IP handling/having to fool around there as well,
the return of the `_checkIP()` is the legacyIP as default and if both
formats are needed and only IP if the `_useIPv6` is set.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/12494
- [x] Ready for review