### PR TITLE
fix log spew when deleting static DHCP maps not in arp table

### DIFF
--- a/src/usr/local/www/services_dhcp_edit.php
+++ b/src/usr/local/www/services_dhcp_edit.php
@@ -425,11 +425,10 @@ if ($_POST['save']) {
 
 		/* Configure static ARP entry, or remove ARP entry if this host is dynamic. See https://redmine.pfsense.org/issues/6821 */
 		if ($mapent['arp_table_static_entry']) {
-			mwexec("/usr/sbin/arp -S " . escapeshellarg($mapent['ipaddr']) . " " . escapeshellarg($mapent['mac']));
+			mwexec("/usr/sbin/arp -S " . escapeshellarg($mapent['ipaddr']) . " " . escapeshellarg($mapent['mac']) . " >/dev/null", true);
 		} else {
-			mwexec("/usr/sbin/arp -d " . escapeshellarg($mapent['ipaddr']));
+			mwexec("/usr/sbin/arp -d " . escapeshellarg($mapent['ipaddr']) . " >/dev/null", true);
 		}
-
 		header("Location: services_dhcp.php?if={$if}");
 		exit;
 	}


### PR DESCRIPTION
Small patch to reduce log spew when deleting static DHCP entries not in arp table.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/13263
- [x] Ready for review
