### PR TITLE
Fixes #14289, #10000 and #15593, plus various code improvements.

### DIFF
--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -347,7 +347,7 @@ $group->add(new Form_Input(
 ));
 
 $group->setHelp('Enter the complete fully qualified domain name. Example: myhost.dyndns.org%1$s' .
-				'Cloudflare, Linode, Porkbun, Name.com: Enter @ as the hostname to indicate an empty field.%1$s' .
+				'Azure, Cloudflare, Linode, Porkbun, Name.com: Enter @ as the hostname to indicate an empty field.%1$s' .
 				'deSEC: Enter the FQDN.%1$s' .
 				'DNSimple: Enter only the domain name.%1$s' .
 				'DNS Made Easy: Dynamic DNS ID (NOT hostname)%1$s' .

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -122,7 +122,7 @@ if ($_POST['save'] || $_POST['force']) {
 	$reqdfieldsn = array(gettext("Service type"));
 
 	if ($pconfig['type'] != "custom" && $pconfig['type'] != "custom-v6") {
-		if (($pconfig['type'] != "dnsomatic")) {
+		if ($pconfig['type'] != "dnsomatic") {
 			$reqdfields[] = "host";
 			$reqdfieldsn[] = gettext("Hostname");
 		}
@@ -152,34 +152,14 @@ if ($_POST['save'] || $_POST['force']) {
 		    (isset($ddns_attr[$pconfig['type']]['wildcard']) && ($ddns_attr[$pconfig['type']]['wildcard'] == true) && 
 		    (($_POST['host'] == '*.') || ($_POST['host'] == '*')))) {
 			$host_to_check = $_POST['domainname'];
-		} elseif (($pconfig['type'] == "cloudflare") || ($pconfig['type'] == "cloudflare-v6")) {
-			$host_to_check = $_POST['host'] == '@' ? $_POST['domainname'] : ( $_POST['host'] . '.' . $_POST['domainname'] );
-			$allow_wildcard = true;
-		} elseif (($pconfig['type'] == "linode") || ($pconfig['type'] == "linode-v6") || ($pconfig['type'] == "name.com") || ($pconfig['type'] == "name.com-v6") || ($pconfig['type'] == "gandi-livedns") || ($pconfig['type'] == "gandi-livedns-v6") || ($pconfig['type'] == "yandex") || ($pconfig['type'] == "yandex-v6") || ($pconfig['type'] == "porkbun") || ($pconfig['type'] == "porkbun-v6")) {
+		} elseif (($pconfig['type'] == "azure") || ($pconfig['type'] == "azurev6") || ($pconfig['type'] == "cloudflare") || ($pconfig['type'] == "cloudflare-v6") || ($pconfig['type'] == "hover") || ($pconfig['type'] == "linode") || ($pconfig['type'] == "linode-v6") || ($pconfig['type'] == "name.com") || ($pconfig['type'] == "name.com-v6") || ($pconfig['type'] == "noip") || ($pconfig['type'] == "gandi-livedns") || ($pconfig['type'] == "gandi-livedns-v6") || ($pconfig['type'] == "yandex") || ($pconfig['type'] == "yandex-v6") || ($pconfig['type'] == "porkbun") || ($pconfig['type'] == "porkbun-v6")) {
 			$host_to_check = $_POST['host'] == '@' ? $_POST['domainname'] : ( $_POST['host'] . '.' . $_POST['domainname'] );
 			$allow_wildcard = true;
 		} elseif (($pconfig['type'] == "route53") || ($pconfig['type'] == "route53-v6")) {
 			$host_to_check = $_POST['host'];
 			$allow_wildcard = true;
-		} elseif ($pconfig['type'] == "hover") {
-			/* hover allows hostnames '@' and '*' also */
-			if ((strcmp("@", $_POST['host']) == 0) || (strcmp("*", $_POST['host']) == 0)) {
-				$host_to_check = $_POST['domainname'];
-			} else {
-				$host_to_check = $_POST['host'] . '.' . $_POST['domainname'];
-			}
 		} else {
 			$host_to_check = $_POST['host'];
-
-			/* No-ip can have a @ in hostname */
-			if (substr($pconfig['type'], 0, 4) == "noip") {
-				$last_to_check = strrpos($host_to_check, '@');
-				if ($last_to_check !== false) {
-					$host_to_check = substr_replace(
-						$host_to_check, '.', $last_to_check, 1);
-				}
-				unset($last_to_check);
-			}
 		}
 
 		if ($pconfig['type'] != "custom" && $pconfig['type'] != "custom-v6") {

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -122,7 +122,7 @@ if ($_POST['save'] || $_POST['force']) {
 	$reqdfieldsn = array(gettext("Service type"));
 
 	if ($pconfig['type'] != "custom" && $pconfig['type'] != "custom-v6") {
-		if ($pconfig['type'] != "dnsomatic") {
+		if (($pconfig['type'] != "dnsomatic")) {
 			$reqdfields[] = "host";
 			$reqdfieldsn[] = gettext("Hostname");
 		}
@@ -155,7 +155,7 @@ if ($_POST['save'] || $_POST['force']) {
 		} elseif (($pconfig['type'] == "cloudflare") || ($pconfig['type'] == "cloudflare-v6")) {
 			$host_to_check = $_POST['host'] == '@' ? $_POST['domainname'] : ( $_POST['host'] . '.' . $_POST['domainname'] );
 			$allow_wildcard = true;
-		} elseif (($pconfig['type'] == "linode") || ($pconfig['type'] == "linode-v6") || ($pconfig['type'] == "gandi-livedns") || ($pconfig['type'] == "gandi-livedns-v6") || ($pconfig['type'] == "yandex") || ($pconfig['type'] == "yandex-v6") || ($pconfig['type'] == "porkbun") || ($pconfig['type'] == "porkbun-v6")) {
+		} elseif (($pconfig['type'] == "linode") || ($pconfig['type'] == "linode-v6") || ($pconfig['type'] == "name.com") || ($pconfig['type'] == "name.com-v6") || ($pconfig['type'] == "gandi-livedns") || ($pconfig['type'] == "gandi-livedns-v6") || ($pconfig['type'] == "yandex") || ($pconfig['type'] == "yandex-v6") || ($pconfig['type'] == "porkbun") || ($pconfig['type'] == "porkbun-v6")) {
 			$host_to_check = $_POST['host'] == '@' ? $_POST['domainname'] : ( $_POST['host'] . '.' . $_POST['domainname'] );
 			$allow_wildcard = true;
 		} elseif (($pconfig['type'] == "route53") || ($pconfig['type'] == "route53-v6")) {
@@ -210,6 +210,9 @@ if ($_POST['save'] || $_POST['force']) {
 			$dyndns['password'] = $this_dyndns_config['password'];;
 		}
 		$dyndns['host'] = $_POST['host'];
+		if (($pconfig['type'] == "name.com") || ($pconfig['type'] == "name.com-v6")) {
+			$dyndns['host'] = $_POST['host'] == "@" ? "" : $_POST['host'];
+		}
 		$dyndns['domainname'] = $_POST['domainname'];
 		$dyndns['mx'] = $_POST['mx'];
 		$dyndns['wildcard'] = $_POST['wildcard'] ? true : false;
@@ -364,7 +367,7 @@ $group->add(new Form_Input(
 ));
 
 $group->setHelp('Enter the complete fully qualified domain name. Example: myhost.dyndns.org%1$s' .
-				'Cloudflare, Linode, Porkbun: Enter @ as the hostname to indicate an empty field.%1$s' .
+				'Cloudflare, Linode, Porkbun, Name.com: Enter @ as the hostname to indicate an empty field.%1$s' .
 				'deSEC: Enter the FQDN.%1$s' .
 				'DNSimple: Enter only the domain name.%1$s' .
 				'DNS Made Easy: Dynamic DNS ID (NOT hostname)%1$s' .


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/14289
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/15593
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/10000
- [ ] Ready for review

Allows dyndns apex records for Name.com and Azure via "@" in the Host input field. 

Unfortunately the Name.com API seems to accept both "@" and empty strings for the Host field while it is only possible to create "empty string"-records in their web application. This means that sending an "@" in the API request creates duplicate records in the Name.com DNS table. In this PR, a workaround solution is provided by replacing "@" with an empty string before saving & updating the record.

Various code improvements.