### PR TITLE
pkg_edit.php XXE -> LFI Injection

### DIFF
--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -54,7 +54,12 @@ if ($xml == "" || $xml_fullpath === false || substr($xml_fullpath, 0, strlen('/u
 }
 
 if ($pkg['include_file'] != "") {
-	require_once($pkg['include_file']);
+	$ext = strstr($pkg['include_file'], "inc");
+	if($ext) {
+		require_once($pkg['include_file']);
+	} else {
+		die("You must be use XML");
+	}
 }
 
 if (!isset($pkg['adddeleteeditpagefields'])) {


### PR DESCRIPTION
Exploit Title: pfSense 2.6.x-2.5.x pfSense XML external entity Vulnerability  (XXE) 
Date: 2022-05-15 
Exploit Author: Ali Can Gönüllü 
Author Company : Defans Security
Version: 2.6.x-2.5.x  
Vendor home page : https://www.netgate.com/  
Authentication Required: Yes 
Tested on : Windows 10 x64 & FreeBSD 13.6

1-Create a XML file on /usr/local/pkg
2-Write this code
3-Write URL on browser http://url/pkg_edit.php?xml=exploit.xml

Proof : https://prnt.sc/RfIa9N4KD7zw
