### PR TITLE
Fix DHCP leases sort

### DIFF
--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -105,6 +105,8 @@ if ($_REQUEST['order']) {
 	usort($leases['lease'], function($a, $b) {
 		return strcmp($a[$_REQUEST['order']], $b[$_REQUEST['order']]);
 	});
+} else {
+	sort($leases['lease']);
 }
 
 /* only print pool status when we have one */

--- a/src/usr/local/www/status_dhcp_leases.php
+++ b/src/usr/local/www/status_dhcp_leases.php
@@ -106,7 +106,12 @@ if ($_REQUEST['order']) {
 		return strcmp($a[$_REQUEST['order']], $b[$_REQUEST['order']]);
 	});
 } else {
-	sort($leases['lease']);
+	usort($leases['lease'], function($a, $b) {
+		if ($a['type'] === $b['type']) {
+			return strnatcmp($a['ip'], $b['ip']);
+		}
+		return strcmp($a['type'], $b['type']);
+	});
 }
 
 /* only print pool status when we have one */


### PR DESCRIPTION
### Description
Commit c4c730b cleaned up a lot of the DHCP lease code, but unfortunately a result of this cleanup was that DHCP leases and reservations are now sorted backwards:
- DHCP leases are now at the bottom of the list (they were at the top before)
- Higher numbered VLANs are sorted above lower numbered VLANs (they were sorted numerically before)

This PR is a minor change that simply restores the sort order to its original function.

- [ ] Redmine Issue: <!-- https://redmine.pfsense.org/issues/NNNN -->
- [X] Ready for review

### Previous sorting: *(restored by this PR)*
![image](https://user-images.githubusercontent.com/34781835/159092347-c4dfaa8b-f47c-4496-8714-16b7660bfb67.png)

### Current sort order:
![image](https://user-images.githubusercontent.com/34781835/159092364-9308c8b3-cfd0-4e9c-8ae9-4addfac8f71c.png)
