### PR TITLE
remove line filename from the  pool section

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -1114,9 +1114,7 @@ EOPP;
 						$dhcpdconf .= "		}";
 					}
 					$dhcpdconf .= "\n\n";
-				} elseif (!empty($filename)) {
-					$dhcpdconf .= "		filename \"{$filename}\";\n";
-				}
+				} 
 				unset($filename);
 
 				if (!empty($poolconf['rootpath']) && ($poolconf['rootpath'] != $dhcpifconf['rootpath'])) {


### PR DESCRIPTION
Remove the filename config single line as it  breaks the conditional dhcp config for pxe;

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/12986
- [ ] Ready for review