### PR TITLE
Update Gandi livedns with PAT instead of API Key

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -1759,7 +1759,7 @@
 					$url = "{$gandi_api}{$this->_dnsDomain}/records/{$this->_dnsHost}/{$record_type}";
 
 					$headers = array(
-						'Authorization: Apikey ' . $this->_dnsPass,
+						'Authorization: Bearer ' . $this->_dnsPass,
 						'Content-Type: application/json'
 					);
 					$body = array(

--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -482,7 +482,7 @@ $section->addPassword(new Form_Input(
 			'Domeneshop: Enter the API secret.%1$s' .
 			'Dreamhost: Enter the API Key.%1$s' .
 			'FreeDNS (freedns.afraid.org): Enter the "Token" provided by FreeDNS. The token is after update.php? for API v1 or after  u/ for v2.%1$s' .
-			'Gandi LiveDNS: Enter API token%1$s' .
+			'Gandi LiveDNS: Enter PAT token%1$s' .
 			'GleSYS: Enter the API key.%1$s' .
 			'GoDaddy: Enter the API secret.%1$s' .
 			'Linode: Enter the Personal Access Token.%1$s' .


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/15258
- [X] Ready for review

Gandi has stopped supporting API keys and instead moved to PAT keys which requires the Bearer attribute in the Authorization header instead of the Apikey attrubite.

Read more [here](https://api.gandi.net/docs/authentication/)