### PR TITLE
DynDNS: add deSEC IPv4&v6 simultaneos update

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -172,6 +172,7 @@
 		var $_dnsDomain;
 		var $_FQDN;
 		var $_dnsIP;
+		var $_dnsLegacyIP;
 		var $_dnsWildcard;
 		var $_dnsProxied;
 		var $_dnsMX;
@@ -194,6 +195,7 @@
 		var $_dnsDummyUpdateDone;
 		var $_forceUpdateNeeded;
 		var $_useIPv6;
+		var $_useIPv4Andv6;
 		var $_existingRecords;
 		var $_curlProxy;
 
@@ -345,6 +347,12 @@
 				default:
 					$this->_useIPv6 = false;
 			}
+
+			switch ($dnsService) {
+				default:
+					$this->_useIPv4Andv6 = false;
+			}
+
 			$this->_dnsService = strtolower($dnsService);
 			$this->_dnsUser = $dnsUser;
 			$this->_dnsPass = base64_decode($dnsPass);
@@ -3126,33 +3134,53 @@
 				log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): _checkIP() starting.'), $this->_dnsService, $this->_FQDN));
 			}
 
-			if ($this->_useIPv6 == true) {
+			if ($this->_useIPv6 == true || $this->_useIPv4Andv6 == true) {
 				$ip_address = get_interface_ipv6($this->_if);
 				if (!is_ipaddrv6($ip_address)) {
 					return 0;
 				}
-			} else {
-				$ip_address = dyndnsCheckIP($this->_if);
-				if (!is_ipaddr($ip_address)) {
+			}
+			if ($this->_useIPv6 == false || $this->_useIPv4Andv6 == true) {
+				$legacy_ip_address = dyndnsCheckIP($this->_if);
+				if (!is_ipaddr($legacy_ip_address)) {
 					log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): IP address could not be extracted from Check IP Service'), $this->_dnsService, $this->_FQDN));
 					return 0;
-				} elseif (is_private_ip($ip_address)) {
+				} elseif (is_private_ip($legacy_ip_address)) {
 					log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): Public IP address could not be extracted from Check IP Service'), $this->_dnsService, $this->_FQDN));
 					return 0;
 				}
 			}
-			if ($this->_useIPv6 == false && is_private_ip(get_interface_ip($this->_if))) {
-				if ($this->_dnsVerboseLog) {
-					log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): %3$s extracted from Check IP Service'), $this->_dnsService, $this->_FQDN, $ip_address));
+			if (($this->_useIPv6 == false || $this->_useIPv4Andv6 == true) && is_private_ip(get_interface_ip($this->_if))) {
+				if (is_ipaddr($legacy_ip_address)) {
+					if ($this->_dnsVerboseLog) {
+						log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): %3$s extracted from Check IP Service'), $this->_dnsService, $this->_FQDN, $legacy_ip_address));
+					}
+				} else {
+					log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): IP address could not be extracted from Check IP Service'), $this->_dnsService, $this->_FQDN));
+					return 0;
 				}
-			} else {
+			}
+			if ($this->_useIPv6 == true || $this->_useIPv4Andv6 == true) {
 				if ($this->_dnsVerboseLog) {
 					log_error(sprintf(gettext('Dynamic DNS %1$s (%2$s): %3$s extracted from local system.'), $this->_dnsService, $this->_FQDN, $ip_address));
 				}
 			}
-			$this->_dnsIP = $ip_address;
 
-			return $ip_address;
+			if ($this->_useIPv6 == true || $this->_useIPv4Andv6 == true) {
+				$this->_dnsIP = $ip_address;
+			} else {
+				$this->_dnsIP = $legacy_ip_address;
+			}
+
+			if ($this->_useIPv4Andv6 == true) {
+				$this->_dnsLegacyIP = $legacy_ip_address;
+			}
+
+			if ($this->_useIPv6 == true) {
+				return $ip_address;
+			} else {
+				return $legacy_ip_address;
+			}
 		}
 
 	}

--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -101,6 +101,7 @@
 	 *  ClouDNS         - Last Tested: 22 August 2017
 	 *  deSEC           - Last Tested: NEVER
 	 *  deSEC IPv6      - Last Tested: NEVER
+	 *  deSEC IPv4&v6   - Last Tested: 31 October 2021
 	 *  DHS             - Last Tested: 12 July 2005
 	 *  DigitalOcean    - Not Yet Tested
 	 *  DNS Made Easy   - Last Tested: 27 April 2015
@@ -268,6 +269,7 @@
 				break;
 			case 'desec':
 			case 'desec-v6':
+			case 'desec-v4v6':
 				if (!$dnsPass) $this->_error(4);
 				if (!$dnsHost) $this->_error(5);
 				break;
@@ -349,6 +351,9 @@
 			}
 
 			switch ($dnsService) {
+				case 'desec-v4v6':
+					$this->_useIPv4Andv6 = true;
+					break;
 				default:
 					$this->_useIPv4Andv6 = false;
 			}
@@ -417,6 +422,7 @@
 					case 'custom-v6':
 					case 'desec':
 					case 'desec-v6':
+					case 'desec-v4v6':
 					case 'dhs':
 					case 'digitalocean':
 					case 'digitalocean-v6':
@@ -1706,6 +1712,11 @@
 					curl_setopt($ch, CURLOPT_URL, 'https://update6.dedyn.io/?hostname=' . $this->_dnsHost);
 					curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Token ' . $this->_dnsPass));
 					break;
+				case 'desec-v4v6':
+					$needIP = TRUE;
+					curl_setopt($ch, CURLOPT_URL, 'https://update.dedyn.io/?hostname=' . $this->_dnsHost . '&myipv4=' . $this->_dnsLegacyIP . '&myipv6=' . $this->_dnsIP);
+					curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Token ' . $this->_dnsPass));
+					break;
 				default:
 					break;
 			}
@@ -2927,6 +2938,7 @@
 					break;
 				case 'desec':
 				case 'desec-v6':
+				case 'desec-v4v6':
 					$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 					switch ($http_code) {
 						case '200':

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -26,8 +26,8 @@
  */
 
 
-define('DYNDNS_PROVIDER_VALUES', 'all-inkl azure azurev6 citynetwork cloudflare cloudflare-v6 cloudns custom custom-v6 desec desec-v6 digitalocean digitalocean-v6 dnsexit dnsimple dnsimple-v6 dnsmadeeasy dnsomatic domeneshop domeneshop-v6 dreamhost dreamhost-v6 duiadns duiadns-v6 dyfi dyndns dyndns-custom dyndns-static dyns dynv6 dynv6-v6 easydns easydns-v6 eurodns freedns freedns-v6 freedns2 freedns2-v6 glesys gandi-livedns gandi-livedns-v6 godaddy godaddy-v6 googledomains gratisdns he-net he-net-v6 he-net-tunnelbroker hover linode linode-v6 loopia mythicbeasts mythicbeasts-v6 name.com name.com-v6 namecheap nicru nicru-v6 noip noip-v6 noip-free noip-free-v6 onecom onecom-v6 ods opendns ovh-dynhost route53 route53-v6 selfhost spdyn spdyn-v6 strato yandex yandex-v6 zoneedit');
-define('DYNDNS_PROVIDER_DESCRIPTIONS', 'All-Inkl.com,Azure DNS,Azure DNS (v6),City Network,Cloudflare,Cloudflare (v6),ClouDNS,Custom,Custom (v6),deSEC,deSEC (v6),DigitalOcean,DigitalOcean (v6),DNSexit,DNSimple,DNSimple (v6),DNS Made Easy,DNS-O-Matic,Domeneshop,Domeneshop (v6),DreamHost,Dreamhost (v6),DuiaDns.net,DuiaDns.net (v6),DY.fi,DynDNS (dynamic),DynDNS (custom),DynDNS (static),DyNS,Dynv6,Dynv6 (v6),easyDNS,easyDNS (v6),Euro Dns,freeDNS,freeDNS (v6),freeDNS API Version 2, freeDNS API Version 2 (v6),GleSYS,Gandi Live DNS,Gandi Live DNS (v6),GoDaddy,GoDaddy (v6),Google Domains,GratisDNS,HE.net,HE.net (v6),HE.net Tunnelbroker,Hover,Linode,Linode (v6),Loopia,Mythic Beasts,Mythic Beasts (v6),Name.com,Name.com (v6),Namecheap,NIC.RU,NIC.RU (v6),No-IP,No-IP (v6),No-IP (free),No-IP (free-v6),One.com,One.com (v6),ODS.org,OpenDNS,OVH DynHOST,Route 53,Route 53 (v6),SelfHost,SPDYN,SPDYN (v6),Strato,Yandex,Yandex (v6),ZoneEdit');
+define('DYNDNS_PROVIDER_VALUES', 'all-inkl azure azurev6 citynetwork cloudflare cloudflare-v6 cloudns custom custom-v6 desec desec-v6 desec-v4v6 digitalocean digitalocean-v6 dnsexit dnsimple dnsimple-v6 dnsmadeeasy dnsomatic domeneshop domeneshop-v6 dreamhost dreamhost-v6 duiadns duiadns-v6 dyfi dyndns dyndns-custom dyndns-static dyns dynv6 dynv6-v6 easydns easydns-v6 eurodns freedns freedns-v6 freedns2 freedns2-v6 glesys gandi-livedns gandi-livedns-v6 godaddy godaddy-v6 googledomains gratisdns he-net he-net-v6 he-net-tunnelbroker hover linode linode-v6 loopia mythicbeasts mythicbeasts-v6 name.com name.com-v6 namecheap nicru nicru-v6 noip noip-v6 noip-free noip-free-v6 onecom onecom-v6 ods opendns ovh-dynhost route53 route53-v6 selfhost spdyn spdyn-v6 strato yandex yandex-v6 zoneedit');
+define('DYNDNS_PROVIDER_DESCRIPTIONS', 'All-Inkl.com,Azure DNS,Azure DNS (v6),City Network,Cloudflare,Cloudflare (v6),ClouDNS,Custom,Custom (v6),deSEC,deSEC (v6),desec (v4 and v6 simultaneously),DigitalOcean,DigitalOcean (v6),DNSexit,DNSimple,DNSimple (v6),DNS Made Easy,DNS-O-Matic,Domeneshop,Domeneshop (v6),DreamHost,Dreamhost (v6),DuiaDns.net,DuiaDns.net (v6),DY.fi,DynDNS (dynamic),DynDNS (custom),DynDNS (static),DyNS,Dynv6,Dynv6 (v6),easyDNS,easyDNS (v6),Euro Dns,freeDNS,freeDNS (v6),freeDNS API Version 2, freeDNS API Version 2 (v6),GleSYS,Gandi Live DNS,Gandi Live DNS (v6),GoDaddy,GoDaddy (v6),Google Domains,GratisDNS,HE.net,HE.net (v6),HE.net Tunnelbroker,Hover,Linode,Linode (v6),Loopia,Mythic Beasts,Mythic Beasts (v6),Name.com,Name.com (v6),Namecheap,NIC.RU,NIC.RU (v6),No-IP,No-IP (v6),No-IP (free),No-IP (free-v6),One.com,One.com (v6),ODS.org,OpenDNS,OVH DynHOST,Route 53,Route 53 (v6),SelfHost,SPDYN,SPDYN (v6),Strato,Yandex,Yandex (v6),ZoneEdit');
 
 /* implement ipv6 route advertising daemon */
 function services_radvd_configure($blacklist = array()) {
@@ -287,11 +287,11 @@ function services_radvd_configure($blacklist = array()) {
 			if (count($dnslist) > 0) {
 				$dnsstring = implode(" ", $dnslist);
 				if ($dnsstring <> "") {
-					/* 
+					/*
 					 * The value of Lifetime SHOULD by default be at least
 					 * 3 * MaxRtrAdvInterval, where MaxRtrAdvInterval is the
 					 * maximum RA interval as defined in [RFC4861].
-					 * see https://redmine.pfsense.org/issues/11105 
+					 * see https://redmine.pfsense.org/issues/11105
 					 */
 					$radvdconf .= "\tRDNSS {$dnsstring} {\n";
 					$radvdconf .= "\t\tAdvRDNSSLifetime {$raadvdnsslifetime};\n";
@@ -313,9 +313,9 @@ function services_radvd_configure($blacklist = array()) {
 				$searchliststring = "";
 			}
 			if (!empty($dhcpv6ifconf['domain'])) {
-				/* 
+				/*
 				 * Lifetime SHOULD by default be at least 3 * MaxRtrAdvInterval
-				 * see https://redmine.pfsense.org/issues/12173 
+				 * see https://redmine.pfsense.org/issues/12173
 				 */
 				$radvdconf .= "\tDNSSL {$dhcpv6ifconf['domain']} {$searchliststring} {\n";
 				$radvdconf .= "\t\tAdvDNSSLLifetime {$raadvdnsslifetime};\n";
@@ -557,7 +557,7 @@ function services_dhcpdv4_configure() {
 				    ($item['number'] == 60) &&
 				    (base64_decode($item['value']) == "HTTPClient")) {
 					$httpclient = true;
-				} 
+				}
 				$idx++;
 			}
 		}
@@ -580,7 +580,7 @@ function services_dhcpdv4_configure() {
 						    ($item['number'] == 60) &&
 						    (base64_decode($item['value']) == "HTTPClient")) {
 							$httpclient = true;
-						} 
+						}
 						$idx++;
 					}
 				}
@@ -607,7 +607,7 @@ function services_dhcpdv4_configure() {
 					    ($item['number'] == 60) &&
 					    (base64_decode($item['value']) == "HTTPClient")) {
 						$httpclient = true;
-					} 
+					}
 					$idx++;
 				}
 				if (!empty($sm['uefihttpboot']) && isset($sm['netboot']) && !$httpclient) {
@@ -635,7 +635,7 @@ update-conflict-detection false;
 EOD;
 
 	/* take these settings from the first DHCP configured interface,
-	 * see https://redmine.pfsense.org/issues/10270 
+	 * see https://redmine.pfsense.org/issues/10270
 	 * TODO: Global Settings tab, see https://redmine.pfsense.org/issues/5080 */
 	foreach ($dhcpdcfg as $dhcpif => $dhcpifconf) {
 		if (!isset($dhcpifconf['disableauthoritative'])) {
@@ -1037,7 +1037,7 @@ EOPP;
 					    ($item['number'] == 60) &&
 					    (base64_decode($item['value']) == "HTTPClient")) {
 						$httpclient = true;
-					} 
+					}
 					$idx++;
 				}
 			}
@@ -1193,7 +1193,7 @@ EOD;
 				    ($item['number'] == 60) &&
 				    (base64_decode($item['value']) == "HTTPClient")) {
 					$httpclient = true;
-				} 
+				}
 				$idx++;
 			}
 		}
@@ -1242,10 +1242,10 @@ EOD;
 						$expr = "option arch = {$pxe[0]} {\n";
 					}
 					if (!$pxeif) {
-						$dhcpdconf .= "	if " . $expr; 
+						$dhcpdconf .= "	if " . $expr;
 						$pxeif = true;
 					} else {
-						$dhcpdconf .= " else if " . $expr; 
+						$dhcpdconf .= " else if " . $expr;
 					}
 					$dhcpdconf .= "		filename \"{$pxe[1]}\";\n";
 					$dhcpdconf .= "	}";
@@ -1326,7 +1326,7 @@ EOD;
 				if (isset($sm['ddnsupdate'])) {
 					if (($sm['ddnsdomain'] <> "") && ($sm['ddnsdomain'] != $dhcpifconf['ddnsdomain'])) {
 						$smdnscfg .= "	ddns-domainname \"{$sm['ddnsdomain']}\";\n";
-				 		$need_sm_ddns_updates = true;	
+				 		$need_sm_ddns_updates = true;
 					}
 					$smdnscfg .= "	ddns-update-style interim;\n";
 				}
@@ -1379,7 +1379,7 @@ EOD;
 					    ($item['number'] == 60) &&
 					    (base64_decode($item['value']) == "HTTPClient")) {
 						$httpclient = true;
-					} 
+					}
 					$idx++;
 				}
 				if (!empty($poolconf['uefihttpboot']) && isset($poolconf['netboot']) && !$httpclient) {
@@ -1427,10 +1427,10 @@ EOD;
 								$expr = "option arch = {$pxe[0]} {\n";
 							}
 							if (!$pxeif) {
-								$dhcpdconf .= "	if " . $expr; 
+								$dhcpdconf .= "	if " . $expr;
 								$pxeif = true;
 							} else {
-								$dhcpdconf .= " else if " . $expr; 
+								$dhcpdconf .= " else if " . $expr;
 							}
 							$dhcpdconf .= "		filename \"{$pxe[1]}\";\n";
 							$dhcpdconf .= "	}";
@@ -2001,7 +2001,7 @@ EOD;
 function services_igmpproxy_configure($interface='') {
 	global $config, $g;
 
-	if (!empty($interface) && is_array($config['igmpproxy']['igmpentry'])) { 
+	if (!empty($interface) && is_array($config['igmpproxy']['igmpentry'])) {
 		foreach ($config['igmpproxy']['igmpentry'] as $igmpentry) {
 			if ($igmpentry['ifname'] == $interface) {
 				$igmpinf = true;
@@ -2065,9 +2065,9 @@ EOD;
 		}
 		$igmpconf .= "\n";
 		if ($igmpcf['type'] == 'upstream') {
-		       $upstream = true;	
+		       $upstream = true;
 		} else {
-		       $downstream = true;	
+		       $downstream = true;
 		}
 	}
 	foreach ($iflist as $ifn) {
@@ -3138,7 +3138,7 @@ function services_dnsupdate_process($int = "", $updatehost = "", $forced = false
 			$wanip = get_interface_ip($if);
 			$bindipv4 = $wanip;
 		}
-		if (is_stf_interface($dnsupdate['interface'])) { 
+		if (is_stf_interface($dnsupdate['interface'])) {
 			$wanipv6 = get_interface_ipv6($dnsupdate['interface'] . '_stf');
 		} else {
 			$wanipv6 = get_interface_ipv6($if);
@@ -3153,7 +3153,7 @@ function services_dnsupdate_process($int = "", $updatehost = "", $forced = false
 		} elseif (!empty($dnsupdate['updatesource'])) {
 			/* Find the alternate binding address */
 			$bindipv4 = get_interface_ip($dnsupdate['updatesource']);
-			if (is_stf_interface($dnsupdate['interface'])) { 
+			if (is_stf_interface($dnsupdate['interface'])) {
 				$bindipv6 = get_interface_ipv6($dnsupdate['updatesource'] . '_stf');
 			} else {
 				$bindipv6 = get_interface_ipv6($dnsupdate['updatesource']);

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -90,6 +90,7 @@ if ($_POST['save'] || $_POST['force']) {
 		"cloudflare-v6" => array("apex" => false, "wildcard" => false, "username_none" => true),
 		"desec" => array("apex" => false, "wildcard" => false, "username_none" => true),
 		"desec-v6" => array("apex" => false, "wildcard" => false, "username_none" => true),
+		"desec-v4v6" => array("apex" => false, "wildcard" => false, "username_none" => true),
 		"digitalocean" => array("apex" => true, "wildcard" => true, "username_none" => true),
 		"digitalocean-v6" => array("apex" => true, "wildcard" => true, "username_none" => true),
 		"dnsmadeeasy" => array("apex" => false, "wildcard" => false, "username_none" => true),
@@ -146,9 +147,9 @@ if ($_POST['save'] || $_POST['force']) {
 
 	if (isset($_POST['host']) && in_array("host", $reqdfields)) {
 		$allow_wildcard = false;
-		if ((isset($ddns_attr[$pconfig['type']]['apex']) && ($ddns_attr[$pconfig['type']]['apex'] == true) && 
+		if ((isset($ddns_attr[$pconfig['type']]['apex']) && ($ddns_attr[$pconfig['type']]['apex'] == true) &&
 		    (($_POST['host'] == '@.') || ($_POST['host'] == '@'))) ||
-		    (isset($ddns_attr[$pconfig['type']]['wildcard']) && ($ddns_attr[$pconfig['type']]['wildcard'] == true) && 
+		    (isset($ddns_attr[$pconfig['type']]['wildcard']) && ($ddns_attr[$pconfig['type']]['wildcard'] == true) &&
 		    (($_POST['host'] == '*.') || ($_POST['host'] == '*')))) {
 			$host_to_check = $_POST['domainname'];
 		} elseif (($pconfig['type'] == "cloudflare") || ($pconfig['type'] == "cloudflare-v6")) {
@@ -593,6 +594,7 @@ events.push(function() {
 				break;
 			case 'desec':
 			case 'desec-v6':
+			case 'desec-v4v6':
 				hideInput('username', true);
 				hideInput('mx', true);
 				hideCheckbox('wildcard', true);


### PR DESCRIPTION
Leaves the yet included services deSEC and deSEC-v6 untouched.
These are using the automatic ip-recognition from the dns service for
both record types.  
This new service to create/update an entry for the same dns name with
both record types requires the IPs for both records simultaneously,
for which this new service is, leaving the distinct record services in
place for people only want to update a dedicated record.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/12495
- [ ] Ready for review

Depends on #4542 
