### PR TITLE
Fix typo in enable

### DIFF
--- a/src/usr/local/www/services_dhcp.php
+++ b/src/usr/local/www/services_dhcp.php
@@ -1484,7 +1484,7 @@ $section->addInput(new Form_StaticText(
 $section->addInput(new Form_Checkbox(
 	'netboot',
 	'Enable',
-	'Enables network booting',
+	'Enable network booting',
 	$pconfig['netboot']
 ));
 


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [X] Ready for review

I fixed a typo in the word "Enable" in services_dhcp.php