### PR TITLE
enhancements to gateway monitor setup / static routing (builds on #4551)

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -190,6 +190,100 @@ function start_dpinger($gateway) {
 	return mwexec("/usr/local/bin/dpinger {$params} {$gateway['monitor']} >/dev/null");
 }
 
+/* Remove temporary static routes that were dynamically added for dpinger */
+function delete_temporary_static_routes($gateway) {
+	global $config;
+	if (empty($gateway)) {
+		return false;
+	}
+	$ipprotocol = $gateway['ipprotocol'];
+	$rtable = route_table()[$ipprotocol];
+	if (empty($rtable)) {
+		return false;
+	}
+	$gwname = $gateway['name'];
+	$friendly = $gateway['interface'];
+	$ifname = get_real_interface($friendly);
+	$routes_ughs = array_filter($rtable, fn($r) => (
+		$r['flags'] == 'UGHS' &&
+		$r['interface-name'] == $ifname
+	));
+	$staticroutes = get_staticroutes();
+	foreach ($routes_ughs as $r) {
+		$tgt = $r['destination'];
+		if (is_ipaddrv4($tgt)) {
+			$cidr = "{$tgt}/32";
+		} elseif (is_ipaddrv6($tgt)) {
+			$cidr = "{$tgt}/128";
+		} else {
+			continue;
+		}
+		// check to see if we can safely remove this route
+		$test_sr = array_filter($staticroutes, fn($sr) => (
+			$sr['network'] == $cidr &&
+			$sr['gateway'] == $gwname
+		));
+		if (empty($test_sr)) {
+			$rkey = implode('_', array($ifname, $tgt));
+			if (is_array($GLOBALS['inuse_static_routes']) &&
+				in_array($rkey, $GLOBALS['inuse_static_routes'])) {
+				continue;
+			}
+			route_del($tgt, $ipprotocol);
+		}
+	}
+}
+
+/* helper function to reduce duplicate code in setup_gateways_monitor() */
+function remove_and_add_routes($gateway) {
+	log_error(sprintf(gettext('Removing static route for monitor %1$s and adding a new route through %2$s'), $gateway['monitor'], $gateway['gateway']));
+	if (interface_isppp_type($gateway['friendlyiface'])) {
+		route_add_or_change($gateway['monitor'], '', $gateway['interface']);
+		system_staticroutes_configure($gateway['friendlyiface']);
+	} else {
+		route_add_or_change($gateway['monitor'], $gateway['gateway']);
+	}
+	return;
+}
+
+/* Configure static routes for Gateway Monitor IPs */
+function setup_dpinger_static_routes($gateway) {
+	global $config, $g;
+	delete_temporary_static_routes($gateway);
+	if (isset($config['system']['dpinger_dont_add_static_routes']) || isset($gateway['dpinger_dont_add_static_route'])) {
+		/* config dictates that we don't create a static route for this monitor IP */
+		return;
+	}
+	/* If monitor IP is the gateway itself, do not add a route as this would break the routing table */
+	if ($gateway['monitor'] == $gateway['gateway']) {
+		return;
+	}
+	$rkey = implode('_', array(get_real_interface($gateway['interface']), $gateway['monitor']));
+	$GLOBALS['inuse_static_routes'][] = $rkey;
+
+	switch ($gateway['ipprotocol']) {
+		case 'inet':
+			if (is_ipaddrv4($gateway['monitor'])) {
+				remove_and_add_routes($gateway);
+				pfSense_kill_states("0.0.0.0/0", utf8_encode($gateway['monitor']), utf8_encode($gateway['interface']), "icmp");
+			} else {
+				log_error(sprintf(gettext('Skipped adding static route for gateway %1$s because %2$s is not a valid IPv4 address'), $gateway['name'], $gateway['monitor']));
+			}
+			break;
+		case 'inet6':
+			if (is_ipaddrv6($gateway['monitor'])) {
+				remove_and_add_routes($gateway);
+				pfSense_kill_states("::0.0.0.0/0", utf8_encode($gateway['monitor']), utf8_encode($gateway['interface']), "icmpv6");
+			} else {
+				log_error(sprintf(gettext('Skipped adding static route for gateway %1$s because %2$s is not a valid IPv6 address'), $gateway['name'], $gateway['monitor']));
+			}
+			break;
+		default:
+			log_error(sprintf(gettext('Gateway %1$s is of unknown type: %2$s, skipping'), $gateway['name'], $gateway['ipprotocol']));
+			break;
+	}
+}
+
 /*
  * Starts dpinger processes and adds appropriate static routes for monitor IPs
  */
@@ -206,6 +300,7 @@ function setup_gateways_monitor() {
 		echo "Setting up gateway monitors...";
 	}
 	$monitor_ips = array();
+	$GLOBALS['inuse_static_routes'][] = array();
 	foreach ($gateways_arr as $gwname => $gateway) {
 		/* Do not monitor if such was requested */
 		if (isset($gateway['monitor_disable'])) {
@@ -236,84 +331,33 @@ function setup_gateways_monitor() {
 			if (!is_ipaddrv4($gwifip)) {
 				continue; //Skip this target
 			}
-
 			if ($gwifip == "0.0.0.0") {
 				continue; //Skip this target - the gateway is still waiting for DHCP
 			}
-
-			/*
-			 * If the gateway is the same as the monitor we do not add a
-			 * route as this will break the routing table.
-			 * Add static routes for each gateway with their monitor IP
-			 * not strictly necessary but is a added level of protection.
-			 */
-			if (!isset($config['system']['dpinger_dont_add_static_routes']) &&
-					!isset($gateway['dpinger_dont_add_static_route'])) {
-				if (is_ipaddrv4($gateway['gateway']) && $gateway['monitor'] != $gateway['gateway']) {
-					log_error(sprintf(gettext('Removing static route for monitor %1$s and adding a new route through %2$s'), $gateway['monitor'], $gateway['gateway']));
-					if (interface_isppp_type($gateway['friendlyiface'])) {
-						route_add_or_change($gateway['monitor'],
-						    '', $gateway['interface']);
-						system_staticroutes_configure($gateway['friendlyiface']);
-					} else {
-						route_add_or_change($gateway['monitor'],
-						    $gateway['gateway']);
-					}
-
-					pfSense_kill_states("0.0.0.0/0", utf8_encode($gateway['monitor']), utf8_encode($gateway['interface']), "icmp");
-				}
-			}
-		} else if ($gateway['ipprotocol'] == "inet6") { // This is an IPv6 gateway...
+		} elseif ($gateway['ipprotocol'] == "inet6") { // This is an IPv6 gateway...
 			if (is_linklocal($gateway['gateway']) &&
 			    get_ll_scope($gateway['gateway']) == '') {
 				$gateway['gateway'] .= '%' . $gateway['interface'];
 			}
-
 			if (is_linklocal($gateway['monitor'])) {
 				if (get_ll_scope($gateway['monitor']) == '') {
 					$gateways_arr[$gwname]['monitor'] .= '%' . $gateway['interface'];
 				}
-
 				$gwifip = find_interface_ipv6_ll($gateway['interface'], true);
-
 				if (get_ll_scope($gwifip) == '') {
 					$gwifip .= '%' . $gateway['interface'];
 				}
 			} else {
 				$gwifip = find_interface_ipv6($gateway['interface'], true);
 			}
-
 			if (!is_ipaddrv6($gwifip)) {
 				continue; //Skip this target
-			}
-
-			/*
-			 * If the gateway is the same as the monitor we do not add a
-			 * route as this will break the routing table.
-			 * Add static routes for each gateway with their monitor IP
-			 * not strictly necessary but is a added level of protection.
-			 */
-
-			if (!isset($config['system']['dpinger_dont_add_static_routes']) &&
-					!isset($gateway['dpinger_dont_add_static_route'])) {
-				if ($gateway['gateway'] != $gateways_arr[$gwname]['monitor']) {
-					log_error(sprintf(gettext('Removing static route for monitor %1$s and adding a new route through %2$s'), $gateway['monitor'], $gateway['gateway']));
-					if (interface_isppp_type($gateway['friendlyiface'])) {
-						route_add_or_change($gateway['monitor'],
-						    '', $gateway['interface']);
-						system_staticroutes_configure($gateway['friendlyiface']);
-					} else {
-						route_add_or_change($gateway['monitor'],
-						    $gateway['gateway']);
-					}
-
-					pfSense_kill_states("::0.0.0.0/0", utf8_encode($gateway['monitor']), utf8_encode($gateway['interface']), "icmpv6");
-				}
 			}
 		} else {
 			continue;
 		}
 
+		setup_dpinger_static_routes($gateway);
 		$monitor_ips[] = $gateway['monitor'];
 		$gateways_arr[$gwname]['enable_dpinger'] = true;
 		$gateways_arr[$gwname]['gwifip'] = $gwifip;

--- a/src/usr/local/pfSense/include/www/system_advanced_misc.inc
+++ b/src/usr/local/pfSense/include/www/system_advanced_misc.inc
@@ -298,10 +298,18 @@ function saveSystemAdvancedMisc($post, $json = false) {
 			unset($config['system']['skip_rules_gw_down']);
 		}
 
+		// if the configuration of this setting changes, re-run the gw monitoring setup so routes get updated without requiring a reboot
+		$old_dpinger_dasr = (isset($config['system']['dpinger_dont_add_static_routes']));
 		if ($post['dpinger_dont_add_static_routes'] == "yes") {
 			$config['system']['dpinger_dont_add_static_routes'] = true;
+			if (!$old_dpinger_dasr) {
+				setup_gateways_monitor();
+			}
 		} else {
 			unset($config['system']['dpinger_dont_add_static_routes']);
+			if ($old_dpinger_dasr) {
+				setup_gateways_monitor();
+			}
 		}
 
 		$tmpvar_set = (isset($config['system']['use_mfs_tmpvar']) ? true:false);

--- a/src/usr/local/www/system_gateways_edit.php
+++ b/src/usr/local/www/system_gateways_edit.php
@@ -234,7 +234,8 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['dpinger_dont_add_static_route']
 ))->setHelp('By default the firewall adds static routes for gateway monitor IP addresses '.
 	'to ensure traffic to the monitor IP address leaves via the correct interface. '.
-	'Enabling this checkbox overrides that behavior.');
+	'Enabling this checkbox overrides that behavior. %1$s',
+	isset($config['system']['dpinger_dont_add_static_routes']) ? '(Currently being <b>overridden</b> by the global setting at <a href=/system_advanced_misc.php>System > Advanced > Miscellaneous</a>)' : '');
 
 $section->addInput(new Form_Checkbox(
 	'force_down',


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/13242
- [x] Ready for review
---
#### Changes
- fixes orphan static routes hanging around after changing monitor IPs
- dynamically turn global or per-gw dont_add_static_route option on/off without requiring a reboot
- refactor setup_gateways_monitor() to reduce duplicate code
- added note to setHelp area on gw edit to notify user when global dont_add_static_routes option would override the local setting

This is my improved v2 patch for #4551. The main difference is the ability to dynamically remove stale/orphan static routes that were added for gateway monitoring with a new `delete_temporary_static_routes()` helper function. I also tried to re-use some code where possible in the `setup_gateways_monitor()` loop by breaking out the identical sections into separate functions.

I have limited IPv6 capability on my test unit here, so I would love to have some more testers in that area. My basic testing shows it working fine.

I also created a helper script to aid in debugging, see [`dpinger_static_routes.php` gist](https://gist.github.com/luckman212/0fdea1cbdc0a561d781a52c7d34fb60d). That will show all the gateway / static route / related config in realtime so you can watch the changes as you adjust in the GUI.

### To run the helper script:

1. install cmdwatch:
```
pkg add https://pkg.freebsd.org/FreeBSD:12:amd64/latest/All/cmdwatch-0.2.0_2.txz
```
2. download the script:
```
fetch https://gist.githubusercontent.com/luckman212/0fdea1cbdc0a561d781a52c7d34fb60d/raw/ffd321ef196fb1c919dd66700acdd4acc02b3e63/dpinger_static_routes.php
```
then
```
cmdwatch --interval=2 'php -q dpinger_static_routes.php'
```
