### PR TITLE
Fix "Alias on CARP"-style VIPs to show up correctly in Gateway Group dropdown

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1432,6 +1432,22 @@ function build_vip_list($fif, $family = "all") {
 			if (get_vip_descr($address)) {
 				$list[$vip] .= " (". get_vip_descr($address) .")";
 			}
+		} else {
+			/**
+			 * additional check necessary: Alias-on-CARP VIPs return a "_vip<id>" string
+			 * that needs to be resolved via an additional check to see if that VIP should
+			 * be displayed here or skipped, as the parent isn't configured on this interface
+			 */
+
+			$parentif = get_configured_vip_interface($vip);
+			if (str_starts_with($parentif, "_vip")) {
+				if ($fif == get_configured_vip_interface($parentif)) {
+					$list[$vip] = "$address";
+					if (get_vip_descr($address)) {
+						$list[$vip] .= " (". get_vip_descr($address) .")";
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Add additional check to correctly display "Alias-on-CARP"-style Virtual IPs in Gateway Group VIP dropdown selection. Fixes #14524

- [x] Redmine Issue: https://redmine.pfsense.org/issues/14524 for details
- [x] Ready for review