### PR TITLE
Fix field validation in system_advanced_firewall.inc

### DIFF
--- a/src/usr/local/pfSense/include/www/system_advanced_firewall.inc
+++ b/src/usr/local/pfSense/include/www/system_advanced_firewall.inc
@@ -93,17 +93,14 @@ function saveSystemAdvancedFirewall($post, $json = false) {
 	if (isset($post['adaptivestart']) && (strlen($post['adaptivestart']) > 0) && !is_numericint($post['adaptivestart'])) {
 		$input_errors[] = gettext("The Firewall Adaptive Start value must be an integer.");
 	}
-	if (isset($post['adaptive-end']) && (strlen($post['adaptive-end']) > 0) && !is_numericint($post['adaptive-end'])) {
+	if (isset($post['adaptiveend']) && (strlen($post['adaptiveend']) > 0) && !is_numericint($post['adaptiveend'])) {
 		$input_errors[] = gettext("The Firewall Adaptive End value must be an integer.");
 	}
-	if ($post['firewall-maximum-states'] && !is_numericint($post['firewall-maximum-states'])) {
+	if ($post['maximumstates'] && !is_numericint($post['maximumstates'])) {
 		$input_errors[] = gettext("The Firewall Maximum States value must be an integer.");
 	}
-	if ($post['aliases-hostnames-resolve-interval'] && !is_numericint($post['aliases-hostnames-resolve-interval'])) {
+	if ($post['aliasesresolveinterval'] && !is_numericint($post['aliasesresolveinterval'])) {
 		$input_errors[] = gettext("The Aliases Hostname Resolve Interval value must be an integer.");
-	}
-	if ($post['firewall-maximum-table-entries'] && !is_numericint($post['firewall-maximum-table-entries'])) {
-		$input_errors[] = gettext("The Firewall Maximum Table Entries value must be an integer.");
 	}
 	if ($post['maximumfrags'] && !is_numericint($post['maximumfrags'])) {
 		$input_errors[] = gettext("The Firewall Maximum Fragment Entries value must be an integer.");


### PR DESCRIPTION
Fixes validation on these fields in system_advanced_firewall.inc:
- `adaptiveend` is incorrectly being referred to as `adaptive-end` during validation.
- `maximumstates` is incorrectly being referred to as `firewall-maximum-states` during validation.
- `aliasesresolveinterval` is incorrectly being referred to as `aliases-hostnames-resolve-interval` during validation. (On the frontend, this field also has its input type `type=text` so any arbitrary value could be entered and accepted here.)
- `maximumtableentries` is incorrectly being referred to as `firewall-maximum-table-entries` during validation, but is validated correctly further down in the file so I've removed the redundant/invalid validation.

I searched for references to the incorrect names and only see them in this file so I'm assuming they were just leftover from a refactor at some point. 

---

- [x] Redmine Issue: https://redmine.pfsense.org/issues/13436
- [x] Ready for review