### PR TITLE
implements reaction on RA SLAAC address changes

### DIFF
--- a/src/etc/devd/inetaddr.conf
+++ b/src/etc/devd/inetaddr.conf
@@ -1,0 +1,5 @@
+notify 0 {
+        match "system" "IFNET";
+        match "type" "ADDR_ADD";
+        action "/etc/rc.newipfromdevd $subsystem $address";
+};

--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -5014,14 +5014,22 @@ function interface_dhcpv6_configure($ifconf, $ifcfg, $destroy = false) {
 				$dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c rebind on {$wanif}\"\n";
 			}
 			$dhcp6cscript .= ";;\n";
-			$dhcp6cscript .= "REQUEST|";
+			$dhcp6cscript .= "REQUEST)\n";
+			$dhcp6cscript .= "/sbin/ifconfig -f inet6:numeric {$wanif} inet6 | /usr/bin/sed -nEe 's/^[[:space:]]*(inet6[[:>:]].*[[:<:]]autoconf[[:>:]].*)$/\\1/p' > /tmp/{$wanif}_ra_configured_inet6.tmp\n";
+			$dhcp6cscript .= "/bin/mv -f /tmp/{$wanif}_ra_configured_inet6.tmp /tmp/{$wanif}_ra_configured_inet6\n";
+			$dhcp6cscript .= "rm -f /tmp/{$wanif}_ra_configured_inet6.lock\n";
+			if ($debugOption == '-D') {
+				$dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c REQUEST on {$wanif} running rc.newwanipv6\"\n";
+			}
+			$dhcp6cscript .= "/usr/local/sbin/fcgicli -f /etc/rc.newwanipv6 -d \"interface={$wanif}&dmnames=\${dmnames}&dmips=\${dmips}&reason=\${REASON}\"\n";
+			$dhcp6cscript .= ";;\n";
 			if (isset($wancfg['dhcp6norelease'])) {
 				$dhcp6cscript .= "EXIT)\n";
 			} else {
 				$dhcp6cscript .= "RELEASE)\n";
 			}
 			if ($debugOption == '-D') {
-				$dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c RELEASE, REQUEST or EXIT on {$wanif} running rc.newwanipv6\"\n";
+				$dhcp6cscript .= "/usr/bin/logger -t dhcp6c \"dhcp6c RELEASE or EXIT on {$wanif} running rc.newwanipv6\"\n";
 			}
 			$dhcp6cscript .= "/usr/local/sbin/fcgicli -f /etc/rc.newwanipv6 -d \"interface={$wanif}&dmnames=\${dmnames}&dmips=\${dmips}&reason=\${REASON}\"\n";
 			$dhcp6cscript .= ";;\n";
@@ -5094,6 +5102,8 @@ EOD;
 				 * Check for a lock file, trying to prevent multiple instances
 				 * of dhcp6c being launched
 				 */
+				$rtsoldscript .= "/sbin/ifconfig -f inet6:numeric {$wanif} inet6 | /usr/bin/sed -nEe 's/^[[:space:]]*(inet6[[:>:]].*[[:<:]]autoconf[[:>:]].*)$/\\1/p' > /tmp/{$wanif}_ra_configured_inet6.tmp\n";
+				$rtsoldscript .= "/bin/mv -f /tmp/{$wanif}_ra_configured_inet6.tmp /tmp/{$wanif}_ra_configured_inet6\n";
 				$rtsoldscript .= "if [ ! -f /tmp/dhcp6c_lock ]; then\n";
 				/*
 				 * Create the lock file, trying to prevent multiple instances
@@ -5114,6 +5124,7 @@ EOD;
 				$rtsoldscript .= "\tdhcp6c_pid=\$(cat \"{$g['varrun_path']}/dhcp6c.pid\")\n";
 				$rtsoldscript .= "\t/bin/kill -1 \${dhcp6c_pid}\n";
 				$rtsoldscript .= "fi\n";
+				$rtsoldscript .= "rm -f /tmp/{$wanif}_ra_configured_inet6.lock\n";
 			} else {
 				/*
 				 * The script needs to run in dhcp6withoutra mode as RA may
@@ -5191,6 +5202,9 @@ EOD;
 			 * ( it does not background, it exits! ) It will launch dhcp6c
 			 * if dhcpwihtoutra is not set
 			 */
+			if (!isset($ifcfg['dhcp6withoutra'])) {
+				file_put_contents("/tmp/{$realif}_ra_configured_inet6.lock", '');
+			}
 			log_error("Starting rtsold process on {$ifconf}({$realif})");
 			sleep(2);
 			mwexec("/usr/sbin/rtsold -1 " .

--- a/src/etc/rc.newipfromdevd
+++ b/src/etc/rc.newipfromdevd
@@ -1,0 +1,155 @@
+#!/usr/local/bin/php-cgi -f
+<?php
+/*
+ * rc.newipfromdevd
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2006-2013 BSD Perimeter
+ * Copyright (c) 2013-2016 Electric Sheep Fencing
+ * Copyright (c) 2014-2023 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Originally part of m0n0wall (http://m0n0.ch/wall)
+ * Copyright (c) 2003-2005 Manuel Kasper <mk@neon1.net>.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* include all configuration functions */
+require_once("globals.inc");
+require_once("util.inc");
+require_once("interfaces.inc");
+require_once("Net/IPv6.php");
+
+if (is_platform_booting()) {
+	exit(1);
+}
+
+function exit_na (string $msg) {
+	log_error("rc.newipfromdevd: no action ({$msg})");
+	exit(0);
+}
+
+// get and check arguments
+$interface_real = trim($argv[1]);
+$address = trim($argv[2]);
+
+log_error("rc.newipfromdevd: started with interface '{$interface_real}' and address '{$address}'");
+
+if (empty($interface_real) || empty ($address)) {
+	log_error("rc.newipfromdevd: interface or address not specified");
+	exit(1);
+}
+
+// only process configured and enabled WAN (DHCP/SLAAC) interfaces
+$interface = convert_real_interface_to_friendly_interface_name($interface_real);
+if (empty($interface)) {
+	exit_na('interface not configured');
+}
+
+$ifinfo = config_get_path("interfaces/{$interface}", []);
+if ($ifinfo['if'] != $interface_real || !array_key_exists('enable', $ifinfo)) {
+	exit_na('interface not enabled');
+}
+
+if ($ifinfo['ipaddrv6'] == 'dhcp6') {
+	if (isset($ifinfo['dhcp6withoutra'])) {
+		exit_na('interface mode dhcp6withoutra');
+	}
+	//dhcp processing
+	$process_dhcp6c = true;
+} elseif ($ifinfo['ipaddrv6'] == 'slaac') {
+	//no dhcpd processing, only call newwanipv6
+	$process_dhcp6c = false;
+} else {
+	exit_na('interface mode not dhcp6 or slaac');
+}
+
+// only process IPv6 GUA addresses
+if (is_ipaddrv4($address)) {
+	exit_na('address is IPv4');
+} elseif (!is_ipaddrv6($address)) {
+	log_error("rc.newipfromdevd: second argument is not an ip address");
+	exit(1);
+} elseif (!is_v6gua($address)) {
+	exit_na('address is no GUA');
+	exit(0);
+}
+
+// only process new autoconfig (SLAAC/RA) addresses
+$v6acaddrs = array();
+
+/* could be used after update of php-pfSense https://github.com/pfsense/FreeBSD-ports/commit/c7d2f956400b2a9192c08039a104154b545a2244
+* $ifaddrs = pfSense_get_ifaddrs('interface');
+* if (isset($ifaddrs['addrs6'])) {
+* 	foreach ($ifaddrs['addrs6'] as $v6addr) {
+* 		if (isset($v6addr['autoconf']) && is_v6gua($v6addr['addr'])) {
+* 			$v6acaddrs[] = Net_IPv6::Uncompress($v6addr['addr'], true);
+* 		}
+* 	}
+* }
+*/
+
+//use ifconfig until above mentioned update done
+$ifconfig = [];
+exec("/sbin/ifconfig -f inet6:numeric {$interface_real} inet6", $ifconfig);
+foreach ($ifconfig as $ifcline) {
+	$ifcltokens = explode(' ', trim($ifcline));
+	if ($ifcltokens[0] == 'inet6' && in_array('autoconf', $ifcltokens) && is_v6gua($ifcltokens[1])) {
+		$v6acaddrs[] = Net_IPv6::Uncompress($ifcltokens[1], true);
+	}
+}
+
+$address = Net_IPv6::Uncompress($address, true);
+
+if (!in_array($address, $v6acaddrs)) {
+	exit_na('address is not autoconf');
+}
+
+if ($process_dhcp6c) {
+	//10 seconds to wait for lock file to disappear
+	$bailtime = time() + 10;
+	while (file_exists("/tmp/{$interface_real}_ra_configured_inet6.lock") && time() < $bailtime) {
+		time_nanosleep(0, 300000);
+	}
+	$ifconfig = file("/tmp/{$interface_real}_ra_configured_inet6", FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+	$v6acaddrs = [];
+	if ($ifconfig) {
+		foreach ($ifconfig as  $ifcline) {
+			$ifcltokens = explode(' ', trim($ifcline));
+			if (is_v6gua($ifcltokens[1])) {
+				$v6acaddrs[] = Net_IPv6::Uncompress($ifcltokens[1], true);
+			}
+		}
+	}
+	if (in_array($address, $v6acaddrs)) {
+		exit_na('already covered');
+	}
+	// force DHCPDv6 REQUEST (which in turn runs the rc.newwanipv6 script)
+	$dhcp6c_pid = file_get_contents("/var/run/dhcp6c.pid");
+	$killrc = 1;
+	if ($dhcp6c_pid) {
+		$dhcp6c_pid = rtrim($dhcp6c_pid);
+		exec("/bin/kill -1 {$dhcp6c_pid}", result_code: $killrc);
+	}
+	if ($killrc > 0) {
+		log_error("rc.newipfromdevd: kill HUP for dhcp6c RC was {$killrc}, running rc.newwanipv6 instead");
+		exec("/etc/rc.newwanipv6 {$interface_real}");
+	} else {
+		log_error("rc.newipfromdevd: initiated dhcp6c REQUEST");
+	}
+} else {
+	log_error("rc.newipfromdevd: running rc.newwanipv6 for interface in SLAAC mode");
+	exec("/etc/rc.newwanipv6 {$interface_real}");
+}


### PR DESCRIPTION
fixes Ticket #12947 and others relating to (dynamic-IP) WAN reconnects (reaction on RA SLAAC address change was missing) does not fix the issue for setups relying primarily on DHCP (dhcp6withoutra mode enabled and necessary)

for installation: need to restart devd after file inetaddr.conf is dropped to devd directory

- [X] Redmine Issue: https://redmine.pfsense.org/issues/12947 
- [X] Ready for review