### PR TITLE
Fix infinite CPU loop on failed restore

### DIFF
--- a/src/etc/inc/crypt.inc
+++ b/src/etc/inc/crypt.inc
@@ -49,7 +49,7 @@ define('PFS_OPENSSL_DEFAULT_ITERATIONS', '500000');
 
 		if (($exitcode == 0) && file_exists("{$file}.enc") && (filesize("{$file}.enc") > 0)) {
 			$result = file_get_contents("{$file}.enc");
-		} elseif ($iterations == PFS_OPENSSL_DEFAULT_ITERATIONS) {
+		} elseif (($legacy === false) && ($iterations == PFS_OPENSSL_DEFAULT_ITERATIONS)) {
 			/* If it failed with the current default iterations,
 			 * next try with previous default number of iterations. */
 			$result = crypt_data($val, $pass, $opt, false, '10000');

--- a/src/etc/inc/crypt.inc
+++ b/src/etc/inc/crypt.inc
@@ -49,12 +49,18 @@ define('PFS_OPENSSL_DEFAULT_ITERATIONS', '500000');
 
 		if (($exitcode == 0) && file_exists("{$file}.enc") && (filesize("{$file}.enc") > 0)) {
 			$result = file_get_contents("{$file}.enc");
-		} elseif (($legacy === false) && ($iterations == PFS_OPENSSL_DEFAULT_ITERATIONS)) {
+		} elseif (($opt == "-d") && ($legacy === false) && ($iterations == PFS_OPENSSL_DEFAULT_ITERATIONS)) {
 			/* If it failed with the current default iterations,
 			 * next try with previous default number of iterations. */
+			unlink_if_exists($file);
+			unlink_if_exists("{$file}.dec");
+			unlink_if_exists("{$file}.enc");
 			$result = crypt_data($val, $pass, $opt, false, '10000');
-		} elseif ($legacy === false) {
+		} elseif (($opt == "-d") && ($legacy === false)) {
 			/* Operation failed without new options, try old. */
+			unlink_if_exists($file);
+			unlink_if_exists("{$file}.dec");
+			unlink_if_exists("{$file}.enc");
 			$result = crypt_data($val, $pass, $opt, true);
 		} else {
 			$result = "";


### PR DESCRIPTION
When restoring a backup with wrong password or a user custom iterations count different than 10k or 500k, GUI timed out in an infinite CPU loop

- [X] Redmine Issue: https://redmine.pfsense.org/issues/12897
- [X] Ready for review