### PR TITLE
gwlb.inc patch to account for changes in `dpinger_dont_add_static_route` - redmine 16861

### DIFF
--- a/src/etc/inc/gwlb.inc
+++ b/src/etc/inc/gwlb.inc
@@ -2663,19 +2663,19 @@ function save_gateway($gateway_settings, $realid = "", $json = false) {
 		$a_gateway_item = config_get_path("gateways/gateway_item/{$realid}");
 		/* NOTE: If gateway ip is changed need to cleanup the old static interface route */
 		if ($gateway_settings['monitor'] != "dynamic" &&
-		    !empty($a_gateway_item) &&
-		    is_ipaddr($a_gateway_item['gateway']) &&
-		    $gateway['gateway'] != $a_gateway_item['gateway'] &&
-		    isset($a_gateway_item["nonlocalgateway"])) {
+			!empty($a_gateway_item) &&
+			is_ipaddr($a_gateway_item['gateway']) &&
+			$gateway['gateway'] != $a_gateway_item['gateway'] &&
+			isset($a_gateway_item["nonlocalgateway"])) {
 			route_del($a_gateway_item['gateway']);
 		}
 
-		/* NOTE: If monitor ip is changed need to cleanup the old static route */
+		/* NOTE: If monitor ip changed, or dpinger_dont_add_static_route is true (globally or per-gateway) remove the old static route */
 		if ($gateway_settings['monitor'] != "dynamic" &&
-		    !empty($a_gateway_item) &&
-		    is_ipaddr($a_gateway_item['monitor']) &&
-		    $gateway_settings['monitor'] != $a_gateway_item['monitor'] &&
-		    $gateway['gateway'] != $a_gateway_item['monitor']) {
+			!empty($a_gateway_item) &&
+			is_ipaddr($a_gateway_item['monitor']) &&
+			(isset($gateway['dpinger_dont_add_static_route']) || $skip_static_route ||
+			($gateway_settings['monitor'] != $a_gateway_item['monitor'] && $gateway['gateway'] != $a_gateway_item['monitor']))) {
 			route_del($a_gateway_item['monitor']);
 		}
 	}


### PR DESCRIPTION
If a gateway monitor IP is set, and then later the `dpinger_dont_add_static_route` option is enabled, the static route is NOT removed.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/16861
- [x] Ready for review

Came up with this patch, which I tested successfully on my 6100 running 26.03.1

It also accounts for the case when the global option is changed from System → Advanced → Miscellaneous

**N.B.** the reason for these few extra changed lines is I couldn't resist the urge to fix the mismatched whitespace just above

<img width="776" height="437" alt="image" src="https://github.com/user-attachments/assets/c9d5f201-8a00-49ff-b339-1b1072aa5ac6" />
