### PR TITLE
Fixed message about adaptive state handling

### DIFF
--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -57,7 +57,7 @@ $sysinfo_items = array(
 
 // Declared here so that JavaScript can access it
 $updtext = sprintf(gettext("Obtaining update status %s"), "<i class='fa fa-cog fa-spin'></i>");
-$state_tt = gettext("Adaptive state handling is enabled, state timeouts are reduced by ");
+$state_tt = gettext("Adaptive state handling is enabled, state timeouts are reduced to ");
 
 if ($_REQUEST['getupdatestatus']) {
 	require_once("pkg-utils.inc");


### PR DESCRIPTION
Fixed misleading message regarding adaptive state handling.

States are reduced from 100% to the $scalingfactor value, NOT by the value.

Optionally, this could be fixed by subtracting the scaling factor from 100%.
