### PR TITLE
Fix MSS clamping for IPsec IPv6 VPNs

### DIFF
--- a/src/etc/inc/filter.inc
+++ b/src/etc/inc/filter.inc
@@ -1132,12 +1132,20 @@ function filter_get_vpns_list() {
 		   See https://redmine.pfsense.org/issues/7005 */
 		$pool_address = config_get_path('ipsec/client/pool_address');
 		$pool_netbits = config_get_path('ipsec/client/pool_netbits');
-		if (config_path_enabled('ipsec/client')
-			&& isset($pool_address)
-			&& isset($pool_netbits)) {
-			$client_subnet = "{$pool_address}/{$pool_netbits}";
-			if (is_subnet($client_subnet)) {
-				 $vpns_arr[] = $client_subnet;
+		$pool_address_v6 = config_get_path('ipsec/client/pool_address_v6');
+		$pool_netbits_v6 = config_get_path('ipsec/client/pool_netbits_v6');
+		if (config_path_enabled('ipsec/client')) {
+			if (isset($pool_address) && isset($pool_netbits)) {
+				$client_subnet = "{$pool_address}/{$pool_netbits}";
+				if (is_subnet($client_subnet)) {
+					 $vpns_arr[] = $client_subnet;
+				}
+			}
+			if (isset($pool_address_v6) && isset($pool_netbits_v6)) {
+				$client_subnet = "{$pool_address_v6}/{$pool_netbits_v6}";
+				if (is_subnet($client_subnet)) {
+					 $vpns_arr[] = $client_subnet;
+				}
 			}
 		}
 		foreach (config_get_path('ipsec/phase2', []) as $ph2ent) {


### PR DESCRIPTION
The definition of vpn_networks did not include the IPsec IPv6 pool.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/14312
- [x] Ready for review