### PR TITLE
Remove unnecessary "(SSH only)" from logout option in console menu - Redmine Issue #15705

### DIFF
--- a/src/etc/rc.initial
+++ b/src/etc/rc.initial
@@ -65,7 +65,7 @@ fi
 
 # display console menu
 echo ""
-echo " 0) Logout (SSH only)                  9) pfTop"
+echo " 0) Logout / Disconnect SSH            9) pfTop"
 echo " 1) Assign Interfaces                 10) Filter Logs"
 echo " 2) Set interface(s) IP address       11) Restart GUI"
 echo " 3) Reset admin account and password  12) PHP shell + ${product_label} tools"


### PR DESCRIPTION
- [x] Ready for review

This PR removes the "(SSH only)" part of the "0) Logout" option on the console menu. This is because the logout option on the menu is not exclusive to people connecting to the console over SSH, and having "(SSH only)" potentially creates confusion.

Password protection for the console menu can in fact be enabled (System/Advanced/Admin Access/Console Options/Password protect the console menu), which secures the physical console as well as remote SSH connections. I have tested and ensured that the "0) Logout" option does still work as expected on a physical console when console password protection is enabled.

I assumed this change falls under a "very minor typo/wording fix", so didn't create a bug entry on Redmine, although I would be happy to do so if this is neccesary :)