### PR TITLE
make dashboard display "Inactive" for Hardware crypto instead of empty string when not in use

### DIFF
--- a/src/usr/local/www/includes/functions.inc.php
+++ b/src/usr/local/www/includes/functions.inc.php
@@ -320,7 +320,7 @@ function crypto_accel_get_algs($crypto) {
 		$algs_str .= $alg;
 	}
 
-	return ($algs_str);
+	return (!empty($algs_str) ? $algs_str : gettext("Inactive"));
 }
 
 


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/12714
- [x] Ready for review

Very small patch that just makes the Dashboard display for **Hardware crypto** a bit friendlier (imo) when there are no actively loaded crypto modules. Instead of a blank row, it will show "Inactive" in line with other sections e.g. Kernel PTI etc.

**without** patch:
![image](https://user-images.githubusercontent.com/1992842/150655905-1c91d931-7cc2-4b91-b200-a45a336fa53a.png)


**with** patch:
![image](https://user-images.githubusercontent.com/1992842/150655887-0f78d197-da3c-4603-87d2-7edf9e74ba89.png)
