### PR TITLE
UPnP IGD & PCP: Simplify service wording

### DIFF
--- a/src/etc/inc/priv.defs.inc
+++ b/src/etc/inc/priv.defs.inc
@@ -1004,8 +1004,8 @@ $priv_list['page-status-dns-resolver']['match'] = array();
 $priv_list['page-status-dns-resolver']['match'][] = "status_unbound.php*";
 
 $priv_list['page-status-upnpstatus'] = array();
-$priv_list['page-status-upnpstatus']['name'] = gettext("WebCfg - Status: UPnP Status");
-$priv_list['page-status-upnpstatus']['descr'] = gettext("Allow access to the 'Status: UPnP Status' page.");
+$priv_list['page-status-upnpstatus']['name'] = gettext("WebCfg - Status: UPnP IGD & PCP");
+$priv_list['page-status-upnpstatus']['descr'] = gettext("Allow access to the 'Status: UPnP IGD & PCP' page.");
 $priv_list['page-status-upnpstatus']['match'] = array();
 $priv_list['page-status-upnpstatus']['match'][] = "status_upnp.php*";
 

--- a/src/etc/inc/priv/user.priv.inc
+++ b/src/etc/inc/priv/user.priv.inc
@@ -146,8 +146,8 @@ $priv_list['page-status-systemlogs-wireless']['match'] = array();
 $priv_list['page-status-systemlogs-wireless']['match'][] = "status_logs.php?logfile=wireless";
 
 $priv_list['page-services-upnp'] = array();
-$priv_list['page-services-upnp']['name'] = gettext("WebCfg - Services: UPnP");
-$priv_list['page-services-upnp']['descr'] = gettext("Allow access to the 'Services: UPnP' page.");
+$priv_list['page-services-upnp']['name'] = gettext("WebCfg - Services: UPnP IGD & PCP");
+$priv_list['page-services-upnp']['descr'] = gettext("Allow access to the 'Services: UPnP IGD & PCP' page.");
 $priv_list['page-services-upnp']['match'] = array();
 $priv_list['page-services-upnp']['match'][] = "pkg_edit.php?xml=miniupnpd.xml";
 

--- a/src/etc/inc/service-utils.inc
+++ b/src/etc/inc/service-utils.inc
@@ -457,7 +457,7 @@ function get_services() {
 	if (config_get_path('installedpackages/miniupnpd/config/0/enable') == 'on') {
 		$pconfig = array();
 		$pconfig['name'] = "miniupnpd";
-		$pconfig['description'] = gettext("UPnP Service");
+		$pconfig['description'] = gettext("UPnP IGD & PCP Service");
 		$pconfig['enabled'] = true;
 		$pconfig['status'] = get_service_status($pconfig);
 		$services[] = $pconfig;

--- a/src/usr/local/pkg/miniupnpd.inc
+++ b/src/usr/local/pkg/miniupnpd.inc
@@ -90,7 +90,7 @@
 
 	function validate_form_miniupnpd($post, &$input_errors) {
 		if ($post['enable'] && (!$post['enable_upnp'] && !$post['enable_natpmp'])) {
-			$input_errors[] = 'At least one of \'UPnP\' or \'NAT-PMP\' must be allowed';
+			$input_errors[] = 'At least one of \'UPnP IGD\' or \'PCP/NAT-PMP\' must be allowed';
 		}
 		if ($post['iface_array']) {
 			foreach ($post['iface_array'] as $iface) {
@@ -280,9 +280,9 @@
 					$config_text .= "queue={$upnp_config['upnpqueue']}\n";
 				}
 
-				/* Allow UPnP or NAT-PMP as requested */
+				/* Allow UPnP IGD or PCP/NAT-PMP as requested */
 				$config_text .= "enable_upnp="   . ($upnp_config['enable_upnp']   ? "yes\n" : "no\n");
-				$config_text .= "enable_natpmp=" . ($upnp_config['enable_natpmp'] ? "yes\n" : "no\n");
+				$config_text .= "enable_pcp_pmp=" . ($upnp_config['enable_natpmp'] ? "yes\n" : "no\n");
 
 				/* STUN configuration */
 				if ($upnp_config['enable_stun']) {

--- a/src/usr/local/pkg/miniupnpd.inc
+++ b/src/usr/local/pkg/miniupnpd.inc
@@ -90,7 +90,7 @@
 
 	function validate_form_miniupnpd($post, &$input_errors) {
 		if ($post['enable'] && (!$post['enable_upnp'] && !$post['enable_natpmp'])) {
-			$input_errors[] = 'At least one UPnP protocol ("UPnP-IGD" or "NAT-PMP") must be allowed';
+			$input_errors[] = 'At least one of \'UPnP\' or \'NAT-PMP\' must be allowed';
 		}
 		if ($post['iface_array']) {
 			foreach ($post['iface_array'] as $iface) {

--- a/src/usr/local/pkg/miniupnpd.xml
+++ b/src/usr/local/pkg/miniupnpd.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-	<title>Services/UPnP &amp; NAT-PMP</title>
+	<title>Services/UPnP IGD &amp; PCP</title>
 	<name>miniupnpd</name>
 	<version>20100712</version>
 	<include_file>/usr/local/pkg/miniupnpd.inc</include_file>
 	<menu>
-		<name>UPnP &amp; NAT-PMP</name>
-		<tooltiptext>Set UPnP &amp; NAT-PMP settings such as interfaces to listen on.</tooltiptext>
+		<name>UPnP IGD &amp; PCP</name>
+		<tooltiptext>Set service settings such as interfaces to listen on.</tooltiptext>
 		<section>Services</section>
 		<url>/pkg_edit.php?xml=miniupnpd.xml&amp;id=0</url>
 	</menu>
@@ -17,7 +17,7 @@
 	</service>
 	<fields>
 		<field>
-			<name>UPnP &amp; NAT-PMP Settings</name>
+			<name>Service Settings</name>
 			<type>listtopic</type>
 			<enablefields>enable_upnp,enable_natpmp,ext_iface,iface_array,download,upload,overridewanip,upnpqueue,logpackets,sysuptime,permdefault</enablefields>
 		</field>
@@ -26,20 +26,21 @@
 			<fieldname>enable</fieldname>
 			<type>checkbox</type>
 			<enablefields>enable_upnp,enable_natpmp,ext_iface,iface_array,download,upload,overridewanip,upnpqueue,logpackets,sysuptime,permdefault</enablefields>
-			<description>Enable UPnP &amp; NAT-PMP</description>
+			<description>Enable service</description>
+			<sethelp>Enable automatic port mapping service.</sethelp>
 		</field>
 		<field>
-			<fielddescr>UPnP Port Mapping</fielddescr>
+			<fielddescr>UPnP IGD</fielddescr>
 			<fieldname>enable_upnp</fieldname>
 			<type>checkbox</type>
-			<description>Allow UPnP Port Mapping</description>
+			<description>Allow UPnP IGD Port Mapping</description>
 			<sethelp>This protocol is often used by Microsoft-compatible systems.</sethelp>
 		</field>
 		<field>
-			<fielddescr>NAT-PMP Port Mapping</fielddescr>
+			<fielddescr>PCP/NAT-PMP</fielddescr>
 			<fieldname>enable_natpmp</fieldname>
 			<type>checkbox</type>
-			<description>Allow NAT-PMP Port Mapping</description>
+			<description>Allow PCP/NAT-PMP Port Mapping</description>
 			<sethelp>This protocol is often used by Apple-compatible systems.</sethelp>
 		</field>
 		<field>
@@ -56,7 +57,7 @@
 			<fieldname>iface_array</fieldname>
 			<default_value>lan</default_value>
 			<type>interfaces_selection</type>
-			<description>Select the internal interfaces, such as LAN, where UPnP/NAT-PMP clients reside. Use the CTRL or COMMAND key to select multiple interfaces.</description>
+			<description>Select the internal interfaces, such as LAN, where service clients reside. Use the CTRL or COMMAND key to select multiple interfaces.</description>
 			<required/>
 			<multiple/>
 		</field>
@@ -88,13 +89,13 @@
 			<fielddescr>Log packets</fielddescr>
 			<fieldname>logpackets</fieldname>
 			<type>checkbox</type>
-			<description>Log packets handled by UPnP &amp; NAT-PMP rules.</description>
+			<description>Log packets handled by service port maps.</description>
 		</field>
 		<field>
 			<fielddescr>Uptime</fielddescr>
 			<fieldname>sysuptime</fieldname>
 			<type>checkbox</type>
-			<description>Use system uptime instead of UPnP &amp; NAT-PMP service uptime.</description>
+			<description>Use system uptime instead of service uptime.</description>
 		</field>
 		<field>
 			<fielddescr>Custom presentation URL</fielddescr>
@@ -119,7 +120,7 @@
 				The External interface must have a public IP address. Otherwise it is behind NAT and port
 				forwarding is impossible. In some cases the External interface can be behind unrestricted NAT 1:1
 				when all incoming traffic is forwarded and routed to the External interface without any filtering.
-				In these cases UPnP service needs to know the public IP address and it can be learned by asking an
+				In these cases service needs to know the public IP address and it can be learned by asking an
 				external server via STUN protocol. The following option enables retrieving the external public IP
 			       	address from a STUN server and detection of the NAT type.
 			</description>
@@ -153,20 +154,20 @@
 			<description>STUN UDP port (Default: 3478)</description>
 		</field>
 		<field>
-			<name>UPnP Access Control Lists</name>
+			<name>Service Access Control Lists</name>
 			<type>listtopic</type>
 		</field>
 		<field>
 			<fielddescr>Default Deny</fielddescr>
 			<fieldname>permdefault</fieldname>
 			<type>checkbox</type>
-			<description>Deny access to UPnP &amp; NAT-PMP by default.</description>
+			<description>Deny access to service by default.</description>
 		</field>
 		<field>
 			<name>ACL Help</name>
 			<type>info</type>
 			<description>
-			These entries control access to the UPnP service. Client systems may be granted or denied access based on several criteria.
+			These entries control access to the service. Client systems may be granted or denied access based on several criteria.
 			&lt;br /&gt;&lt;br /&gt;
 			Format: [allow or deny] [ext port or range] [int ipaddr or ipaddr/CIDR] [int port or range]
 			&lt;br /&gt;Example: allow 1024-65535 192.168.0.0/24 1024-65535</description>

--- a/src/usr/local/pkg/miniupnpd.xml
+++ b/src/usr/local/pkg/miniupnpd.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <packagegui>
-	<title>Services/UPnP Port Mapping</title>
+	<title>Services/UPnP &amp; NAT-PMP</title>
 	<name>miniupnpd</name>
 	<version>20100712</version>
 	<include_file>/usr/local/pkg/miniupnpd.inc</include_file>
 	<menu>
-		<name>UPnP Port Mapping</name>
-		<tooltiptext>Set UPnP Port Mapping settings such as interfaces to listen on.</tooltiptext>
+		<name>UPnP &amp; NAT-PMP</name>
+		<tooltiptext>Set UPnP &amp; NAT-PMP settings such as interfaces to listen on.</tooltiptext>
 		<section>Services</section>
 		<url>/pkg_edit.php?xml=miniupnpd.xml&amp;id=0</url>
 	</menu>
@@ -17,7 +17,7 @@
 	</service>
 	<fields>
 		<field>
-			<name>UPnP Port Mapping Settings</name>
+			<name>UPnP &amp; NAT-PMP Settings</name>
 			<type>listtopic</type>
 			<enablefields>enable_upnp,enable_natpmp,ext_iface,iface_array,download,upload,overridewanip,upnpqueue,logpackets,sysuptime,permdefault</enablefields>
 		</field>
@@ -29,14 +29,14 @@
 			<description>Enable UPnP &amp; NAT-PMP</description>
 		</field>
 		<field>
-			<fielddescr>UPnP-IGD</fielddescr>
+			<fielddescr>UPnP Port Mapping</fielddescr>
 			<fieldname>enable_upnp</fieldname>
 			<type>checkbox</type>
-			<description>Allow UPnP-IGD Port Mapping</description>
+			<description>Allow UPnP Port Mapping</description>
 			<sethelp>This protocol is often used by Microsoft-compatible systems.</sethelp>
 		</field>
 		<field>
-			<fielddescr>NAT-PMP</fielddescr>
+			<fielddescr>NAT-PMP Port Mapping</fielddescr>
 			<fieldname>enable_natpmp</fieldname>
 			<type>checkbox</type>
 			<description>Allow NAT-PMP Port Mapping</description>
@@ -56,7 +56,7 @@
 			<fieldname>iface_array</fieldname>
 			<default_value>lan</default_value>
 			<type>interfaces_selection</type>
-			<description>Select the internal interfaces, such as LAN, where UPnP clients reside. Use the CTRL or COMMAND key to select multiple interfaces.</description>
+			<description>Select the internal interfaces, such as LAN, where UPnP/NAT-PMP clients reside. Use the CTRL or COMMAND key to select multiple interfaces.</description>
 			<required/>
 			<multiple/>
 		</field>
@@ -88,13 +88,13 @@
 			<fielddescr>Log packets</fielddescr>
 			<fieldname>logpackets</fieldname>
 			<type>checkbox</type>
-			<description>Log packets handled by UPnP rules.</description>
+			<description>Log packets handled by UPnP &amp; NAT-PMP rules.</description>
 		</field>
 		<field>
 			<fielddescr>Uptime</fielddescr>
 			<fieldname>sysuptime</fieldname>
 			<type>checkbox</type>
-			<description>Use system uptime instead of the UPnP service uptime.</description>
+			<description>Use system uptime instead of UPnP &amp; NAT-PMP service uptime.</description>
 		</field>
 		<field>
 			<fielddescr>Custom presentation URL</fielddescr>
@@ -160,7 +160,7 @@
 			<fielddescr>Default Deny</fielddescr>
 			<fieldname>permdefault</fieldname>
 			<type>checkbox</type>
-			<description>Deny access to UPnP by default.</description>
+			<description>Deny access to UPnP &amp; NAT-PMP by default.</description>
 		</field>
 		<field>
 			<name>ACL Help</name>

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -350,7 +350,7 @@ if (count(config_get_path('interfaces', [])) > 1) {
 	/* no use for UPnP in single-interface deployments
 	remove to reduce user confusion
 	*/
-	$services_menu[] = array(gettext("UPnP &amp; NAT-PMP"), "/pkg_edit.php?xml=miniupnpd.xml");
+	$services_menu[] = array(gettext("UPnP IGD &amp; PCP"), "/pkg_edit.php?xml=miniupnpd.xml");
 }
 
 $services_menu[] = array(gettext("Wake-on-LAN"), "/services_wol.php");
@@ -384,7 +384,7 @@ $status_menu[] = array(gettext("System Logs"), "/status_logs.php");
 $status_menu[] = array(gettext("Traffic Graph"), "/status_graph.php");
 
 if (count(config_get_path('interfaces', [])) > 1) {
-	$status_menu[] = array(gettext("UPnP &amp; NAT-PMP"), "/status_upnp.php");
+	$status_menu[] = array(gettext("UPnP IGD &amp; PCP"), "/status_upnp.php");
 }
 
 $wifdescrs = array();

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -350,7 +350,7 @@ if (count(config_get_path('interfaces', [])) > 1) {
 	/* no use for UPnP in single-interface deployments
 	remove to reduce user confusion
 	*/
-	$services_menu[] = array(gettext("UPnP Port Mapping"), "/pkg_edit.php?xml=miniupnpd.xml");
+	$services_menu[] = array(gettext("UPnP &amp; NAT-PMP"), "/pkg_edit.php?xml=miniupnpd.xml");
 }
 
 $services_menu[] = array(gettext("Wake-on-LAN"), "/services_wol.php");

--- a/src/usr/local/www/status_upnp.php
+++ b/src/usr/local/www/status_upnp.php
@@ -41,7 +41,7 @@ if ($_POST) {
 $rdr_entries = array();
 exec("/sbin/pfctl -aminiupnpd -sn", $rdr_entries, $pf_ret);
 
-$pgtitle = array(gettext("Status"), gettext("UPnP Port Mapping"));
+$pgtitle = array(gettext("Status"), gettext("UPnP &amp; NAT-PMP"));
 $shortcut_section = "upnp";
 
 include("head.inc");
@@ -53,7 +53,7 @@ if ($savemsg) {
 if (!config_get_path('installedpackages/miniupnpd/config/0/iface_array') ||
     !config_path_enabled('installedpackages/miniupnpd/config/0')) {
 
-	print_info_box(sprintf(gettext('UPnP is currently disabled. It can be enabled here: %1$s%2$s%3$s.'), '<a href="pkg_edit.php?xml=miniupnpd.xml">', gettext('Services &gt; UPnP Port Mapping'), '</a>'), 'danger');
+	print_info_box(sprintf(gettext('UPnP is currently disabled. It can be enabled here: %1$s%2$s%3$s.'), '<a href="pkg_edit.php?xml=miniupnpd.xml">', gettext('Services &gt; UPnP &amp; NAT-PMP'), '</a>'), 'danger');
 	include("foot.inc");
 	exit;
 }
@@ -61,7 +61,7 @@ if (!config_get_path('installedpackages/miniupnpd/config/0/iface_array') ||
 ?>
 
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext("UPnP Port Mapping Rules")?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext("UPnP &amp; NAT-PMP Rules")?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>

--- a/src/usr/local/www/status_upnp.php
+++ b/src/usr/local/www/status_upnp.php
@@ -41,7 +41,7 @@ if ($_POST) {
 $rdr_entries = array();
 exec("/sbin/pfctl -aminiupnpd -sn", $rdr_entries, $pf_ret);
 
-$pgtitle = array(gettext("Status"), gettext("UPnP &amp; NAT-PMP"));
+$pgtitle = array(gettext("Status"), gettext("UPnP IGD &amp; PCP"));
 $shortcut_section = "upnp";
 
 include("head.inc");
@@ -53,7 +53,7 @@ if ($savemsg) {
 if (!config_get_path('installedpackages/miniupnpd/config/0/iface_array') ||
     !config_path_enabled('installedpackages/miniupnpd/config/0')) {
 
-	print_info_box(sprintf(gettext('UPnP is currently disabled. It can be enabled here: %1$s%2$s%3$s.'), '<a href="pkg_edit.php?xml=miniupnpd.xml">', gettext('Services &gt; UPnP &amp; NAT-PMP'), '</a>'), 'danger');
+	print_info_box(sprintf(gettext('Service is currently disabled. It can be enabled here: %1$s%2$s%3$s.'), '<a href="pkg_edit.php?xml=miniupnpd.xml">', gettext('Services &gt; UPnP IGD &amp; PCP'), '</a>'), 'danger');
 	include("foot.inc");
 	exit;
 }
@@ -61,19 +61,19 @@ if (!config_get_path('installedpackages/miniupnpd/config/0/iface_array') ||
 ?>
 
 <div class="panel panel-default">
-	<div class="panel-heading"><h2 class="panel-title"><?=gettext("UPnP &amp; NAT-PMP Rules")?></h2></div>
+	<div class="panel-heading"><h2 class="panel-title"><?=gettext("Active Service Port Maps")?></h2></div>
 	<div class="panel-body">
 		<div class="table-responsive">
 			<table class="table table-striped table-hover table-condensed sortable-theme-bootstrap" data-sortable>
 				<thead>
 					<tr>
 						<th><?=gettext("Interface")?></th>
-						<th><?=gettext("Protocol")?></th>
-						<th><?=gettext("Source IP")?></th>
-						<th><?=gettext("Ext IP")?></th>
-						<th><?=gettext("Port")?></th>
+						<th><?=gettext("Ext Port")?></th>
 						<th><?=gettext("Int IP")?></th>
 						<th><?=gettext("Int Port")?></th>
+						<th><?=gettext("Protocol")?></th>
+						<th><?=gettext("Source IP")?></th>
+						<th><?=gettext("Source Port")?></th>
 						<th><?=gettext("Description")?></th>
 					</tr>
 				</thead>
@@ -84,20 +84,11 @@ $i = 0;
 foreach ($rdr_entries as $rdr_entry) {
 	/* rdr log quick on igb2 inet proto tcp from any to any port = xxxxx keep state label "xxxxx" rtable 0 -> xxx.xxx.xxx.xxx port xxxxx */
 	/* rdr log quick on igb2 inet proto udp from any to xxx.xxx.xxx.xxx port = xxxxxx keep state label "xxxxx" rtable 0 -> xxx.xxx.xxx.xxx port xxxxx */
-	if (preg_match("/on (?P<iface>.*) inet proto (?P<proto>.*) from (?P<srcaddr>.*) to (?P<extaddr>.*) port = (?P<extport>.*) keep state (label \"(?P<descr>.*)\" )?rtable [0-9] -> (?P<intaddr>.*) port (?P<intport>.*)/", $rdr_entry, $matches)) {
+	if (preg_match("/on (?P<iface>.*) inet proto (?P<proto>.*) from (?P<srcaddr>.*) (port (?P<srcport>.*) )?to (?P<extaddr>.*) port = (?P<extport>.*) keep state (label \"(?P<descr>.*)\" )?rtable [0-9] -> (?P<intaddr>.*) port (?P<intport>.*)/", $rdr_entry, $matches)) {
 ?>
 					<tr>
 						<td>
 							<?= htmlspecialchars(convert_real_interface_to_friendly_descr($matches['iface'])) ?>
-						</td>
-						<td>
-							<?= htmlspecialchars($matches['proto']) ?>
-						</td>
-						<td>
-							<?= htmlspecialchars($matches['srcaddr']) ?>
-						</td>
-						<td>
-							<?= htmlspecialchars($matches['extaddr']) ?>
 						</td>
 						<td>
 							<?= htmlspecialchars($matches['extport']) ?>
@@ -107,6 +98,15 @@ foreach ($rdr_entries as $rdr_entry) {
 						</td>
 						<td>
 							<?= htmlspecialchars($matches['intport']) ?>
+						</td>
+						<td>
+							<?= htmlspecialchars(strtoupper($matches['proto'])) ?>
+						</td>
+						<td>
+							<?= htmlspecialchars($matches['srcaddr']) ?>
+						</td>
+						<td>
+							<?= htmlspecialchars($matches['srcport'] ?: "any") ?>
 						</td>
 						<td>
 							<?= htmlspecialchars($matches['descr']) ?>


### PR DESCRIPTION
and change menu/title to `UPnP IGD & PCP` as newer PCP protocol is supported

- Replace the frequently repeated protocols term 9 times with `Service`
- Rename `UPnP & NAT-PMP Rules` to `Active Service Port Maps` and `Port` to `Ext Port`, add `Source Port` and remove `Ext IP` as always `any` on the status page
- Use only `UPnP IGD & PCP`, including the newer IETF protocol, as the full term will get automatic truncated (see screenshot) on mobile to just `NAT-PMP`, but use `PCP/NAT-PMP` in the actual setting
- Use `UPnP IGD` as `UPnP` alone is not specific enough as UPnP is also used as a MediaServer
- Add help text: `Enable automatic port mapping service`

### Proposed service settings UI

![pfsense-igd-pcp-service-settings](https://github.com/pfsense/pfsense/assets/155233284/4ad374ae-2b67-44c6-a276-7f8c5274d143)

*[Full screenshot](https://github.com/pfsense/pfsense/assets/155233284/ec498ee4-a254-4cda-8ce6-ca16dc0d0a3d)*

### Current service settings UI

![pfsense-igd-pcp-service-settings-old](https://github.com/pfsense/pfsense/assets/155233284/0263a98e-efa7-4843-a00c-0f515905e785)

### Proposed status UI

![pfsense-igd-pcp-status](https://github.com/pfsense/pfsense/assets/155233284/4600066b-853a-4bfb-87f2-cf2e995dcf8c)

### Unexpected truncation on mobile

![pfsense-wrapping](https://github.com/pfsense/pfsense/assets/155233284/a2e4657d-f779-497c-863c-5d2fac075629)

Port Control Protocol (PCP) is the successor to NAT-PMP and has similar protocol concepts and packet formats, but adds IPv6 support.

*PCP standard:*
https://datatracker.ietf.org/doc/html/rfc6887
https://en.wikipedia.org/wiki/Port_Control_Protocol
*NAT-PMP std. (see 9.1 Simplicity - 9.3 for some diff. to UPnP IGD):*
https://datatracker.ietf.org/doc/html/rfc6886
*Port Mapping Protocols Overview:*
https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview