### PR TITLE
add warning to menu option 14 when it might kill your connection

### DIFF
--- a/src/etc/rc.initial.toggle_sshd
+++ b/src/etc/rc.initial.toggle_sshd
@@ -31,6 +31,12 @@ require_once("filter.inc");
 $fp = fopen('php://stdin', 'r');
 
 if (isset($config['system']['ssh']['enable'])) {
+	if (!empty(getenv('SSH_CONNECTION'))) {
+		echo gettext("!!! WARNING !!!");
+		echo "\n\n";
+		echo gettext("This session is currently established via SSH. Disabling SSH will terminate this session and prevent future SSH connections from any user. Before disabling SSH, ensure that administrators have alternate means of accessing the firewall, such as the GUI or serial console.");
+		echo "\n\n";
+	}
 	echo "SSHD is currently enabled.  Would you like to disable? [y/n]? ";
 	$yn = chop(fgets($fp));
 	if ($yn[0] == "y") {


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/13103
- [x] Ready for review

Believe it or not, I fat fingered "13" the other day and typed "14" instead when connected via SSH ... and hit "y" which then locked me out of a firewall. Had to dig out the console cable to get it sorted.

This small patch just checks to see if the current session is via SSH and if so, it prints a warning if the user is about to footgun themselves.

Screenshot:

![CleanShot 2022-04-26 at 19 37 04](https://user-images.githubusercontent.com/1992842/165409993-5d3f06dc-2ff3-4dbd-b2de-50d09270c89a.png)
