### PR TITLE
Increase max firewall log entries

### DIFF
--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -205,7 +205,7 @@ events.push(function(){
 
 	// Create an object defining the widget refresh AJAX call
 	var logsObject = new Object();
-	logsObject.name = "Gateways";
+	logsObject.name = "Firewall Logs";
 	logsObject.url = "/widgets/widgets/log.widget.php";
 	logsObject.callback = logs_callback;
 	logsObject.parms = postdata;
@@ -236,7 +236,7 @@ $pconfig['nentriesinterval'] = isset($user_settings['widgets'][$widgetkey]['filt
 			<label for="filterlogentries" class="col-sm-4 control-label"><?=gettext('Number of entries')?></label>
 			<div class="col-sm-6">
 				<input type="number" name="filterlogentries" id="filterlogentries" value="<?=$pconfig['nentries']?>" placeholder="5"
-					min="1" max="20" class="form-control" />
+					min="1" max="50" class="form-control" />
 			</div>
 		</div>
 


### PR DESCRIPTION
### Description
Simple change that performs the following:
- Fixes a minor typo in the module's name
- Increase the max 'number of entries' in firewall logs widget from 20 to 50 (those of us with larger screens appreciate seeing more data)

This PR is a minor change to expand the number of visible log entries.

- [ ] Redmine Issue: <!-- https://redmine.pfsense.org/issues/NNNN -->
- [X] Ready for review