### PR TITLE
Allow specifying a cloudflare host id for dyndns

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -182,6 +182,7 @@
 		var $_dnsPort;
 		var $_dnsUpdateURL;
 		var $_dnsZoneID;
+		var $_dnsHostID;
 		var $_dnsTTL;
 		var $status;
 		var $_debugID;
@@ -211,9 +212,9 @@
 		function __construct($dnsService = '', $dnsHost = '', $dnsDomain = '', $dnsUser = '', $dnsPass = '',
 					$dnsWildcard = 'OFF', $dnsProxied = false, $dnsMX = '', $dnsIf = '', $dnsBackMX = '',
 					$dnsServer = '', $dnsPort = '', $dnsUpdateURL = '', $forceUpdate = false,
-					$dnsZoneID ='', $dnsTTL='', $dnsResultMatch = '', $dnsRequestIf = '', $dnsMaxCacheAge = '',
-					$dnsID = '', $dnsVerboseLog = false, $curlIpresolveV4 = false, $curlSslVerifypeer = true,
-					$curlProxy = false) {
+					$dnsZoneID ='', $dnsHostID='' , $dnsTTL='', $dnsResultMatch = '', $dnsRequestIf = '',
+					$dnsMaxCacheAge = '', $dnsID = '', $dnsVerboseLog = false, $curlIpresolveV4 = false,
+					$curlSslVerifypeer = true, $curlProxy = false) {
 
 			global $config, $g, $dyndns_split_domain_types;
 			if (in_array($dnsService, $dyndns_split_domain_types)) {
@@ -366,6 +367,7 @@
 			$this->_dnsProxied = $dnsProxied;
 			$this->_dnsMX = $dnsMX;
 			$this->_dnsZoneID = $dnsZoneID;
+			$this->_dnsHostID = $dnsHostID;
 			$this->_dnsTTL = $dnsTTL;
 			$this->_if = get_failover_interface($dnsIf);
 			$this->_checkIP();
@@ -1192,11 +1194,15 @@
 					}
 
 					if ($zone) { // If zone ID was found get host ID
-						$getHostId = "https://{$dnsServer}/client/v4/zones/{$zone}/dns_records?name={$this->_FQDN}&type={$recordType}";
-						curl_setopt($ch, CURLOPT_URL, $getHostId);
-						curl_setopt($ch, CURLOPT_FORBID_REUSE, true);
-						$output = json_decode(curl_exec($ch));
-						$host = $output->result[0]->id;
+						if (empty($this->_dnsHostID)) {
+							$getHostId = "https://{$dnsServer}/client/v4/zones/{$zone}/dns_records?name={$this->_FQDN}&type={$recordType}";
+							curl_setopt($ch, CURLOPT_URL, $getHostId);
+							curl_setopt($ch, CURLOPT_FORBID_REUSE, true);
+							$output = json_decode(curl_exec($ch));
+							$host = $output->result[0]->id;
+						} else {
+							$host = $this->_dnsHostID;
+						}
 						if ($host) { // If host ID was found update host
 							$hostData = array(
 								"content" => "{$this->_dnsIP}",

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -3946,6 +3946,7 @@ function services_dyndns_configure_client($conf) {
 		$dnsUpdateURL = "{$conf['updateurl']}",
 		$forceUpdate = $conf['force'],
 		$dnsZoneID = $conf['zoneid'],
+		$dnsHostID = $conf['hostid'],
 		$dnsTTL = $conf['ttl'],
 		$dnsResultMatch = "{$conf['resultmatch']}",
 		$dnsRequestIf = "{$conf['requestif']}",

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -71,6 +71,7 @@ if (isset($id) && isset($a_dyndns[$id])) {
 	$pconfig['curl_ipresolve_v4'] = isset($a_dyndns[$id]['curl_ipresolve_v4']);
 	$pconfig['curl_ssl_verifypeer'] = isset($a_dyndns[$id]['curl_ssl_verifypeer']);
 	$pconfig['zoneid'] = $a_dyndns[$id]['zoneid'];
+	$pconfig['hostid'] = $a_dyndns[$id]['hostid'];
 	$pconfig['ttl'] = $a_dyndns[$id]['ttl'];
 	$pconfig['maxcacheage'] = $a_dyndns[$id]['maxcacheage'];
 	$pconfig['updateurl'] = $a_dyndns[$id]['updateurl'];
@@ -229,6 +230,7 @@ if ($_POST['save'] || $_POST['force']) {
 			$dyndns['interface'] = $_POST['interface'];
 		}
 		$dyndns['zoneid'] = $_POST['zoneid'];
+		$dyndns['hostid'] = $_POST['hostid'];
 		$dyndns['ttl'] = $_POST['ttl'];
 		$dyndns['maxcacheage'] = $_POST['maxcacheage'];
 		$dyndns['updateurl'] = $_POST['updateurl'];
@@ -473,6 +475,13 @@ $section->addInput(new Form_Input(
 			'Route53: Enter AWS Zone ID.', '<br />');
 
 $section->addInput(new Form_Input(
+	'hostid',
+	'Host ID',
+	'text',
+	$pconfig['hostid']
+))->setHelp('Enter the host id of this entry. Leave empty to auto-detect.');
+
+$section->addInput(new Form_Input(
 	'updateurl',
 	'Update URL',
 	'text',
@@ -560,6 +569,7 @@ events.push(function() {
 		hideCheckbox('wildcard', false); // show by default
 		hideCheckbox('proxied', true);
 		hideInput('zoneid', true);
+		hideInput('hostid', true);
 		hideInput('ttl', true);
 		hideInput('maxcacheage', true);
 
@@ -591,6 +601,7 @@ events.push(function() {
 				hideCheckbox('wildcard', true);
 				hideCheckbox('proxied', false);
 				hideInput('ttl', false);
+				hideInput('hostid', false);
 				break;
 			case "cloudns":
 				hideGroupInput('domainname', false);


### PR DESCRIPTION
This can save a HTTP request when updating the entry, and may be used to update multiple entries with the same name but different IPs for round- robin based load-balancing.

Fixes: #15324

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/15324
- [ ] Ready for review