### PR TITLE
Fix destination IPv6 prefix list not properly built

### DIFF
--- a/src/usr/local/www/firewall_nat_npt_edit.php
+++ b/src/usr/local/www/firewall_nat_npt_edit.php
@@ -108,7 +108,7 @@ function build_dsttype_list() {
 		    get_interface_track6ip($if)) {
 			$track6ip = get_interface_track6ip($if);
 			$pdsubnet = gen_subnetv6($track6ip[0], $track6ip[1]);
-			$sntext .= " ({$pdsubnet}/{$track6ip[1]})";
+			$sntext = " ({$pdsubnet}/{$track6ip[1]})";
 			$list[$if] = $ifdesc . $sntext;
 		}
 	}


### PR DESCRIPTION
Destination IPv6 prefix list is not built properly due to wrongly placed string operator
Removed wrong placed string operator from $sntext.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/13310
- [x] Ready for review