### PR TITLE
add an option to disable auto-creation of static routes for dpinger

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -239,18 +239,21 @@ function setup_gateways_monitor() {
 			 * Add static routes for each gateway with their monitor IP
 			 * not strictly necessary but is a added level of protection.
 			 */
-			if (is_ipaddrv4($gateway['gateway']) && $gateway['monitor'] != $gateway['gateway']) {
-				log_error(sprintf(gettext('Removing static route for monitor %1$s and adding a new route through %2$s'), $gateway['monitor'], $gateway['gateway']));
-				if (interface_isppp_type($gateway['friendlyiface'])) {
-					route_add_or_change($gateway['monitor'],
-					    '', $gateway['interface']);
-					system_staticroutes_configure($gateway['friendlyiface']);
-				} else {
-					route_add_or_change($gateway['monitor'],
-					    $gateway['gateway']);
-				}
+			if (!isset($config['system']['dpinger_dont_add_static_routes']) &&
+					!isset($gateway['dpinger_dont_add_static_route'])) {
+				if (is_ipaddrv4($gateway['gateway']) && $gateway['monitor'] != $gateway['gateway']) {
+					log_error(sprintf(gettext('Removing static route for monitor %1$s and adding a new route through %2$s'), $gateway['monitor'], $gateway['gateway']));
+					if (interface_isppp_type($gateway['friendlyiface'])) {
+						route_add_or_change($gateway['monitor'],
+						    '', $gateway['interface']);
+						system_staticroutes_configure($gateway['friendlyiface']);
+					} else {
+						route_add_or_change($gateway['monitor'],
+						    $gateway['gateway']);
+					}
 
-				pfSense_kill_states("0.0.0.0/0", utf8_encode($gateway['monitor']), utf8_encode($gateway['interface']), "icmp");
+					pfSense_kill_states("0.0.0.0/0", utf8_encode($gateway['monitor']), utf8_encode($gateway['interface']), "icmp");
+				}
 			}
 		} else if ($gateway['ipprotocol'] == "inet6") { // This is an IPv6 gateway...
 			if (is_linklocal($gateway['gateway']) &&
@@ -282,18 +285,22 @@ function setup_gateways_monitor() {
 			 * Add static routes for each gateway with their monitor IP
 			 * not strictly necessary but is a added level of protection.
 			 */
-			if ($gateway['gateway'] != $gateways_arr[$gwname]['monitor']) {
-				log_error(sprintf(gettext('Removing static route for monitor %1$s and adding a new route through %2$s'), $gateway['monitor'], $gateway['gateway']));
-				if (interface_isppp_type($gateway['friendlyiface'])) {
-					route_add_or_change($gateway['monitor'],
-					    '', $gateway['interface']);
-					system_staticroutes_configure($gateway['friendlyiface']);
-				} else {
-					route_add_or_change($gateway['monitor'],
-					    $gateway['gateway']);
-				}
 
-				pfSense_kill_states("::0.0.0.0/0", utf8_encode($gateway['monitor']), utf8_encode($gateway['interface']), "icmpv6");
+			if (!isset($config['system']['dpinger_dont_add_static_routes']) &&
+					!isset($gateway['dpinger_dont_add_static_route'])) {
+				if ($gateway['gateway'] != $gateways_arr[$gwname]['monitor']) {
+					log_error(sprintf(gettext('Removing static route for monitor %1$s and adding a new route through %2$s'), $gateway['monitor'], $gateway['gateway']));
+					if (interface_isppp_type($gateway['friendlyiface'])) {
+						route_add_or_change($gateway['monitor'],
+						    '', $gateway['interface']);
+						system_staticroutes_configure($gateway['friendlyiface']);
+					} else {
+						route_add_or_change($gateway['monitor'],
+						    $gateway['gateway']);
+					}
+
+					pfSense_kill_states("::0.0.0.0/0", utf8_encode($gateway['monitor']), utf8_encode($gateway['interface']), "icmpv6");
+				}
 			}
 		} else {
 			continue;
@@ -2077,6 +2084,9 @@ function save_gateway($gateway_settings, $realid = "") {
 	}
 	if ($gateway_settings['nonlocalgateway'] == "yes") {
 		$gateway['nonlocalgateway'] = true;
+	}
+	if ($gateway_settings['dpinger_dont_add_static_route'] == "yes") {
+		$gateway['dpinger_dont_add_static_route'] = true;
 	}
 	if ($gateway_settings['force_down'] == "yes") {
 		$gateway['force_down'] = true;

--- a/src/usr/local/pfSense/include/www/system_advanced_misc.inc
+++ b/src/usr/local/pfSense/include/www/system_advanced_misc.inc
@@ -56,6 +56,7 @@ function getSystemAdvancedMisc($json = false) {
 	$pconfig['schedule_states'] = isset($config['system']['schedule_states']);
 	$pconfig['gw_down_kill_states'] = isset($config['system']['gw_down_kill_states']);
 	$pconfig['skip_rules_gw_down'] = isset($config['system']['skip_rules_gw_down']);
+	$pconfig['dpinger_dont_add_static_routes'] = isset($config['system']['dpinger_dont_add_static_routes']);
 	$pconfig['use_mfs_tmpvar'] = isset($config['system']['use_mfs_tmpvar']);
 	$pconfig['use_mfs_tmp_size'] = $config['system']['use_mfs_tmp_size'];
 	$pconfig['use_mfs_var_size'] = $config['system']['use_mfs_var_size'];

--- a/src/usr/local/www/system_advanced_misc.php
+++ b/src/usr/local/www/system_advanced_misc.php
@@ -304,6 +304,15 @@ $section->addInput(new Form_Checkbox(
 	'down, the rule is created omitting the gateway. This option overrides that '.
 	'behavior by omitting the entire rule instead.');
 
+$section->addInput(new Form_Checkbox(
+	'dpinger_dont_add_static_routes',
+	'Static routes',
+	'Do not add static routes for gateway monitor IP addresses',
+	$pconfig['dpinger_dont_add_static_routes']
+))->setHelp('By default the firewall adds static routes for gateway monitor IP addresses '.
+	'to ensure traffic to the monitor IP address leaves via the correct interface. '.
+	'Enabling this checkbox overrides that behavior.');
+
 $form->add($section);
 $section = new Form_Section('RAM Disk Settings (Reboot to Apply Changes)');
 

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -72,6 +72,7 @@ if (isset($id) && $a_gateways[$id]) {
 	$pconfig['losslow'] = $a_gateways[$id]['losslow'];
 	$pconfig['losshigh'] = $a_gateways[$id]['losshigh'];
 	$pconfig['monitor'] = $a_gateways[$id]['monitor'];
+	$pconfig['dpinger_dont_add_static_route'] = isset($a_gateways[$id]['dpinger_dont_add_static_route']);
 	$pconfig['monitor_disable'] = isset($a_gateways[$id]['monitor_disable']);
 	$pconfig['action_disable'] = isset($a_gateways[$id]['action_disable']);
 	$pconfig['data_payload'] = $a_gateways[$id]['data_payload'];
@@ -222,6 +223,17 @@ $group->add(new Form_Input(
 	'load balancer entries. Use this if the gateway does not respond to ICMP echo '.
 	'requests (pings).');
 $section->add($group);
+
+$section->addInput(new Form_Checkbox(
+	'dpinger_dont_add_static_route',
+	'Static route',
+	'Do not add static route for gateway monitor IP address via the chosen interface',
+	$pconfig['dpinger_dont_add_static_route']
+))->setHelp('By default the firewall adds static routes for gateway monitor IP addresses '.
+	'to ensure traffic to the monitor IP address leaves via the correct interface. '.
+	'Enabling this checkbox overrides that behavior.');
+
+$form->add($section);
 
 $section->addInput(new Form_Checkbox(
 	'force_down',


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/12687
- [x] Ready for review

### Summary

Users may NOT want static routes added for every gateway monitor IP.

This has been discussed before, and I've been running for years with this tiny patch. **_No kittens have died._** 🙀 

The original code was written probably over a decade ago, in the era of `apinger` (anyone remember that?)

`apinger` did not bind to an interface, so the static routes were needed, but I don't think they are anymore now that we've got `dpinger`. There are a lot of footguns when adding routes to anycast IPs (which is the suggested best-practice) since they tend to be DNS servers. I would bet somewhere ~50% of all installs just use 8.8.8.8 etc. So your DNS gets hosed if one of your gateways goes down in Multiwan, defeating the entire purpose.

### Changes

This PR adds a checkbox to System → Advanced → Miscellaneous to disable the auto-added static routes:
<img width=600 src=https://user-images.githubusercontent.com/1992842/149595895-a4b5fc98-80a6-41f0-b71d-a37f98f2fa0b.png>

You can also disable them per-gateway, by ticking the **Do not add static route** checkbox under System → Routing → Gateway → Edit

### Evidence

1. Directly from the code [`/etc/inc/gwlb.inc`](https://github.com/pfsense/pfsense/blob/ba815f3d219e5bdf404be859e723db2ff0c9258c/src/etc/inc/gwlb.inc#L240):
<img width=800 src=https://user-images.githubusercontent.com/1992842/149594295-917439de-91b3-499f-943f-57639b1a156e.png>

2. From the [docs](https://docs.netgate.com/pfsense/en/latest/routing/gateway-configure.html):
<img width=600 src=https://user-images.githubusercontent.com/1992842/149594138-053d59e6-d698-4ec3-be60-69107552352f.png>


### Related discussions

- [Changing the monitor IP of a gateway caused all traffic to that IP to go over said gateway, despite not being default - bug? r/PFSENSE](https://www.reddit.com/r/PFSENSE/comments/rcmho8/changing_the_monitor_ip_of_a_gateway_caused_all/)
- [Gateway monitor IPs are being put into the routing table](https://forum.netgate.com/topic/144488/gateway-monitor-ips-are-being-put-into-the-routing-table/19)
- [Setting host as Monitored IP makes it unreachable? | Netgate Forum](https://forum.netgate.com/topic/127191/setting-host-as-monitored-ip-makes-it-unreachable)
- [Bug #2514: static routes for monitor IPs should be removed - pfSense - pfSense bugtracker](https://redmine.pfsense.org/issues/2514)
- [Bug #12608: WireGuard tunnels monitored by dpinger causing system to stop routing completely in certain situations - pfSense Packages - pfSense bugtracker](https://redmine.pfsense.org/issues/12608)

### Testing

- Tested on a 5100 running 2.4.x and 2.5.x, as well as a 6100 running pfS+ 22.01 rc.
- If anyone would like to test this on their system, install the System Patches package and add commit `ad2dd2c1debaf2281eaed685ad8464c027c3b0b1`.