### PR TITLE
upnp: Update plugin title/menu to include PCP as supported

### DIFF
--- a/src/etc/inc/priv.defs.inc
+++ b/src/etc/inc/priv.defs.inc
@@ -1004,8 +1004,8 @@ $priv_list['page-status-dns-resolver']['match'] = array();
 $priv_list['page-status-dns-resolver']['match'][] = "status_unbound.php*";
 
 $priv_list['page-status-upnpstatus'] = array();
-$priv_list['page-status-upnpstatus']['name'] = gettext("WebCfg - Status: UPnP Status");
-$priv_list['page-status-upnpstatus']['descr'] = gettext("Allow access to the 'Status: UPnP Status' page.");
+$priv_list['page-status-upnpstatus']['name'] = gettext("WebCfg - Status: UPnP IGD & PCP/NAT-PMP");
+$priv_list['page-status-upnpstatus']['descr'] = gettext("Allow access to the 'Status: UPnP IGD & PCP/NAT-PMP' page.");
 $priv_list['page-status-upnpstatus']['match'] = array();
 $priv_list['page-status-upnpstatus']['match'][] = "status_upnp.php*";
 

--- a/src/etc/inc/priv/user.priv.inc
+++ b/src/etc/inc/priv/user.priv.inc
@@ -146,8 +146,8 @@ $priv_list['page-status-systemlogs-wireless']['match'] = array();
 $priv_list['page-status-systemlogs-wireless']['match'][] = "status_logs.php?logfile=wireless";
 
 $priv_list['page-services-upnp'] = array();
-$priv_list['page-services-upnp']['name'] = gettext("WebCfg - Services: UPnP");
-$priv_list['page-services-upnp']['descr'] = gettext("Allow access to the 'Services: UPnP' page.");
+$priv_list['page-services-upnp']['name'] = gettext("WebCfg - Services: UPnP IGD & PCP/NAT-PMP");
+$priv_list['page-services-upnp']['descr'] = gettext("Allow access to the 'Services: UPnP IGD & PCP/NAT-PMP' page.");
 $priv_list['page-services-upnp']['match'] = array();
 $priv_list['page-services-upnp']['match'][] = "pkg_edit.php?xml=miniupnpd.xml";
 

--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -456,7 +456,7 @@ function get_services() {
 	if (config_get_path('installedpackages/miniupnpd/config/0/enable') == 'on') {
 		$pconfig = array();
 		$pconfig['name'] = "miniupnpd";
-		$pconfig['description'] = gettext("UPnP Service");
+		$pconfig['description'] = gettext("UPnP IGD & PCP/NAT-PMP Service");
 		$pconfig['enabled'] = true;
 		$pconfig['status'] = get_service_status($pconfig);
 		$services[] = $pconfig;

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -5040,7 +5040,7 @@ function upnp_start() {
 	}
 
 	if (config_get_path('installedpackages/miniupnpd/config/0/enable') == 'on') {
-		echo gettext("Starting UPnP service... ");
+		echo gettext("Starting UPnP IGD & PCP/NAT-PMP service... ");
 		require_once('/usr/local/pkg/miniupnpd.inc');
 		sync_package_miniupnpd();
 		echo "done.\n";

--- a/src/usr/local/pkg/miniupnpd.inc
+++ b/src/usr/local/pkg/miniupnpd.inc
@@ -91,7 +91,7 @@
 
 	function validate_form_miniupnpd($post, &$input_errors) {
 		if ($post['enable'] && (!$post['enable_upnp'] && !$post['enable_natpmp'])) {
-			$input_errors[] = 'At least one of \'UPnP\' or \'NAT-PMP\' must be allowed';
+			$input_errors[] = 'At least one of \'UPnP IGD\' or \'PCP/NAT-PMP\' must be allowed';
 		}
 		if ($post['iface_array']) {
 			foreach ($post['iface_array'] as $iface) {
@@ -280,7 +280,7 @@
 					$config_text .= "queue={$upnp_config['upnpqueue']}\n";
 				}
 
-				/* Allow UPnP or NAT-PMP as requested */
+				/* Allow UPnP IGD or PCP/NAT-PMP as requested */
 				$config_text .= "enable_upnp="   . ($upnp_config['enable_upnp']   ? "yes\n" : "no\n");
 				$config_text .= "enable_natpmp=" . ($upnp_config['enable_natpmp'] ? "yes\n" : "no\n");
 
@@ -319,7 +319,7 @@
 				@unlink($config_file);
 			}
 		}
-		/* Reload filter to trigger UPnP rule changes */
+		/* Reload filter to trigger UPnP IGD & PCP/NAT-PMP rule changes */
 		send_event("filter reload");
 	}
 ?>

--- a/src/usr/local/pkg/miniupnpd.xml
+++ b/src/usr/local/pkg/miniupnpd.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-	<title>Services/UPnP &amp; NAT-PMP</title>
+	<title>Services/UPnP IGD &amp; PCP/NAT-PMP</title>
 	<name>miniupnpd</name>
 	<version>20100712</version>
 	<include_file>/usr/local/pkg/miniupnpd.inc</include_file>
 	<menu>
-		<name>UPnP &amp; NAT-PMP</name>
-		<tooltiptext>Set UPnP &amp; NAT-PMP settings such as interfaces to listen on.</tooltiptext>
+		<name>UPnP IGD &amp; PCP/NAT-PMP</name>
+		<tooltiptext>Set UPnP IGD &amp; PCP/NAT-PMP settings such as interfaces to listen on.</tooltiptext>
 		<section>Services</section>
 		<url>/pkg_edit.php?xml=miniupnpd.xml&amp;id=0</url>
 	</menu>
@@ -17,7 +17,7 @@
 	</service>
 	<fields>
 		<field>
-			<name>UPnP &amp; NAT-PMP Settings</name>
+			<name>UPnP IGD &amp; PCP/NAT-PMP Settings</name>
 			<type>listtopic</type>
 			<enablefields>enable_upnp,enable_natpmp,ext_iface,iface_array,download,upload,overridewanip,upnpqueue,logpackets,sysuptime,permdefault</enablefields>
 		</field>
@@ -26,20 +26,20 @@
 			<fieldname>enable</fieldname>
 			<type>checkbox</type>
 			<enablefields>enable_upnp,enable_natpmp,ext_iface,iface_array,download,upload,overridewanip,upnpqueue,logpackets,sysuptime,permdefault</enablefields>
-			<description>Enable UPnP &amp; NAT-PMP</description>
+			<description>Enable UPnP IGD &amp; PCP/NAT-PMP</description>
 		</field>
 		<field>
-			<fielddescr>UPnP Port Mapping</fielddescr>
+			<fielddescr>UPnP IGD Port Mapping</fielddescr>
 			<fieldname>enable_upnp</fieldname>
 			<type>checkbox</type>
-			<description>Allow UPnP Port Mapping</description>
+			<description>Allow UPnP IGD Port Mapping</description>
 			<sethelp>This protocol is often used by Microsoft-compatible systems.</sethelp>
 		</field>
 		<field>
-			<fielddescr>NAT-PMP Port Mapping</fielddescr>
+			<fielddescr>PCP/NAT-PMP Port Mapping</fielddescr>
 			<fieldname>enable_natpmp</fieldname>
 			<type>checkbox</type>
-			<description>Allow NAT-PMP Port Mapping</description>
+			<description>Allow PCP/NAT-PMP Port Mapping</description>
 			<sethelp>This protocol is often used by Apple-compatible systems.</sethelp>
 		</field>
 		<field>
@@ -56,7 +56,7 @@
 			<fieldname>iface_array</fieldname>
 			<default_value>lan</default_value>
 			<type>interfaces_selection</type>
-			<description>Select the internal interfaces, such as LAN, where UPnP/NAT-PMP clients reside. Use the CTRL or COMMAND key to select multiple interfaces.</description>
+			<description>Select the internal interfaces, such as LAN, where UPnP &amp; PCP/NAT-PMP clients reside. Use the CTRL or COMMAND key to select multiple interfaces.</description>
 			<required/>
 			<multiple/>
 		</field>
@@ -88,13 +88,13 @@
 			<fielddescr>Log packets</fielddescr>
 			<fieldname>logpackets</fieldname>
 			<type>checkbox</type>
-			<description>Log packets handled by UPnP &amp; NAT-PMP rules.</description>
+			<description>Log packets handled by UPnP IGD &amp; PCP/NAT-PMP rules.</description>
 		</field>
 		<field>
 			<fielddescr>Uptime</fielddescr>
 			<fieldname>sysuptime</fieldname>
 			<type>checkbox</type>
-			<description>Use system uptime instead of UPnP &amp; NAT-PMP service uptime.</description>
+			<description>Use system uptime instead of UPnP IGD &amp; PCP/NAT-PMP service uptime.</description>
 		</field>
 		<field>
 			<fielddescr>Custom presentation URL</fielddescr>
@@ -119,9 +119,9 @@
 				The External interface must have a public IP address. Otherwise it is behind NAT and port
 				forwarding is impossible. In some cases the External interface can be behind unrestricted NAT 1:1
 				when all incoming traffic is forwarded and routed to the External interface without any filtering.
-				In these cases UPnP service needs to know the public IP address and it can be learned by asking an
-				external server via STUN protocol. The following option enables retrieving the external public IP
-			       	address from a STUN server and detection of the NAT type.
+				In these cases UPnP IGD &amp; PCP/NAT-PMP service needs to know the public IP address and it can be
+				learned by asking an external server via STUN protocol. The following option enables retrieving the
+				external public IP address from a STUN server and detection of the NAT type.
 			</description>
 		</field>
 		<field>
@@ -153,20 +153,20 @@
 			<description>STUN UDP port (Default: 3478)</description>
 		</field>
 		<field>
-			<name>UPnP Access Control Lists</name>
+			<name>UPnP IGD &amp; PCP/NAT-PMP Access Control Lists</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Default Deny</fielddescr>
 			<fieldname>permdefault</fieldname>
 			<type>checkbox</type>
-			<description>Deny access to UPnP &amp; NAT-PMP by default.</description>
+			<description>Deny access to UPnP IGD &amp; PCP/NAT-PMP by default.</description>
 		</field>
 		<field>
 			<name>ACL Help</name>
 			<type>info</type>
 			<description>
-			These entries control access to the UPnP service. Client systems may be granted or denied access based on several criteria.
+			These entries control access to the UPnP IGD &amp; PCP/NAT-PMP service. Client systems may be granted or denied access based on several criteria.
 			&lt;br /&gt;&lt;br /&gt;
 			Format: [allow or deny] [ext port or range] [int ipaddr or ipaddr/CIDR] [int port or range]
 			&lt;br /&gt;Example: allow 1024-65535 192.168.0.0/24 1024-65535</description>

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -345,10 +345,10 @@ $services_menu[] = array(gettext("PPPoE Server"), "/services_pppoe.php");
 $services_menu[] = array(gettext("SNMP"), "/services_snmp.php");
 
 if (count($config['interfaces']) > 1) {
-	/* no use for UPnP in single-interface deployments
+	/* no use for UPnP IGD & PCP/NAT-PMP in single-interface deployments
 	remove to reduce user confusion
 	*/
-	$services_menu[] = array(gettext("UPnP &amp; NAT-PMP"), "/pkg_edit.php?xml=miniupnpd.xml");
+	$services_menu[] = array(gettext("UPnP IGD & PCP/NAT-PMP"), "/pkg_edit.php?xml=miniupnpd.xml");
 }
 
 $services_menu[] = array(gettext("Wake-on-LAN"), "/services_wol.php");
@@ -382,7 +382,7 @@ $status_menu[] = array(gettext("System Logs"), "/status_logs.php");
 $status_menu[] = array(gettext("Traffic Graph"), "/status_graph.php");
 
 if (count($config['interfaces']) > 1) {
-	$status_menu[] = array(gettext("UPnP &amp; NAT-PMP"), "/status_upnp.php");
+	$status_menu[] = array(gettext("UPnP IGD & PCP/NAT-PMP"), "/status_upnp.php");
 }
 
 $wifdescrs = array();

--- a/src/usr/local/www/status_upnp.php
+++ b/src/usr/local/www/status_upnp.php
@@ -24,8 +24,8 @@
 
 ##|+PRIV
 ##|*IDENT=page-status-upnpstatus
-##|*NAME=Status: UPnP Status
-##|*DESCR=Allow access to the 'Status: UPnP Status' page.
+##|*NAME=Status: UPnP IGD & PCP/NAT-PMP Status
+##|*DESCR=Allow access to the 'Status: UPnP IGD & PCP/NAT-PMP Status' page.
 ##|*MATCH=status_upnp.php*
 ##|-PRIV
 
@@ -41,7 +41,7 @@ if ($_POST) {
 $rdr_entries = array();
 exec("/sbin/pfctl -aminiupnpd -sn", $rdr_entries, $pf_ret);
 
-$pgtitle = array(gettext("Status"), gettext("UPnP &amp; NAT-PMP"));
+$pgtitle = array(gettext("Status"), gettext("UPnP IGD & PCP/NAT-PMP"));
 $shortcut_section = "upnp";
 
 include("head.inc");
@@ -54,7 +54,7 @@ if (!$config['installedpackages'] ||
     !$config['installedpackages']['miniupnpd']['config'][0]['iface_array'] ||
     !$config['installedpackages']['miniupnpd']['config'][0]['enable']) {
 
-	print_info_box(sprintf(gettext('UPnP is currently disabled. It can be enabled here: %1$s%2$s%3$s.'), '<a href="pkg_edit.php?xml=miniupnpd.xml">', gettext('Services &gt; UPnP &amp; NAT-PMP'), '</a>'), 'danger');
+	print_info_box(sprintf(gettext('UPnP IGD & PCP/NAT-PMP is currently disabled. It can be enabled here: %1$s%2$s%3$s.'), '<a href="pkg_edit.php?xml=miniupnpd.xml">', gettext('Services > UPnP IGD & PCP/NAT-PMP'), '</a>'), 'danger');
 	include("foot.inc");
 	exit;
 }
@@ -62,7 +62,7 @@ if (!$config['installedpackages'] ||
 ?>
 
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext("UPnP &amp; NAT-PMP Rules")?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext("UPnP IGD & PCP/NAT-PMP Rules")?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>


### PR DESCRIPTION
Update plugin title and menu option to `UPnP IGD & PCP/NAT-PMP` as `PCP` is supported and also mention `UPnP IGD` as `UPnP` is probably not specific enough.

*Updated title/menu option:*
`UPnP IGD & PCP/NAT-PMP`
*Current title/menu option:*
`UPnP & NAT-PMP`

Port Control Protocol (PCP) is the successor to NAT-PMP and has similar protocol concepts and packet formats, but adds IPv6 support.
*PCP standard:*
https://datatracker.ietf.org/doc/html/rfc6887
https://en.wikipedia.org/wiki/Port_Control_Protocol
*NAT-PMP std. (see 9.1 Simplicity - 9.3 for some diff. to UPnP IGD):*
https://datatracker.ietf.org/doc/html/rfc6886

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [x] Ready for review