### PR TITLE
improve System menu WebUI for Certificate Manager

### DIFF
--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -255,6 +255,16 @@ $system_menu[] = array(gettext("Routing"), "/system_gateways.php");
 $system_menu[] = array(gettext("Cert. Manager"), "/system_camanager.php");
 $system_menu[] = array(gettext("Register"), "/system_register.php");
 
+// Display "Cert. Manager" on System menu, even if user does not have 
+// "WebCfg - System: CA Manager" privileges
+if (!isAllowedPage("system_camanager.php")) {
+  if (isAllowedPage("system_certmanager.php")) {
+   $system_menu[] = array(gettext("Cert. manager"), "/system_certmanager.php");
+  } else if (isAllowedPage("system_crlmanager.php")) {
+   $system_menu[] = array(gettext("Cert. manager"), "/system_crlmanager.php");
+  }
+}
+
 if (!isAllowedPage("system_usermanager.php")) {
 	$system_menu[] = array(gettext("User Manager"), "/system_usermanager_passwordmg.php");
 } else {


### PR DESCRIPTION
Hello,

I want to have a user that can create or revoke certificates but not manage CA.

Currently, if a user does not have _WebCfg - System: CA Manager_ privilege, the _Cert. Manager_ System menu entry on the navigation bar will not be displayed.

The user can still access the granted pages by copy pasting _/system_certmanager.php_ or _/system_crlmanager.php_ from the URL. But it would be more enjoyable to access these pages using the navigation bar.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/14347
- [x] Ready for review