### PR TITLE
Add warning infobox if duplicate IP is entered in DHCP static map

### DIFF
--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -226,6 +226,11 @@ if ($_POST['save']) {
 			$input_errors[] = gettext("This MAC address or Client identifier already exists.");
 			break;
 		}
+		if (($mapent['ipaddr'] == $_POST['ipaddr']) && $mapent['ipaddr']) {
+			set_flash_message('alert-info', sprintf(gettext('The IP address %1$s is in use by another static DHCP mapping. ' .
+			'This has the potential to cause an IP conflict.'), $mapent['ipaddr']));
+			break;
+		}
 	}
 
 	/* make sure it's not within the dynamic subnet */
@@ -497,8 +502,7 @@ $section->addInput(new Form_IpAddress(
 	$pconfig['ipaddr'],
 	'V4'
 ))->setHelp('If an IPv4 address is entered, the address must be outside of the pool.%1$s' .
-			'If no IPv4 address is given, one will be dynamically allocated from the pool.%1$s%1$s' .
-			'The same IP address may be assigned to multiple mappings.', '<br />');
+			'If no IPv4 address is given, one will be dynamically allocated from the pool.', '<br />');
 
 $section->addInput(new Form_Input(
 	'hostname',


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/13256
- [x] Ready for review

This is an improvement to add a warning back to input validation when a user enters the same IP for multiple DHCP static maps. It still allows this to be done, by adding a pconfig checkbox that the user needs to check. I believe this is the best of both worlds.

#### Example input validation warning
![image](https://user-images.githubusercontent.com/1992842/172645113-8448f973-ca3d-4365-87d0-c406f4d92de8.png)

#### If you want to really do this, just check the box:
<img width="573" alt="image" src="https://user-images.githubusercontent.com/1992842/172645525-70164b89-551d-4647-8add-836429f3b9d3.png">

_related forum thread: https://forum.netgate.com/topic/172698/why-does-the-ui-allow-duplicate-ip-addresses-different-macs-in-dhcp-static-mappings_