### PR TITLE
Improve DY.fi dyndns by allowing wildcard Ticket #13606

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -111,7 +111,7 @@
 	 *  DreamHost IPv6  - Not Yet Tested
 	 *  DuiaDNS         - Last Tested: 25 November 2016
 	 *  DuiaDNS IPv6    - Last Tested: 25 November 2016
-	 *  DY.fi           - Last Tested: 22 April 2021
+	 *  DY.fi           - Last Tested: 28 October 2022
 	 *  DynDNS Custom   - Last Tested: NEVER
 	 *  DynDNS Dynamic  - Last Tested: 12 July 2005
 	 *  DynDNS Static   - Last Tested: NEVER

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -154,6 +154,10 @@ if ($_POST['save'] || $_POST['force']) {
 		} elseif (($pconfig['type'] == "cloudflare") || ($pconfig['type'] == "cloudflare-v6")) {
 			$host_to_check = $_POST['host'] == '@' ? $_POST['domainname'] : ( $_POST['host'] . '.' . $_POST['domainname'] );
 			$allow_wildcard = true;
+		} elseif ($pconfig['type'] == "dyfi") {
+			/* DY.fi allows having wildcard in host */
+			$host_to_check = $_POST['host'];
+			$allow_wildcard = true;
 		} elseif (($pconfig['type'] == "linode") || ($pconfig['type'] == "linode-v6") || ($pconfig['type'] == "gandi-livedns") || ($pconfig['type'] == "gandi-livedns-v6") || ($pconfig['type'] == "yandex") || ($pconfig['type'] == "yandex-v6")) {
 			$host_to_check = $_POST['host'] == '@' ? $_POST['domainname'] : ( $_POST['host'] . '.' . $_POST['domainname'] );
 			$allow_wildcard = true;


### PR DESCRIPTION
DY.fi allows the use of wildcard for Dynamic DNS by having the hostname=*.myname.dy.fi. 

See https://www.dy.fi/?c=news `Support for wildcard records (*.name.dy.fi) has been added!`

This patch modifies the input validation for DY.fi Dynamic DNS Client so that the wildcard is allowed in the host field.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/13606
- [x] Ready for review