### PR TITLE
Securely encrypt config file

### DIFF
--- a/src/etc/inc/crypt.inc
+++ b/src/etc/inc/crypt.inc
@@ -39,10 +39,11 @@
 		 *  unless we need to read old data encrypted without it. */
 		$keyder = ($legacy) ? "" : "-pbkdf2";
 		$md = ($legacy) ? "md5" : "sha256";
+		$iter = ($legacy) ? "" : "-iter 300000";
 
 		$output = "";
 		$exitcode = "";
-		exec("/usr/bin/openssl enc {$opt} -aes-256-cbc -in {$file}.dec -out {$file}.enc -pass pass:" . escapeshellarg($pass) . " -salt -md ${md} {$keyder} 2> /dev/null", $output, $exitcode);
+		exec("/usr/bin/openssl enc {$opt} -aes-256-cbc -in {$file}.dec -out {$file}.enc -pass pass:" . escapeshellarg($pass) . " -salt -md ${md} {$keyder} {$iter} 2> /dev/null", $output, $exitcode);
 
 		if (($exitcode == 0) && file_exists("{$file}.enc") && (filesize("{$file}.enc") > 0)) {
 			$result = file_get_contents("{$file}.enc");

--- a/src/etc/inc/crypt.inc
+++ b/src/etc/inc/crypt.inc
@@ -36,10 +36,12 @@
 		file_put_contents("{$file}.dec", $val);
 
 		/* Use PBKDF2 Key Derivation (https://en.wikipedia.org/wiki/PBKDF2)
-		 *  unless we need to read old data encrypted without it. */
+		 *  unless we need to read old data encrypted without it.
+		 * Specify an iterations count of 500000 for FIPS-140 compliance.
+		 *  https://redmine.pfsense.org/issues/12556 */
 		$keyder = ($legacy) ? "" : "-pbkdf2";
 		$md = ($legacy) ? "md5" : "sha256";
-		$iter = ($legacy) ? "" : "-iter 300000";
+		$iter = ($legacy) ? "" : "-iter 500000";
 
 		$output = "";
 		$exitcode = "";


### PR DESCRIPTION
OpenSSL currently defaults to 10'000 iterations, which is by far a low security standard that was acceptable before 2010.
Nowadays, even on entry level hardware, a count of 100'000 is the minimal.
The impact on import/export of config files is marginal for such an occasional task.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/12556
- [x] Ready for review