### PR TITLE
DynDNS: change Porkbun to use api.porkbun.com instead of porkbun.com

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -142,7 +142,7 @@
 	 *  ODS             - Last Tested: 02 August 2005
 	 *  OpenDNS         - Last Tested: 4 August 2008
 	 *  OVH DynHOST     - Last Tested: NEVER
-	 *  Porkbun         - Last Tested: 26 June 2023
+	 *  Porkbun         - Last Tested: 22 October 2024
 	 *  SelfHost        - Last Tested: 26 December 2011
 	 *  SPDYN           - Last Tested: 02 July 2016
 	 *  SPDYN IPv6      - Last Tested: 02 July 2016
@@ -963,8 +963,8 @@
 					break;
 				case 'porkbun':
 				case 'porkbun-v6':
-					// API documentation: https://porkbun.com/api/json/v3/documentation
-					$porkbun_api = "https://porkbun.com/api/json/v3/dns/retrieve/{$this->_dnsDomain}";
+					// API documentation: https://api.porkbun.com/api/json/v3/documentation
+					$porkbun_api = "https://api.porkbun.com/api/json/v3/dns/retrieve/{$this->_dnsDomain}";
 					$record_type = $this->_useIPv6 ? "AAAA" : "A";
 					// Check if a record already exists for this host.
 					$post_data['apikey'] = $this->_dnsUser;
@@ -999,13 +999,13 @@
 					// No record exists for this host, add one.
 					if (!$record_id)
 					{
-						$porkbun_api = "https://porkbun.com/api/json/v3/dns/create/{$this->_dnsDomain}";
+						$porkbun_api = "https://api.porkbun.com/api/json/v3/dns/create/{$this->_dnsDomain}";
 						if ($this->_dnsHost == "@" || $this->_dnsHost == "")
 							$post_data['name'] = "";
 						else
 							$post_data['name'] = $this->_dnsHost;
 					} else {
-						$porkbun_api = "https://porkbun.com/api/json/v3/dns/edit/{$this->_dnsDomain}/{$record_id}";
+						$porkbun_api = "https://api.porkbun.com/api/json/v3/dns/edit/{$this->_dnsDomain}/{$record_id}";
 						$post_data['name'] = $this->_dnsHost;
 					}
 					$post_data['type'] = $record_type;


### PR DESCRIPTION
Changes the dynDNS provider 'Porkbun' to use the domain `api.porkbun.com` instead of `porkbun.com` as accessing the API through `porkbun.com` will cease to work December 1st. They informed customers by email of this change and now it is also reflected on their API documentation page at https://api.porkbun.com/api/json/v3/documentation

Signed-off-by: Nita Vesa <nita.vesa@outlook.com>

- [X] Redmine Issue: https://redmine.pfsense.org/issues/15779
- [X] Ready for review