### PR TITLE
Fix: local private ipv6 is being used instead of public track interface IPv6 in radvd

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -6589,7 +6589,7 @@ function get_interface_track6ip($interface = "wan") {
 	foreach (pfSense_getall_interface_addresses($realif) as $ifaddr) {
 		list($ip, $bits) = explode("/", $ifaddr);
 		$ip = text_to_compressed_ip6($ip);
-		if (is_ipaddrv6($ip) && !is_linklocal($ip)) {
+		if (is_ipaddrv6($ip) && !is_linklocal($ip) && !is_private_ipv6($ip)) {
 			if (is_array($vips) && !empty($vips)) {
 				foreach ($vips as $vip) {
 					if ($ip == text_to_compressed_ip6($vip)) {

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -831,6 +831,11 @@ function is_linklocal($ipaddr) {
 	return '';
 }
 
+/* Returns true if $ip is private, false otherwise */
+function is_private_ipv6($ip){
+	return str_starts_with($ip, "fc") || str_starts_with($ip, "fd");
+}
+
 /* returns scope of a linklocal address */
 function get_ll_scope($addr) {
 	if (!is_linklocal($addr) || !strstr($addr, "%")) {


### PR DESCRIPTION
- created function is_private_ipv6
- added a check in get_interface_track6ip to skip private v6 address

- [x] Redmine Issue: https://redmine.pfsense.org/issues/15057
- [x] Ready for review

