### PR TITLE
system_generate_nginx_config: when configuring http redirect add /.well-known/ location for ACME webroot challenges

### DIFF
--- a/src/etc/inc/system.inc
+++ b/src/etc/inc/system.inc
@@ -2114,7 +2114,13 @@ EOD;
 	server {
 		listen 80;
 		listen [::]:80;
-		return 301 https://\$http_host$redirectport\$request_uri;
+		location /.well-known/ {
+			alias /usr/local/www/.well-known/;
+		}
+
+		location / {
+			return 301 https://\$http_host$redirectport\$request_uri;
+		}
 	}
 
 EOD;


### PR DESCRIPTION
This fixes issuing/renewing the certificates with webroot challenge when webConfiguration http -> https redirect is configured

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review