### PR TITLE
Correct typographical error

### DIFF
--- a/src/usr/local/www/system_camanager.php
+++ b/src/usr/local/www/system_camanager.php
@@ -598,7 +598,7 @@ $section->addInput(new Form_Checkbox(
 $section->addInput(new Form_Checkbox(
 	'randomserial',
 	'Randomize Serial',
-	'Use random serial numbers when signing certifices',
+	'Use random serial numbers when signing certificates',
 	$pconfig['randomserial']
 ))->setHelp('When enabled, if this CA is capable of signing certificates then ' .
 		'serial numbers for certificates signed by this CA will be ' .


### PR DESCRIPTION
Certificates was misspelled

There is no Redmine issue as the guidelines state that is not necessary for minor typographical corrections.
This change is ready to go. I did make the change on a test environment and ensured it does not break.