### PR TITLE
Packet capture: add Clear Capture button

### DIFF
--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -280,7 +280,6 @@ if ($_POST) {
 			if (file_exists($fp.$fn)) {
 				unlink ($fp.$fn);
 			}
-
 		} elseif ($_POST['stopbtn'] != "") {
 			$action = gettext("Stop");
 			$processes_running = trim(shell_exec("/bin/ps axw -O pid= | /usr/bin/grep tcpdump | /usr/bin/grep {$fn} | /usr/bin/egrep -v '(pflog|grep)'"));
@@ -297,6 +296,11 @@ if ($_POST) {
 		} elseif ($_POST['downloadbtn'] != "") {
 			//download file
 			send_user_download('file', $fp.$fn);
+		} elseif ($_POST['clearbtn'] != "") {
+			//clear log file
+			if (file_exists($fp.$fn)) {
+				unlink ($fp.$fn);
+			}
 		}
 	}
 } else {
@@ -491,6 +495,13 @@ if (file_exists($fp.$fn) and $processisrunning != true) {
 		null,
 		'fa-download'
 	))->addClass('btn-primary');
+
+	$form->addGlobal(new Form_Button(
+		'clearbtn',
+		'Clear Log',
+		null,
+		'fa-undo'
+	))->addClass('btn-danger restore');
 
 	if (file_exists($fp.$fns)) {
 		$section->addInput(new Form_StaticText(

--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -277,9 +277,7 @@ if ($_POST) {
 			$action = gettext("Start");
 
 			//delete previous packet capture if it exists
-			if (file_exists($fp.$fn)) {
-				unlink ($fp.$fn);
-			}
+			unlink_if_exists($fp.$fn);
 		} elseif ($_POST['stopbtn'] != "") {
 			$action = gettext("Stop");
 			$processes_running = trim(shell_exec("/bin/ps axw -O pid= | /usr/bin/grep tcpdump | /usr/bin/grep {$fn} | /usr/bin/egrep -v '(pflog|grep)'"));
@@ -297,10 +295,8 @@ if ($_POST) {
 			//download file
 			send_user_download('file', $fp.$fn);
 		} elseif ($_POST['clearbtn'] != "") {
-			//clear log file
-			if (file_exists($fp.$fn)) {
-				unlink ($fp.$fn);
-			}
+			//delete previous packet capture if it exists
+			unlink_if_exists($fp.$fn);
 		}
 	}
 } else {

--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -494,7 +494,7 @@ if (file_exists($fp.$fn) and $processisrunning != true) {
 
 	$form->addGlobal(new Form_Button(
 		'clearbtn',
-		'Clear Log',
+		'Clear Capture',
 		null,
 		'fa-undo'
 	))->addClass('btn-danger restore');


### PR DESCRIPTION
When there is a capture file, show a "Clear Capture" button to delete the last capture without having to drop to cli

- [X] Redmine Issue: https://redmine.pfsense.org/issues/12968
- [X] Ready for review