### PR TITLE
Packet Capture: add preview results

### DIFF
--- a/src/usr/local/www/diag_packet_capture.php
+++ b/src/usr/local/www/diag_packet_capture.php
@@ -644,22 +644,27 @@ if ($do_tcpdump) {
 		} else {
 			$iscarp = "";
 		}
-		$detail_args = "";
+
+		$options_args = "";
 		switch ($detail) {
 			case "full":
-				$detail_args = "-vv -e";
+				$options_args = "-vv -e";
 				break;
 			case "high":
-				$detail_args = "-vv";
+				$options_args = "-vv";
 				break;
 			case "medium":
-				$detail_args = "-v";
+				$options_args = "-v";
 				break;
 			case "normal":
 			default:
-				$detail_args = "-q";
+				$options_args = "-q";
 				break;
 		}
+
+        if ($dnsquery !== true) {
+            $options_args .= " -n";
+        }
 
 		print('<textarea class="form-control" rows="20" style="font-size: 13px; font-family: consolas,monaco,roboto mono,liberation mono,courier;">');
 		if (file_exists($fp.$fn) && (filesize($fp.$fn) > $max_display_size)) {
@@ -673,7 +678,7 @@ if ($do_tcpdump) {
 		} elseif ($detail === 'none') {
 			print(gettext("Select a detail level to view the contents of the packet capture."));
 		} else {
-			system("/usr/sbin/tcpdump {$disabledns} {$detail_args} {$iscarp} -r {$fp}{$fn}");
+			system("/usr/sbin/tcpdump {$options_args} {$iscarp} -r {$fp}{$fn}");
 		}
 		print('</textarea>');
 


### PR DESCRIPTION
- allow preview results while a capture is still running
- add a capture summary field
- count: if empty value, properly set it to default 100 instead of 0
- do not pass empty argument to tcpdump when no filter options are posted
- do not check form validity when clicking other buttons than start
- more compact GUI (spannable help tool tips)
- info changes and fixes

- [X] Redmine Issue: https://redmine.pfsense.org/issues/13017
- [X] Ready for review