### PR TITLE
Add navigation settings search

### DIFF
--- a/src/usr/local/www/css/Compact-RED.css
+++ b/src/usr/local/www/css/Compact-RED.css
@@ -81,6 +81,14 @@ body {
 .nav>li>a {
     padding: 5px 19px 0px 19px;
 }
+
+@media (max-width: 1199px) {
+    .nav>li>a {
+        padding-right: 9px;
+        padding-left: 9px;
+    }
+}
+
 .navbar-inverse .navbar-nav >li>a {
     border-bottom: 5px solid #600;
 }
@@ -109,6 +117,29 @@ body {
 
 .navbar-right>li>a {
     padding: 2px 15px 1px 15px;
+}
+
+.navbar-nav>li.menu-search {
+    padding: 0;
+}
+
+.menu-search .form-control {
+    height: 29.5px;
+    margin: 0;
+}
+
+@media (max-width: 979px) {
+    .navbar-nav>li.menu-search-expanded {
+        background-color: #600;
+    }
+
+    .navbar-inverse .navbar-nav>li.menu-search-expanded>a,
+    .navbar-inverse .navbar-nav>li.menu-search-expanded>a:focus,
+    .navbar-inverse .navbar-nav>li.menu-search-expanded>a:hover {
+        background-color: transparent;
+        height: 29.5px;
+        padding: 2px 10px 1px;
+    }
 }
 
 .navbar-toggle {

--- a/src/usr/local/www/css/pfSense.css
+++ b/src/usr/local/www/css/pfSense.css
@@ -217,6 +217,49 @@ tr.disabled a:not(".btn") {
 .navbar-right>li>a {
     padding: 14px 15px 10px 15px;
 }
+
+#pf-navbar>.navbar-right {
+    position: relative;
+}
+
+.navbar-nav>li.menu-search {
+    padding: 0;
+    position: relative;
+}
+
+.menu-search .form-control {
+    height: 32px;
+    margin: 0;
+}
+
+.menu-search .form-control[hidden] {
+    display: none;
+}
+
+.navbar-nav>li.menu-search-expanded {
+    z-index: 1;
+}
+
+.navbar-inverse .navbar-nav>li.menu-search-expanded>a {
+    border-bottom-color: #B71C1C;
+}
+
+.menu-search-expanded .form-control {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 5px);
+    width: 320px;
+    z-index: 1;
+}
+
+.ui-autocomplete.menu-search-results {
+    max-height: 50vh;
+    max-width: calc(100vw - 16px);
+    min-width: 320px;
+    margin-left: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
 /* end navigation */
 
 .alert {
@@ -428,7 +471,7 @@ form .btn + .btn {
     width: calc(50% - 15px);
 }
 
-@media (max-width: 991px) {
+@media (max-width: 979px) {
     .col-sm-10 .form-control {
         width: 100%;
     }
@@ -878,7 +921,7 @@ table[data-sortable].sortable-theme-bootstrap thead th {
     }
 }
 
-@media (max-width: 991px) {
+@media (max-width: 979px) {
     /* change top navbar from horizontal to vertical */
     .navbar-header {
         float: none;
@@ -903,6 +946,33 @@ table[data-sortable].sortable-theme-bootstrap thead th {
     .navbar-nav>li>a {
         padding-top: 10px;
         padding-bottom: 10px;
+    }
+    .menu-search .form-control {
+        height: 46px;
+        margin: 0;
+        padding-left: 40px;
+        position: static;
+        width: 100%;
+    }
+    .navbar-inverse .navbar-nav>li.menu-search-expanded>a,
+    .navbar-inverse .navbar-nav>li.menu-search-expanded>a:focus,
+    .navbar-inverse .navbar-nav>li.menu-search-expanded>a:hover {
+        background-color: transparent;
+        border-bottom: 0;
+        color: #777;
+        height: 46px;
+        left: 0;
+        padding: 10px 9px;
+        position: absolute;
+        top: 0;
+        z-index: 1;
+    }
+    .navbar-nav>li.menu-search-expanded {
+        background-color: #212121;
+        padding: 0;
+        position: relative;
+        right: auto;
+        width: auto;
     }
     .navbar-text {
         float: none;

--- a/src/usr/local/www/head.inc
+++ b/src/usr/local/www/head.inc
@@ -532,6 +532,15 @@ if (are_notices_pending()) {
 			 	endforeach?>
 			</ul>
 			<ul class="nav navbar-nav navbar-right">
+				<li class="menu-search">
+					<a href="#" id="menu-search-toggle" role="button" aria-controls="menu-search-input" aria-expanded="false">
+						<i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+						<span class="sr-only"><?=htmlspecialchars(gettext("Search settings"))?></span>
+					</a>
+					<label class="sr-only" for="menu-search-input"><?=htmlspecialchars(gettext("Search settings"))?></label>
+					<input type="search" class="form-control" id="menu-search-input"
+					    placeholder="<?=htmlspecialchars(gettext("Search settings"))?>" autocomplete="off" hidden>
+				</li>
 				<?php if ($display_notices):?>
 					<?php $notices = get_notices()?>
 					<li class="dropdown">

--- a/src/usr/local/www/js/pfSense.js
+++ b/src/usr/local/www/js/pfSense.js
@@ -25,6 +25,102 @@
  */
 
 $(function() {
+	// Search the menu entries already filtered for the current user's privileges.
+	(function()
+	{
+		var search = $('#menu-search-input');
+		var searchItem = search.closest('.menu-search');
+		var searchToggle = $('#menu-search-toggle');
+		var items = [];
+		var setSearchExpanded = function(expanded, restoreFocus) {
+			searchItem.toggleClass('menu-search-expanded open', expanded);
+			searchToggle.attr('aria-expanded', expanded ? 'true' : 'false');
+			search.prop('hidden', !expanded);
+
+			if (expanded) {
+				search.trigger('focus');
+			} else {
+				search.autocomplete('close').val('');
+				if (restoreFocus) {
+					searchToggle.trigger('focus');
+				}
+			}
+		};
+
+		searchToggle.on('click', function(event) {
+			event.preventDefault();
+			setSearchExpanded(!searchItem.hasClass('menu-search-expanded'), true);
+		});
+
+		$('#pf-navbar > ul.navbar-nav:not(.navbar-right) > li.dropdown').each(function() {
+			var section = $.trim($(this).children('.dropdown-toggle').clone().children().remove().end().text());
+
+			$(this).find('.dropdown-menu a.navlnk:not([usepost])').each(function() {
+				if ((this.protocol != window.location.protocol) || (this.host != window.location.host)) {
+					return;
+				}
+
+				items.push({
+					label: section + ' \u2192 ' + $.trim($(this).text()),
+					section: section.toLowerCase(),
+					page: $.trim($(this).text()).toLowerCase(),
+					url: this.href
+				});
+			});
+		});
+
+		search.autocomplete({
+			minLength: 1,
+			position: { my: 'right top', at: 'right bottom', collision: 'flipfit' },
+			source: function(request, response) {
+				var query = $.trim(request.term).toLowerCase();
+				var matches = $.grep(items, function(item) {
+					return (item.page.indexOf(query) != -1) || (item.section.indexOf(query) != -1);
+				});
+
+				matches.sort(function(left, right) {
+					var leftRank = left.page.indexOf(query) == 0 ? 0 : left.section.indexOf(query) == 0 ? 1 : 2;
+					var rightRank = right.page.indexOf(query) == 0 ? 0 : right.section.indexOf(query) == 0 ? 1 : 2;
+					return (leftRank - rightRank) || left.label.localeCompare(right.label);
+				});
+
+				response(matches.slice(0, 10));
+			},
+			focus: function() {
+				return false;
+			},
+			select: function(event, ui) {
+				window.location.assign(ui.item.url);
+				return false;
+			}
+		});
+
+		search.autocomplete('instance')._renderItem = function(list, item) {
+			var query = $.trim(this.term);
+			var offset = item.label.toLowerCase().indexOf(query.toLowerCase());
+			var label = $('<div>');
+
+			label.append(document.createTextNode(item.label.substring(0, offset)));
+			label.append($('<strong>').text(item.label.substring(offset, offset + query.length)));
+			label.append(document.createTextNode(item.label.substring(offset + query.length)));
+
+			return $('<li>').append(label).appendTo(list);
+		};
+		search.autocomplete('widget').addClass('menu-search-results');
+
+		search.on('keydown', function(event) {
+			if (event.key == 'Escape') {
+				setSearchExpanded(false, true);
+			}
+		});
+
+		search.on('blur', function() {
+			window.setTimeout(function() {
+				setSearchExpanded(false, false);
+			}, 0);
+		});
+	})();
+
 	// Attach collapsable behaviour to select options
 	(function()
 	{


### PR DESCRIPTION
- [x] Redmine Issue: https://redmine.pfsense.org/issues/9717
- [x] Ready for review

Adds a settings search action to the navigation bar using the bundled jQuery UI autocomplete. It searches menu entries already filtered for the current user's privileges, including entries added by packages, ranks prefix matches first, and highlights matching text in bold.

At rest, the control occupies one action slot as a magnifier icon. On desktop, activating it keeps the navigation actions visible and opens a compact search field beneath the button; the button reuses the existing open-menu styling. On collapsed/mobile navigation, the search field replaces the full action row. Activating the icon again, pressing Escape, or moving focus away closes and clears the field without stealing focus from the newly focused control.

The responsive cutoff is below 980px so a mobile browser requesting a 980px desktop viewport receives the desktop arrangement.

Validated with JavaScript syntax and diff checks plus responsive browser interaction tests at mobile and desktop widths in the standard and Compact-RED themes. The checks covered open/closed styling, exact input height, the desktop popup gap, mobile full-row behavior, blur/click/Escape collapse behavior, focus handling, autocomplete rendering and selection, and long FQDN menu labels. Plus-safe files were deployed to pfSense Plus 26.03.1 for production visual validation.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
