### PR TITLE
Trim MAC addresses when submitting (e.g. on services_dhcp_edit.php)

### DIFF
--- a/src/usr/local/www/services_captiveportal_mac_edit.php
+++ b/src/usr/local/www/services_captiveportal_mac_edit.php
@@ -93,7 +93,7 @@ if ($_POST['save']) {
 
 	$macfull = explode('/', $_POST['mac']);
 	$macmask = $macfull[1] ? $macfull[1] : false; 
-	$_POST['mac'] = strtolower(str_replace("-", ":", $macfull[0]));
+	$_POST['mac'] = trim(strtolower(str_replace("-", ":", $macfull[0])));
 
 	if ($_POST['mac']) {
 		if (is_macaddr($_POST['mac'])) {

--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -189,7 +189,7 @@ if ($_POST['save']) {
 	}
 
 	/* normalize MAC addresses - lowercase and convert Windows-ized hyphenated MACs to colon delimited */
-	$_POST['mac'] = strtolower(str_replace("-", ":", $_POST['mac']));
+	$_POST['mac'] = trim(strtolower(str_replace("-", ":", $_POST['mac'])));
 
 	if ($_POST['hostname']) {
 		preg_match("/\-\$/", $_POST['hostname'], $matches);

--- a/src/usr/local/www/services_wol_edit.php
+++ b/src/usr/local/www/services_wol_edit.php
@@ -74,7 +74,7 @@ if ($_POST['save']) {
 	do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
 
 	/* normalize MAC addresses - lowercase and convert Windows-ized hyphenated MACs to colon delimited */
-	$_POST['mac'] = strtolower(str_replace("-", ":", $_POST['mac']));
+	$_POST['mac'] = trim(strtolower(str_replace("-", ":", $_POST['mac'])));
 
 	if (($_POST['mac'] && !is_macaddr($_POST['mac']))) {
 		$input_errors[] = gettext("A valid MAC address must be specified.");


### PR DESCRIPTION
Small patch to trim MAC address input on POST. This eases copy & paste which sometimes grabs a little extra whitespace on either end. Previously this would cause input validation to fail.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/13109
- [x] Ready for review