### PR TITLE
add redirect to originally requested page after login (v2)

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -2116,6 +2116,11 @@ function session_auth() {
 				$_SESSION['authsource'] = 'Local Database Fallback';
 			}
 			$_SESSION['Username'] = $_POST['usernamefld'];
+			if (isset($_POST['redirecturi']) && !empty($_POST['redirecturi'])) {
+				if (count(explode('?',$_POST['redirecturi'])) == 1) {
+					$_SESSION['redirecturi'] = htmlspecialchars_decode($_POST['redirecturi']);
+				}
+			}
 			$_SESSION['user_radius_attributes'] = $attributes;
 			$_SESSION['last_access'] = time();
 			$_SESSION['protocol'] = $config['system']['webgui']['protocol'];

--- a/src/etc/inc/authgui.inc
+++ b/src/etc/inc/authgui.inc
@@ -82,6 +82,15 @@ if (!isAllowedPage($_SERVER['REQUEST_URI'])) {
 	$_SESSION['Post_Login'] = true;
 }
 
+/* redirect if user requested a specific page */
+if (!empty($_SESSION['redirecturi'])) {
+	require_once("functions.inc");
+	pfSenseHeader($_SESSION['redirecturi']);
+	unset($_SESSION['redirecturi']);
+	phpsession_end(true);
+	exit;
+}
+
 /*
  * redirect browsers post-login to avoid pages
  * taking action in response to a POST request
@@ -351,6 +360,7 @@ function display_login_form() {
 			                <p class="form-title">Sign In</p>
 			                <input name="usernamefld" id="usernamefld" type="text" placeholder="Username" autocorrect="off" autocapitalize="none"/>
 			                <input name="passwordfld" id="passwordfld" type="password" placeholder="Password" />
+							<input name="redirecturi" id="redirecturi" type="hidden" value="<?=htmlspecialchars($_SERVER['REQUEST_URI'])?>" />
 			                <input type="submit" name="login" value="Sign In" class="btn btn-success btn-sm" />
 		                </form>
 					</div>


### PR DESCRIPTION
Updated version of https://github.com/pfsense/pfsense/pull/4599. I know this will not be accepted. I'm just posting it in case someone else might want to have this now.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/13286
- [x] Ready for review

#### Changes
- will **not** redirect if URI contains params (`foo.php?bar=baz`)
- bugfix: add missing `phpsession_end(true);`
