### PR TITLE
Improve default sha512 password hashing rounds

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -834,7 +834,7 @@ function local_user_set_password(&$user, $password) {
 	switch ($hashalgo) {
 		case 'sha512':
 			$salt = substr(bin2hex(random_bytes(16)),0,16);
-			$user['sha512-hash'] = crypt($password, '$6$'. $salt . '$');
+			$user['sha512-hash'] = crypt($password, '$6$rounds=800000$'. $salt . '$');
 			break;
 		case 'bcrypt':
 		default:


### PR DESCRIPTION
By default, sha512 only does 5000 rounds of encryption which is very weak
Increase rounds to 800k to provide same bcrypt default 10 rounds password resiliance

- [X] Redmine Issue: https://redmine.pfsense.org/issues/12962
- [X] Ready for review