### PR TITLE
More flexible Client-Specific Override options

### DIFF
--- a/src/usr/local/www/vpn_openvpn_csc.php
+++ b/src/usr/local/www/vpn_openvpn_csc.php
@@ -106,9 +106,9 @@ if (($act == "edit") || ($act == "dup")) {
 		$pconfig['dns_server4'] = $a_csc[$id]['dns_server4'];
 
 		if ($pconfig['dns_server1'] ||
-		    $pconfig['dns_server2'] ||
-		    $pconfig['dns_server3'] ||
-		    $pconfig['dns_server4']) {
+				$pconfig['dns_server2'] ||
+				$pconfig['dns_server3'] ||
+				$pconfig['dns_server4']) {
 			$pconfig['dns_server_enable'] = true;
 		}
 
@@ -116,7 +116,7 @@ if (($act == "edit") || ($act == "dup")) {
 		$pconfig['ntp_server2'] = $a_csc[$id]['ntp_server2'];
 
 		if ($pconfig['ntp_server1'] ||
-		    $pconfig['ntp_server2']) {
+				$pconfig['ntp_server2']) {
 			$pconfig['ntp_server_enable'] = true;
 		}
 
@@ -128,7 +128,7 @@ if (($act == "edit") || ($act == "dup")) {
 		$pconfig['wins_server2'] = $a_csc[$id]['wins_server2'];
 
 		if ($pconfig['wins_server1'] ||
-		    $pconfig['wins_server2']) {
+				$pconfig['wins_server2']) {
 			$pconfig['wins_server_enable'] = true;
 		}
 
@@ -151,8 +151,8 @@ if ($_POST['save']) {
 
 	/* input validation */
 	if (isset($pconfig['custom_options']) &&
-	    ($pconfig['custom_options'] != $a_csc[$id]['custom_options']) &&
-	    !$user_can_edit_advanced) {
+		($pconfig['custom_options'] != $a_csc[$id]['custom_options']) &&
+		!$user_can_edit_advanced) {
 		$input_errors[] = gettext("This user does not have sufficient privileges to edit Advanced options on this instance.");
 	}
 	if (!$user_can_edit_advanced && !empty($a_csc[$id]['custom_options'])) {
@@ -241,7 +241,7 @@ if ($_POST['save']) {
 		}
 
 		if (!empty($pconfig['netbios_ntype']) &&
-		    !array_key_exists($pconfig['netbios_ntype'], $netbios_nodetypes)) {
+			!array_key_exists($pconfig['netbios_ntype'], $netbios_nodetypes)) {
 			$input_errors[] = gettext("The selected NetBIOS Node Type is not valid.");
 		}
 	}
@@ -309,8 +309,8 @@ if ($_POST['save']) {
 		}
 
 		if (($act == 'new') || ($csc['disable'] ^ $a_csc[$id]['disable']) ||
-		    ($csc['tunnel_network'] != $a_csc[$id]['tunnel_network']) ||
-		    ($csc['tunnel_networkv6'] != $a_csc[$id]['tunnel_networkv6'])) {
+			($csc['tunnel_network'] != $a_csc[$id]['tunnel_network']) ||
+			($csc['tunnel_networkv6'] != $a_csc[$id]['tunnel_networkv6'])) {
 			$csc['unbound_restart'] = true;
 		}
 
@@ -432,8 +432,8 @@ if ($act == "new" || $act == "edit"):
 		'text',
 		$pconfig['tunnel_network']
 	))->setHelp('The virtual IPv4 network or network type alias with a single entry used for private communications between this client and the server expressed using CIDR (e.g. 10.0.8.5/24). %1$s' .
-		    'With subnet topology, enter the client IP address and the subnet mask must match the IPv4 Tunnel Network on the server. %1$s' .
-		    'With net30 topology, the first network address of the /30 is assumed to be the server address and the second network address will be assigned to the client.',
+			'With subnet topology, enter the client IP address and the subnet mask must match the IPv4 Tunnel Network on the server. %1$s' .
+			'With net30 topology, the first network address of the /30 is assumed to be the server address and the second network address will be assigned to the client.',
 			'<br />');
 
 	$section->addInput(new Form_Input(
@@ -442,7 +442,7 @@ if ($act == "new" || $act == "edit"):
 		'text',
 		$pconfig['tunnel_networkv6']
 	))->setHelp('The virtual IPv6 network or network type alias with a single entry used for private communications between this client and the server expressed using prefix (e.g. 2001:db9:1:1::100/64). %1$s' .
-		    'Enter the client IPv6 address and prefix. The prefix must match the IPv6 Tunnel Network prefix on the server. ',
+			'Enter the client IPv6 address and prefix. The prefix must match the IPv6 Tunnel Network prefix on the server. ',
 			'<br />');
 
 	$section->addInput(new Form_Checkbox(
@@ -458,7 +458,7 @@ if ($act == "new" || $act == "edit"):
 		'text',
 		$pconfig['local_network']
 	))->setHelp('These are the IPv4 server-side networks that will be accessible from this particular client. Expressed as a comma-separated list of one or more CIDR ranges or host/network type aliases. %1$s' .
-		    'NOTE: Networks do not need to be specified here if they have already been defined on the main server configuration.',
+			'NOTE: Networks do not need to be specified here if they have already been defined on the main server configuration.',
 			'<br />');
 
 	$section->addInput(new Form_Input(
@@ -467,7 +467,7 @@ if ($act == "new" || $act == "edit"):
 		'text',
 		$pconfig['local_networkv6']
 	))->setHelp('These are the IPv6 server-side networks that will be accessible from this particular client. Expressed as a comma-separated list of one or more IP/PREFIX networks.%1$s' .
-		    'NOTE: Networks do not need to be specified here if they have already been defined on the main server configuration.',
+			'NOTE: Networks do not need to be specified here if they have already been defined on the main server configuration.',
 			'<br />');
 
 	$section->addInput(new Form_Input(
@@ -476,8 +476,8 @@ if ($act == "new" || $act == "edit"):
 		'text',
 		$pconfig['remote_network']
 	))->setHelp('These are the IPv4 client-side networks that will be routed to this client specifically using iroute, so that a site-to-site VPN can be established. ' .
-		    'Expressed as a comma-separated list of one or more CIDR ranges. May be left blank if there are no client-side networks to be routed.%1$s' .
-		    'NOTE: Remember to add these subnets to the IPv4 Remote Networks list on the corresponding OpenVPN server settings.',
+			'Expressed as a comma-separated list of one or more CIDR ranges. May be left blank if there are no client-side networks to be routed.%1$s' .
+			'NOTE: Remember to add these subnets to the IPv4 Remote Networks list on the corresponding OpenVPN server settings.',
 			'<br />');
 
 	$section->addInput(new Form_Input(
@@ -486,8 +486,8 @@ if ($act == "new" || $act == "edit"):
 		'text',
 		$pconfig['remote_networkv6']
 	))->setHelp('These are the IPv6 client-side networks that will be routed to this client specifically using iroute, so that a site-to-site VPN can be established. ' .
-		    'Expressed as a comma-separated list of one or more IP/PREFIX networks. May be left blank if there are no client-side networks to be routed.%1$s' .
-		    'NOTE: Remember to add these subnets to the IPv6 Remote Networks list on the corresponding OpenVPN server settings.',
+			'Expressed as a comma-separated list of one or more IP/PREFIX networks. May be left blank if there are no client-side networks to be routed.%1$s' .
+			'NOTE: Remember to add these subnets to the IPv6 Remote Networks list on the corresponding OpenVPN server settings.',
 			'<br />');
 
 	$form->add($section);
@@ -499,7 +499,7 @@ if ($act == "new" || $act == "edit"):
 		'DNS Default Domain',
 		'Provide a default domain name to clients',
 		$pconfig['dns_domain_enable']
-	))->toggles('.dnsdomain');
+	));
 
 	$group = new Form_Group('DNS Domain');
 	$group->addClass('dnsdomain');
@@ -519,7 +519,7 @@ if ($act == "new" || $act == "edit"):
 		'DNS Servers',
 		'Provide a DNS server list to clients',
 		$pconfig['dns_server_enable']
-	))->toggles('.dnsservers');
+	));
 
 	$group = new Form_Group(null);
 	$group->addClass('dnsservers');
@@ -560,7 +560,7 @@ if ($act == "new" || $act == "edit"):
 		'NTP Servers',
 		'Provide an NTP server list to clients',
 		$pconfig['ntp_server_enable']
-	))->toggles('.ntpservers');
+	));
 
 	$group = new Form_Group(null);
 	$group->addClass('ntpservers');
@@ -581,7 +581,7 @@ if ($act == "new" || $act == "edit"):
 
 	$section->add($group);
 
-	// NTP servers - For this section we need to use Javascript hiding since there
+	// Netbios - For this section we need to use Javascript hiding since there
 	// are nested toggles
 	$section->addInput(new Form_Checkbox(
 		'netbios_enable',
@@ -671,6 +671,30 @@ if ($act == "new" || $act == "edit"):
 //<![CDATA[
 events.push(function() {
 
+	function dnsdomain_change() {
+		if ($('#dns_domain_enable').prop('checked')) {
+			hideClass('dnsdomain', false);
+		} else {
+			hideClass('dnsdomain', true);
+		}
+	}
+
+	function dnsservers_change() {
+		if ($('#dns_server_enable').prop('checked')) {
+			hideClass('dnsservers', false);
+		} else {
+			hideClass('dnsservers', true);
+		}
+	}
+
+	function ntpservers_change() {
+		if ($('#ntp_server_enable').prop('checked')) {
+			hideClass('ntpservers', false);
+		} else {
+			hideClass('ntpservers', true);
+		}
+	}
+
 	// Hide/show that section, but have to also respect the wins_server_enable checkbox
 	function setNetbios() {
 		if ($('#netbios_enable').prop('checked')) {
@@ -692,6 +716,21 @@ events.push(function() {
 
 	// ---------- Click checkbox handlers ---------------------------------------------------------
 
+	 // On clicking DNS Default Domain
+	$('#dns_domain_enable').click(function () {
+		dnsdomain_change();
+	});
+
+	 // On clicking DNS Servers
+	$('#dns_server_enable').click(function () {
+		dnsservers_change();
+	});
+
+	 // On clicking NTP Servers
+	$('#ntp_server_enable').click(function () {
+		ntpservers_change();
+	});
+
 	// On clicking the netbios_enable checkbox
 	$('#netbios_enable').click(function () {
 		setNetbios();
@@ -705,6 +744,10 @@ events.push(function() {
 	// ---------- On initial page load ------------------------------------------------------------
 
 	setNetbios();
+	dnsdomain_change();
+	dnsservers_change();
+	ntpservers_change();
+
 });
 //]]>
 </script>

--- a/src/usr/local/www/vpn_openvpn_csc.php
+++ b/src/usr/local/www/vpn_openvpn_csc.php
@@ -86,14 +86,14 @@ if (($act == "edit") || ($act == "dup")) {
 
 		$pconfig['tunnel_network'] = $a_csc[$id]['tunnel_network'];
 		$pconfig['tunnel_networkv6'] = $a_csc[$id]['tunnel_networkv6'];
+
+		$pconfig['push_reset'] = $a_csc[$id]['push_reset'];
+		$pconfig['remove_route'] = $a_csc[$id]['remove_route'];
+		$pconfig['gwredir'] = $a_csc[$id]['gwredir'];
 		$pconfig['local_network'] = $a_csc[$id]['local_network'];
 		$pconfig['local_networkv6'] = $a_csc[$id]['local_networkv6'];
 		$pconfig['remote_network'] = $a_csc[$id]['remote_network'];
 		$pconfig['remote_networkv6'] = $a_csc[$id]['remote_networkv6'];
-		$pconfig['gwredir'] = $a_csc[$id]['gwredir'];
-
-		$pconfig['push_reset'] = $a_csc[$id]['push_reset'];
-		$pconfig['remove_route'] = $a_csc[$id]['remove_route'];
 
 		$pconfig['dns_domain'] = $a_csc[$id]['dns_domain'];
 		if ($pconfig['dns_domain']) {
@@ -269,13 +269,13 @@ if ($_POST['save']) {
 		foreach (array('', 'v6') as $ntype) {
 			$csc["tunnel_network{$ntype}"] = openvpn_tunnel_network_fix($pconfig["tunnel_network{$ntype}"]);
 		}
+		$csc['push_reset'] = $pconfig['push_reset'];
+		$csc['remove_route'] = $pconfig['remove_route'];
+		$csc['gwredir'] = $pconfig['gwredir'];
 		$csc['local_network'] = $pconfig['local_network'];
 		$csc['local_networkv6'] = $pconfig['local_networkv6'];
 		$csc['remote_network'] = $pconfig['remote_network'];
 		$csc['remote_networkv6'] = $pconfig['remote_networkv6'];
-		$csc['gwredir'] = $pconfig['gwredir'];
-		$csc['push_reset'] = $pconfig['push_reset'];
-		$csc['remove_route'] = $pconfig['remove_route'];
 
 		if ($pconfig['dns_domain_enable']) {
 			$csc['dns_domain'] = $pconfig['dns_domain'];
@@ -406,6 +406,22 @@ if ($act == "new" || $act == "edit"):
 		true
 		))->setHelp('Select the servers that will utilize this override. When no servers are selected, the override will apply to all servers.');
 
+	$section->addInput(new Form_Checkbox(
+		'push_reset',
+		'Server Definitions',
+		'Prevent this client from receiving any server-defined client settings. ',
+		$pconfig['push_reset']
+	));
+
+	/* as "push-reset" can break subnet topology, 
+	 * "push-remove route" removes only IPv4/IPv6 routes, see #9702 */
+	$section->addInput(new Form_Checkbox(
+		'remove_route',
+		'Remove Server Routes',
+		'Prevent this client from receiving any server-defined routes without removing any other options. ',
+		$pconfig['remove_route']
+	));
+
 	$form->add($section);
 
 	$section = new Form_Section('Tunnel Settings');
@@ -428,6 +444,13 @@ if ($act == "new" || $act == "edit"):
 	))->setHelp('The virtual IPv6 network or network type alias with a single entry used for private communications between this client and the server expressed using prefix (e.g. 2001:db9:1:1::100/64). %1$s' .
 		    'Enter the client IPv6 address and prefix. The prefix must match the IPv6 Tunnel Network prefix on the server. ',
 			'<br />');
+
+	$section->addInput(new Form_Checkbox(
+		'gwredir',
+		'Redirect Gateway',
+		'Force all client generated traffic through the tunnel.',
+		$pconfig['gwredir']
+	));
 
 	$section->addInput(new Form_Input(
 		'local_network',
@@ -467,32 +490,9 @@ if ($act == "new" || $act == "edit"):
 		    'NOTE: Remember to add these subnets to the IPv6 Remote Networks list on the corresponding OpenVPN server settings.',
 			'<br />');
 
-	$section->addInput(new Form_Checkbox(
-		'gwredir',
-		'Redirect Gateway',
-		'Force all client generated traffic through the tunnel.',
-		$pconfig['gwredir']
-	));
-
 	$form->add($section);
 
 	$section = new Form_Section('Client Settings');
-
-	$section->addInput(new Form_Checkbox(
-		'push_reset',
-		'Server Definitions',
-		'Prevent this client from receiving any server-defined client settings. ',
-		$pconfig['push_reset']
-	));
-
-	/* as "push-reset" can break subnet topology, 
-	 * "push-remove route" removes only IPv4/IPv6 routes, see #9702 */
-	$section->addInput(new Form_Checkbox(
-		'remove_route',
-		'Remove Server Routes',
-		'Prevent this client from receiving any server-defined routes without removing any other options. ',
-		$pconfig['remove_route']
-	));
 
 	$section->addInput(new Form_Checkbox(
 		'dns_domain_enable',


### PR DESCRIPTION
**Part 1: More flexible Client-Specific Override options GUI changes**
- add individual server overrides for the optional client settings (local routes/gateway, remote routes, DNS, NTP, Netbios...)
- add option to override topology when selecting "Remove All Server Options" (push-reset)
- add option to set gateways (useful when removing routes)
- add option to override Redirect IPv6 Gateway in addition to existing IPv4 option
- move all server override options to the "Override Configuration" group
- hide override options with a "Select Server Overrides" toggle
- disable un-needed overrides when "Remove All Server Options" (push-reset) is selected
- when "Redirect IPv4/6 Gateway" is toggled, the Local Routes fields are hidden/shown correspondingly like for the server edit page

**Small bug fixes**
- fix bug when "0" is entered in DNS/Domain... fields (using !empty() discards 0)
- fix bug: NTP and DNS options: use javascript instead of toggles class because the latter causes inverted results when repeating clicks too quickly

- [x] Redmine Issue: https://redmine.pfsense.org/issues/12522
- [x] Ready for review