### PR TITLE
remove colon to stay consistent with the rest of the GUI

### DIFF
--- a/src/usr/local/www/firewall_nat_out.php
+++ b/src/usr/local/www/firewall_nat_out.php
@@ -395,7 +395,7 @@ if ($mode == "automatic" || $mode == "hybrid"):
 	$automatic_rules = getAutoRules();
 ?>
 	<div class="panel panel-default">
-		<div class="panel-heading"><h2 class="panel-title"><?=gettext("Automatic Rules:")?></h2></div>
+		<div class="panel-heading"><h2 class="panel-title"><?=gettext("Automatic Rules")?></h2></div>
 		<div class="panel-body table-responsive">
 			<table class="table table-hover table-striped table-condensed">
 				<thead>


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/13149
- [x] Ready for review

Firewall → NAT → Outbound → Automatic rules table header has a `:` after it, which is not seen anywhere else in the GUI. This just removes it for consistency.

![CleanShot 2022-05-11 at 08 28 40](https://user-images.githubusercontent.com/1992842/167849976-7e242c94-4c1f-46ef-9307-58f576dd7e74.png)