### PR TITLE
IPv6/gateway monitoring fixes - attempt to fix #11570 and #12947

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -280,7 +280,7 @@ function setup_gateways_monitor() {
 					$gwifip .= '%' . $gateway['interface'];
 				}
 			} else {
-				$gwifip = find_interface_ipv6($gateway['interface'], true);
+				$gwifip = get_usable_interface_ipv6($gateway['interface'], true)[0];
 			}
 
 			if (!is_ipaddrv6($gwifip)) {

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -6499,6 +6499,58 @@ function link_interface_to_ppp_tunnelif($interface) {
 	return $result;
 }
 
+/* is_v6_bogon($ipaddr): returns true if the supplied address is a bogon
+ * https://en.wikipedia.org/wiki/IPv6_address#Special_addresses
+ */
+function is_v6_bogon($ipaddr) {
+	$is_bogon = false;
+	$addr_els = Net_IPv6::separate($ipaddr);
+	$bogon_ranges = array(
+		'fc00::/7',   // Unique local addresses (ULA)
+		'fe80::/10',  // Link-local unicast
+		'fec0::/10'   // Site-local unicast (deprecated)
+	);
+	foreach ($bogon_ranges as $range) {
+		if (Net_IPv6::isInNetmask($addr_els[0], $range)) {
+			$is_bogon = true;
+			break;
+		}
+	}
+	return $is_bogon;
+}
+
+/* get_usable_interface_ipv6($interface): returns an array of usable, non-bogon (LL/ULA) IPv6 addresses
+ * if $fallback = true then function will return LL address if there is no other available
+ * https://github.com/pear/Net_IPv6/blob/master/Net/IPv6.php
+ */
+function get_usable_interface_ipv6($interface, $firstonly = false, $fallback = false) {
+	$interface = trim($interface);
+	$realifv6 = get_real_interface($interface, "inet6", true);
+	if (!$realifv6) {
+		return;
+	}
+	$ifaddrs = pfSense_getall_interface_addresses($realifv6);
+	if (!is_array($ifaddrs)) {
+		return;
+	}
+	$all_ipv6_addresses = array_filter($ifaddrs, fn($ipaddr) => (
+		is_v6($ipaddr) &&
+		!is_v6_bogon($ipaddr)
+	));
+	if (empty($all_ipv6_addresses) && $fallback == true) {
+		$all_ipv6_addresses = array_filter($ifaddrs, fn($ipaddr) => (is_v6($ipaddr)));
+	}
+	$usable_ipv6_addresses = array();
+	foreach ($all_ipv6_addresses as $ipaddr) {
+		$addr_els = Net_IPv6::separate($ipaddr);
+		$usable_ipv6_addresses[] = array(
+			'address'   => $addr_els[0],
+			'prefixlen' => $addr_els[1]
+		);
+	}
+	return ($firstonly ? array($usable_ipv6_addresses[0]['address'], $usable_ipv6_addresses[0]['prefixlen']) : $usable_ipv6_addresses);
+}
+
 /*
  * find_interface_ip($interface): return the interface ip (first found)
  */
@@ -7715,6 +7767,115 @@ function restart_interface_services($interface, $ipv6type = "") {
 	init_config_arr(array('syslog'));
 	if (isset($config['syslog']['enable']) && ($interface == $config['syslog']['sourceip'])) {
 		system_syslogd_start();
+	}
+}
+
+function get_detached_or_deprecated_ipv6_addresses($interface = "wan", $rtype = "detached") {
+	$realifv6 = get_real_interface($interface, "inet6", true);
+	if (!does_interface_exist($realifv6)) {
+		return array();
+	}
+	switch ($rtype) {
+		case "detached":
+			$re = 'detached';
+			break;
+		case "deprecated":
+			$re = 'deprecated';
+			break;
+		case "both":
+			$re = '(detached|deprecated)';
+			break;
+		default:
+			return array();
+	}
+	exec("/sbin/ifconfig {$realifv6} | /usr/bin/awk '/[\t ]+?inet6 .* {$re}/ { print $2 }'", $output, $ret);
+	return $output;
+}
+
+function remove_detached_or_deprecated_ipv6_address($address, $interface = "wan", $rtype) {
+	if (!is_v6($address)) {
+		log_error(sprintf(gettext('Ignoring request to remove %1$s from %2$s (not an IPv6 address)'), $address, $interface));
+		return false;
+	}
+	$realifv6 = get_real_interface($interface, "inet6", true);
+	if (!does_interface_exist($realifv6)) {
+		log_error(sprintf(gettext('Ignoring request to remove %1$s from %2$s (invalid interface)'), $address, $interface));
+		return false;
+	}
+	list($ipaddr, $prefix) = Net_IPv6::separate($address);
+	if ($ipaddr == $config['interfaces'][$interface]['ipaddrv6']) {
+		log_error(sprintf(gettext('Not removing address %1$s from interface %2$s because it is assigned in config.xml'), $address, $interface));
+		return false;
+	}
+	$all_ipv6_addresses = array_map('Net_IPv6::removeNetmaskSpec', array_filter(
+		pfSense_getall_interface_addresses($realifv6), fn($ipaddr) => (is_v6($ipaddr)))
+	);
+	if (!in_array($ipaddr, $all_ipv6_addresses)) {
+		log_error(sprintf(gettext('Not removing address %1$s (address does not exist on interface %2$s)'), $address, $interface));
+		return false;
+	}
+	if ($rtype && !in_array($ipaddr, get_detached_or_deprecated_ipv6_addresses($interface, $rtype))) {
+		log_error(sprintf(gettext('Not removing address %1$s from interface %2$s (detached/deprecated flag not present)'), $address, $interface));
+		return false;
+	}
+	exec("/sbin/ifconfig {$realifv6} inet6 {$ipaddr} delete", $output, $ret);
+	log_error(sprintf(gettext('Removing address %1$s from interface %2$s, result: %3$s'), $address, $interface, $ret));
+	return $ret;
+}
+
+function remove_all_detached_or_deprecated_ipv6_addresses($interface = "wan", $rtype = "detached") {
+	$detached_or_deprecated_addrs = get_detached_or_deprecated_ipv6_addresses($interface, $rtype);
+	foreach ($detached_or_deprecated_addrs as $address) {
+		remove_detached_or_deprecated_ipv6_address($address, $interface, $rtype);
+	}
+	remove_orphan_ipv6_addresses($interface);
+}
+
+function remove_orphan_ipv6_addresses($interface = "wan") {
+	// loop thru all /128 IPs and remove any that are not contained by another assigned subnet and not assigned by config.xml
+	$all_ips = array_filter(pfSense_getall_interface_addresses($interface), fn($ipaddr) => (is_v6($ipaddr)));
+	$checkips = array_filter($all_ips, fn($ipaddr) => (Net_IPv6::getNetmaskSpec($ipaddr) == 128));
+	$all_ipv6_nets = array_filter($all_ips, fn($ipaddr) => (Net_IPv6::getNetmaskSpec($ipaddr) < 128));
+	foreach ($checkips as $ipaddr) {
+		$addr_els = Net_IPv6::separate($ipaddr);
+		$orphan_test = array_filter($all_ipv6_nets, fn($net) => (Net_IPv6::isInNetmask($addr_els[0], $net)));
+		if (empty($orphan_test)) {
+			log_error(sprintf(gettext('Removing orphan address %1$s from interface %2$s'), $ipaddr, $interface));
+			remove_detached_or_deprecated_ipv6_address($ipaddr, $interface, false);
+		}
+	}
+}
+
+function get_interface_ipv6_cfg($interface) {
+	$realifv6 = get_real_interface($interface, "inet6", true);
+	if (!does_interface_exist($realifv6)) {
+		return false;
+	}
+	$all_ipv6_addresses = array_filter(pfSense_getall_interface_addresses($realifv6), fn($ipaddr) => (is_v6($ipaddr)));
+	sort($all_ipv6_addresses);
+	$all_ipv6_addresses = implode("\n", $all_ipv6_addresses) . "\n";
+	return ($all_ipv6_addresses);
+}
+
+function create_interface_ipv6_cfgcache($interface) {
+	global $g;
+	$curipv6cfg = get_interface_ipv6_cfg($interface);
+	if ($curipv6cfg) {
+		file_put_contents("{$g['vardb_path']}/{$interface}_ipv6_cfgcache", $curipv6cfg);
+	} else {
+		unlink_if_exists("{$g['vardb_path']}/{$interface}_ipv6_cfgcache");
+		return false;
+	}
+}
+
+function compare_interface_ipv6_cfgcache($interface) {
+	global $g;
+	if (!file_exists("{$g['vardb_path']}/{$interface}_ipv6_cfgcache")) {
+		create_interface_ipv6_cfgcache($interface);
+	} else {
+		$oldipv6cfg = file_get_contents("{$g['vardb_path']}/{$interface}_ipv6_cfgcache");
+		$curipv6cfg = get_interface_ipv6_cfg($interface);
+		return ($curipv6cfg == $oldipv6cfg);
 	}
 }
 

--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -1570,8 +1570,7 @@ function get_interface_info($ifdescr) {
 	$ifinfo['ipaddr'] = $ifinfotmp['ipaddr'];
 	$ifinfo['subnet'] = $ifinfotmp['subnet'];
 	$ifinfo['linklocal'] = get_interface_linklocal($ifdescr);
-	$ifinfo['ipaddrv6'] = get_interface_ipv6($ifdescr);
-	$ifinfo['subnetv6'] = get_interface_subnetv6($ifdescr);
+	list($ifinfo['ipaddrv6'], $ifinfo['subnetv6']) = get_usable_interface_ipv6($ifdescr, true, true);
 	if (isset($ifinfotmp['link0'])) {
 		$link0 = "down";
 	}

--- a/src/etc/rc.banner
+++ b/src/etc/rc.banner
@@ -87,8 +87,7 @@ foreach ($iflist as $ifname => $friendly) {
 	}
 	$ipaddr = get_interface_ip($ifname);
 	$subnet = get_interface_subnet($ifname);
-	$ipaddr6 = get_interface_ipv6($ifname);
-	$subnet6 = get_interface_subnetv6($ifname);
+	list($ipaddr6, $subnet6) = get_usable_interface_ipv6($ifname, true, true);
 	$realif = get_real_interface($ifname);
 	$tobanner = "{$friendly} ({$ifname})";
 

--- a/src/etc/rc.checkv6addrchange
+++ b/src/etc/rc.checkv6addrchange
@@ -1,0 +1,44 @@
+#!/usr/local/bin/php-cgi -f
+<?php
+/*
+ * rc.checkv6addrchange
+ *
+ * part of pfSense (https://www.pfsense.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once("globals.inc");
+require_once("config.inc");
+
+$dhcp6_ifs = array_filter($config['interfaces'], fn($interface) => ($interface['ipaddrv6'] == 'dhcp6'));
+$slaac_ifs = array_filter($config['interfaces'], fn($interface) => ($interface['ipaddrv6'] == 'slaac'));
+
+foreach ($dhcp6_ifs as $interface => $ifcfg) {
+	if (!compare_interface_ipv6_cfgcache($interface)) {
+		log_error(sprintf(gettext('IPv6 configuration change detected on interface %1$s, sending SIGHUP to dhcp6c'), $interface));
+		reset_dhcp6client_process();
+		break;
+	}
+}
+
+foreach ($slaac_ifs as $interface => $ifcfg) {
+	if (!compare_interface_ipv6_cfgcache($interface)) {
+		log_error(sprintf(gettext('IPv6 configuration change detected on interface %1$s, starting rc.newwanipv6'), $interface));
+		$realifv6 = get_real_interface($interface, "inet6", true);
+		mwexec("/usr/local/sbin/fcgicli -f /etc/rc.newwanipv6 -d interface={$realifv6}", false);
+		break;
+	}
+}
+
+?>

--- a/src/etc/rc.newwanipv6
+++ b/src/etc/rc.newwanipv6
@@ -59,12 +59,12 @@ log_error("rc.newwanipv6: Info: starting on {$argument}.");
 if (empty($argument)) {
 	$interface = "wan";
 	$interface_real = get_real_interface($interface, "inet6");
-	$curwanipv6 = get_interface_ipv6($interface, true);
 } else {
 	$interface_real = $argument;
 	$interface = convert_real_interface_to_friendly_interface_name($interface_real);
-	$curwanipv6 = get_interface_ipv6($interface, true);
 }
+remove_all_detached_or_deprecated_ipv6_addresses($interface, 'both');
+$curwanipv6 = get_usable_interface_ipv6($interface, true)[0];
 
 $interface_descr = convert_friendly_interface_to_friendly_descr($interface);
 
@@ -115,6 +115,7 @@ if (!empty($new_domain_name)) {
 /* write current WAN IPv6 to file */
 if (is_ipaddrv6($curwanipv6)) {
 	@file_put_contents("{$g['vardb_path']}/{$interface}_ipv6", $curwanipv6);
+	create_interface_ipv6_cfgcache($interface);
 }
 
 log_error("rc.newwanipv6: on (IP address: {$curwanipv6}) (interface: {$interface}) (real interface: {$interface_real}).");


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/11570
- [x] 2nd Redmine Issue: https://redmine.pfsense.org/issues/12947
- [x] Ready for review

## Step-by-step instructions for anyone who wants to test

> _**N.B.** You can open https://github.com/pfsense/pfsense/compare/master...luckman212:ipv6-and-dpinger-fixes-from-4591-4595?diff=split to see a side-by-side diff of the complete changes that will be made._

1. install System Patches package
2. add new patch
```
description: ipv6/dpinger fixes from PR #4595
commit ID:   99d5e29d3aa762a66bf30adea8c841f1b6050fdc
```
3. leave all others at default, hit Save
4. Click Fetch
5. Click Apply
6. ssh or console to your pfSense
7. choose option **8**
8. paste this command: `chmod u+x /etc/rc.checkv6addrchange`
9. run `php -a`
10. paste:
```php
include("config.inc");
install_cron_job('/usr/bin/nice -n20 /etc/rc.checkv6addrchange', true, "*/1", '*', '*', '*', '*', 'root', true);
```
11. press `CTRL+D` or type `exit` to quit
12. for good measure, I suggest rebooting.

## Prerequisite ⚠️

This PR uses some functions that were added in #4591, so that patch would need to be applied first. See above note for full step by step guide for anyone who wants to test this on a "clean" system. 

## Update 6/19/22 👈

This new squashed commit is now somewhat more ambitous and attempts to also fix [redmine 12947](https://redmine.pfsense.org/issues/12947).

to add the required cronjob programmatically, see steps 9-10 above.

I tested with both DHCP6 and SLAAC and and this recovers successfully in both cases on my test system (6100 running 22.05.r.20220617.0613). 

_**More testers wanted!**_

### Previous PR note below...

This attempts to fix an issue with IPv6 gateway monitoring, where the old `find_interface_ipv6()` function is inadequate because it simply returns the first v6 ip on the interface, which could be an LL/ULA address that breaks monitoring.

Before this patch, each night my DHCPv6 WAN would go offline when the carrier issued a new IP or connectivity was momentarily lost. When I checked with `pgrep -lf dpinger`, I saw that it was restarted bound to a bogon IP and was unable to ping out anymore... so the gateway was marked down—even though I had a perfectly valid & working public IPv6.

The main change here is the addition of a `get_usable_interface_ipv6()` function, which, instead of returning the _first_ IPv6 on an interface, instead iterates through all of them and returns either an array of all non-bogon IPs/prefixes, or if the `$firstonly = true` parameter is passed, just the first one. In that mode it's more or less a drop-in replacement for `find_interface_ipv6()`.