### PR TITLE
add capability to redirect to requested page after login

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -2116,6 +2116,7 @@ function session_auth() {
 				$_SESSION['authsource'] = 'Local Database Fallback';
 			}
 			$_SESSION['Username'] = $_POST['usernamefld'];
+			$_SESSION['redirecturi'] = htmlspecialchars_decode($_POST['redirecturi']);
 			$_SESSION['user_radius_attributes'] = $attributes;
 			$_SESSION['last_access'] = time();
 			$_SESSION['protocol'] = $config['system']['webgui']['protocol'];

--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -82,6 +82,14 @@ if (!isAllowedPage($_SERVER['REQUEST_URI'])) {
 	$_SESSION['Post_Login'] = true;
 }
 
+/* redirect if user requested a specific page */
+if (!empty($_SESSION['redirecturi'])) {
+	require_once("functions.inc");
+	pfSenseHeader($_SESSION['redirecturi']);
+	unset($_SESSION['redirecturi']);
+	exit;
+}
+
 /*
  * redirect browsers post-login to avoid pages
  * taking action in response to a POST request
@@ -351,6 +359,7 @@ function display_login_form() {
 			                <p class="form-title">Sign In</p>
 			                <input name="usernamefld" id="usernamefld" type="text" placeholder="Username" autocorrect="off" autocapitalize="none"/>
 			                <input name="passwordfld" id="passwordfld" type="password" placeholder="Password" />
+							<input name="redirecturi" id="redirecturi" type="hidden" value="<?=htmlspecialchars($_SERVER['REQUEST_URI'])?>" />
 			                <input type="submit" name="login" value="Sign In" class="btn btn-success btn-sm" />
 		                </form>
 					</div>


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/13286
- [x] Ready for review

Something that has bugged me for a while now is that if you are logged out of pfSense, and request a "deep" page e.g. https://my.pfsense.lan/services_unbound.php, you will be shown the login page, but after successfully logging in, you are placed on the dashboard instead of the originally requested page. 

This makes bookmarking specific pages impossible.

Here's a small PR that adds this capability.

Tested on 22.05.r.20220617.0613
