### PR TITLE
fix func params for get_dpinger_status() call in gwlb.inc

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -476,7 +476,7 @@ function return_gateways_status($byname = false, $gways = false) {
 		 * down would be misleading (gateway action is disabled)
 		 */
 		$action_disable = $gateways_arr[$gwname]['action_disable'];
-		$dpinger_status = get_dpinger_status($gwname, $action_disable);
+		$dpinger_status = get_dpinger_status($gwname, false, $action_disable);
 		if ($dpinger_status === false) {
 			continue;
 		}


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/13295
- [x] Ready for review

There seems to be an error in `gwlb.inc` around line 479, the call to `get_dpinger_status()` has the `$action_disable` arg at position 2, but the function definition needs it at position 3. So, the bool is actually passed as param 2 which is supposed to be an array (`$gways`). Not sure what problems this may have caused, but it seems incorrect.
