### PR TITLE
fix infoblock placement on firewall_nat_out.php - redmine #13164

### DIFF
--- a/src/usr/local/www/firewall_nat_out.php
+++ b/src/usr/local/www/firewall_nat_out.php
@@ -494,14 +494,12 @@ if ($mode == "automatic" || $mode == "hybrid"):
 							<?=htmlspecialchars($natent['descr'])?>
 						</td>
 					</tr>
-<?php
-	endforeach;
-endif;
-?>
+<?php endforeach; ?>
 				</tbody>
 			</table>
 		</div>
 	</div>
+<?php endif; ?>
 </form>
 
 <div class="infoblock">


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/13164
- [x] Ready for review
 
fixes placement of infoblock when outbound NAT mode is manual

before
![image](https://user-images.githubusercontent.com/1992842/168410245-8fd5d55d-cf5a-4f68-a98c-30ef5cb2391e.png)

after
![image](https://user-images.githubusercontent.com/1992842/168410244-ff902081-0df8-4265-be9c-e51e54f9b958.png)
