### PR TITLE
Expand detection of PC Engines APU2 platform to include all variants

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -3166,9 +3166,14 @@ function system_identify_specific_platform() {
 				return (array('name' => '1540', 'descr' => 'Super Micro XG-1540'));
 			}
 			break;
-		case 'apu2':
 		case 'APU2':
-			return (array('name' => 'apu2', 'descr' => 'PC Engines APU2'));
+		case 'apu2':
+		case 'apu3':
+		case 'apu4':
+		case 'apu5':
+		case 'apu6':
+		case 'apu7':
+			return (array('name' => 'apu2', 'descr' => "PC Engines APU2 Platform (\"{$product[0]}\" model)"));
 			break;
 		case 'VirtualBox':
 			return (array('name' => 'VirtualBox', 'descr' => 'VirtualBox Virtual Machine'));


### PR DESCRIPTION
Fixes #13498 in Redmine.

This fixes a problem with garbled serial console output in the bootloader that was originally described in PR #3268, but that fix is not getting applied to the newer hardware variants because the platform detection code needs to be updated.

The PC Engines naming conventions are a little confusing here.  The motherboard platform is identified as "APU2" (though sometimes it also appears in lowercase), but within this platform there are hardware variants such as "apu4", "apu6", and even "apu2".  For example, one can be the owner of an apu4 APU2, if you can believe it.

The detection code reads the DMI data of the product name from the SMBIOS.  Historically, that value has been `apu2`, then it was `APU2` for a little while, then it changed back to `apu2`.  As the newer variants have been released, they have reported values such as `apu3`, `apu4`, etc.  The APU2 platform uses coreboot for its firmware, so luckily we can see the source code for the current list of reported SMBIOS values.  See [here](https://github.com/pcengines/coreboot/blob/b693f04134f8bb728462f6904a2c2233e5fb4498/src/mainboard/pcengines/apu2/Kconfig#L41-L47) and [here](https://github.com/pcengines/coreboot/blob/b693f04134f8bb728462f6904a2c2233e5fb4498/src/Kconfig#L856-L862).

This pull request adds support for all of the variants currently listed in the firmware, plus leaves intact the historical `APU2` value for those who might still be on a much older BIOS version.

I currently have physical access to an apu4 variant.  I tested this patch against that hardware, and it fixes the problem with the garbled serial console output on this unit, plus the pfSense dashboard now shows the system as "PC Engines APU2" as I would expect instead of the generic "pfSense".

- [X] Redmine Issue: https://redmine.pfsense.org/issues/13498
- [X] Ready for review
