### PR TITLE
Don't unset v4 aliases when invoked with inet6.  Fixes #16103.

### DIFF
--- a/src/usr/local/sbin/ppp-linkdown
+++ b/src/usr/local/sbin/ppp-linkdown
@@ -61,12 +61,15 @@ if [ -f "/tmp/${IF}_router" ]; then
 fi
 
 # cleanup all VIPs, see https://redmine.pfsense.org/issues/11629
-while
-	aliases=$(/sbin/ifconfig "${IF}" | /usr/bin/grep netmask)
-	if [ -z "${aliases}" ]; then
-		break
-	fi
-do ifconfig "${IF}" -alias; done
+# see also https://redmine.pfsense.org/issues/16103
+if [ "${PROTOCOL}" = "inet" ]; then
+        while
+                aliases=$(/sbin/ifconfig "${IF}" | /usr/bin/grep netmask)
+                if [ -z "${aliases}" ]; then
+                        break
+                fi
+        do ifconfig "${IF}" -alias; done
+fi
 
 /bin/rm -f "/tmp/${IF}up"
 /bin/rm -f "/tmp/${IF}_ip"


### PR DESCRIPTION
- [ ] Redmine Issue: https://redmine.pfsense.org/issues/16103
- [ ] Ready for review