### PR TITLE
Add support for filter rules to match IPIP traffic

### DIFF
--- a/src/etc/inc/globals.inc
+++ b/src/etc/inc/globals.inc
@@ -738,6 +738,7 @@ function get_ipprotocols(?string $type = ''):array {
 		'ah' => 'AH',
 		'gre' => 'GRE',
 		'etherip' => 'EoIP',
+		'ipencap' => 'IPIP',
 		'ipv6' => 'IPV6',
 		'igmp' => 'IGMP',
 		'pim' => 'PIM',


### PR DESCRIPTION
Currently there is no way to create filter rules for IP-in-IP encapsulated (aka IPIP, IPEncap, protocol 4) traffic via the GUI, because the protocol is not enumerated by get_ipprotocols.

It just takes a single line to enumerate it in the GUI and it works flawlessly for both plain filter rules and NAT rules.

- [ yes ] Redmine Issue: https://redmine.pfsense.org/issues/15991
- [ yes ] Ready for review