### PR TITLE
Dynamic DNS: Provider Glesys changed API response to "OK"

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -1973,7 +1973,7 @@
 					break;
 				case 'glesys':
 					$status_intro = "GleSYS ({$this->_dnsHost}): ";
-					if (preg_match('/Record updated/i', $data)) {
+					if (preg_match('/OK/i', $data)) {
 						$status = $status_intro . $success_str . gettext("IP Address Changed Successfully!") . " (" . $this->_dnsIP . ")";
 						$successful_update = true;
 					} else {


### PR DESCRIPTION
/services_dyndns_edit.php: GleSYS (xxxxxx): PAYLOAD: {"response":{"status":{"code":200,"timestamp":"2022-01-15T02:19:09+01:00","text":"OK","transactionid":null},"record":{"recordid":xxxxxx,"domainname":"xxx.xx","host":"@","type":"A","data":"xx.xxx.xx.xxx","ttl":900},"debug":{"input":{"recordid":"xxxxxx","data":"xx.xxx.xx.xxx","format":"json","projectkey":"xxxxx","organizationnumber":xxxxx}}}}
