### PR TITLE
tiny change to better align console menu with longer ifnames

### DIFF
--- a/src/etc/rc.banner
+++ b/src/etc/rc.banner
@@ -92,7 +92,7 @@ foreach ($iflist as $ifname => $friendly) {
 	$realif = get_real_interface($ifname);
 	$tobanner = "{$friendly} ({$ifname})";
 
-	printf("\n %-15s -> %-10s -> ",
+	printf("\n %-24s -> %-10s -> ",
 		$tobanner,
 		$realif
 	);
@@ -108,7 +108,7 @@ foreach ($iflist as $ifname => $friendly) {
 	}
 	if (!empty($ipaddr6) && !empty($subnet6)) {
 		if (!$v6first) {
-			printf("\n%s", str_repeat(" ", 34));
+			printf("\n%s", str_repeat(" ", 26));
 		}
 		printf("v6%s: %s/%s",
 			$class6,


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/13268
- [x] Ready for review

small change to add some width and better align things if interface names are longer than just "WAN", "WAN2" etc.

before:
![image](https://user-images.githubusercontent.com/1992842/173255641-7d3d7b8b-4d12-4da3-9222-b80d6fa78a33.png)

after:
![image](https://user-images.githubusercontent.com/1992842/173255645-f04d42c0-b769-412e-8022-d9fd7dc1f40d.png)

I wanted to auto size the columns based on the terminal width, but the shell doesn't seem to export the `$COLUMNS` variable that would be required to do that.
