### PR TITLE
Enable kea DHCP run_script plugin. redmine #15666

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -559,6 +559,16 @@ function services_kea6_configure() {
 		'lease-checks' => 'fix-del'
 	];
 
+	if (config_path_enabled('system', 'dhcpkearunscript')) {
+		$keaconf['Dhcp6']['hooks-libraries'][] = [
+			'library' => '/usr/local/lib/kea/hooks/libdhcp_run_script.so',
+			'parameters' => [
+					'name' => '/usr/local/bin/kea_run6.sh',
+					'sync' => false
+			]
+		];
+	}
+
 	/* required for HA support */
 	$keaconf['Dhcp6']['hooks-libraries'][] = [
 		'library' => '/usr/local/lib/kea/hooks/libdhcp_lease_cmds.so',
@@ -1201,6 +1211,16 @@ function services_kea4_configure() {
 	$keaconf['Dhcp4']['sanity-checks'] = [
 		'lease-checks' => 'fix-del'
 	];
+
+	if (config_path_enabled('system', 'dhcpkearunscript')) {
+		$keaconf['Dhcp4']['hooks-libraries'][] = [
+			'library' => '/usr/local/lib/kea/hooks/libdhcp_run_script.so',
+			'parameters' => [
+					'name' => '/usr/local/bin/kea_run4.sh',
+					'sync' => false
+			]
+		];
+	}
 
 	/* required for HA support */
 	$keaconf['Dhcp4']['hooks-libraries'][] = [

--- a/src/usr/local/bin/kea_run4.sh
+++ b/src/usr/local/bin/kea_run4.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# run kea ipv4 user scripts in directory. requires kea run_script hook library enabled.
+USER_SCRIPTS="/conf/kea4_scripts.d"
+KEA_EVENT="$1"
+if [ -d $USER_SCRIPTS ]; then
+    for kea_rc in $USER_SCRIPTS/*; do
+        if [ -f "$kea_rc" -a -x "$kea_rc" ]; then
+            $kea_rc $KEA_EVENT
+        fi
+    done
+    unset kea_rc
+fi
+

--- a/src/usr/local/bin/kea_run6.sh
+++ b/src/usr/local/bin/kea_run6.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# run kea ipv6 user scripts in directory. requires kea run_script hook library enabled.
+USER_SCRIPTS="/conf/kea6_scripts.d"
+KEA_EVENT="$1"
+if [ -d $USER_SCRIPTS ]; then
+    for kea_rc in $USER_SCRIPTS/*; do
+        if [ -f "$kea_rc" -a -x "$kea_rc" ]; then
+            $kea_rc $KEA_EVENT
+        fi
+    done
+    unset kea_rc
+fi
+

--- a/src/usr/local/pfSense/include/www/system_advanced_network.inc
+++ b/src/usr/local/pfSense/include/www/system_advanced_network.inc
@@ -34,6 +34,7 @@ function getAdvancedNetwork($json = false) {
 	$pconfig['radvddebug'] = config_path_enabled('system', 'radvddebug');
 	$pconfig['ignoreiscwarning'] = config_path_enabled('system', 'ignoreiscwarning');
 	$pconfig['dhcp6debug'] = config_path_enabled('system', 'dhcp6debug');
+	$pconfig['dhcpkearunscript'] = config_path_enabled('system', 'dhcpkearunscript');
 	$pconfig['dhcp6norelease'] = config_path_enabled('system', 'dhcp6norelease');
 	$pconfig['global-v6duid'] = config_path_enabled('system', 'global-v6duid') ? config_get_path('system/global-v6duid') : null;
 	$pconfig['prefer_ipv4'] = config_path_enabled('system', 'prefer_ipv4');
@@ -153,6 +154,12 @@ function saveAdvancedNetworking($post, $json = false) {
 			config_set_path('system/dhcp6debug', true);
 		} else {
 			config_del_path('system/dhcp6debug');
+		}
+
+		if ($post['dhcpkearunscript'] == "yes") {
+			config_set_path('system/dhcpkearunscript', true);
+		} else {
+			config_del_path('system/dhcpkearunscript');
 		}
 
 		if ($post['dhcp6norelease'] == "yes") {

--- a/src/usr/local/www/system_advanced_network.php
+++ b/src/usr/local/www/system_advanced_network.php
@@ -106,6 +106,13 @@ $group->add(new Form_Checkbox(
 $section->add($group);
 
 $section->addInput(new Form_Checkbox(
+	'dhcpkearunscript',
+	'Enable Kea run script plugin',
+	'Runs user defined script(s) upon DHCP events. Only applicable when Kea DHCP is selected as DHCP server',
+	$pconfig['dhcpkearunscript']
+));
+
+$section->addInput(new Form_Checkbox(
 	'radvddebug',
 	'RADVD Debug',
 	'Log all radvd log levels',


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/15666
- [ ] Ready for review

Enables the kea run_script plugin.
Adds a new check box on 'System/Advanced/Networking'
2 new scripts at `/usr/local/bin/`

To test, use Kea as dhcp server, tick 'enable plugin', Goto Services/Dhcp Server and save/apply.
Place a script at `/conf/kea4_scripts.d/test.sh` with something along the lines of `printenv >> /tmp/dhcpinfo.txt`

Should also provide a workaround for those wanting the DHCP server to register client names in a separate zone, by allowing them to host the DNS server elsewhere and registering client names in any zone they wish.