### PR TITLE
Update dyndns.class to support sending the IP address and preserving …

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -1817,11 +1817,11 @@
 					curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body));
 					break;
 				case 'desec':
-					curl_setopt($ch, CURLOPT_URL, 'https://update.dedyn.io/?hostname=' . $this->_dnsHost);
+					curl_setopt($ch, CURLOPT_URL, 'https://update.dedyn.io/?hostname=' . $this->_dnsHost . '&myipv4=' . $this->_dnsIP . '&myipv6=preserve');
 					curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Token ' . $this->_dnsPass));
 					break;
 				case 'desec-v6':
-					curl_setopt($ch, CURLOPT_URL, 'https://update6.dedyn.io/?hostname=' . $this->_dnsHost);
+					curl_setopt($ch, CURLOPT_URL, 'https://update6.dedyn.io/?hostname=' . $this->_dnsHost . '&myipv4=preserve' . '&myipv6=' . $this->_dnsIP);
 					curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Token ' . $this->_dnsPass));
 					break;
 				case 'luadns':


### PR DESCRIPTION
Simpler version of https://github.com/pfsense/pfsense/pull/4543 and https://github.com/pfsense/pfsense/pull/4542

This one sets the IP reported to the API to that detected by the pfsense device, and preserves the non-updated IP.

Per the DeSEC documentation: 
https://desec.readthedocs.io/en/latest/dyndns/update-api.html

'''It is recommended to always specify query string parameters for both IP address types. If your device does not have both types, use preserve for the non-existing address. You can also use the empty value (which will delete any existing such address).'''

This adds the detected IP, and sets the other IP (v6 if updating v4, and v4 if updating v6) to be preserved.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/12494
- [x] Redmine Issue: https://redmine.pfsense.org/issues/12495
- [x] Ready for review