### PR TITLE
OpenVPN: do not use deprecated variables since they are unset

### DIFF
--- a/src/etc/inc/openvpn.inc
+++ b/src/etc/inc/openvpn.inc
@@ -772,11 +772,11 @@ function openvpn_add_dhcpopts(& $settings, & $conf) {
 
 	if ($settings['netbios_enable']) {
 
-		if (!empty($settings['dhcp_nbttype']) && ($settings['dhcp_nbttype'] != 0)) {
-			$conf .= "push \"dhcp-option NBT {$settings['dhcp_nbttype']}\"\n";
+		if (!empty($settings['netbios_ntype']) && ($settings['netbios_ntype'] != 0)) {
+			$conf .= "push \"dhcp-option NBT {$settings['netbios_ntype']}\"\n";
 		}
-		if (!empty($settings['dhcp_nbtscope'])) {
-			$conf .= "push \"dhcp-option NBS {$settings['dhcp_nbtscope']}\"\n";
+		if (!empty($settings['netbios_scope'])) {
+			$conf .= "push \"dhcp-option NBS {$settings['netbios_scope']}\"\n";
 		}
 
 		if (!empty($settings['wins_server1'])) {


### PR DESCRIPTION
Old legacy settings are replaced by new ones on settings load

- [x] Redmine Issue: https://redmine.pfsense.org/issues/13090
- [x] Ready for review