### PR TITLE
Clean up /etc/inc/filter.inc use of pfctl -F

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -1373,17 +1373,8 @@ function filter_generate_optcfg_array() {
 	}
 }
 
-function filter_flush_nat_table() {
-	global $config, $g;
-	if (isset($config['system']['developerspew'])) {
-		$mt = microtime();
-		echo "filter_flush_nat_table() being called $mt\n";
-	}
-	return mwexec("/sbin/pfctl -F nat");
-}
-
 function filter_flush_state_table() {
-	return mwexec("/sbin/pfctl -F state");
+	return mwexec("/sbin/pfctl -F states");
 }
 
 function filter_get_reflection_interfaces($natif = "") {


### PR DESCRIPTION
filter_flush_state_table() in filter.inc calls "/sbin/pfctl -F state" in which 'state' appears to be a typo for 'states' that just happens to work ... on the man page for [pfctl](https://www.freebsd.org/cgi/man.cgi?query=pfctl):

	     -F	nat	   Flush the NAT rules.
	     -F	queue	   Flush the queue rules.
	     -F	rules	   Flush the filter rules.
	     -F	states	   Flush the state table (NAT and filter).
	     -F	Sources	   Flush the source tracking table.
	     -F	info	   Flush the filter information	(statistics that are
			   not bound to	rules).
	     -F	Tables	   Flush the tables.
	     -F	osfp	   Flush the passive operating system fingerprints.
	     -F	all	   Flush all of	the above.

man page matches the code [pfctl.c](https://github.com/freebsd/freebsd-src/blob/main/sbin/pfctl/pfctl.c)

Since this is a function argument, I don't believe it's a minor/cosmetic typographical error to be ignored as it could cease to function in the future with more strict argument matching. 

---
Secondly, filter_flush_nat_table() in filter.inc is never used and was removed. 

- [x] Redmine Issue: https://redmine.pfsense.org/issues/12757
- [x] Ready for review