### PR TITLE
fix: delete vips before calling interface_proxyarp_configure()

### DIFF
--- a/src/usr/local/pfSense/include/www/firewall_virtual_ip.inc
+++ b/src/usr/local/pfSense/include/www/firewall_virtual_ip.inc
@@ -526,6 +526,11 @@ function deleteVIP($id, $json = false) {
 				phpsession_end();
 			}
 
+			config_del_path("virtualip/vip/{$id}");
+			if (count($a_vip) == 0) {
+				config_del_path("virtualip/vip");
+			}
+			write_config(gettext("Deleted a virtual IP."));
 
 			// Special case since every proxyarp vip is handled by the same daemon.
 			if ($a_vip[$id]['mode'] == "proxyarp") {
@@ -534,12 +539,6 @@ function deleteVIP($id, $json = false) {
 			} else {
 				interface_vip_bring_down($a_vip[$id]);
 			}
-
-			config_del_path("virtualip/vip/{$id}");
-			if (count($a_vip) == 0) {
-				config_del_path("virtualip/vip");
-			}
-			write_config(gettext("Deleted a virtual IP."));
 
 			/* Reload filter since removed address may trigger changes in rules
 			 * https://redmine.pfsense.org/issues/13908 */


### PR DESCRIPTION
After deleting a ProxyARP virtual IP, the choparp process is still running. To reproduce:

1. Create a new single address ProxyARP virtual IP and apply it. For this example, I created a virtual IP for 192.168.1.150/32.
2. Run `ps aux | grep choparp` which show the virtual IP is running as expected: `root 65423 0.0 0.3 13392 3244 - S 20:28 0:00.00 /usr/local/sbin/choparp -p /var/run/choparp_em0.pid em0 auto 192.168.1.150/32`
3. Delete the virtual IP and rerun `ps aux | grep choparp`. The process for the deleted virtual IP is still running: `root 65423 0.0 0.3 13392 3244 - S 20:28 0:00.00 /usr/local/sbin/choparp -p /var/run/choparp_em0.pid em0 auto 192.168.1.150/32`

This appears to happen because `interface_proxyarp_configure()` is called before deleting the virtual IP from configuration, which results in the choparp process being re-spawned. Deleting the virtual IP from config fixes the issue, and the other virtual IP types seem to tolerate this change as well.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/14929
- [x] Ready for review