### PR TITLE
OpenVPN Client overrides: properly hide forms

### DIFF
--- a/src/usr/local/www/vpn_openvpn_csc.php
+++ b/src/usr/local/www/vpn_openvpn_csc.php
@@ -499,7 +499,7 @@ if ($act == "new" || $act == "edit"):
 		'DNS Default Domain',
 		'Provide a default domain name to clients',
 		$pconfig['dns_domain_enable']
-	))->toggles('.dnsdomain');
+	));
 
 	$group = new Form_Group('DNS Domain');
 	$group->addClass('dnsdomain');
@@ -519,7 +519,7 @@ if ($act == "new" || $act == "edit"):
 		'DNS Servers',
 		'Provide a DNS server list to clients',
 		$pconfig['dns_server_enable']
-	))->toggles('.dnsservers');
+	));
 
 	$group = new Form_Group(null);
 	$group->addClass('dnsservers');
@@ -560,7 +560,7 @@ if ($act == "new" || $act == "edit"):
 		'NTP Servers',
 		'Provide an NTP server list to clients',
 		$pconfig['ntp_server_enable']
-	))->toggles('.ntpservers');
+	));
 
 	$group = new Form_Group(null);
 	$group->addClass('ntpservers');
@@ -581,7 +581,7 @@ if ($act == "new" || $act == "edit"):
 
 	$section->add($group);
 
-	// NTP servers - For this section we need to use Javascript hiding since there
+	// Netbios - For this section we need to use Javascript hiding since there
 	// are nested toggles
 	$section->addInput(new Form_Checkbox(
 		'netbios_enable',
@@ -670,8 +670,31 @@ if ($act == "new" || $act == "edit"):
 <script type="text/javascript">
 //<![CDATA[
 events.push(function() {
+	function dnsdomain_change() {
+		if ($('#dns_domain_enable').prop('checked')) {
+			hideClass('dnsdomain', false);
+		} else {
+			hideClass('dnsdomain', true);
+		}
+	}
 
-	// Hide/show that section, but have to also respect the wins_server_enable checkbox
+	function dnsservers_change() {
+		if ($('#dns_server_enable').prop('checked')) {
+			hideClass('dnsservers', false);
+		} else {
+			hideClass('dnsservers', true);
+		}
+	}
+
+	function ntpservers_change() {
+		if ($('#ntp_server_enable').prop('checked')) {
+			hideClass('ntpservers', false);
+		} else {
+			hideClass('ntpservers', true);
+		}
+	}
+
+	// Hide/show that section, but have to also respect the wins_server_enable and nbdd_server_enable checkboxes
 	function setNetbios() {
 		if ($('#netbios_enable').prop('checked')) {
 			hideInput('netbios_ntype', false);
@@ -692,6 +715,21 @@ events.push(function() {
 
 	// ---------- Click checkbox handlers ---------------------------------------------------------
 
+	 // On clicking DNS Default Domain
+	$('#dns_domain_enable').click(function () {
+		dnsdomain_change();
+	});
+
+	 // On clicking DNS Servers
+	$('#dns_server_enable').click(function () {
+		dnsservers_change();
+	});
+
+	 // On clicking NTP Servers
+	$('#ntp_server_enable').click(function () {
+		ntpservers_change();
+	});
+
 	// On clicking the netbios_enable checkbox
 	$('#netbios_enable').click(function () {
 		setNetbios();
@@ -705,6 +743,10 @@ events.push(function() {
 	// ---------- On initial page load ------------------------------------------------------------
 
 	setNetbios();
+	dnsdomain_change();
+	dnsservers_change();
+	ntpservers_change();
+
 });
 //]]>
 </script>


### PR DESCRIPTION
- in client specific overrides, NTP and DNS options: use javascript instead of toggles class because the latter causes inverted results when repeating clicks too quickly. This also matches the code used in the server page

- [x] Redmine Issue: https://redmine.pfsense.org/issues/13088
- [x] Ready for review