### PR TITLE
UPnP IGD & PCP: Add `Allow Third-Party Mapping` option

### DIFF
--- a/src/usr/local/pkg/miniupnpd.inc
+++ b/src/usr/local/pkg/miniupnpd.inc
@@ -236,8 +236,10 @@
 					$config_text .= "system_uptime=yes\n";
 				}
 
-				/* set secure_mode */
-				$config_text .= "secure_mode=yes\n";
+				if ($upnp_config['allow_third_party_mapping'] == 'on') {
+					$config_text .= "secure_mode=no\n";
+					$config_text .= "pcp_allow_thirdparty=yes\n";
+				}
 
 				/* set webgui url */
 				$webgui_config = config_get_path('system/webgui');

--- a/src/usr/local/pkg/miniupnpd.xml
+++ b/src/usr/local/pkg/miniupnpd.xml
@@ -35,13 +35,13 @@
 		<field>
 			<name>Service Settings</name>
 			<type>listtopic</type>
-			<enablefields>enable_upnp,enable_natpmp,ext_iface,iface_array,download,upload,overridewanip,upnpqueue,logpackets,sysuptime,permdefault</enablefields>
+			<enablefields>enable_upnp,enable_natpmp,ext_iface,iface_array,download,upload,overridewanip,allow_third_party_mapping,upnpqueue,logpackets,sysuptime,permdefault</enablefields>
 		</field>
 		<field>
 			<fielddescr>Enable</fielddescr>
 			<fieldname>enable</fieldname>
 			<type>checkbox</type>
-			<enablefields>enable_upnp,enable_natpmp,ext_iface,iface_array,download,upload,overridewanip,upnpqueue,logpackets,sysuptime,permdefault</enablefields>
+			<enablefields>enable_upnp,enable_natpmp,ext_iface,iface_array,download,upload,overridewanip,allow_third_party_mapping,upnpqueue,logpackets,sysuptime,permdefault</enablefields>
 			<description>Enable port mapping service</description>
 			<sethelp>
 				<![CDATA[
@@ -191,6 +191,16 @@
 		<field>
 			<name>Advanced Settings</name>
 			<type>listtopic</type>
+		</field>
+		<field>
+			<fielddescr>Allow Third-Party Mapping</fielddescr>
+			<fieldname>allow_third_party_mapping</fieldname>
+			<description>
+				<![CDATA[
+				Allow adding port maps for non-requesting IP addresses
+				]]>
+			</description>
+			<type>checkbox</type>
 		</field>
 		<field>
 			<fielddescr>Download Speed</fielddescr>


### PR DESCRIPTION
To allow adding port maps for non-requesting IP addresses, helps
https://redirect.github.com/opnsense/plugins/pull/3727

- [X] Redmine Issue: https://redmine.pfsense.org/issues/16273
- [X] Ready for review