### PR TITLE
When searching for LDAP group use Base DN instead of current user container

### DIFF
--- a/src/etc/inc/auth.inc
+++ b/src/etc/inc/auth.inc
@@ -1710,7 +1710,7 @@ function ldap_backed($username, $passwd, $authcfg, &$attributes = array()) {
 				$username = $info[0]['dn'];
 			}
 			$ldapgroupfilter = "(&({$ldapgroupattribute}={$username})({$ldapextendedquery}))";
-			$groupsearch = @$ldapfunc($ldap, $ldapdn, $ldapgroupfilter);
+			$groupsearch = @$ldapfunc($ldap, $ldapbasedn, $ldapgroupfilter);
 			if ($debug) {
 				log_error(sprintf(gettext("LDAP Debug: RFC2307 group filter search: %s"), $ldapgroupfilter));
 			}


### PR DESCRIPTION
When LDAP that implements RFC 2307 (OpenLDAP) is used as authentication server and you are limiting to specific groups use the LDAP base DN instead of current user container.
Otherwise group has to be in the same container as the user.

- [X] Redmine Issue: https://redmine.pfsense.org/issues/16029
- [X] Ready for review