### PR TITLE
Change sorting algorithm to natural sort in get_configured_interface_with_descr

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -1684,7 +1684,7 @@ function get_configured_interface_with_descr(bool $with_disabled = false) : arra
 
 	if (is_array($user_settings)
 	    && array_get_path($user_settings, 'webgui/interfacessort')) {
-		asort($iflist);
+		asort($iflist, SORT_NATURAL);
 	}
 
 	return ($iflist);


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/15437

This PR improves interface sorting when _General Settings -> Interfaces Sort/Sort Alphabetically_ is enabled by changing the sorting algorithm from `SORT_REGULAR` (the default for PHP's `asort()`) to `SORT_NATURAL`.

The current implementation causes interfaces to be sort alphabetically. For instance:

- LAN
- VLAN23
- VLAN230
- VLAN31
- VLAN315
- WAN

This behavior is not at all great for interface-descriptions containing numbers as it causes even more confusion than unsorted interfaces. Natural sort would improve this a lot:

- LAN
- VLAN23
- VLAN31
- VLAN230
- VLAN315
- WAN
