### PR TITLE
add type column to firewall_aliases.php

### DIFF
--- a/src/usr/local/pfSense/include/www/alias-utils.inc
+++ b/src/usr/local/pfSense/include/www/alias-utils.inc
@@ -34,6 +34,16 @@ require_once("openvpn.inc");
 init_config_arr(array('aliases', 'alias'));
 $a_aliases = &$config['aliases']['alias'];
 
+$alias_types = array(
+	'host'	=> gettext("Host(s)"),
+	'network' => gettext("Network(s)"),
+	'port' => gettext("Port(s)"),
+	'url' => gettext("URL (IPs)"),
+	'url_ports' => gettext("URL (Ports)"),
+	'urltable' => gettext("URL Table (IPs)"),
+	'urltable_ports' => gettext("URL Table (Ports)"),
+);
+
 function deleteAlias($id, $apply = false) {
 	global $config;
 

--- a/src/usr/local/www/firewall_aliases.php
+++ b/src/usr/local/www/firewall_aliases.php
@@ -107,6 +107,7 @@ display_top_tabs($tab_array);
 	<thead>
 		<tr>
 			<th><?=gettext("Name")?></th>
+			<th><?=gettext("Type")?></th>
 			<th><?=gettext("Values")?></th>
 			<th><?=gettext("Description")?></th>
 			<th><?=gettext("Actions")?></th>
@@ -144,6 +145,9 @@ display_top_tabs($tab_array);
 		<tr>
 			<td ondblclick="document.location='firewall_aliases_edit.php?id=<?=$i;?>';">
 				<?=htmlspecialchars($alias['name'])?>
+			</td>
+			<td nowrap ondblclick="document.location='firewall_aliases_edit.php?id=<?=$i;?>';">
+				<?=htmlspecialchars($alias_types[$alias['type']])?>
 			</td>
 			<td ondblclick="document.location='firewall_aliases_edit.php?id=<?=$i;?>';">
 <?php

--- a/src/usr/local/www/firewall_aliases_edit.php
+++ b/src/usr/local/www/firewall_aliases_edit.php
@@ -171,15 +171,7 @@ if ($_POST['save']) {
 
 include("head.inc");
 
-$section_str = array(
-	'network' => gettext("Network(s)"),
-	'host'	=> gettext("Host(s)"),
-	'port' => gettext("Port(s)"),
-	'url' => gettext("URL (IPs)"),
-	'url_ports' => gettext("URL (Ports)"),
-	'urltable' => gettext("URL Table (IPs)"),
-	'urltable_ports' => gettext("URL Table (Ports)")
-);
+$section_str = $alias_types;
 
 $btn_str = array(
 	'network' => gettext("Add Network"),
@@ -251,16 +243,6 @@ $placeholder_str = array(
 	'urltable_ports'	=> 'URL'
 );
 
-$types = array(
-	'host'	=> gettext("Host(s)"),
-	'network' => gettext("Network(s)"),
-	'port' => gettext("Port(s)"),
-	'url' => gettext("URL (IPs)"),
-	'url_ports' => gettext("URL (Ports)"),
-	'urltable' => gettext("URL Table (IPs)"),
-	'urltable_ports' => gettext("URL Table (Ports)"),
-);
-
 if ($input_errors) {
 	print_input_errors($input_errors);
 }
@@ -320,7 +302,7 @@ $section->addInput(new Form_Select(
 	'type',
 	'*Type',
 	isset($pconfig['type']) ? $pconfig['type'] : $tab,
-	$types
+	$alias_types
 ));
 
 $form->add($section);


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/13245
- [x] Ready for review

Small QoL addition that adds a Type column to the Alias list views. I was recently cleaning up my aliases and being able to see the type (especially on the "All" tab) was very useful. I also moved the `$types` array into `alias-utils.inc` so it can be re-used.

screenshot

![CleanShot 2022-06-04 at 10 20 23@2x](https://user-images.githubusercontent.com/1992842/172006230-6c9f2745-9053-46d9-8d4e-2818a22d2764.png)
