### PR TITLE
Fix typo in is_URL

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2632,7 +2632,7 @@ function pfs_version_compare($cur_time, $cur_text, $remote) {
 function process_alias_urltable($name, $type, $url, $freq, $forceupdate=false, $validateonly=false) {
 	global $g, $config;
 
-	if (!is_validaliasname($name) || !isURL($url)) {
+	if (!is_validaliasname($name) || !is_URL($url)) {
 		return false;
 	}
 


### PR DESCRIPTION
Fix undefined symbol exception

`Fatal error: Uncaught Error: Call to undefined function isURL() in /etc/inc/pfsense-utils.inc:2653 Stack trace: #0 /usr/local/pfSense/include/www/alias-utils.inc(330): process_alias_urltable('pfB_PRI1_6_v6', 'urltable', 'https://127.0.0...', 0, true, true) #1 /usr/local/www/firewall_aliases_edit.php(157): saveAlias(Array, '1') #2 {main}`

- [x] Ready for review