### PR TITLE
Remove deprecated pragma header

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -3642,10 +3642,8 @@ function send_user_download($type, $content, $userfilename = "", $contenttype = 
 
 	/* Send cache headers */
 	if (isset($_SERVER['HTTPS'])) {
-		header('Pragma: ');
 		header('Cache-Control: ');
 	} else {
-		header("Pragma: private");
 		header("Cache-Control: private, must-revalidate");
 	}
 

--- a/src/usr/local/captiveportal/index.php
+++ b/src/usr/local/captiveportal/index.php
@@ -32,7 +32,6 @@ require_once("captiveportal.inc");
 
 header("Expires: 0");
 header("Cache-Control: no-cache, no-store, must-revalidate");
-header("Pragma: no-cache");
 header("Connection: close");
 
 global $cpzone, $cpzoneid, $cpzoneprefix;

--- a/src/usr/local/www/getqueuestats.php
+++ b/src/usr/local/www/getqueuestats.php
@@ -28,8 +28,7 @@
 
 header("Last-Modified: " . gmdate("D, j M Y H:i:s") . " GMT");
 header("Expires: " . gmdate("D, j M Y H:i:s", time()) . " GMT");
-header("Cache-Control: no-cache, no-store, must-revalidate"); // HTTP/1.1
-header("Pragma: no-cache"); // HTTP/1.0
+header("Cache-Control: no-cache, no-store, must-revalidate");
 
 require_once("auth_check.inc");
 include_once("shaper.inc");

--- a/src/usr/local/www/getstats.php
+++ b/src/usr/local/www/getstats.php
@@ -31,8 +31,7 @@
 
 header("Last-Modified: " . gmdate("D, j M Y H:i:s") . " GMT");
 header("Expires: " . gmdate("D, j M Y H:i:s", time()) . " GMT");
-header("Cache-Control: no-cache, no-store, must-revalidate"); // HTTP/1.1
-header("Pragma: no-cache"); // HTTP/1.0
+header("Cache-Control: no-cache, no-store, must-revalidate");
 
 require_once("auth_check.inc");
 include_once("includes/functions.inc.php");

--- a/src/usr/local/www/graph.php
+++ b/src/usr/local/www/graph.php
@@ -39,8 +39,7 @@ require_once("guiconfig.inc");
 
 header("Last-Modified: " . gmdate("D, j M Y H:i:s") . " GMT");
 header("Expires: " . gmdate("D, j M Y H:i:s", time()) . " GMT");
-header("Cache-Control: no-cache, no-store, must-revalidate"); // HTTP/1.1
-header("Pragma: no-cache"); // HTTP/1.0
+header("Cache-Control: no-cache, no-store, must-revalidate");
 header("Content-type: image/svg+xml");
 
 /********** HTTP REQUEST Based Conf ***********/

--- a/src/usr/local/www/graph_cpu.php
+++ b/src/usr/local/www/graph_cpu.php
@@ -39,8 +39,7 @@ require_once("guiconfig.inc");
 
 header("Last-Modified: " . gmdate("D, j M Y H:i:s") . " GMT");
 header("Expires: " . gmdate("D, j M Y H:i:s", time()) . " GMT");
-header("Cache-Control: no-cache, no-store, must-revalidate"); // HTTP/1.1
-header("Pragma: no-cache"); // HTTP/1.0
+header("Cache-Control: no-cache, no-store, must-revalidate");
 header("Content-type: image/svg+xml");
 
 /********* Other conf *******/

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -56,7 +56,6 @@ if (!$omit_nocacheheaders) {
 	header("Expires: 0");
 	header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
 	header("Cache-Control: no-cache, no-store, must-revalidate");
-	header("Pragma: no-cache");
 }
 
 require_once("authgui.inc");

--- a/src/usr/local/www/status_queues.php
+++ b/src/usr/local/www/status_queues.php
@@ -30,8 +30,7 @@
 /*
 header("Last-Modified: " . gmdate("D, j M Y H:i:s") . " GMT");
 header("Expires: " . gmdate("D, j M Y H:i:s", time()) . " GMT");
-header("Cache-Control: no-cache, no-store, must-revalidate"); // HTTP/1.1
-header("Pragma: no-cache"); // HTTP/1.0
+header("Cache-Control: no-cache, no-store, must-revalidate");
 */
 
 require_once("guiconfig.inc");


### PR DESCRIPTION
This removes adding pragma header which is now deprecated. Cache control is used instead.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/15781
- [x] Ready for review