### PR TITLE
Update rc.php_ini_setup to check php version 8.2. Fix #14488

### DIFF
--- a/src/etc/rc.php_ini_setup
+++ b/src/etc/rc.php_ini_setup
@@ -23,8 +23,9 @@
 # Set our operating platform
 VERSION=$(/bin/cat /etc/version)
 MIN_REALMEM_FOR_OPCACHE=512
-
-if /usr/local/sbin/pkg-static info -e php81; then
+if /usr/local/sbin/pkg-static info -e php82; then
+	EXTENSIONSDIR="/usr/local/lib/php/20220829/"
+elif /usr/local/sbin/pkg-static info -e php81; then
 	EXTENSIONSDIR="/usr/local/lib/php/20210902/"
 elif /usr/local/sbin/pkg-static info -e php74; then
 	EXTENSIONSDIR="/usr/local/lib/php/20190902/"


### PR DESCRIPTION
rc.php_ini_setup on 2.7 version not checking php version 8.2

https://redmine.pfsense.org/issues/14488

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review